### PR TITLE
Always include user account as part of organisation list

### DIFF
--- a/pkg/gits/provider_test.go
+++ b/pkg/gits/provider_test.go
@@ -1,0 +1,44 @@
+package gits
+
+import (
+	"errors"
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+type FakeOrgLister struct {
+	orgNames []string
+	fail     bool
+}
+
+func (l FakeOrgLister) ListOrganisations() ([]GitOrganisation, error) {
+	if l.fail {
+		return nil, errors.New("fail")
+	}
+
+	orgs := make([]GitOrganisation, len(l.orgNames))
+	for _, v := range l.orgNames {
+		orgs = append(orgs, GitOrganisation{v})
+	}
+	return orgs, nil
+}
+
+func Test_getOrganizations(t *testing.T) {
+	tests := []struct {
+		testDescription string
+		orgLister       OrganisationLister
+		userName        string
+		want            []string
+	}{
+		{"Should return user name when ListOrganisations() fails", FakeOrgLister{fail: true}, "testuser", []string{"testuser"}},
+		{"Should return user name when organization list is empty", FakeOrgLister{orgNames: []string{}}, "testuser", []string{"testuser"}},
+		{"Should include user name when only 1 organization exists", FakeOrgLister{orgNames: []string{"testorg"}}, "testuser", []string{"testorg", "testuser"}},
+		{"Should include user name together with all organizations when multiple exists", FakeOrgLister{orgNames: []string{"testorg", "anotherorg"}}, "testuser", []string{"anotherorg", "testorg", "testuser"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testDescription, func(t *testing.T) {
+			result := getOrganizations(tt.orgLister, tt.userName)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}


### PR DESCRIPTION
This fixes an issue I was discussing yesterday on the Slack channel with @jstrachan, where if the user belongs to just 1 organisation then that organisation was always used by default to create repos.