### PR TITLE
Added KVM2 support to minikube

### DIFF
--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -44,6 +44,8 @@ func (o *CommonOptions) doInstallMissingDependencies(install []string) error {
 			err = o.installKops()
 		case "kvm":
 			err = o.installKvm()
+		case "kvm2":
+			err = o.installKvm2()
 		case "ksync":
 			_, err = o.installKSync()
 		case "minikube":
@@ -313,6 +315,12 @@ func (o *CommonOptions) installHyperkit() error {
 
 func (o *CommonOptions) installKvm() error {
 	o.warnf("We cannot yet automate the installation of KVM - can you install this manually please?\nPlease see: https://www.linux-kvm.org/page/Downloads\n")
+	return nil
+}
+
+func (o *CommonOptions) installKvm2() error {
+	o.warnf("We cannot yet automate the installation of KVM with KVM2 driver - can you install this manually please?\nPlease see: https://www.linux-kvm.org/page/Downloads " +
+		"and https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver\n")
 	return nil
 }
 

--- a/pkg/jx/cmd/create_cluster_minikube.go
+++ b/pkg/jx/cmd/create_cluster_minikube.go
@@ -175,6 +175,9 @@ func (o *CreateClusterMinikubeOptions) createClusterMinikube() error {
 	// only add drivers that are appropriate for this OS
 	var driver string
 	drivers := []string{vmDriverValue}
+	if vmDriverValue == "kvm" {
+		drivers = append(drivers, "kvm2")
+	}
 	if vmDriverValue != "virtualbox" {
 		drivers = append(drivers, "virtualbox")
 	}


### PR DESCRIPTION
JX should support KVM2 driver which is intended to replace support for KVM driver in Minikube - https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver .