### PR TITLE
Add more information for preview environments

### DIFF
--- a/pkg/apis/jenkins.io/v1/types.go
+++ b/pkg/apis/jenkins.io/v1/types.go
@@ -33,7 +33,7 @@ type EnvironmentSpec struct {
 	Kind              EnvironmentKindType   `json:"kind,omitempty" protobuf:"bytes,7,opt,name=kind"`
 	PullRequestURL    string                `json:"pullRequestURL,omitempty" protobuf:"bytes,8,opt,name=pullRequestURL"`
 	TeamSettings      TeamSettings          `json:"teamSettings,omitempty" protobuf:"bytes,9,opt,name=teamSettings"`
-	//PreviewGitSpec    PreviewGitSpec        `json:"previewGitSpec,omitempty" protobuf:"bytes,8,opt,name=previewGitSpec"`
+	PreviewGitSpec    PreviewGitSpec        `json:"previewGitInfo,omitempty" protobuf:"bytes,10,opt,name=previewGitInfo"`
 }
 
 // EnvironmentStatus is the status for an Environment resource
@@ -119,9 +119,14 @@ type TeamSettings struct {
 
 // PreviewGitSpec is the preview git branch/pull request details
 type PreviewGitSpec struct {
-	Name string   `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
-	URL  string   `json:"url,omitempty" protobuf:"bytes,2,opt,name=url"`
-	User UserSpec `json:"user,omitempty" protobuf:"bytes,3,opt,name=user"`
+	Name            string   `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	URL             string   `json:"url,omitempty" protobuf:"bytes,2,opt,name=url"`
+	User            UserSpec `json:"user,omitempty" protobuf:"bytes,3,opt,name=user"`
+	Title           string   `json:"title,omitempty" protobuf:"bytes,4,opt,name=title"`
+	Description     string   `json:"description,omitempty" protobuf:"bytes,5,opt,name=description"`
+	BuildStatus     string   `json:"buildStatus,omitempty" protobuf:"bytes,6,opt,name=buildStatus"`
+	BuildStatusURL  string   `json:"buildStatusUrl,omitempty" protobuf:"bytes,7,opt,name=buildStatusUrl"`
+	ApplicationName string   `json:"appName,omitempty" protobuf:"bytes,8,opt,name=appName"`
 }
 
 // UserSpec is the user details

--- a/pkg/apis/jenkins.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jenkins.io/v1/zz_generated.deepcopy.go
@@ -29,6 +29,11 @@ func (in *CommitSummary) DeepCopyInto(out *CommitSummary) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.IssueIDs != nil {
+		in, out := &in.IssueIDs, &out.IssueIDs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -156,6 +161,7 @@ func (in *EnvironmentSpec) DeepCopyInto(out *EnvironmentSpec) {
 	*out = *in
 	out.Source = in.Source
 	out.TeamSettings = in.TeamSettings
+	out.PreviewGitSpec = in.PreviewGitSpec
 	return
 }
 

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -3,7 +3,6 @@
 package versioned
 
 import (
-	glog "github.com/golang/glog"
 	jenkinsv1 "github.com/jenkins-x/jx/pkg/client/clientset/versioned/typed/jenkins.io/v1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -58,7 +57,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -16,12 +16,16 @@ import (
 	cache "k8s.io/client-go/tools/cache"
 )
 
+// SharedInformerOption defines the functional option type for SharedInformerFactory.
+type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
+
 type sharedInformerFactory struct {
 	client           versioned.Interface
 	namespace        string
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
 	lock             sync.Mutex
 	defaultResync    time.Duration
+	customResync     map[reflect.Type]time.Duration
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -29,23 +33,62 @@ type sharedInformerFactory struct {
 	startedInformers map[reflect.Type]bool
 }
 
-// NewSharedInformerFactory constructs a new instance of sharedInformerFactory
+// WithCustomResyncConfig sets a custom resync period for the specified informer types.
+func WithCustomResyncConfig(resyncConfig map[v1.Object]time.Duration) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		for k, v := range resyncConfig {
+			factory.customResync[reflect.TypeOf(k)] = v
+		}
+		return factory
+	}
+}
+
+// WithTweakListOptions sets a custom filter on all listers of the configured SharedInformerFactory.
+func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.tweakListOptions = tweakListOptions
+		return factory
+	}
+}
+
+// WithNamespace limits the SharedInformerFactory to the specified namespace.
+func WithNamespace(namespace string) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.namespace = namespace
+		return factory
+	}
+}
+
+// NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
-	return NewFilteredSharedInformerFactory(client, defaultResync, v1.NamespaceAll, nil)
+	return NewSharedInformerFactoryWithOptions(client, defaultResync)
 }
 
 // NewFilteredSharedInformerFactory constructs a new instance of sharedInformerFactory.
 // Listers obtained via this SharedInformerFactory will be subject to the same filters
 // as specified here.
+// Deprecated: Please use NewSharedInformerFactoryWithOptions instead
 func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync time.Duration, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerFactory {
-	return &sharedInformerFactory{
+	return NewSharedInformerFactoryWithOptions(client, defaultResync, WithNamespace(namespace), WithTweakListOptions(tweakListOptions))
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
+func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
+	factory := &sharedInformerFactory{
 		client:           client,
-		namespace:        namespace,
-		tweakListOptions: tweakListOptions,
+		namespace:        v1.NamespaceAll,
 		defaultResync:    defaultResync,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
+		customResync:     make(map[reflect.Type]time.Duration),
 	}
+
+	// Apply all options
+	for _, opt := range options {
+		factory = opt(factory)
+	}
+
+	return factory
 }
 
 // Start initializes all requested informers.
@@ -94,7 +137,13 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+
+	resyncPeriod, exists := f.customResync[informerType]
+	if !exists {
+		resyncPeriod = f.defaultResync
+	}
+
+	informer = newFunc(f.client, resyncPeriod)
 	f.informers[informerType] = informer
 
 	return informer

--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/auth"
 	"gopkg.in/AlecAivazis/survey.v1"
 )
@@ -35,6 +36,8 @@ type GitProvider interface {
 	CreatePullRequest(data *GitPullRequestArguments) (*GitPullRequest, error)
 
 	UpdatePullRequestStatus(pr *GitPullRequest) error
+
+	GetPullRequest(owner, repo string, number int) (*GitPullRequest, error)
 
 	PullRequestLastCommitStatus(pr *GitPullRequest) (string, error)
 
@@ -97,6 +100,12 @@ type GitProvider interface {
 
 	// ServerURL returns the git server URL
 	ServerURL() string
+
+	// Returns the current username
+	CurrentUsername() string
+
+	// Returns user info
+	UserInfo(username string) *v1.UserSpec
 }
 
 type GitOrganisation struct {
@@ -129,6 +138,8 @@ type GitPullRequest struct {
 	ClosedAt       *time.Time
 	MergedAt       *time.Time
 	LastCommitSha  string
+	Title          string
+	Body           string
 }
 
 type GitIssue struct {


### PR DESCRIPTION
For some use cases, we need additional information stored in K8s resources pertaining to the users and pull requests where preview environments were created, this seems to suffice to provide enough data.

@jstrachan PTAL