### PR TITLE
fix: jx import creates Jenkins git credentials with ID

### DIFF
--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -616,6 +616,11 @@ func (o *ImportOptions) DoImport() error {
 	if jenkinsfile == "" {
 		jenkinsfile = jenkins.DefaultJenkinsfile
 	}
+
+	if o.Credentials == "" {
+		// e.g. user-github or user-bitbucket
+		o.Credentials = authConfigSvc.Config().DefaultUsername + "-" + gitProvider.Label()
+	}
 	return jenkins.ImportProject(o.Out, o.Jenkins, gitURL, o.Dir, jenkinsfile, o.BranchPattern, o.Credentials, false, gitProvider, authConfigSvc, false, o.BatchMode)
 }
 


### PR DESCRIPTION
see #622 

@jstrachan not sure if this is what you had in mind for 622 so I left it open, but I think this fixes it.