### PR TITLE
create projects should not scan for local .git/config files

### DIFF
--- a/pkg/jx/cmd/create.go
+++ b/pkg/jx/cmd/create.go
@@ -73,8 +73,9 @@ func (o *CreateOptions) DoImport(outDir string) error {
 	}
 
 	importOptions := &ImportOptions{
-		CommonOptions: o.CommonOptions,
-		Dir:           outDir,
+		CommonOptions:       o.CommonOptions,
+		Dir:                 outDir,
+		DisableDotGitSearch: true,
 	}
 	return importOptions.Run()
 }

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -107,9 +107,10 @@ type ImportOptions struct {
 	SelectAll    bool
 	SelectFilter string
 
-	Jenkins     *gojenkins.Jenkins
-	GitConfDir  string
-	GitProvider gits.GitProvider
+	DisableDotGitSearch bool
+	Jenkins             *gojenkins.Jenkins
+	GitConfDir          string
+	GitProvider         gits.GitProvider
 }
 
 var (
@@ -203,7 +204,7 @@ func (o *ImportOptions) Run() error {
 		if err != nil {
 			return err
 		}
-	} else {
+	} else if o.DisableDotGitSearch {
 		err = o.DiscoverGit()
 		if err != nil {
 			return err


### PR DESCRIPTION
as they will be new projects by definition.

This avoids possible issues if folks run, say, `jx create spring` inside a git clone'd repo