### PR TITLE
Implements remaining BitbucketCloudProvider methods, closes #36

### DIFF
--- a/pkg/gits/bitbucket.go
+++ b/pkg/gits/bitbucket.go
@@ -177,12 +177,14 @@ func (b *BitbucketCloudProvider) ForkRepository(
 	name string,
 	destinationOrg string,
 ) (*GitRepository, error) {
-
+	options := map[string]interface{}{
+		"body": map[string]interface{}{},
+	}
 	repo, _, err := b.Client.RepositoriesApi.RepositoriesUsernameRepoSlugForksPost(
 		b.Context,
-		b.Username,
+		originalOrg,
 		name,
-		nil,
+		options,
 	)
 
 	if err != nil {

--- a/pkg/gits/bitbucket_test.go
+++ b/pkg/gits/bitbucket_test.go
@@ -53,6 +53,13 @@ var router = util.Router{
 	"/repositories/test-user/test-repo/hooks": util.MethodMap{
 		"POST": "webhooks.example.json",
 	},
+	"/repositories/test-user/test-repo/issues": util.MethodMap{
+		"POST": "issues.test-repo.issue-1.json",
+		"GET":  "issues.test-repo.json",
+	},
+	"/repositories/test-user/test-repo/issues/1": util.MethodMap{
+		"GET": "issues.test-repo.issue-1.json",
+	},
 }
 
 func (suite *BitbucketCloudProviderTestSuite) SetupSuite() {
@@ -242,6 +249,52 @@ func (suite *BitbucketCloudProviderTestSuite) TestCreateWebHook() {
 	err := suite.provider.CreateWebHook(data)
 
 	suite.Require().Nil(err)
+}
+
+func (suite *BitbucketCloudProviderTestSuite) TestSearchIssues() {
+	issues, err := suite.provider.SearchIssues("test-user", "test-repo", "")
+
+	suite.Require().Nil(err)
+	suite.Require().NotNil(issues)
+
+	for _, issue := range issues {
+		suite.Require().NotNil(issue)
+	}
+}
+
+func (suite *BitbucketCloudProviderTestSuite) TestGetIssue() {
+	issue, err := suite.provider.GetIssue("test-user", "test-repo", 1)
+
+	suite.Require().Nil(err)
+	suite.Require().NotNil(issue)
+	suite.Require().Equal(*issue.Number, 1)
+}
+
+func (suite *BitbucketCloudProviderTestSuite) TestCreateIssue() {
+
+	issueToCreate := &GitIssue{
+		Title: "This is a test issue",
+	}
+
+	issue, err := suite.provider.CreateIssue("test-user", "test-repo", issueToCreate)
+
+	suite.Require().Nil(err)
+	suite.Require().NotNil(issue)
+}
+
+func (suite *BitbucketCloudProviderTestSuite) TestAddPRComment() {
+	err := suite.provider.AddPRComment(nil, "")
+	suite.Require().Error(err)
+}
+
+func (suite *BitbucketCloudProviderTestSuite) TestCreateIssueComment() {
+	err := suite.provider.CreateIssueComment("", "", 0, "")
+	suite.Require().Error(err)
+}
+
+func (suite *BitbucketCloudProviderTestSuite) TestUpdateRelease() {
+	err := suite.provider.UpdateRelease("", "", "", nil)
+	suite.Require().Error(err)
 }
 
 func TestBitbucketCloudProviderTestSuite(t *testing.T) {

--- a/pkg/gits/bitbucket_test.go
+++ b/pkg/gits/bitbucket_test.go
@@ -139,6 +139,8 @@ func (suite *BitbucketCloudProviderTestSuite) TestForkRepository() {
 
 	suite.Require().NotNil(fork)
 	suite.Require().Nil(err)
+
+	suite.Require().Equal(fork.Name, "test-fork")
 }
 
 func (suite *BitbucketCloudProviderTestSuite) TestValidateRepositoryName() {

--- a/pkg/gits/test_data/bitbucket/issues.test-repo.issue-1.json
+++ b/pkg/gits/test_data/bitbucket/issues.test-repo.issue-1.json
@@ -1,0 +1,77 @@
+{
+    "priority": "major",
+    "kind": "bug",
+    "repository": {
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo"
+            },
+            "html": {
+                "href": "https://bitbucket.org/test-user/test-repo"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/test-user/test-repo/avatar/32/"
+            }
+        },
+        "type": "repository",
+        "name": "test-repo",
+        "full_name": "test-user/test-repo",
+        "uuid": "{2422942f-0f92-4c12-80b8-bc07b9bf3064}"
+    },
+    "links": {
+        "attachments": {
+            "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/1/attachments"
+        },
+        "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/1"
+        },
+        "watch": {
+            "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/1/watch"
+        },
+        "comments": {
+            "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/1/comments"
+        },
+        "html": {
+            "href": "https://bitbucket.org/test-user/test-repo/issues/1/this-is-a-test-issue"
+        },
+        "vote": {
+            "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/1/vote"
+        }
+    },
+    "reporter": {
+        "username": "test-user",
+        "display_name": "Test User",
+        "type": "user",
+        "uuid": "{0a3c1273-f935-421f-848c-c21435948831}",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/users/test-user"
+            },
+            "html": {
+                "href": "https://bitbucket.org/test-user/"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/account/test-user/avatar/32/"
+            }
+        }
+    },
+    "title": "This is a test issue",
+    "component": null,
+    "votes": 0,
+    "watches": 1,
+    "content": {
+        "raw": "",
+        "markup": "markdown",
+        "html": "",
+        "type": "rendered"
+    },
+    "assignee": null,
+    "state": "new",
+    "version": null,
+    "edited_on": null,
+    "created_on": "2018-04-07T01:54:34.607193+00:00",
+    "milestone": null,
+    "updated_on": "2018-04-07T01:54:34.607193+00:00",
+    "type": "issue",
+    "id": 1
+}

