### PR TITLE
Helm repository installation should provide basic information in non-verbose mode.

### DIFF
--- a/pkg/jx/cmd/common_helm.go
+++ b/pkg/jx/cmd/common_helm.go
@@ -75,7 +75,12 @@ func (o *CommonOptions) addHelmRepoIfMissing(helmUrl string, repoName string) er
 		return err
 	}
 	if missing {
-		return o.runCommand("helm", "repo", "add", repoName, helmUrl)
+		fmt.Fprintf(o.Out, "Helm repository %s (%s) not found. Adding...\n", repoName, helmUrl)
+		err = o.runCommand("helm", "repo", "add", repoName, helmUrl)
+		if err == nil {
+			fmt.Fprintf(o.Out, "Succesfully added Helm repository %s.\n", repoName)
+		}
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
After merging #768 jx is that "chatty" anymore, what is cool! However now we have to add some nice minimal messages in places where jx dumped std out/err before.

For example when adding add-on jx should inform users nicely if it tries to register new Helm repo:

```
$ jx create addon ambassador
Helm repository datawire (https://www.getambassador.io) not found. Adding...
Succesfully added Helm repository datawire.
```

There's a bunch of places like this - I will try to make appropriate pull requests over the time. Starting with this one.