### PR TITLE
fix:(create git token) prompt for API token on `tryFindAPITokenFromBr…

### DIFF
--- a/pkg/jx/cmd/create_git_api_token.go
+++ b/pkg/jx/cmd/create_git_api_token.go
@@ -125,13 +125,10 @@ func (o *CreateGitTokenOptions) Run() error {
 	tokenUrl := gits.ProviderAccessTokenURL(server.Kind, server.URL, userAuth.Username)
 
 	if userAuth.IsInvalid() && o.Password != "" {
-		err := o.tryFindAPITokenFromBrowser(tokenUrl, userAuth)
-		if err != nil {
-			return err
-		}
+		err = o.tryFindAPITokenFromBrowser(tokenUrl, userAuth)
 	}
 
-	if userAuth.IsInvalid() {
+	if err != nil || userAuth.IsInvalid() {
 		f := func(username string) error {
 			tokenUrl := gits.ProviderAccessTokenURL(server.Kind, server.URL, username)
 


### PR DESCRIPTION
…owser` failure

This is relevant not only for `create git token` but also for git servers creation flows.