### PR TITLE
Minikube: Prompt for VM driver should not be invoked if driver option has been used

### DIFF
--- a/pkg/jx/cmd/create_cluster_minikube.go
+++ b/pkg/jx/cmd/create_cluster_minikube.go
@@ -224,7 +224,7 @@ func (o *CreateClusterMinikubeOptions) createClusterMinikube() error {
 		args = append(args, "--kubernetes-version", kubernetesVersion)
 	}
 	o.Out.Write([]byte("Creating Minikube cluster...\n"))
-	err = o.runCommand("minikube", args...)
+	err := o.runCommand("minikube", args...)
 	if err != nil {
 		return err
 	} else {

--- a/pkg/jx/cmd/create_cluster_minikube.go
+++ b/pkg/jx/cmd/create_cluster_minikube.go
@@ -197,13 +197,17 @@ func (o *CreateClusterMinikubeOptions) createClusterMinikube() error {
 		Help:    "VM driver, defaults to recommended native virtualisation",
 	}
 
-	err := survey.AskOne(prompts, &driver, nil)
-	if err != nil {
-		return err
+	if o.Flags.Driver == "" {
+		err := survey.AskOne(prompts, &driver, nil)
+		if err != nil {
+			return err
+		}
+	} else {
+		driver = o.Flags.Driver
 	}
 
 	if driver != "none" {
-		err = o.doInstallMissingDependencies([]string{driver})
+		err := o.doInstallMissingDependencies([]string{driver})
 		if err != nil {
 			log.Errorf("error installing missing dependencies %v, please fix or install manually then try again", err)
 			os.Exit(-1)
@@ -219,7 +223,7 @@ func (o *CreateClusterMinikubeOptions) createClusterMinikube() error {
 	if kubernetesVersion != "" {
 		args = append(args, "--kubernetes-version", kubernetesVersion)
 	}
-	err = o.runCommand("minikube", args...)
+	err := o.runCommand("minikube", args...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When creating Minikube cluster prompt for VM driver should not be invoked if driver option has been used. 

Basically if I execute `jx create cluster minikube --vm-driver=kvm2` I don't want jx to prompt me again for VM driver, but with `kvm2` selected as default. I just want jx to use `kvm2` instead.