### PR TITLE
Fix environment pull request hasSCM parameter

### DIFF
--- a/pkg/gits/git.go
+++ b/pkg/gits/git.go
@@ -274,9 +274,8 @@ func GetGitInfo(dir string) (*GitRepositoryInfo, error) {
 
 	rUrl := string(data)
 	rUrl = strings.TrimSpace(rUrl)
-	hasSCM := strings.Index(rUrl, "/scm/") != -1
 
-	repo, err := ParseGitURL(rUrl, hasSCM)
+	repo, err := ParseGitURL(rUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse git URL %s due to %s", rUrl, err)
 	}

--- a/pkg/gits/git_url_test.go
+++ b/pkg/gits/git_url_test.go
@@ -8,7 +8,6 @@ import (
 
 type parseGitUrlData struct {
 	url          string
-	hasSCM       bool
 	host         string
 	organisation string
 	name         string
@@ -17,41 +16,41 @@ type parseGitUrlData struct {
 func TestParseGitURL(t *testing.T) {
 	testCases := []parseGitUrlData{
 		{
-			"git://host.xz/org/repo", false, "host.xz", "org", "repo",
+			"git://host.xz/org/repo", "host.xz", "org", "repo",
 		},
 		{
-			"git://host.xz/org/repo.git", false, "host.xz", "org", "repo",
+			"git://host.xz/org/repo.git", "host.xz", "org", "repo",
 		},
 		{
-			"git://host.xz/org/repo.git/", false, "host.xz", "org", "repo",
+			"git://host.xz/org/repo.git/", "host.xz", "org", "repo",
 		},
 		{
-			"git://github.com/jstrachan/npm-pipeline-test-project.git", false, "github.com", "jstrachan", "npm-pipeline-test-project",
+			"git://github.com/jstrachan/npm-pipeline-test-project.git", "github.com", "jstrachan", "npm-pipeline-test-project",
 		},
 		{
-			"https://github.com/fabric8io/foo.git", false, "github.com", "fabric8io", "foo",
+			"https://github.com/fabric8io/foo.git", "github.com", "fabric8io", "foo",
 		},
 		{
-			"https://github.com/fabric8io/foo", false, "github.com", "fabric8io", "foo",
+			"https://github.com/fabric8io/foo", "github.com", "fabric8io", "foo",
 		},
 		{
-			"git@github.com:jstrachan/npm-pipeline-test-project.git", false, "github.com", "jstrachan", "npm-pipeline-test-project",
+			"git@github.com:jstrachan/npm-pipeline-test-project.git", "github.com", "jstrachan", "npm-pipeline-test-project",
 		},
 		{
-			"git@github.com:bar/foo.git", false, "github.com", "bar", "foo",
+			"git@github.com:bar/foo.git", "github.com", "bar", "foo",
 		},
 		{
-			"git@github.com:bar/foo", false, "github.com", "bar", "foo",
+			"git@github.com:bar/foo", "github.com", "bar", "foo",
 		},
 		{
-			"bar/foo", false, "github.com", "bar", "foo",
+			"bar/foo", "github.com", "bar", "foo",
 		},
 		{
-			"http://test-user@auth.example.com/scm/bar/foo.git", true, "auth.example.com", "bar", "foo",
+			"http://test-user@auth.example.com/scm/bar/foo.git", "auth.example.com", "bar", "foo",
 		},
 	}
 	for _, data := range testCases {
-		info, err := ParseGitURL(data.url, data.hasSCM)
+		info, err := ParseGitURL(data.url)
 		assert.Nil(t, err)
 		assert.NotNil(t, info)
 		assert.Equal(t, data.host, info.Host, "Host does not match for input %s", data.url)

--- a/pkg/jx/cmd/common_environments.go
+++ b/pkg/jx/cmd/common_environments.go
@@ -25,7 +25,7 @@ func (o *CommonOptions) createEnvironmentPullRequest(env *v1.Environment, modify
 	if gitURL == "" {
 		return answer, fmt.Errorf("No source git URL")
 	}
-	gitInfo, err := gits.ParseGitURL(gitURL, false)
+	gitInfo, err := gits.ParseGitURL(gitURL)
 	if err != nil {
 		return answer, err
 	}

--- a/pkg/jx/cmd/common_git.go
+++ b/pkg/jx/cmd/common_git.go
@@ -31,7 +31,7 @@ func (o *CommonOptions) createGitProvider(dir string) (*gits.GitRepositoryInfo, 
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	gitInfo, err := gits.ParseGitURL(gitUrl, false)
+	gitInfo, err := gits.ParseGitURL(gitUrl)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -262,7 +262,7 @@ func (o *CommonOptions) GitServerHostURLKind(hostURL string) (string, error) {
 
 // gitProviderForURL returns a GitProvider for the given git URL
 func (o *CommonOptions) gitProviderForURL(gitURL string, message string) (gits.GitProvider, error) {
-	gitInfo, err := gits.ParseGitURL(gitURL, false)
+	gitInfo, err := gits.ParseGitURL(gitURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jx/cmd/common_import.go
+++ b/pkg/jx/cmd/common_import.go
@@ -28,7 +28,7 @@ func (o *CommonOptions) ImportProject(gitURL string, dir string, jenkinsfile str
 		return fmt.Errorf("No Git repository URL found!")
 	}
 
-	gitInfo, err := gits.ParseGitURL(gitURL, gits.HasScm(gitProvider))
+	gitInfo, err := gits.ParseGitURL(gitURL)
 	if err != nil {
 		return fmt.Errorf("Failed to parse git URL %s due to: %s", gitURL, err)
 	}

--- a/pkg/jx/cmd/common_issues.go
+++ b/pkg/jx/cmd/common_issues.go
@@ -67,7 +67,7 @@ func (o *CommonOptions) createIssueProvider(dir string) (issues.IssueProvider, e
 	if err != nil {
 		return nil, fmt.Errorf("No issue tracker configured and could not find the upstream git URL for dir %s, due to: %s\n", dir, err)
 	}
-	gitInfo, err := gits.ParseGitURL(gitUrl, false)
+	gitInfo, err := gits.ParseGitURL(gitUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jx/cmd/create_issue.go
+++ b/pkg/jx/cmd/create_issue.go
@@ -119,7 +119,7 @@ func (o *CreateIssueOptions) FindGitInfo(dir string) (*gits.GitRepositoryInfo, e
 		if err != nil {
 			return nil, fmt.Errorf("Could not find the remote git source URL:  %s", err)
 		}
-		return gits.ParseGitURL(gitURL, false)
+		return gits.ParseGitURL(gitURL)
 	}
 }
 

--- a/pkg/jx/cmd/gc_previews.go
+++ b/pkg/jx/cmd/gc_previews.go
@@ -89,7 +89,7 @@ func (o *GCPreviewsOptions) Run() error {
 
 	for _, e := range envs.Items {
 		if e.Spec.Kind == v1.EnvironmentKindTypePreview {
-			gitInfo, err := gits.ParseGitURL(e.Spec.Source.URL, false)
+			gitInfo, err := gits.ParseGitURL(e.Spec.Source.URL)
 			if err != nil {
 				return err
 			}

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -218,7 +218,7 @@ func (o *ImportOptions) Run() error {
 		config := authConfigSvc.Config()
 		var server *auth.AuthServer
 		if o.RepoURL != "" {
-			gitInfo, err := gits.ParseGitURL(o.RepoURL, gits.HasScm(o.GitProvider))
+			gitInfo, err := gits.ParseGitURL(o.RepoURL)
 			if err != nil {
 				return err
 			}
@@ -627,7 +627,7 @@ func (o *ImportOptions) CloneRepository() error {
 	if url == "" {
 		return fmt.Errorf("no git repository URL defined!")
 	}
-	gitInfo, err := gits.ParseGitURL(url, gits.HasScm(o.GitProvider))
+	gitInfo, err := gits.ParseGitURL(url)
 	if err != nil {
 		return fmt.Errorf("failed to parse git URL %s due to: %s", url, err)
 	}

--- a/pkg/jx/cmd/preview.go
+++ b/pkg/jx/cmd/preview.go
@@ -574,7 +574,7 @@ func (o *PreviewOptions) defaultValues(ns string, warnMissingName bool) error {
 	o.PullRequestName = strings.TrimPrefix(o.PullRequest, "PR-")
 
 	if o.SourceURL != "" {
-		o.GitInfo, err = gits.ParseGitURL(o.SourceURL, gits.HasScm(o.GitProvider))
+		o.GitInfo, err = gits.ParseGitURL(o.SourceURL)
 		if err != nil {
 			o.warnf("Could not parse the git URL %s due to %s\n", o.SourceURL, err)
 		} else {

--- a/pkg/jx/cmd/step_changelog.go
+++ b/pkg/jx/cmd/step_changelog.go
@@ -267,7 +267,7 @@ func (o *StepChangelogOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	gitInfo, err := gits.ParseGitURL(gitUrl, false)
+	gitInfo, err := gits.ParseGitURL(gitUrl)
 	if err != nil {
 		return err
 	}

--- a/pkg/kube/env.go
+++ b/pkg/kube/env.go
@@ -375,7 +375,7 @@ func createEnvironmentGitRepo(out io.Writer, batchMode bool, authConfigSvc auth.
 		fmt.Fprintf(out, "Creating git repository %s/%s\n", util.ColorInfo(owner), util.ColorInfo(repoName))
 
 		if forkEnvGitURL != "" {
-			gitInfo, err := gits.ParseGitURL(forkEnvGitURL, false)
+			gitInfo, err := gits.ParseGitURL(forkEnvGitURL)
 			if err != nil {
 				return "", nil, err
 			}


### PR DESCRIPTION
The bitbucketserver git urls are of the form
http://test-user@example.bitbucketserver.com/scm/test-org/node-http.git

while others are of the form https://github.com/jenkins-x/jx.git

I think I took a wrong approach to solve this problem by introducing the `hasSCM` parameter to the `parsePath` function - https://github.com/jenkins-x/jx/blob/master/pkg/gits/git_url.go#L156

```
func parsePath(path string, hasSCM bool, info *GitRepositoryInfo) (*GitRepositoryInfo, error) {
	arr := strings.Split(strings.TrimPrefix(path, "/"), "/")
	if len(arr) >= 2 {
		if hasSCM {
			info.Organisation = arr[1]
			info.Project = arr[1]
			info.Name = strings.TrimSuffix(arr[2], ".git")
		} else {
			info.Organisation = arr[0]
			info.Name = strings.TrimSuffix(arr[1], ".git")
		}

		return info, nil
	} else {
		return info, fmt.Errorf("Invalid path %s could not determine organisation and repository name", path)
	}
}
```
Could have avoided sending the hasSCM parameter and updated the method as follows:

```
func parsePath(path string, info *GitRepositoryInfo) (*GitRepositoryInfo, error) {
        trimPath := strings.TrimSuffix(path, "/")
	trimPath := strings.TrimSuffix(path, ".git")
	arr := strings.Split(trimPath, "/")
	arrayLength := len(arr)
	if arrayLength >= 2 {
		info.Organisation = arr[arrayLength-2]
		info.Project = arr[arrayLength-2]
		info.Name = arr[arrayLength-1]

		return info, nil
	}

	return info, fmt.Errorf("Invalid path %s could not determine organisation and repository name", path)
}
```