### PR TITLE
Fix preview author

### DIFF
--- a/pkg/gits/bitbucket.go
+++ b/pkg/gits/bitbucket.go
@@ -368,6 +368,7 @@ func (b *BitbucketCloudProvider) UpdatePullRequestStatus(pr *GitPullRequest) err
 	pr.State = &bitbucketPR.State
 	pr.Title = bitbucketPR.Title
 	pr.Body = bitbucketPR.Summary.Raw
+	pr.Author = bitbucketPR.Author.Username
 
 	if bitbucketPR.MergeCommit != nil {
 		pr.MergeCommitSHA = &bitbucketPR.MergeCommit.Hash

--- a/pkg/gits/gitea.go
+++ b/pkg/gits/gitea.go
@@ -276,6 +276,7 @@ func (p *GiteaProvider) UpdatePullRequestStatus(pr *GitPullRequest) error {
 	if err != nil {
 		return fmt.Errorf("Could not find pull request for %s/%s #%d: %s", pr.Owner, pr.Repo, n, err)
 	}
+	pr.Author = result.Poster.UserName
 	merged := result.HasMerged
 	pr.Merged = &merged
 	pr.Mergeable = &result.Mergeable

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -363,6 +363,9 @@ func (p *GitHubProvider) UpdatePullRequestStatus(pr *GitPullRequest) error {
 	} else {
 		pr.LastCommitSha = ""
 	}
+	if pr.Author == "" && result.User != nil && result.User.Login != nil {
+		pr.Author = *result.User.Login
+	}
 	if result.Mergeable != nil {
 		pr.Mergeable = result.Mergeable
 	}
@@ -778,7 +781,7 @@ func (p *GitHubProvider) UserInfo(username string) *v1.UserSpec {
 		Username: username,
 		Name:     *user.Name,
 		ImageURL: *user.AvatarURL,
-		LinkURL:  *user.URL,
+		LinkURL:  *user.HTMLURL,
 	}
 }
 

--- a/pkg/gits/gitlab.go
+++ b/pkg/gits/gitlab.go
@@ -195,6 +195,7 @@ func (g *GitlabProvider) CreatePullRequest(data *GitPullRequestArguments) (*GitP
 
 func fromMergeRequest(mr *gitlab.MergeRequest, owner, repo string) *GitPullRequest {
 	return &GitPullRequest{
+		Author: mr.Author.Username,
 		URL:    mr.WebURL,
 		Owner:  owner,
 		Repo:   repo,

--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -125,6 +125,7 @@ type GitRepository struct {
 
 type GitPullRequest struct {
 	URL            string
+	Author         string
 	Owner          string
 	Repo           string
 	Number         *int

--- a/pkg/jx/cmd/preview.go
+++ b/pkg/jx/cmd/preview.go
@@ -250,13 +250,16 @@ func (o *PreviewOptions) Run() error {
 
 	gitProvider, err := gitInfo.CreateProvider(authConfigSvc, gitKind)
 
-	user := gitProvider.UserInfo(gitProvider.CurrentUsername())
 	prNum, err := strconv.Atoi(prName)
 	if err != nil {
 		log.Warn("Unable to convert PR " + prName + " to a number" + "\n")
 	}
 
 	pullRequest, _ := gitProvider.GetPullRequest(gitInfo.Organisation, gitInfo.Name, prNum)
+
+	log.Info("PR author: " + pullRequest.Author)
+
+	user := gitProvider.UserInfo(pullRequest.Author)
 
 	statuses, err := gitProvider.ListCommitStatus(gitInfo.Organisation, gitInfo.Name, pullRequest.LastCommitSha)
 

--- a/pkg/jx/cmd/preview.go
+++ b/pkg/jx/cmd/preview.go
@@ -257,9 +257,12 @@ func (o *PreviewOptions) Run() error {
 
 	pullRequest, _ := gitProvider.GetPullRequest(gitInfo.Organisation, gitInfo.Name, prNum)
 
-	log.Info("PR author: " + pullRequest.Author)
+	username := gitProvider.CurrentUsername()
+	if pullRequest.Author != "" {
+		username = pullRequest.Author
+	}
 
-	user := gitProvider.UserInfo(pullRequest.Author)
+	user := gitProvider.UserInfo(username)
 
 	statuses, err := gitProvider.ListCommitStatus(gitInfo.Organisation, gitInfo.Name, pullRequest.LastCommitSha)
 


### PR DESCRIPTION
There was an issue where the preview was always reporting the cluster creator as the author, this corrects it as reported by the git provider.

@jstrachan PTAL