### PR TITLE
lets default git auth setup to using github, this can be overridden b…

### DIFF
--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -54,7 +54,7 @@ func (f *ServerFlags) IsEmpty() bool {
 }
 
 func addGitRepoOptionsArguments(cmd *cobra.Command, repositoryOptions *gits.GitRepositoryOptions) {
-	cmd.Flags().StringVarP(&repositoryOptions.ServerURL, "git-provider-url", "", "", "The git server URL to create new git repositories inside")
+	cmd.Flags().StringVarP(&repositoryOptions.ServerURL, "git-provider-url", "", "github.com", "The git server URL to create new git repositories inside")
 	cmd.Flags().StringVarP(&repositoryOptions.Username, "git-username", "", "", "The git username to use for creating new git repositories")
 	cmd.Flags().StringVarP(&repositoryOptions.ApiToken, "git-api-token", "", "", "The git API token to use for creating new git repositories")
 }


### PR DESCRIPTION
…y the `--git-provider-url` flag

fixes #212