### PR TITLE
Minikube cpu/memory cmd options should not invoke prompt

### DIFF
--- a/pkg/jx/cmd/constants.go
+++ b/pkg/jx/cmd/constants.go
@@ -1,0 +1,7 @@
+package cmd
+
+const (
+	MinikubeDefaultCpu = "3"
+
+	MinikubeDefaultMemory = "4096"
+)


### PR DESCRIPTION
This is continuation of #772. Choosing cpu and memory via cmd options should not invoke input prompt. In particular executing command like `jx create cluster minikube --cpu=4 --memory=8000 --vm-driver=kvm2` should work in a kinda "batch mode".