### PR TITLE
Cleanup the configuration when uninstalling the jenkins platform

### DIFF
--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -125,6 +125,21 @@ func (c *AuthConfig) GetServerByKind(kind string) *AuthServer {
 	return nil
 }
 
+//DeleteServer deletes the server for the given URL and updates the current server
+//if is the same with the deleted server
+func (c *AuthConfig) DeleteServer(url string) {
+	for i, s := range c.Servers {
+		if urlsEqual(s.URL, url) {
+			c.Servers = append(c.Servers[:i], c.Servers[i+1:]...)
+		}
+	}
+	if urlsEqual(c.CurrentServer, url) && len(c.Servers) > 0 {
+		c.CurrentServer = c.Servers[0].URL
+	} else {
+		c.CurrentServer = ""
+	}
+}
+
 func (c *AuthConfig) GetOrCreateServer(url string) *AuthServer {
 	name := ""
 	kind := ""

--- a/pkg/auth/config_service.go
+++ b/pkg/auth/config_service.go
@@ -80,3 +80,9 @@ func (s *AuthConfigService) SaveUserAuth(url string, userAuth *UserAuth) error {
 	config.CurrentServer = url
 	return s.SaveConfig()
 }
+
+// DeleteServer removes the given server from the configuration
+func (s *AuthConfigService) DeleteServer(url string) error {
+	s.config.DeleteServer(url)
+	return s.SaveConfig()
+}

--- a/pkg/auth/config_test.go
+++ b/pkg/auth/config_test.go
@@ -138,3 +138,32 @@ func TestAuthConfigGetsDefaultName(t *testing.T) {
 	assert.True(t, server.Name != "", "Should have a server name!")
 	assert.Equal(t, expectedUrl, server.URL, "Server.URL")
 }
+
+func TestDeleteServer(t *testing.T) {
+	c := &AuthConfig{}
+	url := "https://foo.com"
+	server := c.GetOrCreateServer(url)
+	assert.NotNil(t, server, "Failed to add the server to the configuration")
+	assert.Equal(t, 1, len(c.Servers), "No server found in the configuration")
+
+	c.DeleteServer(url)
+	assert.Equal(t, 0, len(c.Servers), "Failed to remove the server from configuration")
+	assert.Equal(t, "", c.CurrentServer, "Should be no current server")
+}
+
+func TestDeleteServer2(t *testing.T) {
+	c := &AuthConfig{}
+	url1 := "https://foo1.com"
+	server1 := c.GetOrCreateServer(url1)
+	assert.NotNil(t, server1, "Failed to add the server to the configuration")
+	url2 := "https://foo2.com"
+	server2 := c.GetOrCreateServer(url2)
+	assert.NotNil(t, server2, "Failed to the server to the configuration!")
+	assert.Equal(t, 2, len(c.Servers), "Must have 2 servers in the configuration")
+	c.CurrentServer = url2
+
+	c.DeleteServer(url2)
+	assert.Equal(t, 1, len(c.Servers), "Failed to remove one server from configuration")
+	assert.Equal(t, url1, c.Servers[0].URL, "Failed to remove the right server from the configuration")
+	assert.Equal(t, url1, c.CurrentServer, "Server 1 should be current server")
+}

--- a/pkg/jx/cmd/uninstall.go
+++ b/pkg/jx/cmd/uninstall.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/log"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/util"
 	cmdutil "github.com/jenkins-x/jx/pkg/jx/cmd/util"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"gopkg.in/AlecAivazis/survey.v1"
@@ -74,6 +75,11 @@ func (o *UninstallOptions) Run() error {
 	if !flag {
 		return nil
 	}
+
+	err = o.cleanupConfig()
+	if err != nil {
+		return err
+	}
 	envNames, err := kube.GetEnvironmentNames(jxClient, namespace)
 	if err != nil {
 		return err
@@ -108,4 +114,23 @@ func (o *UninstallOptions) Run() error {
 	}
 	log.Success("Jenkins X has been successfully uninstalled ")
 	return nil
+}
+
+func (o *UninstallOptions) cleanupConfig() error {
+	authConfigSvc, err := o.Factory.CreateAuthConfigService(util.JenkinsAuthConfigFile)
+	if err != nil {
+		return nil
+	}
+	server := authConfigSvc.Config().CurrentServer
+	err = authConfigSvc.DeleteServer(server)
+	if err != nil {
+		return err
+	}
+
+	chartConfigSvc, err := o.Factory.CreateChartmuseumAuthConfigService()
+	if err != nil {
+		return err
+	}
+	server = chartConfigSvc.Config().CurrentServer
+	return chartConfigSvc.DeleteServer(server)
 }


### PR DESCRIPTION
Remove the current servers from Jenkins and Chartmuseum configuration when uninstalling the Jenkins platform.