### PR TITLE
Refactoring too generic function argument name

### DIFF
--- a/pkg/jx/cmd/create_addon.go
+++ b/pkg/jx/cmd/create_addon.go
@@ -76,13 +76,13 @@ func (o *CreateAddonOptions) Run() error {
 	return nil
 }
 
-func (o *CreateAddonOptions) CreateAddon(arg string) error {
+func (o *CreateAddonOptions) CreateAddon(addon string) error {
 	charts := kube.AddonCharts
-	chart := charts[arg]
+	chart := charts[addon]
 	if chart == "" {
-		return util.InvalidArg(arg, util.SortedMapKeys(charts))
+		return util.InvalidArg(addon, util.SortedMapKeys(charts))
 	}
-	err := o.installChart(arg, chart, o.Version, o.Namespace, o.HelmUpdate, nil)
+	err := o.installChart(addon, chart, o.Version, o.Namespace, o.HelmUpdate, nil)
 	if err != nil {
 		return fmt.Errorf("Failed to install chart %s: %s", chart, err)
 	}


### PR DESCRIPTION
Refactored `arg` => `addon` to make code more readable.