### PR TITLE
Pass repo type as parameter to the library

### DIFF
--- a/pkg/gits/bitbucket_cloud.go
+++ b/pkg/gits/bitbucket_cloud.go
@@ -143,6 +143,7 @@ func (b *BitbucketCloudProvider) CreateRepository(
 	options := map[string]interface{}{}
 	options["body"] = bitbucket.Repository{
 		IsPrivate: private,
+		Scm: "git",
 	}
 
 	result, _, err := b.Client.RepositoriesApi.RepositoriesUsernameRepoSlugPost(


### PR DESCRIPTION
In some cases Mercurial repo is created, while we intend to create Git repo. I suspect this has something to do with organization settings in Bitbucket.

As we currently support only Git type of repositories anyway, it should be ok to hardcode it here for now.

Note: there's separate bug in go_bitbucket library, which does not seem to pass these options to the API at all. I've notified author of the library about this, and investigating a fix there.