### PR TITLE
Enhance help message with note for WIP quickstarts

### DIFF
--- a/pkg/jx/cmd/create_quickstart.go
+++ b/pkg/jx/cmd/create_quickstart.go
@@ -28,6 +28,7 @@ var (
 		Create a new project from a sample/starter (found in https://github.com/jenkins-x-quickstarts)
 
 		This will create a new project for you from the selected template.
+		It will exclude any work-in-progress repos (containing the "WIP-" pattern)
 
 		For more documentation see: [http://jenkins-x.io/developing/create-quickstart/](http://jenkins-x.io/developing/create-quickstart/)
 

--- a/pkg/jx/cmd/create_quickstart.go
+++ b/pkg/jx/cmd/create_quickstart.go
@@ -38,6 +38,7 @@ var (
 		Create a new project from a sample/starter (found in https://github.com/jenkins-x-quickstarts)
 
 		This will create a new project for you from the selected template.
+		It will exclude any work-in-progress repos (containing the "WIP-" pattern)
 
 		jx create quickstart
 


### PR DESCRIPTION
"WIP-" quickstarts are excluded from the shown quickstarts, but this is not something currently depicted in the help message of the command.