### PR TITLE
Align list of valid resource types for create

### DIFF
--- a/pkg/jx/cmd/create.go
+++ b/pkg/jx/cmd/create.go
@@ -32,7 +32,7 @@ var (
 	* cluster
 	* env
 	* git
-    * spring (aka 'springboot')
+	* spring (aka 'springboot')
     `
 
 	create_long = templates.LongDesc(`


### PR DESCRIPTION
Sorry, just a small OCD thing.

```
jx create options
Creates a new resource.

  Valid resource types include:

  * archetype
  * cluster
  * env
  * git
    * spring (aka 'springboot')
```

The first 4 lines were tab indented and the last one space indented :)