--- a/pkg/gits/test_data/bitbucket/issues.test-repo.json
+++ b/pkg/gits/test_data/bitbucket/issues.test-repo.json
@@ -1,0 +1,238 @@
+{
+    "pagelen": 20,
+    "values": [
+        {
+            "priority": "major",
+            "kind": "bug",
+            "repository": {
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test-user/test-repo"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/test-user/test-repo/avatar/32/"
+                    }
+                },
+                "type": "repository",
+                "name": "test-repo",
+                "full_name": "test-user/test-repo",
+                "uuid": "{2422942f-0f92-4c12-80b8-bc07b9bf3064}"
+            },
+            "links": {
+                "attachments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/3/attachments"
+                },
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/3"
+                },
+                "watch": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/3/watch"
+                },
+                "comments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/3/comments"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/test-user/test-repo/issues/3/this-is-yet-another-test-issue"
+                },
+                "vote": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/3/vote"
+                }
+            },
+            "reporter": {
+                "username": "test-user",
+                "display_name": "Test User",
+                "type": "user",
+                "uuid": "{0a3c1273-f935-421f-848c-c21435948831}",
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/users/test-user"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test-user/"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/account/test-user/avatar/32/"
+                    }
+                }
+            },
+            "title": "This is yet another test issue",
+            "component": null,
+            "votes": 0,
+            "watches": 1,
+            "content": {
+                "raw": "",
+                "markup": "markdown",
+                "html": "",
+                "type": "rendered"
+            },
+            "assignee": null,
+            "state": "new",
+            "version": null,
+            "edited_on": null,
+            "created_on": "2018-04-07T01:56:47.588977+00:00",
+            "milestone": null,
+            "updated_on": "2018-04-07T01:56:47.588977+00:00",
+            "type": "issue",
+            "id": 3
+        },
+        {
+            "priority": "major",
+            "kind": "bug",
+            "repository": {
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test-user/test-repo"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/test-user/test-repo/avatar/32/"
+                    }
+                },
+                "type": "repository",
+                "name": "test-repo",
+                "full_name": "test-user/test-repo",
+                "uuid": "{2422942f-0f92-4c12-80b8-bc07b9bf3064}"
+            },
+            "links": {
+                "attachments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/2/attachments"
+                },
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/2"
+                },
+                "watch": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/2/watch"
+                },
+                "comments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/2/comments"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/test-user/test-repo/issues/2/this-is-another-test-issue"
+                },
+                "vote": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/2/vote"
+                }
+            },
+            "reporter": {
+                "username": "test-user",
+                "display_name": "Test User",
+                "type": "user",
+                "uuid": "{0a3c1273-f935-421f-848c-c21435948831}",
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/users/test-user"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test-user/"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/account/test-user/avatar/32/"
+                    }
+                }
+            },
+            "title": "This is another test issue",
+            "component": null,
+            "votes": 0,
+            "watches": 1,
+            "content": {
+                "raw": "",
+                "markup": "markdown",
+                "html": "",
+                "type": "rendered"
+            },
+            "assignee": null,
+            "state": "new",
+            "version": null,
+            "edited_on": null,
+            "created_on": "2018-04-07T01:56:40.813341+00:00",
+            "milestone": null,
+            "updated_on": "2018-04-07T01:56:40.813341+00:00",
+            "type": "issue",
+            "id": 2
+        },
+        {
+            "priority": "major",
+            "kind": "bug",
+            "repository": {
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test-user/test-repo"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/test-user/test-repo/avatar/32/"
+                    }
+                },
+                "type": "repository",
+                "name": "test-repo",
+                "full_name": "test-user/test-repo",
+                "uuid": "{2422942f-0f92-4c12-80b8-bc07b9bf3064}"
+            },
+            "links": {
+                "attachments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/1/attachments"
+                },
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/1"
+                },
+                "watch": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/1/watch"
+                },
+                "comments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/1/comments"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/test-user/test-repo/issues/1/this-is-a-test-issue"
+                },
+                "vote": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test-user/test-repo/issues/1/vote"
+                }
+            },
+            "reporter": {
+                "username": "test-user",
+                "display_name": "Test User",
+                "type": "user",
+                "uuid": "{0a3c1273-f935-421f-848c-c21435948831}",
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/users/test-user"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test-user/"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/account/test-user/avatar/32/"
+                    }
+                }
+            },
+            "title": "This is a test issue",
+            "component": null,
+            "votes": 0,
+            "watches": 1,
+            "content": {
+                "raw": "",
+                "markup": "markdown",
+                "html": "",
+                "type": "rendered"
+            },
+            "assignee": null,
+            "state": "new",
+            "version": null,
+            "edited_on": null,
+            "created_on": "2018-04-07T01:54:34.607193+00:00",
+            "milestone": null,
+            "updated_on": "2018-04-07T01:54:34.607193+00:00",
+            "type": "issue",
+            "id": 1
+        }
+    ],
+    "page": 1,
+    "size": 3
+}

