### PR TITLE
Added ability to use g1-small nodes in GKE

### DIFF
--- a/pkg/jx/cmd/gke/helper.go
+++ b/pkg/jx/cmd/gke/helper.go
@@ -55,7 +55,7 @@ func GetGoogleZones() []string {
 func GetGoogleMachineTypes() []string {
 
 	return []string{
-        "g1-small",
+		"g1-small",
 		"n1-standard-1",
 		"n1-standard-2",
 		"n1-standard-4",

--- a/pkg/jx/cmd/gke/helper.go
+++ b/pkg/jx/cmd/gke/helper.go
@@ -55,6 +55,7 @@ func GetGoogleZones() []string {
 func GetGoogleMachineTypes() []string {
 
 	return []string{
+        "g1-small",
 		"n1-standard-1",
 		"n1-standard-2",
 		"n1-standard-4",


### PR DESCRIPTION
When using the GCE trial account, i'd like the "free" allowance to last a bit longer, g1-small's should be about as low in terms of available memory/cpu as you can go - I think f1-micros are too small.