### PR TITLE
write the preview app url to the workspace so other cli tools can use it

### DIFF
--- a/pkg/jx/cmd/preview.go
+++ b/pkg/jx/cmd/preview.go
@@ -434,6 +434,7 @@ func (o *PreviewOptions) Run() error {
 	for _, n := range appNames {
 		url, err = kube.FindServiceURL(kubeClient, o.Namespace, n)
 		if url != "" {
+			writePreviewURL(o, url)
 			break
 		}
 	}
@@ -611,6 +612,14 @@ func (o *PreviewOptions) defaultValues(ns string, warnMissingName bool) error {
 		o.warnf("No GitInfo could be found!")
 	}
 	return nil
+}
+
+func writePreviewURL(o *PreviewOptions, url string) {
+	previewFileName := filepath.Join(o.Dir, ".previewUrl")
+	err := ioutil.WriteFile(previewFileName, []byte(url), 0644)
+	if err != nil {
+		log.Warn("Unable to write preview file")
+	}
 }
 
 func getImageName() (string, error) {


### PR DESCRIPTION
Could help with: 
https://github.com/jenkins-x/jx/issues/919

Seemed a simple way to pump out the temporary/preview url so other tools could use it. 

Thoughts @jstrachan @rawlingsj ? 