### PR TITLE
Paste-able Hyperkit driver installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Then install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/). 
 
 Install the HyperKit driver:
 
-   curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit \
-   && chmod +x docker-machine-driver-hyperkit \
-   && sudo mv docker-machine-driver-hyperkit /usr/local/bin/ \
-   && sudo chown root:wheel /usr/local/bin/docker-machine-driver-hyperkit \
-   && sudo chmod u+s /usr/local/bin/docker-machine-driver-hyperkit
+    curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit && \
+    chmod +x docker-machine-driver-hyperkit && \
+    sudo mv docker-machine-driver-hyperkit /usr/local/bin/ && \
+    sudo chown root:wheel /usr/local/bin/docker-machine-driver-hyperkit && \
+    sudo chmod u+s /usr/local/bin/docker-machine-driver-hyperkit
 
 To start Kubernetes:
 


### PR DESCRIPTION
Update Hyperkit driver installation instructions so that they can be pased into a command prompt