### PR TITLE
feat: Add gc for helm configmaps

### DIFF
--- a/pkg/jx/cmd/gc.go
+++ b/pkg/jx/cmd/gc.go
@@ -22,6 +22,7 @@ const (
 
     * previews
     * activities
+		* helm
     `
 )
 
@@ -36,6 +37,7 @@ var (
 	gc_example = templates.Examples(`
 		jx gc previews
 		jx gc activities
+		jx gc helm
 
 	`)
 )
@@ -66,6 +68,7 @@ func NewCmdGC(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command
 
 	cmd.AddCommand(NewCmdGCActivities(f, out, errOut))
 	cmd.AddCommand(NewCmdGCPreviews(f, out, errOut))
+	cmd.AddCommand(NewCmdGCHelm(f, out, errOut))
 
 	return cmd
 }

--- a/pkg/jx/cmd/gc_helm.go
+++ b/pkg/jx/cmd/gc_helm.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/ghodss/yaml"
+	"io"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/log"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	cmdutil "github.com/jenkins-x/jx/pkg/jx/cmd/util"
+)
+
+// GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
+// referencing the cmd.Flags()
+type GCHelmOptions struct {
+	CommonOptions
+
+	RevisionHistoryLimit int
+	OutDir               string
+	DryRun               bool
+	NoBackup             bool
+}
+
+var (
+	GCHelmLong = templates.LongDesc(`
+		Garbage collect Helm ConfigMaps.  To facilitate rollbacks, Helm leaves a history of chart versions in place in Kubernetes and these should be pruned at intervals to avoid consuming excessive system resources.
+
+`)
+
+	GCHelmExample = templates.Examples(`
+		jx garbage collect helm
+		jx gc helm
+`)
+)
+
+// NewCmdGCHelm  a command object for the "garbage collect" command
+func NewCmdGCHelm(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
+	options := &GCHelmOptions{
+		CommonOptions: CommonOptions{
+			Factory: f,
+			Out:     out,
+			Err:     errOut,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "helm",
+		Short:   "garbage collection for Helm ConfigMaps",
+		Long:    GCHelmLong,
+		Example: GCHelmExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			cmdutil.CheckErr(err)
+		},
+	}
+	options.addCommonFlags(cmd)
+	cmd.Flags().IntVarP(&options.RevisionHistoryLimit, "revision-history-limit", "", 10, "Minimum number of versions per release to keep")
+	cmd.Flags().StringVarP(&options.OutDir, optionOutputDir, "o", "configmaps", "Relative directory to output backup to. Defaults to ./configmaps")
+	cmd.Flags().BoolVarP(&options.DryRun, "dry-run", "", false, "Does not perform the delete operation on Kubernetes")
+	cmd.Flags().BoolVarP(&options.NoBackup, "no-backup", "", false, "Does not perform the backup operation to store files locally")
+	return cmd
+}
+
+func (o *GCHelmOptions) Run() error {
+	f := o.Factory
+	kubeClient, _, err := f.CreateClient()
+	if err != nil {
+		return err
+	}
+
+	kubeNamespace := "kube-system"
+
+	cms, err := kubeClient.CoreV1().ConfigMaps(kubeNamespace).List(metav1.ListOptions{LabelSelector: "OWNER=TILLER"})
+	if err != nil {
+		return err
+	}
+	if len(cms.Items) == 0 {
+		// no configmaps found so lets return gracefully
+		if o.Verbose {
+			log.Info("no config maps found\n")
+		}
+		return nil
+	}
+
+	releases := extractReleases(cms)
+	if o.Verbose {
+		log.Info(fmt.Sprintf("Found %d releases.\n", len(releases)))
+		log.Info(fmt.Sprintf("Releases: %v\n", releases))
+	}
+
+	for _, release := range releases {
+		if o.Verbose {
+			log.Info(fmt.Sprintf("Checking %s. ", release))
+		}
+		versions := extractVersions(cms, release)
+		if o.Verbose {
+			log.Info(fmt.Sprintf("Found %d.\n", len(versions)))
+			log.Info(fmt.Sprintf("%v\n", versions))
+		}
+		to_delete := versionsToDelete(versions, o.RevisionHistoryLimit)
+		if len(to_delete) > 0 {
+			if o.DryRun {
+				fmt.Println("Would delete:")
+				fmt.Printf("%v\n", to_delete)
+			} else {
+				// Backup and delete
+				if o.NoBackup == false {
+					// First make sure that destination path exists
+					err3 := os.MkdirAll(o.OutDir, 0755)
+					if err3 != nil {
+						// Failed to create path
+						return err3
+					}
+				}
+				for _, version := range to_delete {
+					cm, err1 := extractConfigMap(cms, version)
+					if err1 == nil {
+						if o.NoBackup == false {
+							// Create backup for ConfigMap about to be deleted
+							filename := o.OutDir + "/" + version + ".yaml"
+							log.Info(fmt.Sprintf("Backing up %v. ", filename))
+							y, err2 := yaml.Marshal(cm)
+							if err2 != nil {
+								// Failed to Marshall to YAML
+								return err2
+							}
+							// Add apiVersion and Kind
+							var b bytes.Buffer
+							b.WriteString("apiVersion: v1\nkind: ConfigMap\n")
+							b.Write(y)
+							err4 := ioutil.WriteFile(filename, b.Bytes(), 0644)
+							if err4 == nil {
+								fmt.Printf("Success. ")
+							} else {
+								// Failed to write backup so abort
+								return err4
+							}
+						}
+						// Now delete
+						var opts *metav1.DeleteOptions
+						err5 := kubeClient.CoreV1().ConfigMaps(kubeNamespace).Delete(version, opts)
+						if err5 == nil {
+							log.Info(fmt.Sprintf("ConfigMap %v deleted.\n", version))
+						} else {
+							// Failed to delete
+							return err5
+						}
+					} else {
+						// Failed to find a ConfigMap that we know was in memory. Unlikely to occur.
+						log.Warn(fmt.Sprintf("Failed to find ConfigMap %s. \n", version))
+					}
+				}
+			}
+		} else {
+			if o.Verbose {
+				fmt.Println("Nothing to do.")
+			}
+		}
+	}
+	return nil
+}
+
+// Extract a set of releases from a list of ConfigMaps
+func extractReleases(cms *v1.ConfigMapList) []string {
+	found := make(map[string]bool)
+	for _, cm := range cms.Items {
+		if cmname, ok := cm.Labels["NAME"]; ok {
+			// Collect unique names
+			if _, seen := found[cmname]; !seen {
+				found[cmname] = true
+			}
+		}
+	}
+
+	// Return a set of unique helm releases
+	releases := []string{}
+	for key, _ := range found {
+		releases = append(releases, key)
+	}
+	return releases
+}
+
+// Extract a set of versions of a named release from a list of ConfigMaps
+func extractVersions(cms *v1.ConfigMapList, release string) []string {
+	found := []string{}
+	for _, cm := range cms.Items {
+		if release == cm.Labels["NAME"] {
+			found = append(found, cm.Name)
+		}
+	}
+	return found
+}
+
+func versionsToDelete(versions []string, desired int) []string {
+	if desired >= len(versions) {
+		// nothing to delete
+		return []string{}
+	}
+	sort.Sort(ByVersion(versions))
+	return versions[:len(versions)-desired]
+}
+
+func extractConfigMap(cms *v1.ConfigMapList, version string) (v1.ConfigMap, error) {
+	for _, cm := range cms.Items {
+		if version == cm.Name {
+			return cm, nil
+		}
+	}
+	return v1.ConfigMap{}, errors.New("Not found")
+}
+
+// Components for sorting versions by numeric version number where version name ends in .vddd where ddd is an arbitrary sequence of digits
+type ByVersion []string
+
+func (a ByVersion) Len() int      { return len(a) }
+func (a ByVersion) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByVersion) Less(i, j int) bool {
+	r, _ := regexp.Compile(`.v\d*$`)
+	loc := r.FindStringIndex(a[i])
+	if loc == nil {
+		return false
+	}
+	trim := loc[0] + 2 // start of numeric
+	version_number_i, err_i := strconv.Atoi(a[i][trim:])
+	version_number_j, err_j := strconv.Atoi(a[j][trim:])
+	if (err_i == nil) && (err_j == nil) {
+		return version_number_i < version_number_j
+	}
+
+	return false
+}

--- a/pkg/jx/cmd/gc_helm_test.go
+++ b/pkg/jx/cmd/gc_helm_test.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"bytes"
+	//"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sort"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	cmtemplate = `{
+    "apiVersion": "v1",
+    "data": {
+        "release": "TESTDATA"
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+        "creationTimestamp": "2018-04-26T22:56:12Z",
+        "labels": {
+            "MODIFIED_AT": "1525125621",
+            "NAME": "{{.Name}}",
+            "OWNER": "TILLER",
+            "STATUS": "SUPERSEDED",
+            "VERSION": "{{.Version}}"
+        },
+        "name": "{{.Name}}.v{{.Version}}",
+        "namespace": "kube-system",
+        "resourceVersion": "3983355",
+        "selfLink": "/api/v1/namespaces/kube-system/configmaps/{{.Name}}.v{{.Version}}",
+        "uid": "0447f9e9-49a5-11e8-95cd-42010a9a0000"
+    }
+}`
+	cmlisttemplate = `{
+    "apiVersion": "v1",
+    "items": [{{.List}}],
+    "kind": "ConfigMapList",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+`
+	v_jx_staging    = 27
+	v_jenkins_x     = 20
+	v_jx_production = 3
+)
+
+type CMConfig struct {
+	Name    string
+	Version int
+}
+
+type CMListConfig struct {
+	List string
+}
+
+func TestGCHelmSortVersion(t *testing.T) {
+	test_versions := []string{"jx-production.v2", "jx-production.v3", "jx-production.v1"}
+	sort.Sort(ByVersion(test_versions))
+	assert.Equal(t, "jx-production.v1", test_versions[0])
+	assert.Equal(t, "jx-production.v2", test_versions[1])
+	assert.Equal(t, "jx-production.v3", test_versions[2])
+}
+
+func TestGCHelmSortVersionComplex(t *testing.T) {
+	test_versions := []string{"jx-p.v3.complex.v2", "jx-p.v1.complex.v3", "jx-p.v2.complex.v1"}
+	sort.Sort(ByVersion(test_versions))
+	assert.Equal(t, "jx-p.v2.complex.v1", test_versions[0])
+	assert.Equal(t, "jx-p.v3.complex.v2", test_versions[1])
+	assert.Equal(t, "jx-p.v1.complex.v3", test_versions[2])
+
+}
+
+func TestGCHelmSortVersionMissing(t *testing.T) {
+	test_versions := []string{"aptly-broken3", "aptly-broken2", "aptly-broken1"}
+	sort.Sort(ByVersion(test_versions))
+	assert.Equal(t, "aptly-broken3", test_versions[0])
+	assert.Equal(t, "aptly-broken2", test_versions[1])
+	assert.Equal(t, "aptly-broken1", test_versions[2])
+}
+
+func TestGCHelmExtract(t *testing.T) {
+
+	var b strings.Builder
+	b.WriteString(createConfigMaps(t, "jx-staging", v_jx_staging))
+	b.WriteString(",")
+	b.WriteString(createConfigMaps(t, "jenkins-x", v_jenkins_x))
+	b.WriteString(",")
+	b.WriteString(createConfigMaps(t, "jx-production", v_jx_production))
+	configmaplist := createConfigMapList(t, b.String())
+
+	//	fmt.Printf("%#v\n", configmaplist)
+
+	releases := extractReleases(configmaplist)
+	//	fmt.Printf("%#v\n", releases)
+
+	assert.Contains(t, releases, "jx-staging")
+	assert.Contains(t, releases, "jx-production")
+	assert.Contains(t, releases, "jenkins-x")
+
+	versions := extractVersions(configmaplist, "jx-production")
+	//	fmt.Printf("%#v\n", versions)
+	expected_versions := []string{"jx-production.v1", "jx-production.v2", "jx-production.v3"}
+	assert.Equal(t, expected_versions, versions)
+
+	to_delete := versionsToDelete(versions, 10)
+	assert.Empty(t, to_delete)
+
+	versions = extractVersions(configmaplist, "jx-staging")
+	//	fmt.Printf("%#v\n", versions)
+	expected_versions = []string{"jx-staging.v1", "jx-staging.v2", "jx-staging.v3", "jx-staging.v4", "jx-staging.v5", "jx-staging.v6", "jx-staging.v7", "jx-staging.v8", "jx-staging.v9", "jx-staging.v10", "jx-staging.v11", "jx-staging.v12", "jx-staging.v13", "jx-staging.v14", "jx-staging.v15", "jx-staging.v16", "jx-staging.v17", "jx-staging.v18", "jx-staging.v19", "jx-staging.v20", "jx-staging.v21", "jx-staging.v22", "jx-staging.v23", "jx-staging.v24", "jx-staging.v25", "jx-staging.v26", "jx-staging.v27"}
+	assert.Equal(t, expected_versions, versions)
+
+	to_delete = versionsToDelete(versions, 10)
+	expected_to_delete := []string{"jx-staging.v1", "jx-staging.v2", "jx-staging.v3", "jx-staging.v4", "jx-staging.v5", "jx-staging.v6", "jx-staging.v7", "jx-staging.v8", "jx-staging.v9", "jx-staging.v10", "jx-staging.v11", "jx-staging.v12", "jx-staging.v13", "jx-staging.v14", "jx-staging.v15", "jx-staging.v16", "jx-staging.v17"}
+	assert.Equal(t, expected_to_delete, to_delete)
+
+	versions = extractVersions(configmaplist, "jenkins-x")
+	//	fmt.Printf("%#v\n", versions)
+	expected_versions = []string{"jenkins-x.v1", "jenkins-x.v2", "jenkins-x.v3", "jenkins-x.v4", "jenkins-x.v5", "jenkins-x.v6", "jenkins-x.v7", "jenkins-x.v8", "jenkins-x.v9", "jenkins-x.v10", "jenkins-x.v11", "jenkins-x.v12", "jenkins-x.v13", "jenkins-x.v14", "jenkins-x.v15", "jenkins-x.v16", "jenkins-x.v17", "jenkins-x.v18", "jenkins-x.v19", "jenkins-x.v20"}
+	assert.Equal(t, expected_versions, versions)
+
+	to_delete = versionsToDelete(versions, 10)
+	expected_to_delete = []string{"jenkins-x.v1", "jenkins-x.v2", "jenkins-x.v3", "jenkins-x.v4", "jenkins-x.v5", "jenkins-x.v6", "jenkins-x.v7", "jenkins-x.v8", "jenkins-x.v9", "jenkins-x.v10"}
+	assert.Equal(t, expected_to_delete, to_delete)
+
+	versions = extractVersions(configmaplist, "flaming-flamingo")
+	assert.Empty(t, versions)
+
+	cm, err := extractConfigMap(configmaplist, "flaming-flamingo.v1")
+	assert.NotNil(t, err)
+
+	cm, err = extractConfigMap(configmaplist, "jenkins-x.v1")
+	assert.Nil(t, err)
+	assert.NotNil(t, cm)
+
+}
+
+func createConfigMaps(t *testing.T, name string, versions int) string {
+	var b bytes.Buffer
+	cmtmpl := template.New("configmap")
+	cmtmpl, err := cmtmpl.Parse(cmtemplate)
+	assert.Nil(t, err)
+	for i := 1; i <= versions; i++ {
+		cmc := CMConfig{name, i}
+		err1 := cmtmpl.Execute(&b, cmc)
+		assert.Nil(t, err1)
+		if i < versions {
+			b.WriteString(",")
+		}
+	}
+	return b.String()
+}
+
+func createConfigMapList(t *testing.T, configmaps string) *v1.ConfigMapList {
+	var cmlistc CMListConfig
+	cmlistc.List = configmaps
+	cmlisttmpl := template.New("configmaplist")
+	cmlisttmpl, err3 := cmlisttmpl.Parse(cmlisttemplate)
+	assert.Nil(t, err3)
+	var b1 bytes.Buffer
+	err4 := cmlisttmpl.Execute(&b1, cmlistc)
+	assert.Nil(t, err4)
+
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+
+	obj, _, err2 := decode(b1.Bytes(), nil, nil)
+	assert.Nil(t, err2)
+	return obj.(*v1.ConfigMapList)
+}

--- a/pkg/jx/cmd/gc_helm_test.go
+++ b/pkg/jx/cmd/gc_helm_test.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"bytes"
-	//"fmt"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sort"
-	"strings"
 	"testing"
 	"text/template"
 
@@ -87,7 +85,7 @@ func TestGCHelmSortVersionMissing(t *testing.T) {
 
 func TestGCHelmExtract(t *testing.T) {
 
-	var b strings.Builder
+	var b bytes.Buffer
 	b.WriteString(createConfigMaps(t, "jx-staging", v_jx_staging))
 	b.WriteString(",")
 	b.WriteString(createConfigMaps(t, "jenkins-x", v_jenkins_x))
@@ -95,17 +93,13 @@ func TestGCHelmExtract(t *testing.T) {
 	b.WriteString(createConfigMaps(t, "jx-production", v_jx_production))
 	configmaplist := createConfigMapList(t, b.String())
 
-	//	fmt.Printf("%#v\n", configmaplist)
-
 	releases := extractReleases(configmaplist)
-	//	fmt.Printf("%#v\n", releases)
 
 	assert.Contains(t, releases, "jx-staging")
 	assert.Contains(t, releases, "jx-production")
 	assert.Contains(t, releases, "jenkins-x")
 
 	versions := extractVersions(configmaplist, "jx-production")
-	//	fmt.Printf("%#v\n", versions)
 	expected_versions := []string{"jx-production.v1", "jx-production.v2", "jx-production.v3"}
 	assert.Equal(t, expected_versions, versions)
 
@@ -113,7 +107,6 @@ func TestGCHelmExtract(t *testing.T) {
 	assert.Empty(t, to_delete)
 
 	versions = extractVersions(configmaplist, "jx-staging")
-	//	fmt.Printf("%#v\n", versions)
 	expected_versions = []string{"jx-staging.v1", "jx-staging.v2", "jx-staging.v3", "jx-staging.v4", "jx-staging.v5", "jx-staging.v6", "jx-staging.v7", "jx-staging.v8", "jx-staging.v9", "jx-staging.v10", "jx-staging.v11", "jx-staging.v12", "jx-staging.v13", "jx-staging.v14", "jx-staging.v15", "jx-staging.v16", "jx-staging.v17", "jx-staging.v18", "jx-staging.v19", "jx-staging.v20", "jx-staging.v21", "jx-staging.v22", "jx-staging.v23", "jx-staging.v24", "jx-staging.v25", "jx-staging.v26", "jx-staging.v27"}
 	assert.Equal(t, expected_versions, versions)
 
@@ -122,7 +115,6 @@ func TestGCHelmExtract(t *testing.T) {
 	assert.Equal(t, expected_to_delete, to_delete)
 
 	versions = extractVersions(configmaplist, "jenkins-x")
-	//	fmt.Printf("%#v\n", versions)
 	expected_versions = []string{"jenkins-x.v1", "jenkins-x.v2", "jenkins-x.v3", "jenkins-x.v4", "jenkins-x.v5", "jenkins-x.v6", "jenkins-x.v7", "jenkins-x.v8", "jenkins-x.v9", "jenkins-x.v10", "jenkins-x.v11", "jenkins-x.v12", "jenkins-x.v13", "jenkins-x.v14", "jenkins-x.v15", "jenkins-x.v16", "jenkins-x.v17", "jenkins-x.v18", "jenkins-x.v19", "jenkins-x.v20"}
 	assert.Equal(t, expected_versions, versions)
 


### PR DESCRIPTION
Checks for versions of ConfigMaps in kube-system created by Helm for each release and prunes the number of versions retained to a value defined by --revision-history-limit (defaults to 10).