### PR TITLE
feat:(jx step gpg credentials) automate setting up the gpg credentials

### DIFF
--- a/pkg/jx/cmd/step.go
+++ b/pkg/jx/cmd/step.go
@@ -44,6 +44,7 @@ func NewCmdStep(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comma
 	cmd.AddCommand(NewCmdStepBlog(f, out, errOut))
 	cmd.AddCommand(NewCmdStepChangelog(f, out, errOut))
 	cmd.AddCommand(NewCmdStepGit(f, out, errOut))
+	cmd.AddCommand(NewCmdStepGpgCredentials(f, out, errOut))
 	cmd.AddCommand(NewCmdStepNexus(f, out, errOut))
 	cmd.AddCommand(NewCmdStepNextVersion(f, out, errOut))
 	cmd.AddCommand(NewCmdStepPR(f, out, errOut))

--- a/pkg/jx/cmd/step_gpg_credentials.go
+++ b/pkg/jx/cmd/step_gpg_credentials.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	cmdutil "github.com/jenkins-x/jx/pkg/jx/cmd/util"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// StepGpgCredentialsOptions contains the command line flags
+type StepGpgCredentialsOptions struct {
+	StepOptions
+
+	OutputDir string
+}
+
+var (
+	StepGpgCredentialsLong = templates.LongDesc(`
+		This pipeline step generates GPG credentials files from the ` + kube.SecretJenkinsReleaseGPG + ` secret
+
+`)
+
+	StepGpgCredentialsExample = templates.Examples(`
+		# generate the GPG credentials file in the canonical location
+		jx step gpg credentials
+
+		# generate the git credentials to a output file
+		jx step gpg credentials -o /tmp/mycreds
+
+`)
+)
+
+func NewCmdStepGpgCredentials(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
+	options := StepGpgCredentialsOptions{
+		StepOptions: StepOptions{
+			CommonOptions: CommonOptions{
+				Factory: f,
+				Out:     out,
+				Err:     errOut,
+			},
+		},
+	}
+	cmd := &cobra.Command{
+		Use:     "gpg credentials",
+		Short:   "Creates the GPG credentials file for GPG signing releases",
+		Long:    StepGpgCredentialsLong,
+		Example: StepGpgCredentialsExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			cmdutil.CheckErr(err)
+		},
+	}
+	cmd.Flags().StringVarP(&options.OutputDir, optionOutputFile, "o", "", "The output directory")
+	return cmd
+}
+
+func (o *StepGpgCredentialsOptions) Run() error {
+	kubeClient, curNs, err := o.KubeClient()
+	if err != nil {
+		return err
+	}
+	ns, _, err := kube.GetDevNamespace(kubeClient, curNs)
+	if err != nil {
+		return err
+	}
+	secret, err := kubeClient.CoreV1().Secrets(ns).Get(kube.SecretJenkinsReleaseGPG, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	return o.GenerateGpgFiles(secret)
+}
+
+func (o *StepGpgCredentialsOptions) GenerateGpgFiles(secret *v1.Secret) error {
+	outputDir := o.OutputDir
+	if outputDir == "" {
+		outputDir = filepath.Join(util.HomeDir(), ".gnupg")
+	}
+	if outputDir == "" {
+		return util.MissingOption(optionOutputFile)
+	}
+	err := os.MkdirAll(outputDir, DefaultWritePermissions)
+
+	for k, v := range secret.Data {
+		fileName := filepath.Join(outputDir, k)
+		err = ioutil.WriteFile(fileName, []byte(v), DefaultWritePermissions)
+		if err != nil {
+			return err
+		}
+		o.Printf("Generated file %s\n", util.ColorInfo(fileName))
+	}
+	return nil
+}

--- a/pkg/jx/cmd/step_gpg_credentials.go
+++ b/pkg/jx/cmd/step_gpg_credentials.go
@@ -82,6 +82,8 @@ func (o *StepGpgCredentialsOptions) Run() error {
 			if err2 == nil {
 				secret = secret2
 				err = nil
+			} else {
+				o.warnf("Failed to find secret %s in namespace %s due to: %s", name, curNs, err2)
 			}
 		}
 	}

--- a/pkg/jx/cmd/step_gpg_credentials_test.go
+++ b/pkg/jx/cmd/step_gpg_credentials_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStepGPGCredentials(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "test-step-gpg")
+	assert.NoError(t, err)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{},
+		Data: map[string][]byte{
+			"pubring.gpg":     []byte("Pubring"),
+			"sec-jenkins.gpg": []byte("sec jenkins"),
+			"secring.gpg":     []byte("secring"),
+			"trustdb.gpg":     []byte("trustdb"),
+		},
+	}
+
+	options := &StepGpgCredentialsOptions{
+		OutputDir: tempDir,
+	}
+
+	err = options.GenerateGpgFiles(secret)
+	assert.NoError(t, err)
+
+	assertFileExists(t, filepath.Join(tempDir, "pubring.gpg"))
+	assertFileExists(t, filepath.Join(tempDir, "sec-jenkins.gpg"))
+	assertFileExists(t, filepath.Join(tempDir, "secring.gpg"))
+	assertFileExists(t, filepath.Join(tempDir, "trustdb.gpg"))
+}

--- a/pkg/kube/constants.go
+++ b/pkg/kube/constants.go
@@ -37,6 +37,9 @@ const (
 	// SecretJenkinsGitCredentials the git credentials secret
 	SecretJenkinsGitCredentials = "jenkins-git-credentials"
 
+	// SecretJenkinsReleaseGPG the GPG secrets for doing releases
+	SecretJenkinsReleaseGPG = "jenkins-release-gpg"
+
 	// SecretJenkinsPipelineAddonCredentials the chat credentials secret
 	SecretJenkinsPipelineAddonCredentials = "jx-pipeline-addon-"
 


### PR DESCRIPTION
as mounting the GPG secrets no longer works on k8s clusters due to the `~/.gnugpg` folder needing to be mutable

fixes #947