### PR TITLE
Fixes a helptext typo

### DIFF
--- a/pkg/jx/cmd/step_post_build.go
+++ b/pkg/jx/cmd/step_post_build.go
@@ -73,7 +73,7 @@ func NewCmdStepPostBuild(f cmdutil.Factory, out io.Writer, errOut io.Writer) *co
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.FullImageName, "image", "", "", "The full image name to be analysed including teh registry prefix")
+	cmd.Flags().StringVarP(&options.FullImageName, "image", "", "", "The full image name to be analysed including the registry prefix")
 
 	return cmd
 }


### PR DESCRIPTION
Fixes a very small typo.

```
Options:
      --image='': The full image name to be analysed including teh registry prefix
```