### PR TITLE
feat:(jx step git credentials) add new command to generate git creds

### DIFF
--- a/docs/contributing/hacking.md
+++ b/docs/contributing/hacking.md
@@ -68,6 +68,28 @@ Run `make` to build the `jx`  binaries:
 $ make build      # runs glide and builds `jx`  inside the build/
 ```
 
+## Testing
+
+There's a handy script to output nice syntax highlighted output of test results via:
+
+```shell 
+./test.sh
+```
+
+Or you can use `make`
+
+```shell 
+make test
+```
+
+### Debug logging
+
+Lots of the test have debug output to try figure out when things fail. You can enable verbose debug logging for tests via
+
+```shell 
+export JX_TEST_DEBUG=true
+```
+
 ## Debugging
 
 First you need to [install Delve](https://github.com/derekparker/delve/blob/master/Documentation/installation/README.md)

--- a/pkg/auth/config_service.go
+++ b/pkg/auth/config_service.go
@@ -9,16 +9,19 @@ import (
 )
 
 func (s *AuthConfigService) Config() *AuthConfig {
-	return &s.config
+	if s.config == nil {
+		s.config = &AuthConfig{}
+	}
+	return s.config
 }
 
-func (s *AuthConfigService) SetConfig(c AuthConfig) {
+func (s *AuthConfigService) SetConfig(c *AuthConfig) {
 	s.config = c
 }
 
 // LoadConfig loads the configuration from the users JX config directory
 func (s *AuthConfigService) LoadConfig() (*AuthConfig, error) {
-	config := &s.config
+	config := s.Config()
 	fileName := s.FileName
 	if fileName != "" {
 		exists, err := util.FileExists(fileName)
@@ -30,7 +33,7 @@ func (s *AuthConfigService) LoadConfig() (*AuthConfig, error) {
 			if err != nil {
 				return config, fmt.Errorf("Failed to load file %s due to %s", fileName, err)
 			}
-			err = yaml.Unmarshal(data, &config)
+			err = yaml.Unmarshal(data, config)
 			if err != nil {
 				return config, fmt.Errorf("Failed to unmarshal YAML file %s due to %s", fileName, err)
 			}
@@ -67,7 +70,7 @@ func (s *AuthConfigService) SaveConfig() error {
 
 // SaveUserAuth saves the given user auth for the server url
 func (s *AuthConfigService) SaveUserAuth(url string, userAuth *UserAuth) error {
-	config := &s.config
+	config := s.config
 	config.SetUserAuth(url, userAuth)
 	user := userAuth.Username
 	if user != "" {

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -30,5 +30,5 @@ type AuthConfig struct {
 // AuthConfigService is a service for handing the config of auth tokens
 type AuthConfigService struct {
 	FileName string
-	config   AuthConfig
+	config   *AuthConfig
 }

--- a/pkg/config/admin_secrets_test.go
+++ b/pkg/config/admin_secrets_test.go
@@ -1,11 +1,10 @@
 package config
 
 import (
+	"io/ioutil"
 	"testing"
 
-	"io/ioutil"
-
-	"github.com/jenkins-x/jx/pkg/jx/cmd/log"
+	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +19,7 @@ func TestAdminSecrets(t *testing.T) {
 	assert.NoError(t, err)
 
 	s, err := service.Secrets.String()
-	log.Infof("%s", s)
+	tests.Debugf("%s", s)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(testFile), s, "expected admin secret values do not match")

--- a/pkg/gits/constants.go
+++ b/pkg/gits/constants.go
@@ -1,0 +1,8 @@
+package gits
+
+const (
+	KindBitBucket = "bitbucket"
+	KindGitea     = "gitea"
+	KindGitlab    = "gitlab"
+	KindGitHub    = "github"
+)

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -647,7 +647,7 @@ func (p *GitHubProvider) IsGitea() bool {
 }
 
 func (p *GitHubProvider) Kind() string {
-	return "github"
+	return KindGitHub
 }
 
 func (p *GitHubProvider) JenkinsWebHookPath(gitURL string, secret string) string {

--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -218,9 +218,9 @@ func (i *GitIssue) Name() string {
 
 func CreateProvider(server *auth.AuthServer, user *auth.UserAuth) (GitProvider, error) {
 	switch server.Kind {
-	case "gitea":
+	case KindGitea:
 		return NewGiteaProvider(server, user)
-	case "bitbucket":
+	case KindBitBucket:
 		return NewBitbucketCloudProvider(server, user)
 	default:
 		return NewGitHubProvider(server, user)
@@ -229,10 +229,10 @@ func CreateProvider(server *auth.AuthServer, user *auth.UserAuth) (GitProvider, 
 
 func ProviderAccessTokenURL(kind string, url string, username string) string {
 	switch kind {
-	case "bitbucket":
+	case KindBitBucket:
 		// TODO pass in the username
 		return BitbucketAccessTokenURL(url, username)
-	case "gitea":
+	case KindGitea:
 		return GiteaAccessTokenURL(url)
 	default:
 		return GitHubAccessTokenURL(url)

--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -191,7 +191,7 @@ func (o *CommonOptions) gitProviderForURL(gitURL string, message string) (gits.G
 	if err != nil {
 		return nil, err
 	}
-	authConfigSvc, err := o.Factory.CreateGitAuthConfigServiceForURL(gitInfo.HostURL())
+	authConfigSvc, err := o.Factory.CreateGitAuthConfigService()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -620,10 +620,10 @@ func (o *ImportOptions) DoImport() error {
 }
 
 func (o *ImportOptions) replacePlaceholders() error {
-	log.Infof("replacing placeholders in directory %s\n", o.Dir)
+	o.Printf("replacing placeholders in directory %s\n", o.Dir)
 	gitServer := strings.TrimSuffix(strings.TrimPrefix(o.GitRepositoryOptions.ServerURL, "https://"), "/")
 
-	log.Infof("app name: %s, git server: %s, org: %s\n", o.AppName, gitServer, o.Organisation)
+	o.Printf("app name: %s, git server: %s, org: %s\n", o.AppName, gitServer, o.Organisation)
 
 	if err := filepath.Walk(o.Dir, func(f string, fi os.FileInfo, err error) error {
 		if fi.Name() == ".git" {

--- a/pkg/jx/cmd/import_test.go
+++ b/pkg/jx/cmd/import_test.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 
-	"io/ioutil"
-
-	"path"
-
-	"os"
-
+	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,6 +23,7 @@ func TestReplacePlaceholders(t *testing.T) {
 
 	assert.NoError(t, err)
 	o := ImportOptions{}
+	o.Out = tests.Output()
 	o.Dir = f
 	o.AppName = "bar"
 	o.GitRepositoryOptions.ServerURL = "https://github.com"

--- a/pkg/jx/cmd/step.go
+++ b/pkg/jx/cmd/step.go
@@ -42,8 +42,9 @@ func NewCmdStep(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comma
 	}
 
 	cmd.AddCommand(NewCmdStepChangelog(f, out, errOut))
-	cmd.AddCommand(NewCmdStepPR(f, out, errOut))
+	cmd.AddCommand(NewCmdStepGit(f, out, errOut))
 	cmd.AddCommand(NewCmdStepNexus(f, out, errOut))
+	cmd.AddCommand(NewCmdStepPR(f, out, errOut))
 	cmd.AddCommand(NewCmdStepTag(f, out, errOut))
 	cmd.AddCommand(NewCmdStepValidate(f, out, errOut))
 	return cmd

--- a/pkg/jx/cmd/step_git.go
+++ b/pkg/jx/cmd/step_git.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"fmt"
+	cmdutil "github.com/jenkins-x/jx/pkg/jx/cmd/util"
+	"github.com/jenkins-x/jx/pkg/util"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+)
+
+// StepGitOptions contains the command line flags
+type StepGitOptions struct {
+	StepOptions
+}
+
+// NewCmdStepGit Steps a command object for the "step" command
+func NewCmdStepGit(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
+	options := &StepGitOptions{
+		StepOptions: StepOptions{
+			CommonOptions: CommonOptions{
+				Factory: f,
+				Out:     out,
+				Err:     errOut,
+			},
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "git",
+		Short: "git [command]",
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			cmdutil.CheckErr(err)
+		},
+	}
+	cmd.AddCommand(NewCmdStepGitCredentials(f, out, errOut))
+	return cmd
+}
+
+// Run implements this command
+func (o *StepGitOptions) Run() error {
+	return o.Cmd.Help()
+}
+
+func (o *StepGitOptions) findStagingRepoIds() ([]string, error) {
+	answer := []string{}
+	files, err := filepath.Glob(statingRepositoryProperties)
+	if err != nil {
+		return answer, err
+	}
+	for _, f := range files {
+		data, err := ioutil.ReadFile(f)
+		if err != nil {
+			return answer, fmt.Errorf("Failed to load file %s: %s", f, err)
+		}
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, statingRepositoryIdPrefix) {
+				id := strings.TrimSpace(strings.TrimPrefix(line, statingRepositoryIdPrefix))
+				if id != "" {
+					answer = append(answer, id)
+				}
+			}
+		}
+	}
+	return answer, nil
+}
+
+func (o *StepGitOptions) dropRepositories(repoIds []string, message string) error {
+	var answer error
+	for _, repoId := range repoIds {
+		err := o.dropRepository(repoId, message)
+		if err != nil {
+			o.warnf("Failed to drop repository %s: %s\n", util.ColorInfo(repoIds), util.ColorError(err))
+			if answer == nil {
+				answer = err
+			}
+		}
+	}
+	return answer
+}
+
+func (o *StepGitOptions) dropRepository(repoId string, message string) error {
+	if repoId == "" {
+		return nil
+	}
+	o.Printf("Dropping nexus release repository %s\n", util.ColorInfo(repoId))
+	err := o.runCommand("mvn",
+		"org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-drop",
+		"-DserverId=oss-sonatype-staging",
+		"-DnexusUrl=https://oss.sonatype.org",
+		"-DstagingRepositoryId="+repoId,
+		"-Ddescription=\""+message+"\" -DstagingProgressTimeoutMinutes=60")
+	if err != nil {
+		o.warnf("Failed to drop repository %s due to: %s\n", repoId, err)
+	} else {
+		o.Printf("Dropped repository %s\n", util.ColorInfo(repoId))
+	}
+	return err
+}
+
+func (o *StepGitOptions) releaseRepository(repoId string) error {
+	if repoId == "" {
+		return nil
+	}
+	o.Printf("Releasing nexus release repository %s\n", util.ColorInfo(repoId))
+	options := o
+	err := options.runCommand("mvn",
+		"org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-release",
+		"-DserverId=oss-sonatype-staging",
+		"-DnexusUrl=https://oss.sonatype.org",
+		"-DstagingRepositoryId="+repoId,
+		"-Ddescription=\"Next release is ready\" -DstagingProgressTimeoutMinutes=60")
+	if err != nil {
+		o.warnf("Failed to release repository %s due to: %s\n", repoId, err)
+	} else {
+		o.Printf("Released repository %s\n", util.ColorInfo(repoId))
+	}
+	return err
+}

--- a/pkg/jx/cmd/step_git_credentials.go
+++ b/pkg/jx/cmd/step_git_credentials.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	cmdutil "github.com/jenkins-x/jx/pkg/jx/cmd/util"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	optionOutputFile = "output"
+)
+
+// StepGitCredentialsOptions contains the command line flags
+type StepGitCredentialsOptions struct {
+	StepOptions
+
+	OutputFile string
+}
+
+var (
+	StepGitCredentialsLong = templates.LongDesc(`
+		This pipeline step generates a git credentials file for the current Git provider pipeline Secrets
+
+`)
+
+	StepGitCredentialsExample = templates.Examples(`
+		# generate the git credentials file in the canonical location
+		jx step git credentials
+
+		# generate the git credentials to a output file
+		jx step git credentials -o /tmp/mycreds
+
+`)
+)
+
+func NewCmdStepGitCredentials(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
+	options := StepGitCredentialsOptions{
+		StepOptions: StepOptions{
+			CommonOptions: CommonOptions{
+				Factory: f,
+				Out:     out,
+				Err:     errOut,
+			},
+		},
+	}
+	cmd := &cobra.Command{
+		Use:     "credentials",
+		Short:   "Creates the git credentials file for the current pipeline git credentials",
+		Aliases: []string{"nexus_stage"},
+		Long:    StepGitCredentialsLong,
+		Example: StepGitCredentialsExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			cmdutil.CheckErr(err)
+		},
+	}
+	cmd.Flags().StringVarP(&options.OutputFile, optionOutputFile, "o", "", "The output file name")
+	return cmd
+}
+
+func (o *StepGitCredentialsOptions) Run() error {
+	outFile := o.OutputFile
+	if outFile == "" {
+		// lets figure out the default output file
+		cfgHome := os.Getenv("XDG_CONFIG_HOME")
+		if cfgHome != "" {
+			outFile = filepath.Join(cfgHome, "git", "credentials")
+		}
+	}
+	if outFile == "" {
+		return util.MissingOption(optionOutputFile)
+	}
+	secrets, err := o.Factory.LoadPipelineSecrets(kube.ValueKindGit)
+	if err != nil {
+		return err
+	}
+	return o.createGitCredentialsFile(outFile, secrets)
+}
+
+func (o *StepGitCredentialsOptions) createGitCredentialsFile(fileName string, secrets *corev1.SecretList) error {
+	data := o.createGitCredentialsFromSecrets(secrets)
+	err := ioutil.WriteFile(fileName, data, DefaultWritePermissions)
+	if err != nil {
+		return fmt.Errorf("Failed to write to %s: %s", fileName, err)
+	}
+	o.Printf("Generated git credentials file %s\n", util.ColorInfo(fileName))
+	return nil
+}
+
+func (o *StepGitCredentialsOptions) createGitCredentialsFromSecrets(secretList *corev1.SecretList) []byte {
+	var buffer bytes.Buffer
+	if secretList != nil {
+		for _, secret := range secretList.Items {
+			labels := secret.Labels
+			annotations := secret.Annotations
+			data := secret.Data
+			if labels != nil && labels[kube.LabelKind] == kube.ValueKindGit && annotations != nil {
+				u := annotations[kube.AnnotationURL]
+				if u != "" && data != nil {
+					username := data[kube.SecretDataUsername]
+					pwd := data[kube.SecretDataPassword]
+					if len(username) > 0 && len(pwd) > 0 {
+						u2, err := url.Parse(u)
+						if err != nil {
+							o.warnf("Ignoring invalid git service URL %s for pipeline credential %s\n", u, secret.Name)
+						} else {
+							u2.User = url.UserPassword(string(username), string(pwd))
+							buffer.WriteString(u2.String() + "\n")
+						}
+					}
+				}
+			}
+		}
+	}
+	return buffer.Bytes()
+}

--- a/pkg/jx/cmd/step_git_credentials_test.go
+++ b/pkg/jx/cmd/step_git_credentials_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStepGitCredentials(t *testing.T) {
+	scheme1 := "https://"
+	host1 := "github.com"
+	user1 := "jstrachan"
+	pwd1 := "lovelyLager"
+
+	scheme2 := "http://"
+	host2 := "github.beescloud.com"
+	user2 := "rawlingsj"
+	pwd2 := "glassOfNice"
+
+	expected := createGitCredentialLine(scheme1, host1, user1, pwd1) +
+		createGitCredentialLine(scheme2, host2, user2, pwd2)
+
+	secretList := &corev1.SecretList{
+		Items: []corev1.Secret{
+			createGitSecret("foo", scheme1+host1, user1, pwd1),
+			createGitSecret("bar", scheme2+host2, user2, pwd2),
+		},
+	}
+
+	options := &StepGitCredentialsOptions{}
+
+	data := options.createGitCredentialsFromSecrets(secretList)
+	actual := string(data)
+
+	assert.Equal(t, expected, actual, "generated git credentials file")
+
+	fmt.Printf("Generated git credentials: %s\n", actual)
+}
+
+func createGitCredentialLine(scheme string, host string, user string, pwd string) string {
+	return scheme + user + ":" + pwd + "@" + host + "\n"
+}
+
+func createGitSecret(name string, gitUrl string, username string, password string) corev1.Secret {
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				kube.AnnotationURL: gitUrl,
+			},
+			Labels: map[string]string{
+				kube.LabelKind: kube.ValueKindGit,
+			},
+		},
+		Data: map[string][]byte{
+			kube.SecretDataUsername: []byte(username),
+			kube.SecretDataPassword: []byte(password),
+		},
+	}
+}

--- a/pkg/jx/cmd/step_git_credentials_test.go
+++ b/pkg/jx/cmd/step_git_credentials_test.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/testkube"
 	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -28,8 +28,8 @@ func TestStepGitCredentials(t *testing.T) {
 
 	secretList := &corev1.SecretList{
 		Items: []corev1.Secret{
-			tests.CreateTestPipelineGitSecret(kind1, "foo", scheme1+host1, user1, pwd1),
-			tests.CreateTestPipelineGitSecret(kind2, "bar", scheme2+host2, user2, pwd2),
+			testkube.CreateTestPipelineGitSecret(kind1, "foo", scheme1+host1, user1, pwd1),
+			testkube.CreateTestPipelineGitSecret(kind2, "bar", scheme2+host2, user2, pwd2),
 		},
 	}
 
@@ -40,7 +40,7 @@ func TestStepGitCredentials(t *testing.T) {
 
 	assert.Equal(t, expected, actual, "generated git credentials file")
 
-	fmt.Printf("Generated git credentials: %s\n", actual)
+	tests.Debugf("Generated git credentials: %s\n", actual)
 }
 
 func createGitCredentialLine(scheme string, host string, user string, pwd string) string {

--- a/pkg/jx/cmd/step_git_credentials_test.go
+++ b/pkg/jx/cmd/step_git_credentials_test.go
@@ -4,18 +4,20 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestStepGitCredentials(t *testing.T) {
+	kind1 := gits.KindGitHub
 	scheme1 := "https://"
 	host1 := "github.com"
 	user1 := "jstrachan"
 	pwd1 := "lovelyLager"
 
+	kind2 := gits.KindGitHub
 	scheme2 := "http://"
 	host2 := "github.beescloud.com"
 	user2 := "rawlingsj"
@@ -26,8 +28,8 @@ func TestStepGitCredentials(t *testing.T) {
 
 	secretList := &corev1.SecretList{
 		Items: []corev1.Secret{
-			createGitSecret("foo", scheme1+host1, user1, pwd1),
-			createGitSecret("bar", scheme2+host2, user2, pwd2),
+			tests.CreateTestPipelineGitSecret(kind1, "foo", scheme1+host1, user1, pwd1),
+			tests.CreateTestPipelineGitSecret(kind2, "bar", scheme2+host2, user2, pwd2),
 		},
 	}
 
@@ -43,22 +45,4 @@ func TestStepGitCredentials(t *testing.T) {
 
 func createGitCredentialLine(scheme string, host string, user string, pwd string) string {
 	return scheme + user + ":" + pwd + "@" + host + "\n"
-}
-
-func createGitSecret(name string, gitUrl string, username string, password string) corev1.Secret {
-	return corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Annotations: map[string]string{
-				kube.AnnotationURL: gitUrl,
-			},
-			Labels: map[string]string{
-				kube.LabelKind: kube.ValueKindGit,
-			},
-		},
-		Data: map[string][]byte{
-			kube.SecretDataUsername: []byte(username),
-			kube.SecretDataPassword: []byte(password),
-		},
-	}
 }

--- a/pkg/jx/cmd/step_validate_test.go
+++ b/pkg/jx/cmd/step_validate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,12 +26,14 @@ func TestStepValidate(t *testing.T) {
 }
 
 func AssertValidateWorks(t *testing.T, options *StepValidateOptions) error {
+	options.Out = tests.Output()
 	err := options.Run()
 	assert.NoError(t, err, "Command failed: %#v", options)
 	return err
 }
 
 func AssertValidateFails(t *testing.T, options *StepValidateOptions) error {
+	options.Out = tests.Output()
 	err := options.Run()
 	assert.NotNil(t, err, "Command should have failed: %#v", options)
 	return err

--- a/pkg/jx/cmd/util/factory.go
+++ b/pkg/jx/cmd/util/factory.go
@@ -66,6 +66,8 @@ type Factory interface {
 	CreateTable(out io.Writer) table.Table
 
 	SetBatch(batch bool)
+
+	LoadPipelineSecrets(kind string) (*corev1.SecretList, error)
 }
 
 type factory struct {
@@ -249,7 +251,7 @@ func (f *factory) CreateGitAuthConfigServiceForURL(gitURL string) (auth.AuthConf
 			},
 		}
 	}
-	secrets, err := f.loadPipelineSecrets(kube.ValueKindGit)
+	secrets, err := f.LoadPipelineSecrets(kube.ValueKindGit)
 	if err != nil {
 
 		kubeConfig, _, configLoadErr := kube.LoadConfig()
@@ -269,7 +271,7 @@ func (f *factory) CreateGitAuthConfigServiceForURL(gitURL string) (auth.AuthConf
 	return authConfigSvc, nil
 }
 
-func (f *factory) loadPipelineSecrets(kind string) (*corev1.SecretList, error) {
+func (f *factory) LoadPipelineSecrets(kind string) (*corev1.SecretList, error) {
 	kubeClient, curNs, err := f.CreateClient()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create a kuberntees client %s", err)

--- a/pkg/jx/cmd/util/factory.go
+++ b/pkg/jx/cmd/util/factory.go
@@ -242,6 +242,10 @@ func (f *factory) createGitAuthConfigServiceFromSecrets(fileName string, secrets
 		return authConfigSvc, err
 	}
 
+	if secrets != nil {
+		f.authMergePipelineSecrets(config, secrets, kube.ValueKindGit, isCDPipeline)
+	}
+
 	// lets add a default if there's none defined yet
 	if len(config.Servers) == 0 {
 		// if in cluster then there's no user configfile, so check for env vars first
@@ -274,9 +278,6 @@ func (f *factory) createGitAuthConfigServiceFromSecrets(fileName string, secrets
 		}
 	}
 
-	if secrets != nil {
-		f.authMergePipelineSecrets(config, secrets, kube.ValueKindGit, isCDPipeline)
-	}
 	return authConfigSvc, nil
 }
 

--- a/pkg/jx/cmd/util/factory.go
+++ b/pkg/jx/cmd/util/factory.go
@@ -185,10 +185,11 @@ func (f *factory) authMergePipelineSecrets(config *auth.AuthConfig, secrets *cor
 			if u != "" {
 				server := config.GetOrCreateServer(u)
 				if server != nil {
-					if server.Kind == "" {
+					// lets use the latest values from the credential
+					if k != "" {
 						server.Kind = k
 					}
-					if server.Name == "" {
+					if name != "" {
 						server.Name = name
 					}
 					if data != nil {

--- a/pkg/jx/cmd/util/factory_auth_test.go
+++ b/pkg/jx/cmd/util/factory_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/testkube"
 	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -28,7 +29,7 @@ func TestAuthLoadFromPipelineGitCredentials(t *testing.T) {
 	}
 
 	for _, td := range testData {
-		secretList.Items = append(secretList.Items, tests.CreateTestPipelineGitSecret(td.Kind, td.Name, td.URL, td.User, td.Password))
+		secretList.Items = append(secretList.Items, testkube.CreateTestPipelineGitSecret(td.Kind, td.Name, td.URL, td.User, td.Password))
 	}
 
 	f := &factory{}

--- a/pkg/jx/cmd/util/factory_auth_test.go
+++ b/pkg/jx/cmd/util/factory_auth_test.go
@@ -1,0 +1,66 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/tests"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type gitTestData struct {
+	Kind, Name, URL, User, Password string
+}
+
+func TestAuthLoadFromPipelineGitCredentials(t *testing.T) {
+	testData := []gitTestData{
+		{
+			gits.KindGitHub, "GitHub", "https://github.com", "jstrachan", "loverlyLarger",
+		},
+		{
+			gits.KindGitHub, "GHE", "https://github.beescloud.com", "rawlingsj", "glassOfNice",
+		},
+	}
+
+	secretList := &corev1.SecretList{
+		Items: []corev1.Secret{},
+	}
+
+	for _, td := range testData {
+		secretList.Items = append(secretList.Items, tests.CreateTestPipelineGitSecret(td.Kind, td.Name, td.URL, td.User, td.Password))
+	}
+
+	f := &factory{}
+
+	fileName := "doesNotExist.yaml"
+
+	authConfSvc, err := f.createGitAuthConfigServiceFromSecrets(fileName, secretList, true)
+	assert.Nil(t, err, "Could not load Git Auth Config Service: %s", err)
+
+	config := authConfSvc.Config()
+
+	for _, svc := range config.Servers {
+		tests.Debugf("Git URL %s has %d user(s)\n", svc.URL, len(svc.Users))
+	}
+
+	for _, td := range testData {
+		url := td.URL
+		user := td.User
+		server := config.GetServer(url)
+		assert.NotNil(t, server, "Could not find a git server for url %s", url)
+		assert.Equal(t, td.Name, server.Name)
+		assert.Equal(t, td.Kind, server.Kind, "Kinds don't match for %s", url)
+		assert.Equal(t, url, server.URL)
+
+		userAuth := config.FindUserAuth(url, user)
+		for _, u := range server.Users {
+			tests.Debugf("Git URL %s has user %s/%s\n", url, u.Username, u.ApiToken)
+		}
+		assert.NotNil(t, userAuth, "No UserAuth found for url %s user %s", url, user)
+		if userAuth != nil {
+			assert.Equal(t, user, userAuth.Username)
+			assert.Equal(t, td.Password, userAuth.ApiToken)
+		}
+	}
+}

--- a/pkg/kube/activity_test.go
+++ b/pkg/kube/activity_test.go
@@ -155,5 +155,5 @@ func TestCreateOrUpdateActivities(t *testing.T) {
 	assert.Equal(t, v1.ActivityStatusTypeSucceeded, updateStep.Status, "updateStep status")
 	assert.Equal(t, v1.ActivityStatusTypeSucceeded, promote.Status, "promote status")
 
-	//fmt.Printf("Has Promote %#v\n", promote)
+	//tests.Debugf("Has Promote %#v\n", promote)
 }

--- a/pkg/testkube/secrets.go
+++ b/pkg/testkube/secrets.go
@@ -1,4 +1,4 @@
-package tests
+package testkube
 
 import (
 	"github.com/jenkins-x/jx/pkg/kube"

--- a/pkg/tests/helpers.go
+++ b/pkg/tests/helpers.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -14,4 +16,12 @@ func Debugf(message string, args ...interface{}) {
 	if IsDebugLog() {
 		fmt.Printf(message, args...)
 	}
+}
+
+// Output returns the output to use for tests
+func Output() io.Writer {
+	if IsDebugLog() {
+		return os.Stdout
+	}
+	return ioutil.Discard
 }

--- a/pkg/tests/helpers.go
+++ b/pkg/tests/helpers.go
@@ -1,0 +1,17 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func IsDebugLog() bool {
+	return strings.ToLower(os.Getenv("JX_TEST_DEBUG")) == "true"
+}
+
+func Debugf(message string, args ...interface{}) {
+	if IsDebugLog() {
+		fmt.Printf(message, args...)
+	}
+}

--- a/pkg/tests/secrets.go
+++ b/pkg/tests/secrets.go
@@ -1,0 +1,29 @@
+package tests
+
+import (
+	"github.com/jenkins-x/jx/pkg/kube"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateTestPipelineGitSecret creates a test git pipeline credential secret
+func CreateTestPipelineGitSecret(gitServiceKind string, name string, gitUrl string, username string, password string) corev1.Secret {
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: kube.ToValidName(name),
+			Annotations: map[string]string{
+				kube.AnnotationURL:  gitUrl,
+				kube.AnnotationName: name,
+			},
+			Labels: map[string]string{
+				kube.LabelKind:            kube.ValueKindGit,
+				kube.LabelCredentialsType: kube.ValueCredentialTypeUsernamePassword,
+				kube.LabelServiceKind:     gitServiceKind,
+			},
+		},
+		Data: map[string][]byte{
+			kube.SecretDataUsername: []byte(username),
+			kube.SecretDataPassword: []byte(password),
+		},
+	}
+}


### PR DESCRIPTION
uses the current pipeline git credentials to generate the git credentials file
this avoids build pods having to mount a secret and having to post process any secrets after any changes are made incrementally to add new git services

fixes #596