--- a/pkg/jx/cmd/util/factory.go
+++ b/pkg/jx/cmd/util/factory.go
@@ -251,7 +251,18 @@ func (f *factory) CreateGitAuthConfigServiceForURL(gitURL string) (auth.AuthConf
 	}
 	secrets, err := f.loadPipelineSecrets(kube.ValueKindGit)
 	if err != nil {
-		fmt.Printf("WARNING: The current user cannot query secrets in the namespace %s: %s\n", err)
+
+		kubeConfig, _, configLoadErr := kube.LoadConfig()
+		if err != nil {
+			fmt.Printf("WARNING: Could not load config: %s", configLoadErr)
+		}
+
+		ns := kube.CurrentNamespace(kubeConfig)
+		if ns == "" {
+			fmt.Printf("WARNING: Could not get the current namespace")
+		}
+
+		fmt.Printf("WARNING: The current user cannot query secrets in the namespace %s: %s\n", ns, err)
 	} else if secrets != nil {
 		f.authMergePipelineSecrets(config, secrets, kube.ValueKindGit)
 	}


### PR DESCRIPTION
Some things aren't supported by the Bitbucket Cloud API, and as such the following methods throw errors:

* `AddPRComment`
* `CreateIssueComment`
* `UpdateRelease`

The first two can be done by POSTing to the same URLs that the web interface uses. This method doesn't support app passwords, however, so we'd have to get the user's web password. 2FA would then have to be dealt with. Releases are simply not supported on Bitbucket Cloud. There is a notion of downloads, but they don't support tagging, release notes, change logs, or really any of the fields of a `GitRelease`