### PR TITLE
Default to BlueOcean

### DIFF
--- a/pkg/jx/cmd/console.go
+++ b/pkg/jx/cmd/console.go
@@ -32,7 +32,10 @@ var (
 		jx console
 
 		# Print the Jenkins X console URL but do not open a browser
-		jx console -u`)
+		jx console -u
+		
+		# Open the Jenkins X console in a browser using the classic skin
+		jx console --classic`)
 )
 
 func NewCmdConsole(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
@@ -65,6 +68,7 @@ func NewCmdConsole(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Co
 
 func (o *ConsoleOptions) addConsoleFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&o.OnlyViewURL, "url", "u", false, "Only displays and the URL and does not open the browser")
+	cmd.Flags().BoolVarP(&o.ClassicMode, "classic", "", false, "Use the classic Jenkins skin instead of Blue Ocean")
 
 	o.addGetUrlFlags(cmd)
 }

--- a/pkg/jx/cmd/console.go
+++ b/pkg/jx/cmd/console.go
@@ -17,7 +17,12 @@ type ConsoleOptions struct {
 	GetURLOptions
 
 	OnlyViewURL bool
+	ClassicMode bool
 }
+
+const (
+	BlueOceanPath = "/blue"
+)
 
 var (
 	console_long = templates.LongDesc(`
@@ -89,9 +94,18 @@ func (o *ConsoleOptions) Open(name string, label string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(o.Out, "%s: %s\n", label, util.ColorInfo(url))
+	fullUrl := o.urlForMode(url)
+	fmt.Fprintf(o.Out, "%s: %s\n", label, util.ColorInfo(fullUrl))
 	if !o.OnlyViewURL {
-		browser.OpenURL(url)
+		browser.OpenURL(fullUrl)
 	}
 	return nil
+}
+
+func (o *ConsoleOptions) urlForMode(url string) string {
+	if o.ClassicMode {
+		return url
+	} else {
+		return util.UrlJoin(url, BlueOceanPath)
+	}
 }


### PR DESCRIPTION
This PR addresses #470 - which asks to use BlueOcean as a default for `jx console`. From @jstrachan's idea, I went ahead and added a `--classic` for people that would still like to use the original skin (sadists 😜). 

I decided to keep this option without modifying `Open` as was discussed, as I felt this was currently a pretty specific use case, and would have involved opening a pretty big can of worms (at what level
 should something know if it has a path?). `Open` gets used a lot, so I decided to just keep this in the `console` command. The downside of this is that `jx open jenkins` does not open Blue, but the classic skin. It might get messy supporting this - as open would have to allow a special call for `jx open jenkins` :/

Let me know if anyone has ideas here!