### PR TITLE
Sanitize user name label when creating GKE cluster

### DIFF
--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
+	"regexp"
 )
 
 // CreateClusterOptions the flags for running crest cluster
@@ -67,6 +68,7 @@ var (
 		jx create cluster gke
 
 `)
+	disallowedLabelCharacters = regexp.MustCompile("[^a-z0-9-]")
 )
 
 // NewCmdGet creates a command object for the generic "init" action, which
@@ -223,7 +225,7 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 	labels := o.Flags.Labels
 	user, err := os_user.Current()
 	if err == nil && user != nil {
-		username := user.Username
+		username := sanitizeLabel(user.Username)
 		if username != "" {
 			sep := ""
 			if labels != "" {
@@ -276,6 +278,11 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 		return err
 	}
 	return nil
+}
+
+func sanitizeLabel(username string) string {
+	sanitized := strings.ToLower(username)
+	return disallowedLabelCharacters.ReplaceAllString(sanitized, "-")
 }
 
 // asks to chose from existing projects or optionally creates one if none exist

--- a/pkg/jx/cmd/create_cluster_gke_test.go
+++ b/pkg/jx/cmd/create_cluster_gke_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_sanitizeLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		want     string
+	}{
+		{"Replaces . in username for -", "test.person", "test-person"},
+		{"Replaces _ in username for -", "test_person", "test-person"},
+		{"Replaces uppercase in username for lowercase", "Test", "test"},
+		{"Doesn't do anything for empty user names", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, sanitizeLabel(tt.username), tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Hi there!

Amazing project, really looking forward to see what I can contribute with.

This tries to fix an issue I had today while trying out the `jx create cluster gke` command. My user name is "firstname.lastname" on mac so the command failed with 

`ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=invalid field 'cluster.resource_labels.value': "jose.ordiales". It must begin with a lowercase character ([a-z]), end with a lowercase alphanumeric ([a-z0-9]) with dashes (-), and lowercase alphanumeric ([a-z0-9]) between.`

The sanitize function just replaces any non-allowed characters with `-` but I guess it could be made smarter if there's a need.

I only applied this to the "created-by" label because the user doesn't have a lot of control over that one. The ones passed through the CLI are set explicitly so maybe it's ok for the command to fail when those are not valid.