### PR TITLE
Fix typo in help text

### DIFF
--- a/pkg/jx/cmd/upgrade_cli.go
+++ b/pkg/jx/cmd/upgrade_cli.go
@@ -43,7 +43,7 @@ func NewCmdUpgradeCLI(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra
 
 	cmd := &cobra.Command{
 		Use:     "cli",
-		Short:   "Upgrades the command li applications - if there are new versions available",
+		Short:   "Upgrades the command line applications - if there are new versions available",
 		Aliases: []string{"client", "clients"},
 		Long:    upgradeCLILong,
 		Example: upgradeCLIExample,


### PR DESCRIPTION
Noticed by chance while upgrading and thought I'd offer a quick fix.

Coincidentally doing the CLI upgrade updated the version at `/root/jx/bin/jx` while the one in use was at `/usr/local/bin/jx` - had to copy it over manually then all was fine. Not sure if that's a quirk in my environment setup or a legit bug. Using root since random throwaway cloud workspace.