### PR TITLE
fix(quickstarts): use the git provider hostname rather than git serve…

### DIFF
--- a/pkg/gits/git.go
+++ b/pkg/gits/git.go
@@ -444,3 +444,19 @@ func ToGitLabels(names []string) []GitLabel {
 	}
 	return answer
 }
+
+// GetHost returns the Git Provider hostname, e.g github.com
+func GetHost(gitProvider GitProvider) (string, error) {
+	if gitProvider == nil {
+		return "", fmt.Errorf("no git provider")
+	}
+
+	if gitProvider.ServerURL() == "" {
+		return "", fmt.Errorf("no git provider server URL found")
+	}
+	url, err := url.Parse(gitProvider.ServerURL())
+	if err != nil {
+		return "", fmt.Errorf("error parsing ")
+	}
+	return url.Host, nil
+}

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -371,8 +371,13 @@ func (o *ImportOptions) DraftCreate() error {
 		return err
 	}
 
+	gitServerName, err := gits.GetHost(o.GitProvider)
+	if err != nil {
+		return err
+	}
+
 	//walk through every file in the given dir and update the placeholders
-	err = o.replacePlaceholders(o.GitProvider.ServerURL(), o.GitServer.CurrentUser)
+	err = o.replacePlaceholders(gitServerName, o.GitServer.CurrentUser)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
…r URL in placeholder replacement fixes #635