### PR TITLE
fix:(create cluster minikube) avoid installing driver 'none'

### DIFF
--- a/pkg/jx/cmd/create_cluster_minikube.go
+++ b/pkg/jx/cmd/create_cluster_minikube.go
@@ -197,10 +197,12 @@ func (o *CreateClusterMinikubeOptions) createClusterMinikube() error {
 		return err
 	}
 
-	err = o.doInstallMissingDependencies([]string{driver})
-	if err != nil {
-		log.Errorf("error installing missing dependencies %v, please fix or install manually then try again", err)
-		os.Exit(-1)
+	if driver != "none" {
+		err = o.doInstallMissingDependencies([]string{driver})
+		if err != nil {
+			log.Errorf("error installing missing dependencies %v, please fix or install manually then try again", err)
+			os.Exit(-1)
+		}
 	}
 
 	args := []string{"start", "--memory", mem, "--cpus", cpu, "--vm-driver", driver, "--extra-config", "apiserver.Authorization.Mode=RBAC"}


### PR DESCRIPTION
OS: Any Linux dist

By default, `create cluster minikube` tries to install the virtualisation driver.
Expected behaviour: `none` driver should not be installed.