### PR TITLE
feat(gc) add a `jx gc previews` command

### DIFF
--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -411,13 +411,10 @@ func (p *GitHubProvider) GetPullRequest(owner, repo string, number int) (*GitPul
 	err := p.UpdatePullRequestStatus(pr)
 
 	if pr.Author != nil {
-		log.Info("Got pr Author: " + pr.Author.Login + " <" + pr.Author.Email + ">\n")
-
 		if pr.Author.Email == "" {
 			existing := p.UserInfo(pr.Author.Login)
 
 			if existing != nil {
-				log.Info("Got existing User: " + existing.Login + " <" + existing.Email + ">\n")
 				if existing.Email != "" {
 					pr.Author = existing
 				}

--- a/pkg/jx/cmd/cmd.go
+++ b/pkg/jx/cmd/cmd.go
@@ -5,10 +5,11 @@ import (
 
 	cmdutil "github.com/jenkins-x/jx/pkg/jx/cmd/util"
 
+	"strings"
+
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/version"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 const (
@@ -94,6 +95,7 @@ func NewJXCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cobra.Co
 				NewCmdCompletion(f, out),
 				NewCmdContext(f, out, err),
 				NewCmdEnvironment(f, out, err),
+				NewCmdGC(f, out, err),
 				NewCmdNamespace(f, out, err),
 				NewCmdPrompt(f, out, err),
 				NewCmdShell(f, out, err),

--- a/pkg/jx/cmd/gc.go
+++ b/pkg/jx/cmd/gc.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	cmdutil "github.com/jenkins-x/jx/pkg/jx/cmd/util"
+)
+
+// GCOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
+// referencing the cmd.Flags()
+type GCOptions struct {
+	CommonOptions
+
+	Output string
+}
+
+const (
+	valid_gc_resources = `Valid resource types include:
+
+    * previews
+    * activities
+    `
+)
+
+var (
+	gc_long = templates.LongDesc(`
+		Garbage collect resources
+
+		` + valid_gc_resources + `
+
+`)
+
+	gc_example = templates.Examples(`
+		jx gc previews
+		jx gc activities
+
+	`)
+)
+
+// NewCmdGC creates a command object for the generic "gc" action, which
+// retrieves one or more resources from a server.
+func NewCmdGC(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
+	options := &GCOptions{
+		CommonOptions: CommonOptions{
+			Factory: f,
+			Out:     out,
+			Err:     errOut,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "gc TYPE [flags]",
+		Short:   "Garbage collects Jenkins X resources",
+		Long:    gc_long,
+		Example: gc_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			cmdutil.CheckErr(err)
+		},
+	}
+
+	cmd.AddCommand(NewCmdGCActivities(f, out, errOut))
+	cmd.AddCommand(NewCmdGCPreviews(f, out, errOut))
+
+	return cmd
+}
+
+// Run implements this command
+func (o *GCOptions) Run() error {
+	return o.Cmd.Help()
+}

--- a/pkg/jx/cmd/gc_activities.go
+++ b/pkg/jx/cmd/gc_activities.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/log"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	cmdutil "github.com/jenkins-x/jx/pkg/jx/cmd/util"
+)
+
+// GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
+// referencing the cmd.Flags()
+type GCActivitiesOptions struct {
+	CommonOptions
+
+	DisableImport bool
+	OutDir        string
+}
+
+var (
+	GCActivitiesLong = templates.LongDesc(`
+		Gargabe collect the Jenkins X Activity Custom Resource Definitions
+
+`)
+
+	GCActivitiesExample = templates.Examples(`
+		jx garbage collect activities
+		jx gc activities
+`)
+)
+
+// NewCmd s a command object for the "step" command
+func NewCmdGCActivities(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
+	options := &GCActivitiesOptions{
+		CommonOptions: CommonOptions{
+			Factory: f,
+			Out:     out,
+			Err:     errOut,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "activities",
+		Short:   "garbage collection for activities",
+		Long:    GCActivitiesLong,
+		Example: GCActivitiesExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			cmdutil.CheckErr(err)
+		},
+	}
+
+	return cmd
+}
+
+// Run implements this command
+func (o *GCActivitiesOptions) Run() error {
+
+	log.Warn("this function is not yet implemented\n")
+
+	return nil
+}

--- a/pkg/jx/cmd/gc_previews.go
+++ b/pkg/jx/cmd/gc_previews.go
@@ -1,10 +1,18 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"strconv"
+
+	"strings"
+
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/log"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	cmdutil "github.com/jenkins-x/jx/pkg/jx/cmd/util"
@@ -54,14 +62,73 @@ func NewCmdGCPreviews(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra
 			cmdutil.CheckErr(err)
 		},
 	}
-
+	options.addCommonFlags(cmd)
 	return cmd
 }
 
 // Run implements this command
 func (o *GCPreviewsOptions) Run() error {
+	f := o.Factory
+	client, currentNs, err := f.CreateJXClient()
+	if err != nil {
+		return err
+	}
 
-	log.Warn("this function is not yet implemented\n")
+	// cannot use field selectors like `spec.kind=Preview` on CRDs so list all environments
+	envs, err := client.JenkinsV1().Environments(currentNs).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	if len(envs.Items) == 0 {
+		// no preview environments found so lets return gracefully
+		if o.Verbose {
+			log.Info("no preview environments found\n")
+		}
+		return nil
+	}
 
+	for _, e := range envs.Items {
+		if e.Spec.Kind == v1.EnvironmentKindTypePreview {
+			gitInfo, err := gits.ParseGitURL(e.Spec.Source.URL)
+			if err != nil {
+				return err
+			}
+			// we need pull request info to include
+			authConfigSvc, err := o.Factory.CreateGitAuthConfigService()
+			if err != nil {
+				return err
+			}
+
+			gitKind, err := o.GitServerKind(gitInfo)
+			if err != nil {
+				return err
+			}
+
+			gitProvider, err := gitInfo.CreateProvider(authConfigSvc, gitKind)
+			if err != nil {
+				return err
+			}
+			prNum, err := strconv.Atoi(e.Spec.PreviewGitSpec.Name)
+			if err != nil {
+				log.Warn("Unable to convert PR " + e.Spec.PreviewGitSpec.Name + " to a number" + "\n")
+			}
+
+			pullRequest, _ := gitProvider.GetPullRequest(gitInfo.Organisation, gitInfo.Name, prNum)
+			lowerState := strings.ToLower(*pullRequest.State)
+
+			if strings.HasPrefix(lowerState, "clos") {
+				// lets delete the preview environment
+				deleteOpts := DeleteEnvOptions{
+					DeleteNamespace: true,
+					CommonOptions:   o.CommonOptions,
+				}
+				deleteOpts.CommonOptions.Args = []string{e.Name}
+				err = deleteOpts.Run()
+				if err != nil {
+					return fmt.Errorf("failed to delete preview environment %s: %v\n", e.Name, err)
+				}
+			}
+		}
+	}
 	return nil
 }

--- a/pkg/jx/cmd/gc_previews.go
+++ b/pkg/jx/cmd/gc_previews.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/log"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	cmdutil "github.com/jenkins-x/jx/pkg/jx/cmd/util"
+)
+
+// GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
+// referencing the cmd.Flags()
+type GCPreviewsOptions struct {
+	CommonOptions
+
+	DisableImport bool
+	OutDir        string
+}
+
+var (
+	GCPreviewsLong = templates.LongDesc(`
+		Gargabe collect Jenkins X preview environments.  If a pull request is merged or closed the associated preview
+		environment will be deleted.
+
+`)
+
+	GCPreviewsExample = templates.Examples(`
+		jx garbage collect previews
+		jx gc previews
+`)
+)
+
+// NewCmd s a command object for the "step" command
+func NewCmdGCPreviews(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
+	options := &GCPreviewsOptions{
+		CommonOptions: CommonOptions{
+			Factory: f,
+			Out:     out,
+			Err:     errOut,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "previews",
+		Short:   "garbage collection for preview environments",
+		Long:    GCPreviewsLong,
+		Example: GCPreviewsExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			cmdutil.CheckErr(err)
+		},
+	}
+
+	return cmd
+}
+
+// Run implements this command
+func (o *GCPreviewsOptions) Run() error {
+
+	log.Warn("this function is not yet implemented\n")
+
+	return nil
+}

--- a/pkg/jx/cmd/step_report_activities.go
+++ b/pkg/jx/cmd/step_report_activities.go
@@ -124,7 +124,7 @@ func (o *StepReportActivitiesOptions) watchPipelineActivities(jxClient *versione
 	_, controller := cache.NewInformer(
 		listWatch,
 		activity,
-		time.Minute*10,
+		time.Hour*24,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				// send to registered backends


### PR DESCRIPTION
This command will delete any temporary preview environments that have had their corresponding Pull Requests merged or closed.