### PR TITLE
Running commands should not be verbose by default

### DIFF
--- a/pkg/jx/cmd/common_commands.go
+++ b/pkg/jx/cmd/common_commands.go
@@ -23,8 +23,10 @@ func (o *CommonOptions) runCommandFromDir(dir, name string, args ...string) erro
 
 func (o *CommonOptions) runCommand(name string, args ...string) error {
 	e := exec.Command(name, args...)
-	e.Stdout = o.Out
-	e.Stderr = o.Err
+	if o.Verbose {
+		e.Stdout = o.Out
+		e.Stderr = o.Err
+	}
 	err := e.Run()
 	if err != nil {
 		o.Printf("Error: Command failed  %s %s\n", name, strings.Join(args, " "))

--- a/pkg/jx/cmd/create_cluster_minikube.go
+++ b/pkg/jx/cmd/create_cluster_minikube.go
@@ -219,9 +219,12 @@ func (o *CreateClusterMinikubeOptions) createClusterMinikube() error {
 	if kubernetesVersion != "" {
 		args = append(args, "--kubernetes-version", kubernetesVersion)
 	}
+	o.Out.Write([]byte("Creating Minikube cluster...\n"))
 	err = o.runCommand("minikube", args...)
 	if err != nil {
 		return err
+	} else {
+		o.Out.Write([]byte("Minikube cluster created.\n"))
 	}
 
 	err = o.retry(3, 10*time.Second, func() (err error) {


### PR DESCRIPTION
Hi,

Currently `jx` is kinda "chatty" ;) . For example creating new minikube cluster generates the following output:

```
Starting local Kubernetes v1.7.3 cluster...
Starting VM...
oving files into cluster...
Setting up certs...
Starting cluster components...
Connecting to cluster...
Setting up kubeconfig...
Kubectl is now configured to use the cluster.
```

While by default the following should be more than enough:

```
Creating Minikube cluster...
Minikube cluster created.
```

Jx already comes with common `--verbose` flag set to `false` by default, so I propose to start respecting it more.

In particular I would like to start by changing `CommonOptions#runCommand` not to redirect std out and err in non-verbose mode and limit it only to displaying error message. Std out and err should be redirected to console only in verbose mode.

From what I know I'm not the only who thinks that `jx` tells us too much by default and it will be better to make it less chatty.

What do you think?