### PR TITLE
Feature: during import use file .gitignore to skip directories and/or files

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,23 +2,18 @@
 
 
 [[projects]]
-  digest = "1:5c3894b2aa4d6bead0ceeea6831b305d62879c871780e7b76296ded1b004bc57"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  pruneopts = "NUT"
   revision = "aad3f485ee528456e0768f20397b4d9dd941e755"
   version = "v0.25.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:b8077437db55fd0a13fa94b3e6f70dac1d6a21d82772be31a0d98e91457bdc36"
   name = "code.gitea.io/sdk"
   packages = ["gitea"]
-  pruneopts = "NUT"
   revision = "79a281c4e34ae44cf96a23f0283729a074a6c2a0"
 
 [[projects]]
-  digest = "1:08c4cb88a54781515499c708ba6a32ba774c479d8928decb0060a8572e2d6fbe"
   name = "github.com/Azure/draft"
   packages = [
     "pkg/draft/draftpath",
@@ -27,83 +22,65 @@
     "pkg/linguist/data",
     "pkg/linguist/tokenizer",
     "pkg/osutil",
-    "pkg/version",
+    "pkg/version"
   ]
-  pruneopts = "NUT"
   revision = "9d73889a1318a435d126bc5df846610d30cfbe7f"
   version = "v0.15.0"
 
 [[projects]]
-  digest = "1:8a2b4c3a4f1fb471ee3951cc9af189715abe4a00c79f503657d669ccb1d0320e"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
     "autorest/adal",
     "autorest/azure",
-    "autorest/date",
+    "autorest/date"
   ]
-  pruneopts = "NUT"
   revision = "1f7cd6cfe0adea687ad44a512dfe76140f804318"
   version = "v10.12.0"
 
 [[projects]]
-  digest = "1:e0499b93857a1b91efbdc0c21e26f1130685de98035008f3b01eeeb0713798cb"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b26d9c308763d68093482582cea63d69be07a0f0"
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:638c457cbc4894895add73f34bf5b7d3ba9a614e999826b3fad0aa9715d988b9"
   name = "github.com/Jeffail/gabs"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "7a0fed31069aba77993a518cc2f37b28ee7aa883"
   version = "1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:5c3da1e5d06de403fff791e185009015230b30111aabd56125cae296b7e581cf"
   name = "github.com/MakeNowJust/heredoc"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e9091a26100e9cfb2b6a8f470085bfa541931a91"
 
 [[projects]]
-  digest = "1:a26f8da48b22e6176c1c6a2459904bb30bd0c49ada04b2963c2c3a203e81a620"
   name = "github.com/Masterminds/semver"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c7af12943936e8c39859482e61f0574c2fd7fc75"
   version = "v1.4.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:2b8081e47e5a4673ad1217bf551f5e007a0059231c6bc32dfc5a77bb970a23da"
   name = "github.com/Pallinder/go-randomdata"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "15df0648130a623e418886f81b2aaecd0a00547b"
 
 [[projects]]
-  digest = "1:843e2c7759bf0105806f70e262e7573fbda644e76222cb7eb148e3ac82a4ec5e"
   name = "github.com/andygrunwald/go-gerrit"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "95b11af228a177a6c9961202fa40ff284ba86849"
   version = "0.5.2"
 
 [[projects]]
-  digest = "1:1cf94ad68844b0df24ef9d962c8d6caa679a7d2833454762fe562a92450a48d3"
   name = "github.com/andygrunwald/go-jira"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0298784c4606cdf01e99644da115863c052a737c"
   version = "v1.5.0"
 
 [[projects]]
-  digest = "1:4f6be3aeb355f3c374d88df7a9aa8efc8ae9a0ae4263bb1f22ae48f4e4964ea0"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -142,39 +119,31 @@
     "service/ecr",
     "service/route53",
     "service/s3",
-    "service/sts",
+    "service/sts"
   ]
-  pruneopts = "NUT"
   revision = "9e9afa0895e9daff556cc18f90dc53eb91f41ffd"
   version = "v1.14.26"
 
 [[projects]]
-  digest = "1:f4298c81d8a94ab68d9e387eaf6e653387df5da17702f06c6d8718a7a8e549d0"
   name = "github.com/beevik/etree"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9d7e8feddccb4ed1b8afb54e368bd323d2ff652c"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:8e1fd672f2ef6b5d6da27ebda8d313a3f37bc8081dd780173576d5d85338ff08"
   name = "github.com/blang/semver"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c5e971dbed7850a93c23aa6ff69db5771d8e23b3"
 
 [[projects]]
   branch = "master"
-  digest = "1:2755397479777565ae0c383f63be30e8975da63805281283bdde46d73bed9a7d"
   name = "github.com/c2h5oh/datasize"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4eba002a5eaea69cf8d235a388fc6b65ae68d2dd"
 
 [[projects]]
   branch = "master"
-  digest = "1:f829236113d3ea62f6c5d62dcb74ffae842c90c91f0bb2113e2ed7082ccdf746"
   name = "github.com/chromedp/cdproto"
   packages = [
     ".",
@@ -215,69 +184,67 @@
     "systeminfo",
     "target",
     "tethering",
-    "tracing",
+    "tracing"
   ]
-  pruneopts = "NUT"
   revision = "e314dc1070136cd1453b86e8ef125271d9c16f29"
 
 [[projects]]
   branch = "master"
-  digest = "1:b2a4fd10f23a7463af90979f88134d5f6c1e9c0bfe0711b2d43f39181430af7d"
   name = "github.com/chromedp/chromedp"
   packages = [
     ".",
     "client",
     "kb",
-    "runner",
+    "runner"
   ]
-  pruneopts = "NUT"
   revision = "34591780d9d429c470ccf81a2760c40245fc823a"
 
 [[projects]]
-  digest = "1:7cb4fdca4c251b3ef8027c90ea35f70c7b661a593b9eeae34753c65499098bb1"
   name = "github.com/cpuguy83/go-md2man"
   packages = ["md2man"]
-  pruneopts = "NUT"
   revision = "20f5889cbdc3c73dbd2862796665e7c465ade7d1"
   version = "v1.0.8"
 
 [[projects]]
-  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
+  branch = "master"
+  name = "github.com/danwakefield/fnmatch"
+  packages = ["."]
+  revision = "cbb64ac3d964b81592e64f957ad53df015803288"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"
+  branch = "master"
+  name = "github.com/denormal/go-gitignore"
+  packages = ["."]
+  revision = "75ce8f3e513c43114d0f650d5d2e91505fd944ef"
+
+[[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
-  digest = "1:474af74658db619c7c5b1c67c61c3a6bbcc8f97ee5fdf48730be4518783e2c2c"
   name = "github.com/disintegration/imaging"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bbcee2f5c9d5e94ca42c8b50ec847fec64a6c134"
   version = "v1.4.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:ff6b9b62a30f2237a6f4f8fbe5e89ec522db652998b00f9ded76bd63c1f284fb"
   name = "github.com/docker/spdystream"
   packages = [
     ".",
-    "spdy",
+    "spdy"
   ]
-  pruneopts = "NUT"
   revision = "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
 
 [[projects]]
-  digest = "1:0417f48517eafe384b94fd38238b699c3714b5f12554e8a212446d58b024d2a2"
   name = "github.com/emirpasic/gods"
   packages = [
     "containers",
@@ -285,62 +252,48 @@
     "lists/arraylist",
     "trees",
     "trees/binaryheap",
-    "utils",
+    "utils"
   ]
-  pruneopts = "NUT"
   revision = "f6c17b524822278a87e3b3bd809fec33b51f5b46"
   version = "v1.9.0"
 
 [[projects]]
-  digest = "1:ade392a843b2035effb4b4a2efa2c3bab3eb29b992e98bacf9c898b0ecb54e45"
   name = "github.com/fatih/color"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
   version = "v1.7.0"
 
 [[projects]]
-  digest = "1:52ec55889de2c93a772ceba253313c12f65444aac61a11182d4d119ef97479e8"
   name = "github.com/fatih/structs"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "a720dfa8df582c51dee1b36feabb906bde1588bd"
   version = "v1.0"
 
 [[projects]]
-  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
   branch = "master"
-  digest = "1:144657ab1f77693259f835fcb7fda7c94bee0c5c01d216a417bce9f930ecf225"
   name = "github.com/gfleury/go-bitbucket-v1"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "66450bf1565578f9c872f4c009848d6c8d6b6228"
 
 [[projects]]
-  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:f59266de09e138237bf9df9deb57b9ebbdb1e33b8399bb739c3745e7d3d2787b"
   name = "github.com/go-ini/ini"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "358ee7663966325963d4e8b2e1fbd570c5195153"
   version = "v1.38.1"
 
 [[projects]]
-  digest = "1:c34b254950cbbcfc71edaec88d329f1cf56902ec47de568417549a418879674c"
   name = "github.com/gobwas/glob"
   packages = [
     ".",
@@ -350,92 +303,74 @@
     "syntax/ast",
     "syntax/lexer",
     "util/runes",
-    "util/strings",
+    "util/strings"
   ]
-  pruneopts = "NUT"
   revision = "5ccd90ef52e1e632236f7326478d4faa74f99438"
   version = "v0.2.3"
 
 [[projects]]
-  digest = "1:556f22e028349b0c471e93810944e497418feccc75e6cf763cbadbc636ce0882"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys",
+    "sortkeys"
   ]
-  pruneopts = "NUT"
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  digest = "1:713cc7628304d027a7e9edcb52da888a8912d6405250a8d9c8eff6f41dd54398"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "NUT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:245bd4eb633039cd66106a5d340ae826d87f4e36a8602fcc940e14176fd26ea7"
   name = "github.com/google/btree"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
   branch = "master"
-  digest = "1:de46a46d41ebe21423ca10aec51fd6facd33653e8ccf3545a54a1155145dec66"
   name = "github.com/google/go-github"
   packages = ["github"]
-  pruneopts = "NUT"
   revision = "e96f1f1b07a5be7cba161bc7c1fd636044bfd75c"
 
 [[projects]]
   branch = "master"
-  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
   name = "github.com/google/go-querystring"
   packages = ["query"]
-  pruneopts = "NUT"
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
   branch = "master"
-  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
-  digest = "1:add738701bd5b2b985c0c37011092c57218bdc46caf1e682a73dc210ad36b03f"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions",
+    "extensions"
   ]
-  pruneopts = "NUT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:aa3a067550eb289197d305562495d6c094a18a9a9195f2a0e463fa98330e88e0"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -444,68 +379,54 @@
     "openstack/identity/v2/tokens",
     "openstack/identity/v3/tokens",
     "openstack/utils",
-    "pagination",
+    "pagination"
   ]
-  pruneopts = "NUT"
   revision = "ea2f0eefdc4eeac2e4db99e1a37ede0314efbff4"
 
 [[projects]]
-  digest = "1:c01767916c59f084bb7c41a7d5877c0f3099b1595cfa066e84ec6ad6b084dd89"
   name = "github.com/gorilla/context"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:bf5cf1d53d703332e9bd8984c69784645b73a938317bf5ace9aadf20ac49379a"
   name = "github.com/gorilla/mux"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
 
 [[projects]]
-  digest = "1:3b708ebf63bfa9ba3313bedb8526bc0bb284e51474e65e958481476a9d4a12aa"
   name = "github.com/gorilla/websocket"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:a1db0214936912602a7a8cedc09a2e3211f5c097dc89189fb4b3bc86346c9e89"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache",
+    "diskcache"
   ]
-  pruneopts = "NUT"
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
   branch = "master"
-  digest = "1:8925116d1edcd85fc0c014e1aa69ce12892489b48ee633a605c46d893b8c151f"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "23480c0665776210b5fbbac6eaaee40e3e6a96b7"
 
 [[projects]]
   branch = "master"
-  digest = "1:13e2fa5735a82a5fb044f290cfd0dba633d1c5e516b27da0509e0dbb3515a18e"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
-  pruneopts = "NUT"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
-  digest = "1:02e4365951e1bc55bd6505938ea88e12b5a9d5dfedcb1ae35d5a3833e502833e"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -517,14 +438,12 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token",
+    "json/token"
   ]
-  pruneopts = "NUT"
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   branch = "master"
-  digest = "1:72be08c66400a8a687cc36f2c689ae53e2ef60f65f28ca523517df42c552087d"
   name = "github.com/heptio/sonobuoy"
   packages = [
     "pkg/backplane/ca",
@@ -545,193 +464,147 @@
     "pkg/plugin/loader",
     "pkg/plugin/manifest",
     "pkg/tarball",
-    "pkg/templates",
+    "pkg/templates"
   ]
-  pruneopts = "NUT"
   revision = "786ff490d49df92569b086bf27c4d9d9ef150742"
 
 [[projects]]
-  digest = "1:65300ccc4bcb38b107b868155c303312978981e56bca707c81efec57575b5e06"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
   version = "v0.3.5"
 
 [[projects]]
-  digest = "1:406338ad39ab2e37b7f4452906442a3dbf0eb3379dd1f06aafb5c07e769a5fbb"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:62fe3a7ea2050ecbd753a71889026f83d73329337ada66325cbafd5dea5f713d"
   name = "github.com/jbenet/go-context"
   packages = ["io"]
-  pruneopts = "NUT"
   revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
 
 [[projects]]
   branch = "master"
-  digest = "1:e5c7b633818f5fecd2497cc236ef026f67eded1e351a2b3585286f6212cb493a"
   name = "github.com/jbrukh/bayesian"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bf3f261f9a9c61145c60d47665b0518cc32c774f"
 
 [[projects]]
   branch = "master"
-  digest = "1:0958ee220299f675940313365940c686e56018d6ff98513d57fb42304c13b130"
   name = "github.com/jenkins-x/chyle"
   packages = ["chyle/git"]
-  pruneopts = "NUT"
   revision = "68f7a93a63ec3c6485c01103b85f608d0dd2ca97"
 
 [[projects]]
   branch = "copy-pack-contents"
-  digest = "1:8b645d2e0e4c0ab87d086d4cce341255a33def95d7397a9e0230676db37bc18f"
   name = "github.com/jenkins-x/draft-repo"
   packages = ["pkg/draft/pack"]
-  pruneopts = "NUT"
   revision = "2f66cc518135de45b732980fa90af2cd056bd975"
 
 [[projects]]
   branch = "master"
-  digest = "1:ccbc66086c63de1d2e23eec87a223a12e3771c6ea7d109092798c88644da1a7b"
   name = "github.com/jenkins-x/golang-jenkins"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b5ec7e72291c19eeb6a0916609eb359897f6cdf8"
 
 [[projects]]
-  digest = "1:ac6d01547ec4f7f673311b4663909269bfb8249952de3279799289467837c3cc"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0b12d6b5"
 
 [[projects]]
-  digest = "1:0243cffa4a3410f161ee613dfdd903a636d07e838a42d341da95d81f42cd1d41"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
   version = "1.1.4"
 
 [[projects]]
-  digest = "1:8021af4dcbd531ae89433c8c3a6520e51064114aaf8eb1724c3cf911c497c9ba"
   name = "github.com/kevinburke/ssh_config"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9fc7bb800b555d63157c65a904c86a2cc7b4e795"
   version = "0.4"
 
 [[projects]]
   branch = "master"
-  digest = "1:5e5cd60c25b84e890f22a729011347a5d79de4c61792a010cf3d6709c9812576"
   name = "github.com/knq/snaker"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d9ad1e7f342a5b58202aa92c5f1106d7bb8b9c73"
 
 [[projects]]
   branch = "master"
-  digest = "1:598a3dbd5757a629350876f5b0a41ba7a81f229929cb772fac720ac3c43f0067"
   name = "github.com/knq/sysutil"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0218e141a794643e8c0fa283b9cd076fc0df662d"
 
 [[projects]]
-  digest = "1:d244f8666a838fe6ad70ec8fe77f50ebc29fdc3331a2729ba5886bef8435d10d"
   name = "github.com/magiconair/properties"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c2353362d570a7bfa228149c62842019201cfb71"
   version = "v1.8.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:31f5a6f269d478f3deb8f6b64aa407a34d72f9f27ee1e05d18d4863a32d596f4"
   name = "github.com/mailru/easyjson"
   packages = [
     ".",
     "buffer",
     "jlexer",
-    "jwriter",
+    "jwriter"
   ]
-  pruneopts = "NUT"
   revision = "3fdea8d05856a0c8df22ed4bc71b3219245e4485"
 
 [[projects]]
-  digest = "1:08c231ec84231a7e23d67e4b58f975e1423695a32467a362ee55a803f9de8061"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
-  digest = "1:bc4f7eec3b7be8c6cb1f0af6c1e3333d5bb71072951aaaae2f05067b0803f287"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:063d55b87e200bced5e2be658cc70acafb4c5bbc4afa04d4b82f66298b73d089"
   name = "github.com/mgutz/ansi"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
   branch = "master"
-  digest = "1:9db29b604bd78452d167abed82386ddd2f93973df3841896fb6ab8aff936f1d6"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3864e76763d94a6df2f9960b16a20a33da9f9a66"
 
 [[projects]]
   branch = "master"
-  digest = "1:ffbb5e45e7e69a915767cc2fcff99525645afdfefffee72c551940e4b055e538"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bb74f1db0675b241733089d5a1faa5dd8b0ef57b"
 
 [[projects]]
-  digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
-  digest = "1:c6aca19413b13dc59c220ad7430329e2ec454cc310bc6d8de2c7e2b93c18a0f6"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:8af51f8e617f3994931a3b8e1192e95cc9d77874b6015e3821409b8605db9c30"
   name = "github.com/nlopes/slack"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "1a894400a36157b34f9887c4d8ded3c608b43ccd"
 
 [[projects]]
-  digest = "1:ef4e60b8875f84f2e5606397fd43f821a04d7c041633723d54baf4e3b09360a3"
   name = "github.com/onsi/ginkgo"
   packages = [
     "config",
@@ -739,241 +612,187 @@
     "reporters/stenographer",
     "reporters/stenographer/support/go-colorable",
     "reporters/stenographer/support/go-isatty",
-    "types",
+    "types"
   ]
-  pruneopts = "NUT"
   revision = "fa5fabab2a1bfbd924faf4c067d07ae414e2aedf"
   version = "v1.5.0"
 
 [[projects]]
-  digest = "1:cce3a18fb0b96b5015cd8ca03a57d20a662679de03c4dc4b6ff5f17ea2050fa6"
   name = "github.com/pborman/uuid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
-  digest = "1:cf254277d898b713195cc6b4a3fac8bf738b9f1121625df27843b52b267eec6c"
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:51ea800cff51752ff68e12e04106f5887b4daec6f9356721238c28019f0b42db"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
-  pruneopts = "NUT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
-  digest = "1:6c6d91dc326ed6778783cff869c49fb2f61303cdd2ebbcf90abe53505793f3b6"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:fb519f672ebe265e5316551188145afd54dfb928452b125afe6dfaa26f800397"
   name = "github.com/pkg/browser"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c90ca0c84f15f81c982e32665bffd8d7aac8f097"
 
 [[projects]]
-  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:6afa627bbe35c115d7797e9a7ae1d869c80fbeae9bce67c448486d0f1d28a3cc"
   name = "github.com/rifflock/lfshook"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bf539943797a1f34c1f502d07de419b5238ae6c6"
   version = "v2.3"
 
 [[projects]]
-  digest = "1:bcfa8e184764796499312e55cd8a5fff63896eca0d6faff6b6e43ac6a98a498a"
   name = "github.com/russross/blackfriday"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "55d61fa8aa702f59229e6cff85793c22e580eaf5"
   version = "v1.5.1"
 
 [[projects]]
-  digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:d917313f309bda80d27274d53985bc65651f81a5b66b820749ac7f8ef061fd04"
   name = "github.com/sergi/go-diff"
   packages = ["diffmatchpatch"]
-  pruneopts = "NUT"
   revision = "1744e2970ca51c86172c8190fadad617561ed6e7"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:6989062eb7ccf25cf38bf4fe3dba097ee209f896cda42cefdca3927047bef7b6"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
-  digest = "1:a36d61943d51cd4a1d7ecaf6993190527535a57382114ebf6549956b3e4cb612"
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem",
+    "mem"
   ]
-  pruneopts = "NUT"
   revision = "787d034dfe70e44075ccc060d346146ef53270ad"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:3fa7947ca83b98ae553590d993886e845a4bff19b7b007e869c6e0dd3b9da9cd"
   name = "github.com/spf13/cast"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "8965335b8c7107321228e3e3702cab9832751bac"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:e9d79c7c83750d7a14141c335dd581c7fdeb0a0f7c47aba80a32562e53aff480"
   name = "github.com/spf13/cobra"
   packages = [
     ".",
-    "doc",
+    "doc"
   ]
-  pruneopts = "NUT"
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:f29f83301ed096daed24a90f4af591b7560cb14b9cc3e1827abbf04db7269ab5"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
-  digest = "1:15e5c398fbd9d2c439b635a08ac161b13d04f0c2aa587fe256b65dc0c3efe8b7"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:ea67fb4941c0a1a92f828e73cf426533c71db02df45a2cdf55a14c3e7b74c07a"
   name = "github.com/spf13/viper"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:b8e3d68722a983a3451af8ca1acab725782cbc8cf28948a7c08cf394d8e2ad17"
   name = "github.com/src-d/gcfg"
   packages = [
     ".",
     "scanner",
     "token",
-    "types",
+    "types"
   ]
-  pruneopts = "NUT"
   revision = "f187355171c936ac84a82793659ebb4936bc1c23"
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:ea401d5768217268c640bfbdf50bc58780b948866e79ffac57b07e310a560510"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "require",
-    "suite",
+    "suite"
   ]
-  pruneopts = "NUT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
-  digest = "1:6e1958b49fab87f74e5f6356e6ce1904be8215bb5323c07a08dd0af8b3cb7521"
   name = "github.com/trivago/tgo"
   packages = [
     "tcontainer",
-    "treflect",
+    "treflect"
   ]
-  pruneopts = "NUT"
   revision = "e4d1ddd28c17dd89ed26327cf69fded22060671b"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:233fccaf1bd0c3afd7bb7ffba68e3231846249b712bde7bf4a67822b296a4a8c"
   name = "github.com/viniciuschiele/tarx"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "6e3da540444d5fdf37d385434447dcbc51e7d0cb"
 
 [[projects]]
   branch = "master"
-  digest = "1:c3156c5a6dd2207ba73e4e734637efdc8f8038d922d2c2f9ff940b7299679b14"
   name = "github.com/wbrefvem/go-bitbucket"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "27c6c0db883c8ad9910a61155fd00e210f195ef9"
 
 [[projects]]
   branch = "master"
-  digest = "1:cce44e69aeb4940e6afe41f6418ef78a1974dbfe64f6581744a0b7d72cfbe848"
   name = "github.com/wbrefvem/go-gitlab"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "ecc4c5b8455a01dc64009b828cd19db9db3f3590"
 
 [[projects]]
-  digest = "1:3148cb3478c26a92b4c1a18abb9428234b281e278af6267840721a24b6cbc6a3"
   name = "github.com/xanzy/ssh-agent"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "640f0ab560aeb89d523bb6ac322b1244d5c3796c"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:d2705e5ca5ffaf16703484e4e787e2142a5b4ee0dfde7587302f4c2a44b92277"
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
@@ -992,26 +811,22 @@
     "ssh",
     "ssh/agent",
     "ssh/knownhosts",
-    "ssh/terminal",
+    "ssh/terminal"
   ]
-  pruneopts = "NUT"
   revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
 
 [[projects]]
   branch = "master"
-  digest = "1:d7ca20afe3232af92ca012f69bdb647bfb4e420e47140da3a8bfdc913fbddfce"
   name = "golang.org/x/image"
   packages = [
     "bmp",
     "tiff",
-    "tiff/lzw",
+    "tiff/lzw"
   ]
-  pruneopts = "NUT"
   revision = "c73c2afc3b812cdd6385de5a50616511c4a3d458"
 
 [[projects]]
   branch = "master"
-  digest = "1:c4d0664f1ee66ab010c55abfdb544a2d89041d265ae5f1035049ca94b810e5b9"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -1019,38 +834,32 @@
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna",
+    "idna"
   ]
-  pruneopts = "NUT"
   revision = "d0887baf81f4598189d4e12a37c6da86f0bba4d0"
 
 [[projects]]
   branch = "master"
-  digest = "1:4182888816989aa2ac1cd1f160bc9c8f32a831d7317d33731616eb27496e6e98"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "google",
     "internal",
     "jws",
-    "jwt",
+    "jwt"
   ]
-  pruneopts = "NUT"
   revision = "ef147856a6ddbb60760db74283d2424e98c87bff"
 
 [[projects]]
   branch = "master"
-  digest = "1:64107e3c8f52f341891a565d117bf263ed396fe0c16bad19634b25be25debfaa"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "NUT"
   revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
 
 [[projects]]
-  digest = "1:a0f29009397dc27c9dc8440f0945d49e5cbb9b72d0b0fc745474d9bfdea2d9f8"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -1066,34 +875,28 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
-  pruneopts = "NUT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
-  digest = "1:a464115f461c773a2b5ac42633ded88addc01fa36458345a7620959d839c578b"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
-    "internal/fastwalk",
+    "internal/fastwalk"
   ]
-  pruneopts = "NUT"
   revision = "2087f8c10712366cfc2f4fcb1bf99eeef61ab21e"
 
 [[projects]]
-  digest = "1:0f41a4605e6df63445a5fc4e6df9262976cb56811b1db33d6c53c44459a91c02"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -1105,48 +908,40 @@
     "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch",
+    "urlfetch"
   ]
-  pruneopts = "NUT"
   revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:aa9b6fa6ab1135b116a08ded70a7fd694f9fc6e156b1157c4f03c7ac13cdee78"
   name = "gopkg.in/AlecAivazis/survey.v1"
   packages = [
     ".",
     "core",
-    "terminal",
+    "terminal"
   ]
-  pruneopts = "NUT"
   revision = "17861e192dc11fd2f5081df1932c94cce262fa1e"
   version = "v1.6.1"
 
 [[projects]]
-  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:d5886a8d33e96de494a8aec0c4d40b8562ae377ac065e76657284926703e7357"
   name = "gopkg.in/src-d/go-billy.v4"
   packages = [
     ".",
     "helper/chroot",
     "helper/polyfill",
     "osfs",
-    "util",
+    "util"
   ]
-  pruneopts = "NUT"
   revision = "83cf655d40b15b427014d7875d10850f96edba14"
   version = "v4.2.0"
 
 [[projects]]
-  digest = "1:b7142a72df12707f9c05cf26ee3229e71c1be215f8d273c99d13c1345090b694"
   name = "gopkg.in/src-d/go-git.v4"
   packages = [
     ".",
@@ -1188,31 +983,25 @@
     "utils/merkletrie/filesystem",
     "utils/merkletrie/index",
     "utils/merkletrie/internal/frame",
-    "utils/merkletrie/noder",
+    "utils/merkletrie/noder"
   ]
-  pruneopts = "NUT"
   revision = "3bd5e82b2512d85becae9677fa06b5a973fd4cfb"
   version = "v4.5.0"
 
 [[projects]]
-  digest = "1:b233ad4ec87ac916e7bf5e678e98a2cb9e8b52f6de6ad3e11834fc7a71b8e3bf"
   name = "gopkg.in/warnings.v0"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "ec4a0fea49c7b46c2aeb0b51aac55779c607e52b"
   version = "v0.1.2"
 
 [[projects]]
-  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
   branch = "release-1.11"
-  digest = "1:2b1dcda8169f9c511ebe70133cffab17a3fcc77c8d44b619e1d21dd375817e08"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -1243,14 +1032,12 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1",
+    "storage/v1beta1"
   ]
-  pruneopts = "NUT"
   revision = "2d6f90ab1293a1fb871cf149423ebb72aa7423aa"
 
 [[projects]]
   branch = "release-1.11"
-  digest = "1:a1d88bbb35b41acd43d1b6e239b474dbacbd25671da7b918e87e08a9de02ca14"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -1259,14 +1046,12 @@
     "pkg/client/clientset/clientset/fake",
     "pkg/client/clientset/clientset/scheme",
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
-    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake"
   ]
-  pruneopts = "NUT"
   revision = "bbc52469f98bf18f81d6010a32c3377726cbfd84"
 
 [[projects]]
   branch = "release-1.11"
-  digest = "1:8ddad3a6a5b1cbdca023cd7f175313bcefc4c526fb48919deb7321bbb11824c3"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -1314,14 +1099,12 @@
     "pkg/watch",
     "third_party/forked/golang/json",
     "third_party/forked/golang/netutil",
-    "third_party/forked/golang/reflect",
+    "third_party/forked/golang/reflect"
   ]
-  pruneopts = "NUT"
   revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
 
 [[projects]]
   branch = "release-8.0"
-  digest = "1:bbf71ff6cdb213ef9d46b4fd622f3ba7e7fe1f24c1040daa9a91649c24544741"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1423,14 +1206,12 @@
     "util/homedir",
     "util/integer",
     "util/jsonpath",
-    "util/retry",
+    "util/retry"
   ]
-  pruneopts = "NUT"
   revision = "e5bc2a7bbbdf78f2a331b8c23838d1bbb1c6b40a"
 
 [[projects]]
   branch = "release-1.11"
-  digest = "1:277094fe099ad3ae25f5b4f7b5d67a5495b73a17392715083ece6caef89d5fc0"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -1441,51 +1222,43 @@
     "cmd/client-gen/generators/util",
     "cmd/client-gen/path",
     "cmd/client-gen/types",
-    "pkg/util",
+    "pkg/util"
   ]
-  pruneopts = ""
   revision = "6702109cc68eb6fe6350b83e14407c8d7309fd1a"
 
 [[projects]]
   branch = "master"
-  digest = "1:3ae27658bc8700d70f12b22275206853d6806fa4f21b0df3c3f3de9113d6d218"
   name = "k8s.io/gengo"
   packages = [
     "args",
     "generator",
     "namer",
     "parser",
-    "types",
+    "types"
   ]
-  pruneopts = ""
   revision = "fdcf9f9480fdd5bf2b3c3df9bf4ecd22b25b87e2"
 
 [[projects]]
-  digest = "1:cfb9b0c6dfb8433427e5070525f5e6567ac95a71a814d60b43866df1e78449bf"
   name = "k8s.io/helm"
   packages = [
     "pkg/chartutil",
     "pkg/ignore",
     "pkg/proto/hapi/chart",
     "pkg/proto/hapi/version",
-    "pkg/version",
+    "pkg/version"
   ]
-  pruneopts = "NUT"
   revision = "8478fb4fc723885b155c924d1c8c410b7a9444e6"
   source = "https://github.com/jenkins-x/helm.git"
   version = "v2.7.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:a2c842a1e0aed96fd732b535514556323a6f5edfded3b63e5e0ab1bce188aa54"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
-  pruneopts = "NUT"
   revision = "0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803"
 
 [[projects]]
   branch = "release-1.10"
-  digest = "1:7eb78c1f14fb653f358af37ba1a79b5d5055b42c35ad7be66fb4fd734e941c13"
   name = "k8s.io/metrics"
   packages = [
     "pkg/apis/metrics",
@@ -1494,111 +1267,13 @@
     "pkg/client/clientset_generated/clientset",
     "pkg/client/clientset_generated/clientset/scheme",
     "pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1",
-    "pkg/client/clientset_generated/clientset/typed/metrics/v1beta1",
+    "pkg/client/clientset_generated/clientset/typed/metrics/v1beta1"
   ]
-  pruneopts = "NUT"
   revision = "b11cf31b380ba10a99b7c0b900f6a71f1045db45"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "code.gitea.io/sdk/gitea",
-    "github.com/Azure/draft/pkg/draft/draftpath",
-    "github.com/Azure/draft/pkg/draft/pack/repo",
-    "github.com/Azure/draft/pkg/linguist",
-    "github.com/Jeffail/gabs",
-    "github.com/MakeNowJust/heredoc",
-    "github.com/Pallinder/go-randomdata",
-    "github.com/andygrunwald/go-gerrit",
-    "github.com/andygrunwald/go-jira",
-    "github.com/aws/aws-sdk-go/aws",
-    "github.com/aws/aws-sdk-go/aws/awserr",
-    "github.com/aws/aws-sdk-go/aws/session",
-    "github.com/aws/aws-sdk-go/service/ec2",
-    "github.com/aws/aws-sdk-go/service/ecr",
-    "github.com/aws/aws-sdk-go/service/route53",
-    "github.com/aws/aws-sdk-go/service/s3",
-    "github.com/aws/aws-sdk-go/service/sts",
-    "github.com/beevik/etree",
-    "github.com/blang/semver",
-    "github.com/chromedp/cdproto/cdp",
-    "github.com/chromedp/chromedp",
-    "github.com/chromedp/chromedp/runner",
-    "github.com/fatih/color",
-    "github.com/gfleury/go-bitbucket-v1",
-    "github.com/ghodss/yaml",
-    "github.com/golang/glog",
-    "github.com/google/go-github/github",
-    "github.com/hashicorp/go-version",
-    "github.com/heptio/sonobuoy/pkg/buildinfo",
-    "github.com/heptio/sonobuoy/pkg/client",
-    "github.com/heptio/sonobuoy/pkg/client/results",
-    "github.com/heptio/sonobuoy/pkg/config",
-    "github.com/heptio/sonobuoy/pkg/dynamic",
-    "github.com/heptio/sonobuoy/pkg/plugin/aggregation",
-    "github.com/jenkins-x/chyle/chyle/git",
-    "github.com/jenkins-x/draft-repo/pkg/draft/pack",
-    "github.com/jenkins-x/golang-jenkins",
-    "github.com/mitchellh/mapstructure",
-    "github.com/nlopes/slack",
-    "github.com/onsi/ginkgo/reporters",
-    "github.com/pborman/uuid",
-    "github.com/pkg/browser",
-    "github.com/pkg/errors",
-    "github.com/russross/blackfriday",
-    "github.com/spf13/cobra",
-    "github.com/spf13/cobra/doc",
-    "github.com/spf13/pflag",
-    "github.com/stretchr/testify/assert",
-    "github.com/stretchr/testify/suite",
-    "github.com/wbrefvem/go-bitbucket",
-    "github.com/wbrefvem/go-gitlab",
-    "golang.org/x/oauth2",
-    "gopkg.in/AlecAivazis/survey.v1",
-    "gopkg.in/src-d/go-git.v4",
-    "gopkg.in/src-d/go-git.v4/config",
-    "gopkg.in/src-d/go-git.v4/plumbing/object",
-    "gopkg.in/yaml.v2",
-    "k8s.io/api/apps/v1beta1",
-    "k8s.io/api/batch/v1",
-    "k8s.io/api/core/v1",
-    "k8s.io/api/rbac/v1",
-    "k8s.io/api/storage/v1",
-    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
-    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
-    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake",
-    "k8s.io/apimachinery/pkg/api/errors",
-    "k8s.io/apimachinery/pkg/api/meta",
-    "k8s.io/apimachinery/pkg/api/resource",
-    "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/fields",
-    "k8s.io/apimachinery/pkg/labels",
-    "k8s.io/apimachinery/pkg/runtime",
-    "k8s.io/apimachinery/pkg/runtime/schema",
-    "k8s.io/apimachinery/pkg/runtime/serializer",
-    "k8s.io/apimachinery/pkg/types",
-    "k8s.io/apimachinery/pkg/util/errors",
-    "k8s.io/apimachinery/pkg/util/uuid",
-    "k8s.io/apimachinery/pkg/util/validation",
-    "k8s.io/apimachinery/pkg/util/wait",
-    "k8s.io/apimachinery/pkg/watch",
-    "k8s.io/client-go/discovery",
-    "k8s.io/client-go/discovery/fake",
-    "k8s.io/client-go/kubernetes",
-    "k8s.io/client-go/kubernetes/fake",
-    "k8s.io/client-go/kubernetes/scheme",
-    "k8s.io/client-go/plugin/pkg/client/auth",
-    "k8s.io/client-go/rest",
-    "k8s.io/client-go/testing",
-    "k8s.io/client-go/tools/cache",
-    "k8s.io/client-go/tools/clientcmd",
-    "k8s.io/client-go/tools/clientcmd/api",
-    "k8s.io/client-go/util/flowcontrol",
-    "k8s.io/code-generator/cmd/client-gen",
-    "k8s.io/helm/pkg/chartutil",
-    "k8s.io/metrics/pkg/apis/metrics/v1beta1",
-    "k8s.io/metrics/pkg/client/clientset_generated/clientset",
-  ]
+  inputs-digest = "e7f71782c3f330b2530f73bb56636f5abebcb83797f480ce0b54f55745df366d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -169,3 +169,7 @@ required = [
 [[constraint]]
   name = "github.com/andygrunwald/go-gerrit"
   version = "0.5.2"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/denormal/go-gitignore"

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -28,6 +28,7 @@ import (
 	gitcfg "gopkg.in/src-d/go-git.v4/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	//_ "github.com/Azure/draft/pkg/linguist"
+	"github.com/denormal/go-gitignore"
 )
 
 const (
@@ -876,11 +877,31 @@ func (o *ImportOptions) replacePlaceholders(gitServerName, gitOrg string) error 
 	log.Infof("replacing placeholders in directory %s\n", o.Dir)
 	log.Infof("app name: %s, git server: %s, org: %s\n", o.AppName, gitServerName, gitOrg)
 
+	ignore, err := gitignore.NewRepository(o.Dir)
+	if err != nil {
+		return err
+	}
+
 	if err := filepath.Walk(o.Dir, func(f string, fi os.FileInfo, err error) error {
-		if fi.IsDir() && (fi.Name() == ".git" || fi.Name() == "node_modules" || fi.Name() == "vendor" || fi.Name() == "target") {
-			return filepath.SkipDir
+		relPath, _ := filepath.Rel(o.Dir, f)
+		match := ignore.Relative(relPath, fi.IsDir())
+		matchIgnore := match != nil && match.Ignore() //Defaults to including if match == nil
+
+		if fi.IsDir() {
+			if matchIgnore || fi.Name() == ".git" {
+				log.Infof("skipping directory %q\n", f)
+				return filepath.SkipDir
+			}
+			return nil
 		}
-		if !fi.IsDir() && (fi.Mode()&os.ModeSymlink) != os.ModeSymlink {
+
+		// Dont process nor follow symlinks
+		if (fi.Mode() & os.ModeSymlink) == os.ModeSymlink {
+			log.Infof("skipping symlink file %q\n", f)
+			return nil
+		}
+
+		if !matchIgnore {
 			input, err := ioutil.ReadFile(f)
 			if err != nil {
 				log.Errorf("failed to read file %s: %v", f, err)

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -880,7 +880,7 @@ func (o *ImportOptions) replacePlaceholders(gitServerName, gitOrg string) error 
 		if fi.IsDir() && (fi.Name() == ".git" || fi.Name() == "node_modules" || fi.Name() == "vendor" || fi.Name() == "target") {
 			return filepath.SkipDir
 		}
-		if !fi.IsDir() {
+		if !fi.IsDir() && (fi.Mode()&os.ModeSymlink) != os.ModeSymlink {
 			input, err := ioutil.ReadFile(f)
 			if err != nil {
 				log.Errorf("failed to read file %s: %v", f, err)

--- a/vendor/github.com/danwakefield/fnmatch/LICENSE
+++ b/vendor/github.com/danwakefield/fnmatch/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2016, Daniel Wakefield
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/danwakefield/fnmatch/fnmatch.go
+++ b/vendor/github.com/danwakefield/fnmatch/fnmatch.go
@@ -1,0 +1,219 @@
+// Provide string-matching based on fnmatch.3
+package fnmatch
+
+// There are a few issues that I believe to be bugs, but this implementation is
+// based as closely as possible on BSD fnmatch. These bugs are present in the
+// source of BSD fnmatch, and so are replicated here. The issues are as follows:
+//
+// * FNM_PERIOD is no longer observed after the first * in a pattern
+//   This only applies to matches done with FNM_PATHNAME as well
+// * FNM_PERIOD doesn't apply to ranges. According to the documentation,
+//   a period must be matched explicitly, but a range will match it too
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	FNM_NOESCAPE = (1 << iota)
+	FNM_PATHNAME
+	FNM_PERIOD
+
+	FNM_LEADING_DIR
+	FNM_CASEFOLD
+
+	FNM_IGNORECASE = FNM_CASEFOLD
+	FNM_FILE_NAME  = FNM_PATHNAME
+)
+
+func unpackRune(str *string) rune {
+	rune, size := utf8.DecodeRuneInString(*str)
+	*str = (*str)[size:]
+	return rune
+}
+
+// Matches the pattern against the string, with the given flags,
+// and returns true if the match is successful.
+// This function should match fnmatch.3 as closely as possible.
+func Match(pattern, s string, flags int) bool {
+	// The implementation for this function was patterned after the BSD fnmatch.c
+	// source found at http://src.gnu-darwin.org/src/contrib/csup/fnmatch.c.html
+	noescape := (flags&FNM_NOESCAPE != 0)
+	pathname := (flags&FNM_PATHNAME != 0)
+	period := (flags&FNM_PERIOD != 0)
+	leadingdir := (flags&FNM_LEADING_DIR != 0)
+	casefold := (flags&FNM_CASEFOLD != 0)
+	// the following is some bookkeeping that the original fnmatch.c implementation did not do
+	// We are forced to do this because we're not keeping indexes into C strings but rather
+	// processing utf8-encoded strings. Use a custom unpacker to maintain our state for us
+	sAtStart := true
+	sLastAtStart := true
+	sLastSlash := false
+	sLastUnpacked := rune(0)
+	unpackS := func() rune {
+		sLastSlash = (sLastUnpacked == '/')
+		sLastUnpacked = unpackRune(&s)
+		sLastAtStart = sAtStart
+		sAtStart = false
+		return sLastUnpacked
+	}
+	for len(pattern) > 0 {
+		c := unpackRune(&pattern)
+		switch c {
+		case '?':
+			if len(s) == 0 {
+				return false
+			}
+			sc := unpackS()
+			if pathname && sc == '/' {
+				return false
+			}
+			if period && sc == '.' && (sLastAtStart || (pathname && sLastSlash)) {
+				return false
+			}
+		case '*':
+			// collapse multiple *'s
+			// don't use unpackRune here, the only char we care to detect is ASCII
+			for len(pattern) > 0 && pattern[0] == '*' {
+				pattern = pattern[1:]
+			}
+			if period && s[0] == '.' && (sAtStart || (pathname && sLastUnpacked == '/')) {
+				return false
+			}
+			// optimize for patterns with * at end or before /
+			if len(pattern) == 0 {
+				if pathname {
+					return leadingdir || (strchr(s, '/') == -1)
+				} else {
+					return true
+				}
+				return !(pathname && strchr(s, '/') >= 0)
+			} else if pathname && pattern[0] == '/' {
+				offset := strchr(s, '/')
+				if offset == -1 {
+					return false
+				} else {
+					// we already know our pattern and string have a /, skip past it
+					s = s[offset:] // use unpackS here to maintain our bookkeeping state
+					unpackS()
+					pattern = pattern[1:] // we know / is one byte long
+					break
+				}
+			}
+			// general case, recurse
+			for test := s; len(test) > 0; unpackRune(&test) {
+				// I believe the (flags &^ FNM_PERIOD) is a bug when FNM_PATHNAME is specified
+				// but this follows exactly from how fnmatch.c implements it
+				if Match(pattern, test, (flags &^ FNM_PERIOD)) {
+					return true
+				} else if pathname && test[0] == '/' {
+					break
+				}
+			}
+			return false
+		case '[':
+			if len(s) == 0 {
+				return false
+			}
+			if pathname && s[0] == '/' {
+				return false
+			}
+			sc := unpackS()
+			if !rangematch(&pattern, sc, flags) {
+				return false
+			}
+		case '\\':
+			if !noescape {
+				if len(pattern) > 0 {
+					c = unpackRune(&pattern)
+				}
+			}
+			fallthrough
+		default:
+			if len(s) == 0 {
+				return false
+			}
+			sc := unpackS()
+			switch {
+			case sc == c:
+			case casefold && unicode.ToLower(sc) == unicode.ToLower(c):
+			default:
+				return false
+			}
+		}
+	}
+	return len(s) == 0 || (leadingdir && s[0] == '/')
+}
+
+func rangematch(pattern *string, test rune, flags int) bool {
+	if len(*pattern) == 0 {
+		return false
+	}
+	casefold := (flags&FNM_CASEFOLD != 0)
+	noescape := (flags&FNM_NOESCAPE != 0)
+	if casefold {
+		test = unicode.ToLower(test)
+	}
+	var negate, matched bool
+	if (*pattern)[0] == '^' || (*pattern)[0] == '!' {
+		negate = true
+		(*pattern) = (*pattern)[1:]
+	}
+	for !matched && len(*pattern) > 1 && (*pattern)[0] != ']' {
+		c := unpackRune(pattern)
+		if !noescape && c == '\\' {
+			if len(*pattern) > 1 {
+				c = unpackRune(pattern)
+			} else {
+				return false
+			}
+		}
+		if casefold {
+			c = unicode.ToLower(c)
+		}
+		if (*pattern)[0] == '-' && len(*pattern) > 1 && (*pattern)[1] != ']' {
+			unpackRune(pattern) // skip the -
+			c2 := unpackRune(pattern)
+			if !noescape && c2 == '\\' {
+				if len(*pattern) > 0 {
+					c2 = unpackRune(pattern)
+				} else {
+					return false
+				}
+			}
+			if casefold {
+				c2 = unicode.ToLower(c2)
+			}
+			// this really should be more intelligent, but it looks like
+			// fnmatch.c does simple int comparisons, therefore we will as well
+			if c <= test && test <= c2 {
+				matched = true
+			}
+		} else if c == test {
+			matched = true
+		}
+	}
+	// skip past the rest of the pattern
+	ok := false
+	for !ok && len(*pattern) > 0 {
+		c := unpackRune(pattern)
+		if c == '\\' && len(*pattern) > 0 {
+			unpackRune(pattern)
+		} else if c == ']' {
+			ok = true
+		}
+	}
+	return ok && matched != negate
+}
+
+// define strchr because strings.Index() seems a bit overkill
+// returns the index of c in s, or -1 if there is no match
+func strchr(s string, c rune) int {
+	for i, sc := range s {
+		if sc == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/vendor/github.com/denormal/go-gitignore/LICENSE
+++ b/vendor/github.com/denormal/go-gitignore/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Denormal Limited
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/denormal/go-gitignore/cache.go
+++ b/vendor/github.com/denormal/go-gitignore/cache.go
@@ -1,0 +1,60 @@
+package gitignore
+
+import (
+	"sync"
+)
+
+// Cache is the interface for the GitIgnore cache
+type Cache interface {
+	// Set stores the GitIgnore ignore against its path.
+	Set(path string, ig GitIgnore)
+
+	// Get attempts to retrieve an GitIgnore instance associated with the given
+	// path. If the path is not known nil is returned.
+	Get(path string) GitIgnore
+}
+
+// cache is the default thread-safe cache implementation
+type cache struct {
+	_i    map[string]GitIgnore
+	_lock sync.Mutex
+}
+
+// NewCache returns a Cache instance. This is a thread-safe, in-memory cache
+// for GitIgnore instances.
+func NewCache() Cache {
+	return &cache{}
+} // Cache()
+
+// Set stores the GitIgnore ignore against its path.
+func (c *cache) Set(path string, ignore GitIgnore) {
+	if ignore == nil {
+		return
+	}
+
+	// ensure the map is defined
+	if c._i == nil {
+		c._i = make(map[string]GitIgnore)
+	}
+
+	// set the cache item
+	c._lock.Lock()
+	c._i[path] = ignore
+	c._lock.Unlock()
+} // Set()
+
+// Get attempts to retrieve an GitIgnore instance associated with the given
+// path. If the path is not known nil is returned.
+func (c *cache) Get(path string) GitIgnore {
+	c._lock.Lock()
+	_ignore, _ok := c._i[path]
+	c._lock.Unlock()
+	if _ok {
+		return _ignore
+	} else {
+		return nil
+	}
+} // Get()
+
+// ensure cache supports the Cache interface
+var _ Cache = &cache{}

--- a/vendor/github.com/denormal/go-gitignore/doc.go
+++ b/vendor/github.com/denormal/go-gitignore/doc.go
@@ -1,0 +1,8 @@
+/*
+Package gitignore provides an interface for parsing .gitignore files,
+either individually, or within a repository, and
+matching paths against the retrieved patterns. Path matching is done using
+fnmatch as specified by git (see https://git-scm.com/docs/gitignore), with
+support for recursive matching via the "**" pattern.
+*/
+package gitignore

--- a/vendor/github.com/denormal/go-gitignore/error.go
+++ b/vendor/github.com/denormal/go-gitignore/error.go
@@ -1,0 +1,30 @@
+package gitignore
+
+type Error interface {
+	error
+
+	// Position returns the position of the error within the .gitignore file
+	// (if any)
+	Position() Position
+
+	// Underlying returns the underlying error, permitting direct comparison
+	// against the wrapped error.
+	Underlying() error
+}
+
+type err struct {
+	error
+	_position Position
+} // err()
+
+// NewError returns a new Error instance for the given error e and position p.
+func NewError(e error, p Position) Error {
+	return &err{error: e, _position: p}
+} // NewError()
+
+func (e *err) Position() Position { return e._position }
+
+func (e *err) Underlying() error { return e.error }
+
+// ensure err satisfies the Error interface
+var _ Error = &err{}

--- a/vendor/github.com/denormal/go-gitignore/errors.go
+++ b/vendor/github.com/denormal/go-gitignore/errors.go
@@ -1,0 +1,11 @@
+package gitignore
+
+import (
+	"errors"
+)
+
+var (
+	CarriageReturnError   = errors.New("unexpected carriage return '\\r'")
+	InvalidPatternError   = errors.New("invalid pattern")
+	InvalidDirectoryError = errors.New("invalid directory")
+)

--- a/vendor/github.com/denormal/go-gitignore/exclude.go
+++ b/vendor/github.com/denormal/go-gitignore/exclude.go
@@ -1,0 +1,40 @@
+package gitignore
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// exclude attempts to return the GitIgnore instance for the
+// $GIT_DIR/info/exclude from the working copy to which path belongs.
+func exclude(path string) (GitIgnore, error) {
+	// attempt to locate GIT_DIR
+	_gitdir := os.Getenv("GIT_DIR")
+	if _gitdir == "" {
+		_gitdir = filepath.Join(path, ".git")
+	}
+	_info, _err := os.Stat(_gitdir)
+	if _err != nil {
+		if os.IsNotExist(_err) {
+			return nil, nil
+		} else {
+			return nil, _err
+		}
+	} else if !_info.IsDir() {
+		return nil, nil
+	}
+
+	// is there an info/exclude file within this directory?
+	_file := filepath.Join(_gitdir, "info", "exclude")
+	_, _err = os.Stat(_file)
+	if _err != nil {
+		if os.IsNotExist(_err) {
+			return nil, nil
+		} else {
+			return nil, _err
+		}
+	}
+
+	// attempt to load the exclude file
+	return NewFromFile(_file)
+} // exclude()

--- a/vendor/github.com/denormal/go-gitignore/gitignore.go
+++ b/vendor/github.com/denormal/go-gitignore/gitignore.go
@@ -1,0 +1,307 @@
+package gitignore
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// use an empty GitIgnore for cached lookups
+var empty = &ignore{}
+
+// GitIgnore is the interface to .gitignore files and repositories. It defines
+// methods for testing files for matching the .gitignore file, and then
+// determining whether a file should be ignored or included.
+type GitIgnore interface {
+	// Base returns the directory containing the .gitignore file.
+	Base() string
+
+	// Match attempts to match the path against this GitIgnore, and will
+	// return its Match if successful. Match will invoke the GitIgnore error
+	// handler (if defined) if it is not possible to determine the absolute
+	// path of the given path, or if its not possible to determine if the
+	// path represents a file or a directory. If an error occurs, Match
+	// returns nil and the error handler (if defined via New, NewWithErrors
+	// or NewWithCache) will be invoked.
+	Match(path string) Match
+
+	// Absolute attempts to match an absolute path against this GitIgnore. If
+	// the path is not located under the base directory of this GitIgnore, or
+	// is not matched by this GitIgnore, nil is returned.
+	Absolute(string, bool) Match
+
+	// Relative attempts to match a path relative to the GitIgnore base
+	// directory. isdir is used to indicate whether the path represents a file
+	// or a directory. If the path is not matched by the GitIgnore, nil is
+	// returned.
+	Relative(path string, isdir bool) Match
+
+	// Ignore returns true if the path is ignored by this GitIgnore. Paths
+	// that are not matched by this GitIgnore are not ignored. Internally,
+	// Ignore uses Match, and will return false if Match() returns nil for path.
+	Ignore(path string) bool
+
+	// Include returns true if the path is included by this GitIgnore. Paths
+	// that are not matched by this GitIgnore are always included. Internally,
+	// Include uses Match, and will return true if Match() returns nil for path.
+	Include(path string) bool
+}
+
+// ignore is the implementation of a .gitignore file.
+type ignore struct {
+	_base    string
+	_pattern []Pattern
+	_errors  func(Error) bool
+}
+
+// NewGitIgnore creates a new GitIgnore instance from the patterns listed in t,
+// representing a .gitignore file in the base directory. If errors is given, it
+// will be invoked for every error encountered when parsing the .gitignore
+// patterns. Parsing will terminate if errors is called and returns false,
+// otherwise, parsing will continue until end of file has been reached.
+func New(r io.Reader, base string, errors func(Error) bool) GitIgnore {
+	// do we have an error handler?
+	_errors := errors
+	if _errors == nil {
+		_errors = func(e Error) bool { return true }
+	}
+
+	// extract the patterns from the reader
+	_parser := NewParser(r, _errors)
+	_patterns := _parser.Parse()
+
+	return &ignore{_base: base, _pattern: _patterns, _errors: _errors}
+} // New()
+
+// NewFromFile creates a GitIgnore instance from the given file. An error
+// will be returned if file cannot be opened or its absolute path determined.
+func NewFromFile(file string) (GitIgnore, error) {
+	// define an error handler to catch any file access errors
+	//		- record the first encountered error
+	var _error Error
+	_errors := func(e Error) bool {
+		if _error == nil {
+			_error = e
+		}
+		return true
+	}
+
+	// attempt to retrieve the GitIgnore represented by this file
+	_ignore := NewWithErrors(file, _errors)
+
+	// did we encounter an error?
+	//		- if the error has a zero Position then it was encountered
+	//		  before parsing was attempted, so we return that error
+	if _error != nil {
+		if _error.Position().Zero() {
+			return nil, _error.Underlying()
+		}
+	}
+
+	// otherwise, we ignore the parser errors
+	return _ignore, nil
+} // NewFromFile()
+
+// NewWithErrors creates a GitIgnore instance from the given file.
+// If errors is given, it will be invoked for every error encountered when
+// parsing the .gitignore patterns. Parsing will terminate if errors is called
+// and returns false, otherwise, parsing will continue until end of file has
+// been reached. NewWithErrors returns nil if the .gitignore could not be read.
+func NewWithErrors(file string, errors func(Error) bool) GitIgnore {
+	var _err error
+
+	// do we have an error handler?
+	_file := file
+	_errors := errors
+	if _errors == nil {
+		_errors = func(e Error) bool { return true }
+	} else {
+		// augment the error handler to include the .gitignore file name
+		//		- we do this here since the parser and lexer interfaces are
+		//		  not aware of file names
+		_errors = func(e Error) bool {
+			// augment the position with the file name
+			_position := e.Position()
+			_position.File = _file
+
+			// create a new error with the updated Position
+			_error := NewError(e.Underlying(), _position)
+
+			// invoke the original error handler
+			return errors(_error)
+		}
+	}
+
+	// we need the absolute path for the GitIgnore base
+	_file, _err = filepath.Abs(file)
+	if _err != nil {
+		_errors(NewError(_err, Position{}))
+		return nil
+	}
+	_base := filepath.Dir(_file)
+
+	// attempt to open the ignore file to create the io.Reader
+	_fh, _err := os.Open(_file)
+	if _err != nil {
+		_errors(NewError(_err, Position{}))
+		return nil
+	}
+
+	// return the GitIgnore instance
+	return New(_fh, _base, _errors)
+} // NewWithErrors()
+
+// NewWithCache returns a GitIgnore instance (using NewWithErrors)
+// for the given file. If the file has been loaded before, its GitIgnore
+// instance will be returned from the cache rather than being reloaded. If
+// cache is not defined, NewWithCache will behave as NewWithErrors
+//
+// If NewWithErrors returns nil, NewWithCache will store an empty
+// GitIgnore (i.e. no patterns) against the file to prevent repeated parse
+// attempts on subsequent requests for the same file. Subsequent calls to
+// NewWithCache for a file that could not be loaded due to an error will
+// return nil.
+//
+// If errors is given, it will be invoked for every error encountered when
+// parsing the .gitignore patterns. Parsing will terminate if errors is called
+// and returns false, otherwise, parsing will continue until end of file has
+// been reached.
+func NewWithCache(file string, cache Cache, errors func(Error) bool) GitIgnore {
+	// do we have an error handler?
+	_errors := errors
+	if _errors == nil {
+		_errors = func(e Error) bool { return true }
+	}
+
+	// use the file absolute path as its key into the cache
+	_abs, _err := filepath.Abs(file)
+	if _err != nil {
+		_errors(NewError(_err, Position{}))
+		return nil
+	}
+
+	var _ignore GitIgnore
+	if cache != nil {
+		_ignore = cache.Get(_abs)
+	}
+	if _ignore == nil {
+		_ignore = NewWithErrors(file, _errors)
+		if _ignore == nil {
+			// if the load failed, cache an empty GitIgnore to prevent
+			// further attempts to load this file
+			_ignore = empty
+		}
+		if cache != nil {
+			cache.Set(_abs, _ignore)
+		}
+	}
+
+	// return the ignore (if we have it)
+	if _ignore == empty {
+		return nil
+	} else {
+		return _ignore
+	}
+} // NewWithCache()
+
+// Base returns the directory containing the .gitignore file for this GitIgnore.
+func (i *ignore) Base() string {
+	return i._base
+} // Base()
+
+// Match attempts to match the path against this GitIgnore, and will
+// return its Match if successful. Match will invoke the GitIgnore error
+// handler (if defined) if it is not possible to determine the absolute
+// path of the given path, or if its not possible to determine if the
+// path represents a file or a directory. If an error occurs, Match
+// returns nil and the error handler (if defined via New, NewWithErrors
+// or NewWithCache) will be invoked.
+func (i *ignore) Match(path string) Match {
+	// ensure we have the absolute path for the given file
+	_path, _err := filepath.Abs(path)
+	if _err != nil {
+		i._errors(NewError(_err, Position{}))
+		return nil
+	}
+
+	// is the path a file or a directory?
+	_info, _err := os.Stat(_path)
+	if _err != nil {
+		i._errors(NewError(_err, Position{}))
+		return nil
+	}
+	_isdir := _info.IsDir()
+
+	// attempt to match the absolute path
+	return i.Absolute(_path, _isdir)
+} // Match()
+
+// Absolute attempts to match an absolute path against this GitIgnore. If
+// the path is not located under the base directory of this GitIgnore, or
+// is not matched by this GitIgnore, nil is returned.
+func (i *ignore) Absolute(path string, isdir bool) Match {
+	// does the file share the same directory as this ignore file?
+	if !strings.HasPrefix(path, i._base) {
+		return nil
+	}
+
+	// extract the relative path of this file
+	_prefix := len(i._base) + 1
+	_rel := string(path[_prefix:])
+	return i.Relative(_rel, isdir)
+} // Absolute()
+
+// Relative attempts to match a path relative to the GitIgnore base
+// directory. isdir is used to indicate whether the path represents a file
+// or a directory. If the path is not matched by the GitIgnore, nil is
+// returned.
+func (i *ignore) Relative(path string, isdir bool) Match {
+	// if we are on Windows, then translate the path to Unix form
+	_rel := path
+	if runtime.GOOS == "windows" {
+		_rel = filepath.ToSlash(_rel)
+	}
+
+	// iterate over the patterns for this ignore file
+	//      - iterate in reverse, since later patterns overwrite earlier
+	for _i := len(i._pattern) - 1; _i >= 0; _i-- {
+		_pattern := i._pattern[_i]
+		if _pattern.Match(_rel, isdir) {
+			return _pattern
+		}
+	}
+
+	// we don't match this file
+	return nil
+} // Relative()
+
+// Ignore returns true if the path is ignored by this GitIgnore. Paths
+// that are not matched by this GitIgnore are not ignored. Internally,
+// Ignore uses Match, and will return false if Match() returns nil for path.
+func (i *ignore) Ignore(path string) bool {
+	_match := i.Match(path)
+	if _match != nil {
+		return _match.Ignore()
+	}
+
+	// we didn't match this path, so we don't ignore it
+	return false
+} // Ignore()
+
+// Include returns true if the path is included by this GitIgnore. Paths
+// that are not matched by this GitIgnore are always included. Internally,
+// Include uses Match, and will return true if Match() returns nil for path.
+func (i *ignore) Include(path string) bool {
+	_match := i.Match(path)
+	if _match != nil {
+		return _match.Include()
+	}
+
+	// we didn't match this path, so we include it
+	return true
+} // Include()
+
+// ensure Ignore satisfies the GitIgnore interface
+var _ GitIgnore = &ignore{}

--- a/vendor/github.com/denormal/go-gitignore/lexer.go
+++ b/vendor/github.com/denormal/go-gitignore/lexer.go
@@ -1,0 +1,474 @@
+package gitignore
+
+import (
+	"bufio"
+	"io"
+)
+
+//
+// inspired by https://blog.gopheracademy.com/advent-2014/parsers-lexers/
+//
+
+// lexer is the implementation of the .gitignore lexical analyser
+type lexer struct {
+	_r        *bufio.Reader
+	_unread   []rune
+	_offset   int
+	_line     int
+	_column   int
+	_previous []int
+} // lexer{}
+
+// Lexer is the interface to the lexical analyser for .gitignore files
+type Lexer interface {
+	// Next returns the next Token from the Lexer reader. If an error is
+	// encountered, it will be returned as an Error instance, detailing the
+	// error and its position within the stream.
+	Next() (*Token, Error)
+
+	// Position returns the current position of the Lexer.
+	Position() Position
+
+	// String returns the string representation of the current position of the
+	// Lexer.
+	String() string
+}
+
+// NewLexer returns a Lexer instance for the io.Reader r.
+func NewLexer(r io.Reader) Lexer {
+	return &lexer{_r: bufio.NewReader(r), _line: 1, _column: 1}
+} // NewLexer()
+
+// Next returns the next Token from the Lexer reader. If an error is
+// encountered, it will be returned as an Error instance, detailing the error
+// and its position within the stream.
+func (l *lexer) Next() (*Token, Error) {
+	// are we at the beginning of the line?
+	_beginning := l.beginning()
+
+	// read the next rune
+	_r, _err := l.read()
+	if _err != nil {
+		return nil, _err
+	}
+
+	switch _r {
+	// end of file
+	case _EOF:
+		return l.token(EOF, nil, nil)
+
+	// whitespace ' ', '\t'
+	case _SPACE:
+		fallthrough
+	case _TAB:
+		l.unread(_r)
+		_rtn, _err := l.whitespace()
+		return l.token(WHITESPACE, _rtn, _err)
+
+	// end of line '\n' or '\r\n'
+	case _CR:
+		fallthrough
+	case _NEWLINE:
+		l.unread(_r)
+		_rtn, _err := l.eol()
+		return l.token(EOL, _rtn, _err)
+
+	// separator '/'
+	case _SEPARATOR:
+		return l.token(SEPARATOR, []rune{_r}, nil)
+
+	// '*' or any '**'
+	case _WILDCARD:
+		// is the wildcard followed by another wildcard?
+		//      - does this represent the "any" token (i.e. "**")
+		_next, _err := l.peek()
+		if _err != nil {
+			return nil, _err
+		} else if _next == _WILDCARD {
+			// we know read() will succeed here since we used peek() above
+			l.read()
+			return l.token(ANY, []rune{_WILDCARD, _WILDCARD}, nil)
+		}
+
+		// we have a single wildcard, so treat this as a pattern
+		l.unread(_r)
+		_rtn, _err := l.pattern()
+		return l.token(PATTERN, _rtn, _err)
+
+	// comment '#'
+	case _COMMENT:
+		l.unread(_r)
+
+		// if we are at the start of the line, then we treat this as a comment
+		if _beginning {
+			_rtn, _err := l.comment()
+			return l.token(COMMENT, _rtn, _err)
+		}
+
+		// otherwise, we regard this as a pattern
+		_rtn, _err := l.pattern()
+		return l.token(PATTERN, _rtn, _err)
+
+	// negation '!'
+	case _NEGATION:
+		if _beginning {
+			return l.token(NEGATION, []rune{_r}, nil)
+		}
+		fallthrough
+
+	// pattern
+	default:
+		l.unread(_r)
+		_rtn, _err := l.pattern()
+		return l.token(PATTERN, _rtn, _err)
+	}
+} // Next()
+
+// Position returns the current position of the Lexer.
+func (l *lexer) Position() Position {
+	return Position{"", l._line, l._column, l._offset}
+} // Position()
+
+// String returns the string representation of the current position of the
+// Lexer.
+func (l *lexer) String() string {
+	return l.Position().String()
+} // String()
+
+//
+// private methods
+//
+
+// read the next rune from the stream. Return an Error if there is a problem
+// reading from the stream. If the end of stream is reached, return the EOF
+// Token.
+func (l *lexer) read() (rune, Error) {
+	var _r rune
+	var _err error
+
+	// do we have any unread runes to read?
+	_length := len(l._unread)
+	if _length > 0 {
+		_r = l._unread[_length-1]
+		l._unread = l._unread[:_length-1]
+
+		// otherwise, attempt to read a new rune
+	} else {
+		_r, _, _err = l._r.ReadRune()
+		if _err == io.EOF {
+			return _EOF, nil
+		}
+	}
+
+	// increment the offset and column counts
+	l._offset++
+	l._column++
+
+	return _r, l.err(_err)
+} // read()
+
+// unread returns the given runes to the stream, making them eligible to be
+// read again. The runes are returned in the order given, so the last rune
+// specified will be the next rune read from the stream.
+func (l *lexer) unread(r ...rune) {
+	// ignore EOF runes
+	_r := make([]rune, 0)
+	for _, _rune := range r {
+		if _rune != _EOF {
+			_r = append(_r, _rune)
+		}
+	}
+
+	// initialise the unread rune list if necessary
+	if l._unread == nil {
+		l._unread = make([]rune, 0)
+	}
+	if len(_r) != 0 {
+		l._unread = append(l._unread, _r...)
+	}
+
+	// decrement the offset and column counts
+	//      - we have to take care of column being 0
+	//      - at present we can only unwind across a single line boundary
+	_length := len(_r)
+	for ; _length > 0; _length-- {
+		l._offset--
+		if l._column == 1 {
+			_length := len(l._previous)
+			if _length > 0 {
+				l._column = l._previous[_length-1]
+				l._previous = l._previous[:_length-1]
+				l._line--
+			}
+		} else {
+			l._column--
+		}
+	}
+} // unread()
+
+// peek returns the next rune in the stream without consuming it (i.e. it will
+// be returned by the next call to read or peek). peek will return an error if
+// there is a problem reading from the stream.
+func (l *lexer) peek() (rune, Error) {
+	// read the next rune
+	_r, _err := l.read()
+	if _err != nil {
+		return _r, _err
+	}
+
+	// unread & return the rune
+	l.unread(_r)
+	return _r, _err
+} // peek()
+
+// newline adjusts the positional counters when an end of line is reached
+func (l *lexer) newline() {
+	// adjust the counters for the new line
+	if l._previous == nil {
+		l._previous = make([]int, 0)
+	}
+	l._previous = append(l._previous, l._column)
+	l._column = 1
+	l._line++
+} // newline()
+
+// comment reads all runes until a newline or end of file is reached. An
+// error is returned if an error is encountered reading from the stream.
+func (l *lexer) comment() ([]rune, Error) {
+	_comment := make([]rune, 0)
+
+	// read until we reach end of line or end of file
+	//		- as we are in a comment, we ignore escape characters
+	for {
+		_next, _err := l.read()
+		if _err != nil {
+			return _comment, _err
+		}
+
+		// read until we have end of line or end of file
+		switch _next {
+		case _CR:
+			fallthrough
+		case _NEWLINE:
+			fallthrough
+		case _EOF:
+			// return the read run to the stream and stop
+			l.unread(_next)
+			return _comment, nil
+		}
+
+		// otherwise, add this run to the comment
+		_comment = append(_comment, _next)
+	}
+} // comment()
+
+// escape attempts to read an escape sequence (e.g. '\ ') form the input
+// stream. An error will be returned if there is an error reading from the
+// stream. escape returns just the escape rune if the following rune is either
+// end of line or end of file (since .gitignore files do not support line
+// continuations).
+func (l *lexer) escape() ([]rune, Error) {
+	// attempt to process the escape sequence
+	_peek, _err := l.peek()
+	if _err != nil {
+		return nil, _err
+	}
+
+	// what is the next rune after the escape?
+	switch _peek {
+	// are we at the end of the line or file?
+	//      - we return just the escape rune
+	case _CR:
+		fallthrough
+	case _NEWLINE:
+		fallthrough
+	case _EOF:
+		return []rune{_ESCAPE}, nil
+	}
+
+	// otherwise, return the escape and the next rune
+	//      - we know read() will succeed here since we used peek() above
+	l.read()
+	return []rune{_ESCAPE, _peek}, nil
+} // escape()
+
+// eol returns all runes from the current position to the end of the line. An
+// error is returned if there is a problem reading from the stream, or if a
+// carriage return character '\r' is encountered that is not followed by a
+// newline '\n'.
+func (l *lexer) eol() ([]rune, Error) {
+	// read the to the end of the line
+	//      - we should only be called here when we encounter an end of line
+	//        sequence
+	_line := make([]rune, 0, 1)
+
+	// loop until there's nothing more to do
+	for {
+		_next, _err := l.read()
+		if _err != nil {
+			return _line, _err
+		}
+
+		// read until we have a newline or we're at end of file
+		switch _next {
+		// end of file
+		case _EOF:
+			return _line, nil
+
+		// carriage return - we expect to see a newline next
+		case _CR:
+			_line = append(_line, _next)
+			_next, _err = l.read()
+			if _err != nil {
+				return _line, _err
+			} else if _next != _NEWLINE {
+				l.unread(_next)
+				return _line, l.err(CarriageReturnError)
+			}
+			fallthrough
+
+		// newline
+		case _NEWLINE:
+			_line = append(_line, _next)
+			return _line, nil
+		}
+	}
+} // eol()
+
+// whitespace returns all whitespace (i.e. ' ' and '\t') runes in a sequence,
+// or an error if there is a problem reading the next runes.
+func (l *lexer) whitespace() ([]rune, Error) {
+	// read until we hit the first non-whitespace rune
+	_ws := make([]rune, 0, 1)
+
+	// loop until there's nothing more to do
+	for {
+		_next, _err := l.read()
+		if _err != nil {
+			return _ws, _err
+		}
+
+		// what is this next rune?
+		switch _next {
+		// space or tab is consumed
+		case _SPACE:
+			fallthrough
+		case _TAB:
+			break
+
+		// non-whitespace rune
+		default:
+			// return the rune to the buffer and we're done
+			l.unread(_next)
+			return _ws, nil
+		}
+
+		// add this rune to the whitespace
+		_ws = append(_ws, _next)
+	}
+} // whitespace()
+
+// pattern returns all runes representing a file or path pattern, delimited
+// either by unescaped whitespace, a path separator '/' or enf of file. An
+// error is returned if a problem is encountered reading from the stream.
+func (l *lexer) pattern() ([]rune, Error) {
+	// read until we hit the first whitespace/end of line/eof rune
+	_pattern := make([]rune, 0, 1)
+
+	// loop until there's nothing more to do
+	for {
+		_r, _err := l.read()
+		if _err != nil {
+			return _pattern, _err
+		}
+
+		// what is the next rune?
+		switch _r {
+		// whitespace, newline, end of file, separator
+		//		- this is the end of the pattern
+		case _SPACE:
+			fallthrough
+		case _TAB:
+			fallthrough
+		case _CR:
+			fallthrough
+		case _NEWLINE:
+			fallthrough
+		case _SEPARATOR:
+			fallthrough
+		case _EOF:
+			// return what we have
+			l.unread(_r)
+			return _pattern, nil
+
+		// a wildcard is the end of the pattern if it is part of any '**'
+		case _WILDCARD:
+			_next, _err := l.peek()
+			if _err != nil {
+				return _pattern, _err
+			} else if _next == _WILDCARD {
+				l.unread(_r)
+				return _pattern, _err
+			} else {
+				_pattern = append(_pattern, _r)
+			}
+
+		// escape sequence - consume the next rune
+		case _ESCAPE:
+			_escape, _err := l.escape()
+			if _err != nil {
+				return _pattern, _err
+			}
+
+			// add the escape sequence as part of the pattern
+			_pattern = append(_pattern, _escape...)
+
+		// any other character, we add to the pattern
+		default:
+			_pattern = append(_pattern, _r)
+		}
+	}
+} // pattern()
+
+// token returns a Token instance of the given type_ represented by word runes.
+func (l *lexer) token(type_ TokenType, word []rune, e Error) (*Token, Error) {
+	// if we have an error, then we return a BAD token
+	if e != nil {
+		type_ = BAD
+	}
+
+	// extract the lexer position
+	//      - the column is taken from the current column position
+	//        minus the length of the consumed "word"
+	_word := len(word)
+	_column := l._column - _word
+	_offset := l._offset - _word
+	position := Position{"", l._line, _column, _offset}
+
+	// if this is a newline token, we adjust the line & column counts
+	if type_ == EOL {
+		l.newline()
+	}
+
+	// return the Token
+	return NewToken(type_, word, position), e
+} // token()
+
+// err returns an Error encapsulating the error e and the current Lexer
+// position.
+func (l *lexer) err(e error) Error {
+	// do we have an error?
+	if e == nil {
+		return nil
+	} else {
+		return NewError(e, l.Position())
+	}
+} // err()
+
+// beginning returns true if the Lexer is at the start of a new line.
+func (l *lexer) beginning() bool {
+	return l._column == 1
+} // beginning()
+
+// ensure the lexer conforms to the lexer interface
+var _ Lexer = &lexer{}

--- a/vendor/github.com/denormal/go-gitignore/match.go
+++ b/vendor/github.com/denormal/go-gitignore/match.go
@@ -1,0 +1,23 @@
+package gitignore
+
+// Match represents the interface of successful matches against a .gitignore
+// pattern set. A Match can be queried to determine whether the matched path
+// should be ignored or included (i.e. was the path matched by a negated
+// pattern), and to extract the position of the pattern within the .gitignore,
+// and a string representation of the pattern.
+type Match interface {
+	// Ignore returns true if the match pattern describes files or paths that
+	// should be ignored.
+	Ignore() bool
+
+	// Include returns true if the match pattern describes files or paths that
+	// should be included.
+	Include() bool
+
+	// String returns a string representation of the matched pattern.
+	String() string
+
+	// Position returns the position in the .gitignore file at which the
+	// matching pattern was defined.
+	Position() Position
+}

--- a/vendor/github.com/denormal/go-gitignore/parser.go
+++ b/vendor/github.com/denormal/go-gitignore/parser.go
@@ -1,0 +1,444 @@
+package gitignore
+
+import (
+	"io"
+)
+
+// Parser is the interface for parsing .gitignore files and extracting the set
+// of patterns specified in the .gitignore file.
+type Parser interface {
+	// Parse returns all well-formed .gitignore Patterns contained within the
+	// parser stream. Parsing will terminate at the end of the stream, or if
+	// the parser error handler returns false.
+	Parse() []Pattern
+
+	// Next returns the next well-formed .gitignore Pattern from the parser
+	// stream.  If an error is encountered, and the error handler is either
+	// not defined, or returns true, Next will skip to the end of the current
+	// line and attempt to parse the next Pattern. If the error handler
+	// returns false, or the parser reaches the end of the stream, Next
+	// returns nil.
+	Next() Pattern
+
+	// Position returns the current position of the parser in the input stream.
+	Position() Position
+} // Parser{}
+
+// parser is the implementation of the .gitignore parser
+type parser struct {
+	_lexer Lexer
+	_undo  []*Token
+	_error func(Error) bool
+} // parser{}
+
+// NewParser returns a new Parser instance for the given stream r.
+// If err is not nil, it will be called for every error encountered during
+// parsing. Parsing will terminate at the end of the stream, or if err
+// returns false.
+func NewParser(r io.Reader, err func(Error) bool) Parser {
+	return &parser{_lexer: NewLexer(r), _error: err}
+} // NewParser()
+
+// Parse returns all well-formed .gitignore Patterns contained within the
+// parser stream. Parsing will terminate at the end of the stream, or if
+// the parser error handler returns false.
+func (p *parser) Parse() []Pattern {
+	// keep parsing until there's no more patterns
+	_patterns := make([]Pattern, 0)
+	for {
+		_pattern := p.Next()
+		if _pattern == nil {
+			return _patterns
+		}
+		_patterns = append(_patterns, _pattern)
+	}
+} // Parse()
+
+// Next returns the next well-formed .gitignore Pattern from the parser stream.
+// If an error is encountered, and the error handler is either not defined, or
+// returns true, Next will skip to the end of the current line and attempt to
+// parse the next Pattern. If the error handler returns false, or the parser
+// reaches the end of the stream, Next returns nil.
+func (p *parser) Next() Pattern {
+	// keep searching until we find the next pattern, or until we
+	// reach the end of the file
+	for {
+		_token, _err := p.next()
+		if _err != nil {
+			if !p.errors(_err) {
+				return nil
+			}
+
+			// we got an error from the lexer, so skip the remainder
+			// of this line and try again from the next line
+			for _err != nil {
+				_err = p.skip()
+				if _err != nil {
+					if !p.errors(_err) {
+						return nil
+					}
+				}
+			}
+			continue
+		}
+
+		switch _token.Type {
+		// we're at the end of the file
+		case EOF:
+			return nil
+
+		// we have a blank line or comment
+		case EOL:
+			continue
+		case COMMENT:
+			continue
+
+		// otherwise, attempt to build the next pattern
+		default:
+			_pattern, _err := p.build(_token)
+			if _err != nil {
+				if !p.errors(_err) {
+					return nil
+				}
+
+				// we encountered an error parsing the retrieved tokens
+				//      - skip to the end of the line
+				for _err != nil {
+					_err = p.skip()
+					if _err != nil {
+						if !p.errors(_err) {
+							return nil
+						}
+					}
+				}
+
+				// skip to the next token
+				continue
+			} else if _pattern != nil {
+				return _pattern
+			}
+		}
+	}
+} // Next()
+
+// Position returns the current position of the parser in the input stream.
+func (p *parser) Position() Position {
+	// if we have any previously read tokens, then the token at
+	// the end of the "undo" list (most recently "undone") gives the
+	// position of the parser
+	_length := len(p._undo)
+	if _length != 0 {
+		return p._undo[_length-1].Position
+	}
+
+	// otherwise, return the position of the lexer
+	return p._lexer.Position()
+} // Position()
+
+//
+// private methods
+//
+
+// build attempts to build a well-formed .gitignore Pattern starting from the
+// given Token t. An Error will be returned if the sequence of tokens returned
+// by the Lexer does not represent a valid Pattern.
+func (p *parser) build(t *Token) (Pattern, Error) {
+	// attempt to create a valid pattern
+	switch t.Type {
+	// we have a negated pattern
+	case NEGATION:
+		return p.negation(t)
+
+	// attempt to build a path specification
+	default:
+		return p.path(t)
+	}
+} // build()
+
+// negation attempts to build a well-formed negated .gitignore Pattern starting
+// from the negation Token t. As with build, negation returns an Error if the
+// sequence of tokens returned by the Lexer does not represent a valid Pattern.
+func (p *parser) negation(t *Token) (Pattern, Error) {
+	// a negation appears before a path specification, so
+	// skip the negation token
+	_next, _err := p.next()
+	if _err != nil {
+		return nil, _err
+	}
+
+	// extract the sequence of tokens for this path
+	_tokens, _err := p.sequence(_next)
+	if _err != nil {
+		return nil, _err
+	}
+
+	// include the "negation" token at the front of the sequence
+	_tokens = append([]*Token{t}, _tokens...)
+
+	// return the Pattern instance
+	return NewPattern(_tokens), nil
+} // negation()
+
+// path attempts to build a well-formed .gitignore Pattern representing a path
+// specification, starting with the Token t. If the sequence of tokens returned
+// by the Lexer does not represent a valid Pattern, path returns an Error.
+// Trailing whitespace is dropped from the sequence of pattern tokens.
+func (p *parser) path(t *Token) (Pattern, Error) {
+	// extract the sequence of tokens for this path
+	_tokens, _err := p.sequence(t)
+	if _err != nil {
+		return nil, _err
+	}
+
+	// remove trailing whitespace tokens
+	_length := len(_tokens)
+	for _length > 0 {
+		// if we have a non-whitespace token, we can stop
+		_length--
+		if _tokens[_length].Type != WHITESPACE {
+			break
+		}
+
+		// otherwise, truncate the token list
+		_tokens = _tokens[:_length]
+	}
+
+	// return the Pattern instance
+	return NewPattern(_tokens), nil
+} // path()
+
+// sequence attempts to extract a well-formed Token sequence from the Lexer
+// representing a .gitignore Pattern. sequence returns an Error if the
+// retrieved sequence of tokens does not represent a valid Pattern.
+func (p *parser) sequence(t *Token) ([]*Token, Error) {
+	// extract the sequence of tokens for a valid path
+	//      - this excludes the negation token, which is handled as
+	//        a special case before sequence() is called
+	switch t.Type {
+	// the path starts with a separator
+	case SEPARATOR:
+		return p.separator(t)
+
+	// the path starts with the "any" pattern ("**")
+	case ANY:
+		return p.any(t)
+
+	// the path starts with whitespace, wildcard or a pattern
+	case WHITESPACE:
+		fallthrough
+	case PATTERN:
+		return p.pattern(t)
+	}
+
+	// otherwise, we have an invalid specification
+	p.undo(t)
+	return nil, p.err(InvalidPatternError)
+} // sequence()
+
+// separator attempts to retrieve a valid sequence of tokens that may appear
+// after the path separator '/' Token t. An Error is returned if the sequence if
+// tokens is not valid, or if there is an error extracting tokens from the
+// input stream.
+func (p *parser) separator(t *Token) ([]*Token, Error) {
+	// build a list of tokens that may appear after a separator
+	_tokens := []*Token{t}
+	_token, _err := p.next()
+	if _err != nil {
+		return _tokens, _err
+	}
+
+	// what tokens are we allowed to have follow a separator?
+	switch _token.Type {
+	// a separator can be followed by a pattern or
+	// an "any" pattern (i.e. "**")
+	case ANY:
+		_next, _err := p.any(_token)
+		return append(_tokens, _next...), _err
+
+	case WHITESPACE:
+		fallthrough
+	case PATTERN:
+		_next, _err := p.pattern(_token)
+		return append(_tokens, _next...), _err
+
+	// if we encounter end of line or file we are done
+	case EOL:
+		fallthrough
+	case EOF:
+		return _tokens, nil
+
+	// a separator can be followed by another separator
+	//      - it's not ideal, and not very useful, but it's interpreted
+	//        as a single separator
+	//      - we could clean it up here, but instead we pass
+	//        everything down to the matching later on
+	case SEPARATOR:
+		_next, _err := p.separator(_token)
+		return append(_tokens, _next...), _err
+	}
+
+	// any other token is invalid
+	p.undo(_token)
+	return _tokens, p.err(InvalidPatternError)
+} // separator()
+
+// any attempts to retrieve a valid sequence of tokens that may appear
+// after the any '**' Token t. An Error is returned if the sequence if
+// tokens is not valid, or if there is an error extracting tokens from the
+// input stream.
+func (p *parser) any(t *Token) ([]*Token, Error) {
+	// build the list of tokens that may appear after "any" (i.e. "**")
+	_tokens := []*Token{t}
+	_token, _err := p.next()
+	if _err != nil {
+		return _tokens, _err
+	}
+
+	// what tokens are we allowed to have follow an "any" symbol?
+	switch _token.Type {
+	// an "any" token may only be followed by a separator
+	case SEPARATOR:
+		_next, _err := p.separator(_token)
+		return append(_tokens, _next...), _err
+
+	// whitespace is acceptable if it takes us to the end of the line
+	case WHITESPACE:
+		return _tokens, p.eol()
+
+	// if we encounter end of line or file we are done
+	case EOL:
+		fallthrough
+	case EOF:
+		return _tokens, nil
+	}
+
+	// any other token is invalid
+	p.undo(_token)
+	return _tokens, p.err(InvalidPatternError)
+} // any()
+
+// pattern attempts to retrieve a valid sequence of tokens that may appear
+// after the path pattern Token t. An Error is returned if the sequence if
+// tokens is not valid, or if there is an error extracting tokens from the
+// input stream.
+func (p *parser) pattern(t *Token) ([]*Token, Error) {
+	// build the list of tokens that may appear after a pattern
+	_tokens := []*Token{t}
+	_token, _err := p.next()
+	if _err != nil {
+		return _tokens, _err
+	}
+
+	// what tokens are we allowed to have follow a pattern?
+	var _next []*Token
+	switch _token.Type {
+	case SEPARATOR:
+		_next, _err = p.separator(_token)
+		return append(_tokens, _next...), _err
+
+	case WHITESPACE:
+		fallthrough
+	case PATTERN:
+		_next, _err = p.pattern(_token)
+		return append(_tokens, _next...), _err
+
+	// if we encounter end of line or file we are done
+	case EOL:
+		fallthrough
+	case EOF:
+		return _tokens, nil
+	}
+
+	// any other token is invalid
+	p.undo(_token)
+	return _tokens, p.err(InvalidPatternError)
+} // pattern()
+
+// eol attempts to consume the next Lexer token to read the end of line or end
+// of file. If a EOL or EOF is not reached , eol will return an error.
+func (p *parser) eol() Error {
+	// are we at the end of the line?
+	_token, _err := p.next()
+	if _err != nil {
+		return _err
+	}
+
+	// have we encountered whitespace only?
+	switch _token.Type {
+	// if we're at the end of the line or file, we're done
+	case EOL:
+		fallthrough
+	case EOF:
+		p.undo(_token)
+		return nil
+	}
+
+	// otherwise, we have an invalid pattern
+	p.undo(_token)
+	return p.err(InvalidPatternError)
+} // eol()
+
+// next returns the next token from the Lexer, or an error if there is a
+// problem reading from the input stream.
+func (p *parser) next() (*Token, Error) {
+	// do we have any previously read tokens?
+	_length := len(p._undo)
+	if _length > 0 {
+		_token := p._undo[_length-1]
+		p._undo = p._undo[:_length-1]
+		return _token, nil
+	}
+
+	// otherwise, attempt to retrieve the next token from the lexer
+	return p._lexer.Next()
+} // next()
+
+// skip reads Tokens from the input until the end of line or end of file is
+// reached. If there is a problem reading tokens, an Error is returned.
+func (p *parser) skip() Error {
+	// skip to the next end of line or end of file token
+	for {
+		_token, _err := p.next()
+		if _err != nil {
+			return _err
+		}
+
+		// if we have an end of line or file token, then we can stop
+		switch _token.Type {
+		case EOL:
+			fallthrough
+		case EOF:
+			return nil
+		}
+	}
+} // skip()
+
+// undo returns the given Token t to the parser input stream to be retrieved
+// again on a subsequent call to next.
+func (p *parser) undo(t *Token) {
+	// add this token to the list of previously read tokens
+	//      - initialise the undo list if required
+	if p._undo == nil {
+		p._undo = make([]*Token, 0, 1)
+	}
+	p._undo = append(p._undo, t)
+} // undo()
+
+// err returns an Error for the error e, capturing the current parser Position.
+func (p *parser) err(e error) Error {
+	// convert the error to include the parser position
+	return NewError(e, p.Position())
+} // err()
+
+// errors returns the response from the parser error handler to the Error e. If
+// no error handler has been configured for this parser, errors returns true.
+func (p *parser) errors(e Error) bool {
+	// do we have an error handler?
+	if p._error == nil {
+		return true
+	}
+
+	// pass the error through to the error handler
+	//      - if this returns false, parsing will stop
+	return p._error(e)
+} // errors()

--- a/vendor/github.com/denormal/go-gitignore/pattern.go
+++ b/vendor/github.com/denormal/go-gitignore/pattern.go
@@ -1,0 +1,279 @@
+package gitignore
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/danwakefield/fnmatch"
+)
+
+// Pattern represents per-line patterns within a .gitignore file
+type Pattern interface {
+	Match
+
+	// Match returns true if the given path matches the name pattern. If the
+	// pattern is meant for directories only, and the path is not a directory,
+	// Match will return false. The matching is performed by fnmatch(). It
+	// is assumed path is relative to the base path of the owning GitIgnore.
+	Match(string, bool) bool
+}
+
+// pattern is the base implementation of a .gitignore pattern
+type pattern struct {
+	_negated   bool
+	_anchored  bool
+	_directory bool
+	_string    string
+	_fnmatch   string
+	_position  Position
+} // pattern()
+
+// name represents patterns matching a file or path name (i.e. the last
+// component of a path)
+type name struct {
+	pattern
+} // name{}
+
+// path represents a pattern that contains at least one path separator within
+// the pattern (i.e. not at the start or end of the pattern)
+type path struct {
+	pattern
+	_depth int
+} // path{}
+
+// any represents a pattern that contains at least one "any" token "**"
+// allowing for recursive matching.
+type any struct {
+	pattern
+	_tokens []*Token
+} // any{}
+
+// NewPattern returns a Pattern from the ordered slice of Tokens. The tokens are
+// assumed to represent a well-formed .gitignore pattern. A Pattern may be
+// negated, anchored to the start of the path (relative to the base directory
+// of tie containing .gitignore), or match directories only.
+func NewPattern(tokens []*Token) Pattern {
+	// extract the pattern position from first token
+	_position := tokens[0].Position
+	_string := tokenset(tokens).String()
+
+	// is this a negated pattern?
+	_negated := false
+	if tokens[0].Type == NEGATION {
+		_negated = true
+		tokens = tokens[1:]
+	}
+
+	// is this pattern anchored to the start of the path?
+	_anchored := false
+	if tokens[0].Type == SEPARATOR {
+		_anchored = true
+		tokens = tokens[1:]
+	}
+
+	// is this pattern for directories only?
+	_directory := false
+	_last := len(tokens) - 1
+	if tokens[_last].Type == SEPARATOR {
+		_directory = true
+		tokens = tokens[:_last]
+	}
+
+	// build the pattern expression
+	_fnmatch := tokenset(tokens).String()
+	_pattern := &pattern{
+		_negated:   _negated,
+		_anchored:  _anchored,
+		_position:  _position,
+		_directory: _directory,
+		_string:    _string,
+		_fnmatch:   _fnmatch,
+	}
+	return _pattern.compile(tokens)
+} // NewPattern()
+
+// compile generates a specific Pattern (i.e. name, path or any)
+// represented by the list of tokens.
+func (p *pattern) compile(tokens []*Token) Pattern {
+	// what tokens do we have in this pattern?
+	//      - ANY token means we can match to any depth
+	//      - SEPARATOR means we have path rather than file matching
+	_separator := false
+	for _, _token := range tokens {
+		switch _token.Type {
+		case ANY:
+			return p.any(tokens)
+		case SEPARATOR:
+			_separator = true
+		}
+	}
+
+	// should we perform path or name/file matching?
+	if _separator {
+		return p.path(tokens)
+	} else {
+		return p.name(tokens)
+	}
+} // compile()
+
+// Ignore returns true if the pattern describes files or paths that should be
+// ignored.
+func (p *pattern) Ignore() bool { return !p._negated }
+
+// Include returns true if the pattern describes files or paths that should be
+// included (i.e. not ignored)
+func (p *pattern) Include() bool { return p._negated }
+
+// Position returns the position of the first token of this pattern.
+func (p *pattern) Position() Position { return p._position }
+
+// String returns the string representation of the pattern.
+func (p *pattern) String() string { return p._string }
+
+//
+// name patterns
+//      - designed to match trailing file/directory names only
+//
+
+// name returns a Pattern designed to match file or directory names, with no
+// path elements.
+func (p *pattern) name(tokens []*Token) Pattern {
+	return &name{*p}
+} // name()
+
+// Match returns true if the given path matches the name pattern. If the
+// pattern is meant for directories only, and the path is not a directory,
+// Match will return false. The matching is performed by fnmatch(). It
+// is assumed path is relative to the base path of the owning GitIgnore.
+func (n *name) Match(path string, isdir bool) bool {
+	// are we expecting a directory?
+	if n._directory && !isdir {
+		return false
+	}
+
+	// should we match the whole path, or just the last component?
+	if n._anchored {
+		return fnmatch.Match(n._fnmatch, path, 0)
+	} else {
+		_, _base := filepath.Split(path)
+		return fnmatch.Match(n._fnmatch, _base, 0)
+	}
+} // Match()
+
+//
+// path patterns
+//      - designed to match complete or partial paths (not just filenames)
+//
+
+// path returns a Pattern designed to match paths that include at least one
+// path separator '/' neither at the end nor the start of the pattern.
+func (p *pattern) path(tokens []*Token) Pattern {
+	// how many directory components are we expecting?
+	_depth := 0
+	for _, _token := range tokens {
+		if _token.Type == SEPARATOR {
+			_depth++
+		}
+	}
+
+	// return the pattern instance
+	return &path{pattern: *p, _depth: _depth}
+} // path()
+
+// Match returns true if the given path matches the path pattern. If the
+// pattern is meant for directories only, and the path is not a directory,
+// Match will return false. The matching is performed by fnmatch()
+// with flags set to FNM_PATHNAME. It is assumed path is relative to the
+// base path of the owning GitIgnore.
+func (p *path) Match(path string, isdir bool) bool {
+	// are we expecting a directory
+	if p._directory && !isdir {
+		return false
+	}
+
+	if fnmatch.Match(p._fnmatch, path, fnmatch.FNM_PATHNAME) {
+		return true
+	} else if p._anchored {
+		return false
+	}
+
+	// match against the trailing path elements
+	return fnmatch.Match(p._fnmatch, path, fnmatch.FNM_PATHNAME)
+} // Match()
+
+//
+// "any" patterns
+//
+
+// any returns a Pattern designed to match paths that include at least one
+// any pattern '**', specifying recursive matching.
+func (p *pattern) any(tokens []*Token) Pattern {
+	// consider only the non-SEPARATOR tokens, as these will be matched
+	// against the path components
+	_tokens := make([]*Token, 0)
+	for _, _token := range tokens {
+		if _token.Type != SEPARATOR {
+			_tokens = append(_tokens, _token)
+		}
+	}
+
+	return &any{*p, _tokens}
+} // any()
+
+// Match returns true if the given path matches the any pattern. If the
+// pattern is meant for directories only, and the path is not a directory,
+// Match will return false. The matching is performed by recursively applying
+// fnmatch() with flags set to FNM_PATHNAME. It is assumed path is relative to
+// the base path of the owning GitIgnore.
+func (a *any) Match(path string, isdir bool) bool {
+	// are we expecting a directory?
+	if a._directory && !isdir {
+		return false
+	}
+
+	// split the path into components
+	_parts := strings.Split(path, string(_SEPARATOR))
+
+	// attempt to match the parts against the pattern tokens
+	return a.match(_parts, a._tokens)
+} // Match()
+
+// match performs the recursive matching for 'any' patterns. An 'any'
+// token '**' may match any path component, or no path component.
+func (a *any) match(path []string, tokens []*Token) bool {
+	// if we have no more tokens, then we have matched this path
+	// if there are also no more path elements, otherwise there's no match
+	if len(tokens) == 0 {
+		return len(path) == 0
+	}
+
+	// what token are we trying to match?
+	_token := tokens[0]
+	switch _token.Type {
+	case ANY:
+		if len(path) == 0 {
+			return a.match(path, tokens[1:])
+		} else {
+			return a.match(path, tokens[1:]) || a.match(path[1:], tokens)
+		}
+
+	default:
+		// if we have a non-ANY token, then we must have a non-empty path
+		if len(path) != 0 {
+			// if the current path element matches this token,
+			// we match if the remainder of the path matches the
+			// remaining tokens
+			if fnmatch.Match(_token.Token(), path[0], fnmatch.FNM_PATHNAME) {
+				return a.match(path[1:], tokens[1:])
+			}
+		}
+	}
+
+	// if we are here, then we have no match
+	return false
+} // match()
+
+// ensure the patterns confirm to the Pattern interface
+var _ Pattern = &name{}
+var _ Pattern = &path{}
+var _ Pattern = &any{}

--- a/vendor/github.com/denormal/go-gitignore/position.go
+++ b/vendor/github.com/denormal/go-gitignore/position.go
@@ -1,0 +1,35 @@
+package gitignore
+
+import (
+	"fmt"
+)
+
+// Position represents the position of the .gitignore parser, and the position
+// of a .gitignore pattern within the parsed stream.
+type Position struct {
+	File   string
+	Line   int
+	Column int
+	Offset int
+}
+
+// String returns a string representation of the current position.
+func (p Position) String() string {
+	_prefix := ""
+	if p.File != "" {
+		_prefix = p.File + ": "
+	}
+
+	if p.Line == 0 {
+		return fmt.Sprintf("%s+%d", _prefix, p.Offset)
+	} else if p.Column == 0 {
+		return fmt.Sprintf("%s%d", _prefix, p.Line)
+	} else {
+		return fmt.Sprintf("%s%d:%d", _prefix, p.Line, p.Column)
+	}
+} // String()
+
+// Zero returns true if the Position represents the zero Position
+func (p Position) Zero() bool {
+	return p.Line+p.Column+p.Offset == 0
+} // Zero()

--- a/vendor/github.com/denormal/go-gitignore/repository.go
+++ b/vendor/github.com/denormal/go-gitignore/repository.go
@@ -1,0 +1,274 @@
+package gitignore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const File = ".gitignore"
+
+// repository is the implementation of the set of .gitignore files within a
+// repository hierarchy
+type repository struct {
+	ignore
+	_errors  func(e Error) bool
+	_cache   Cache
+	_file    string
+	_exclude GitIgnore
+} // repository{}
+
+// NewRepository returns a GitIgnore instance representing a git repository
+// with root directory base. If base is not a directory, or base cannot be
+// read, NewRepository will return an error.
+//
+// Internally, NewRepository uses NewRepositoryWithFile.
+func NewRepository(base string) (GitIgnore, error) {
+	return NewRepositoryWithFile(base, File)
+} // NewRepository()
+
+// NewRepositoryWithFile returns a GitIgnore instance representing a git
+// repository with root directory base. The repository will use file as
+// the name of the files within the repository from which to load the
+// .gitignore patterns. If file is the empty string, NewRepositoryWithFile
+// uses ".gitignore". If the ignore file name is ".gitignore", the returned
+// GitIgnore instance will also consider patterns listed in
+// $GIT_DIR/info/exclude when performing repository matching.
+//
+// Internally, NewRepositoryWithFile uses NewRepositoryWithErrors.
+func NewRepositoryWithFile(base, file string) (GitIgnore, error) {
+	// define an error handler to catch any file access errors
+	//		- record the first encountered error
+	var _error Error
+	_errors := func(e Error) bool {
+		if _error == nil {
+			_error = e
+		}
+		return true
+	}
+
+	// attempt to retrieve the repository represented by this file
+	_repository := NewRepositoryWithErrors(base, file, _errors)
+
+	// did we encounter an error?
+	//		- if the error has a zero Position then it was encountered
+	//		  before parsing was attempted, so we return that error
+	if _error != nil {
+		if _error.Position().Zero() {
+			return nil, _error.Underlying()
+		}
+	}
+
+	// otherwise, we ignore the parser errors
+	return _repository, nil
+} // NewRepositoryWithFile()
+
+// NewRepositoryWithErrors returns a GitIgnore instance representing a git
+// repository with a root directory base. As with NewRepositoryWithFile, file
+// specifies the name of the files within the repository containing the
+// .gitignore patterns, and defaults to ".gitignore" if file is not specified.
+// If the ignore file name is ".gitignore", the returned GitIgnore instance
+// will also consider patterns listed in $GIT_DIR/info/exclude when performing
+// repository matching.
+//
+// If errors is given, it will be invoked for each error encountered while
+// matching a path against the repository GitIgnore (such as file permission
+// denied, or errors during .gitignore parsing). See Match below.
+//
+// Internally, NewRepositoryWithErrors uses NewRepositoryWithCache.
+func NewRepositoryWithErrors(base, file string, errors func(e Error) bool) GitIgnore {
+	return NewRepositoryWithCache(base, file, NewCache(), errors)
+} // NewRepositoryWithErrors()
+
+// NewRepositoryWithCache returns a GitIgnore instance representing a git
+// repository with a root directory base. As with NewRepositoryWithErrors,
+// file specifies the name of the files within the repository containing the
+// .gitignore patterns, and defaults to ".gitignore" if file is not specified.
+// If the ignore file name is ".gitignore", the returned GitIgnore instance
+// will also consider patterns listed in $GIT_DIR/info/exclude when performing
+// repository matching.
+//
+// NewRepositoryWithCache will attempt to load each .gitignore within the
+// repository only once, using NewWithCache to store the corresponding
+// GitIgnore instance in cache. If cache is given as nil,
+// NewRepositoryWithCache will create a Cache instance for this repository.
+//
+// If errors is given, it will be invoked for each error encountered while
+// matching a path against the repository GitIgnore (such as file permission
+// denied, or errors during .gitignore parsing). See Match below.
+func NewRepositoryWithCache(base, file string, cache Cache, errors func(e Error) bool) GitIgnore {
+	// do we have an error handler?
+	_errors := errors
+	if _errors == nil {
+		_errors = func(e Error) bool { return true }
+	}
+
+	// extract the absolute path of the base directory
+	_base, _err := filepath.Abs(base)
+	if _err != nil {
+		_errors(NewError(_err, Position{}))
+		return nil
+	}
+
+	// ensure the given base is a directory
+	_info, _err := os.Stat(_base)
+	if _info != nil {
+		if !_info.IsDir() {
+			_err = InvalidDirectoryError
+		}
+	}
+	if _err != nil {
+		_errors(NewError(_err, Position{}))
+		return nil
+	}
+
+	// if we haven't been given a base file name, use the default
+	if file == "" {
+		file = File
+	}
+
+	// are we matching .gitignore files?
+	//		- if we are, we also consider $GIT_DIR/info/exclude
+	var _exclude GitIgnore
+	if file == File {
+		_exclude, _err = exclude(_base)
+		if _err != nil {
+			_errors(NewError(_err, Position{}))
+			return nil
+		}
+	}
+
+	// create the repository instance
+	_ignore := ignore{_base: _base}
+	_repository := &repository{
+		ignore:   _ignore,
+		_errors:  _errors,
+		_exclude: _exclude,
+		_cache:   cache,
+		_file:    file,
+	}
+
+	return _repository
+} // NewRepositoryWithCache()
+
+// Match attempts to match the path against this repository. Matching proceeds
+// according to normal gitignore rules, where .gtignore files in the same
+// directory as path, take precedence over .gitignore files higher up the
+// path hierarchy, and child files and directories are ignored if the parent
+// is ignored. If the path is matched by a gitignore pattern in the repository,
+// a Match is returned detailing the matched pattern. The returned Match
+// can be used to determine if the path should be ignored or included according
+// to the repository.
+//
+// If an error is encountered during matching, the repository error handler
+// (if configured via NewRepositoryWithErrors or NewRepositoryWithCache), will
+// be called. If the error handler returns false, matching will terminate and
+// Match will return nil. If handler returns true, Match will continue
+// processing in an attempt to match path.
+//
+// Match will raise an error and return nil if the absolute path cannot be
+// determined, or if its not possible to determine if path represents a file
+// or a directory.
+//
+// If path is not located under the root of this repository, Match returns nil.
+func (r *repository) Match(path string) Match {
+	// ensure we have the absolute path for the given file
+	_path, _err := filepath.Abs(path)
+	if _err != nil {
+		r._errors(NewError(_err, Position{}))
+		return nil
+	}
+
+	// is the path a file or a directory?
+	_info, _err := os.Stat(_path)
+	if _err != nil {
+		r._errors(NewError(_err, Position{}))
+		return nil
+	}
+	_isdir := _info.IsDir()
+
+	// attempt to match the absolute path
+	return r.Absolute(_path, _isdir)
+} // Match()
+
+// Absolute attempts to match an absolute path against this repository. If the
+// path is not located under the base directory of this repository, or is not
+// matched by this repository, nil is returned.
+func (r *repository) Absolute(path string, isdir bool) Match {
+	// does the file share the same directory as this ignore file?
+	if !strings.HasPrefix(path, r.Base()) {
+		return nil
+	}
+
+	// extract the relative path of this file
+	_prefix := len(r.Base()) + 1
+	_rel := string(path[_prefix:])
+	return r.Relative(_rel, isdir)
+} // Absolute()
+
+// Relative attempts to match a path relative to the repository base directory.
+// If the path is not matched by the repository, nil is returned.
+func (r *repository) Relative(path string, isdir bool) Match {
+	// if there's no path, then there's nothing to match
+	_path := filepath.Clean(path)
+	if _path == "." {
+		return nil
+	}
+
+	// repository matching:
+	//		- a child path cannot be considered if its parent is ignored
+	//		- a .gitignore in a lower directory overrides a .gitignore in a
+	//		  higher directory
+
+	// first, is the parent directory ignored?
+	//		- extract the parent directory from the current path
+	_parent, _local := filepath.Split(_path)
+	_match := r.Relative(_parent, true)
+	if _match != nil {
+		if _match.Ignore() {
+			return _match
+		}
+	}
+	_parent = filepath.Clean(_parent)
+
+	// the parent directory isn't ignored, so we now look at the original path
+	//		- we consider .gitignore files in the current directory first, then
+	//		  move up the path hierarchy
+	var _last string
+	for {
+		_file := filepath.Join(r._base, _parent, r._file)
+		_ignore := NewWithCache(_file, r._cache, r._errors)
+		if _ignore != nil {
+			_match := _ignore.Relative(_local, isdir)
+			if _match != nil {
+				return _match
+			}
+		}
+
+		// if there's no parent, then we're done
+		//		- since we use filepath.Clean() we look for "."
+		if _parent == "." {
+			break
+		}
+
+		// we don't have a match for this file, so we progress up the
+		// path hierarchy
+		//		- we are manually building _local using the .gitignore
+		//		  separator "/", which is how we handle operating system
+		//		  file system differences
+		_parent, _last = filepath.Split(_parent)
+		_parent = filepath.Clean(_parent)
+		_local = _last + string(_SEPARATOR) + _local
+	}
+
+	// do we have a global exclude file? (i.e. GIT_DIR/info/exclude)
+	if r._exclude != nil {
+		return r._exclude.Relative(path, isdir)
+	}
+
+	// we have no match
+	return nil
+} // Relative()
+
+// ensure repository satisfies the GitIgnore interface
+var _ GitIgnore = &repository{}

--- a/vendor/github.com/denormal/go-gitignore/rune.go
+++ b/vendor/github.com/denormal/go-gitignore/rune.go
@@ -1,0 +1,15 @@
+package gitignore
+
+const (
+	// define the sentinel runes of the lexer
+	_EOF       = rune(0)
+	_CR        = rune('\r')
+	_NEWLINE   = rune('\n')
+	_COMMENT   = rune('#')
+	_SEPARATOR = rune('/')
+	_ESCAPE    = rune('\\')
+	_SPACE     = rune(' ')
+	_TAB       = rune('\t')
+	_NEGATION  = rune('!')
+	_WILDCARD  = rune('*')
+)

--- a/vendor/github.com/denormal/go-gitignore/token.go
+++ b/vendor/github.com/denormal/go-gitignore/token.go
@@ -1,0 +1,43 @@
+package gitignore
+
+import (
+	"fmt"
+)
+
+// Token represents a parsed token from a .gitignore stream, encapsulating the
+// token type, the runes comprising the token, and the position within the
+// stream of the first rune of the token.
+type Token struct {
+	Type TokenType
+	Word []rune
+	Position
+}
+
+// NewToken returns a Token instance of the given t, represented by the
+// word runes, at the stream position pos. If the token type is not know, the
+// returned instance will have type BAD.
+func NewToken(t TokenType, word []rune, pos Position) *Token {
+	// ensure the type is valid
+	if t < ILLEGAL || t > BAD {
+		t = BAD
+	}
+
+	// return the token
+	return &Token{Type: t, Word: word, Position: pos}
+} // NewToken()
+
+// Name returns a string representation of the Token type.
+func (t *Token) Name() string {
+	return t.Type.String()
+} // Name()
+
+// Token returns the string representation of the Token word.
+func (t *Token) Token() string {
+	return string(t.Word)
+} // Token()
+
+// String returns a string representation of the Token, encapsulating its
+// position in the input stream, its name (i.e. type), and its runes.
+func (t *Token) String() string {
+	return fmt.Sprintf("%s: %s %q", t.Position.String(), t.Name(), t.Token())
+} // String()

--- a/vendor/github.com/denormal/go-gitignore/tokenset.go
+++ b/vendor/github.com/denormal/go-gitignore/tokenset.go
@@ -1,0 +1,15 @@
+package gitignore
+
+// tokenset represents an ordered list of Tokens
+type tokenset []*Token
+
+// String() returns a concatenated string of all runes represented by the
+// list of tokens.
+func (t tokenset) String() string {
+	// concatenate the tokens into a single string
+	_rtn := ""
+	for _, _t := range []*Token(t) {
+		_rtn = _rtn + _t.Token()
+	}
+	return _rtn
+} // String()

--- a/vendor/github.com/denormal/go-gitignore/tokentype.go
+++ b/vendor/github.com/denormal/go-gitignore/tokentype.go
@@ -1,0 +1,42 @@
+package gitignore
+
+type TokenType int
+
+const (
+	ILLEGAL TokenType = iota
+	EOF
+	EOL
+	WHITESPACE
+	COMMENT
+	SEPARATOR
+	NEGATION
+	PATTERN
+	ANY
+	BAD
+)
+
+// String returns a string representation of the Token type.
+func (t TokenType) String() string {
+	switch t {
+	case ILLEGAL:
+		return "ILLEGAL"
+	case EOF:
+		return "EOF"
+	case EOL:
+		return "EOL"
+	case WHITESPACE:
+		return "WHITESPACE"
+	case COMMENT:
+		return "COMMENT"
+	case SEPARATOR:
+		return "SEPARATOR"
+	case NEGATION:
+		return "NEGATION"
+	case PATTERN:
+		return "PATTERN"
+	case ANY:
+		return "ANY"
+	default:
+		return "BAD TOKEN"
+	}
+} // String()

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_agpl.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_agpl.go
@@ -1,0 +1,683 @@
+package cmd
+
+func initAgpl() {
+	Licenses["agpl"] = License{
+		Name:            "GNU Affero General Public License",
+		PossibleMatches: []string{"agpl", "affero gpl", "gnu agpl"},
+		Header: `
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.`,
+		Text: `                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.
+`,
+	}
+}

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_apache_2.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_apache_2.go
@@ -1,0 +1,238 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts inspired by https://github.com/ryanuber/go-license
+
+package cmd
+
+func initApache2() {
+	Licenses["apache"] = License{
+		Name:            "Apache 2.0",
+		PossibleMatches: []string{"apache", "apache20", "apache 2.0", "apache2.0", "apache-2.0"},
+		Header: `
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.`,
+		Text: `
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+`,
+	}
+}

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_bsd_clause_2.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_bsd_clause_2.go
@@ -1,0 +1,71 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts inspired by https://github.com/ryanuber/go-license
+
+package cmd
+
+func initBsdClause2() {
+	Licenses["freebsd"] = License{
+		Name: "Simplified BSD License",
+		PossibleMatches: []string{"freebsd", "simpbsd", "simple bsd", "2-clause bsd",
+			"2 clause bsd", "simplified bsd license"},
+		Header: `All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.`,
+		Text: `{{ .copyright }}
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+`,
+	}
+}

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_bsd_clause_3.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_bsd_clause_3.go
@@ -1,0 +1,78 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts inspired by https://github.com/ryanuber/go-license
+
+package cmd
+
+func initBsdClause3() {
+	Licenses["bsd"] = License{
+		Name:            "NewBSD",
+		PossibleMatches: []string{"bsd", "newbsd", "3 clause bsd", "3-clause bsd"},
+		Header: `All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.`,
+		Text: `{{ .copyright }}
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+`,
+	}
+}

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_gpl_2.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_gpl_2.go
@@ -1,0 +1,376 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts inspired by https://github.com/ryanuber/go-license
+
+package cmd
+
+func initGpl2() {
+	Licenses["gpl2"] = License{
+		Name:            "GNU General Public License 2.0",
+		PossibleMatches: []string{"gpl2", "gnu gpl2", "gplv2"},
+		Header: `
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.`,
+		Text: `                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type 'show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type 'show c' for details.
+
+The hypothetical commands 'show w' and 'show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than 'show w' and 'show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  'Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.
+`,
+	}
+}

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_gpl_3.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_gpl_3.go
@@ -1,0 +1,711 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts inspired by https://github.com/ryanuber/go-license
+
+package cmd
+
+func initGpl3() {
+	Licenses["gpl3"] = License{
+		Name:            "GNU General Public License 3.0",
+		PossibleMatches: []string{"gpl3", "gplv3", "gpl", "gnu gpl3", "gnu gpl"},
+		Header: `
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.`,
+		Text: `                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type 'show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type 'show c' for details.
+
+The hypothetical commands 'show w' and 'show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+`,
+	}
+}

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_lgpl.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_lgpl.go
@@ -1,0 +1,186 @@
+package cmd
+
+func initLgpl() {
+	Licenses["lgpl"] = License{
+		Name:            "GNU Lesser General Public License",
+		PossibleMatches: []string{"lgpl", "lesser gpl", "gnu lgpl"},
+		Header: `
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.`,
+		Text: `                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.`,
+	}
+}

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_mit.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_mit.go
@@ -1,0 +1,63 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts inspired by https://github.com/ryanuber/go-license
+
+package cmd
+
+func initMit() {
+	Licenses["mit"] = License{
+		Name:            "MIT License",
+		PossibleMatches: []string{"mit"},
+		Header: `
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.`,
+		Text: `The MIT License (MIT)
+
+{{ .copyright }}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+`,
+	}
+}

--- a/vendor/github.com/spf13/cobra/cobra/cmd/licenses.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/licenses.go
@@ -1,0 +1,118 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts inspired by https://github.com/ryanuber/go-license
+
+package cmd
+
+import (
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// Licenses contains all possible licenses a user can choose from.
+var Licenses = make(map[string]License)
+
+// License represents a software license agreement, containing the Name of
+// the license, its possible matches (on the command line as given to cobra),
+// the header to be used with each file on the file's creating, and the text
+// of the license
+type License struct {
+	Name            string   // The type of license in use
+	PossibleMatches []string // Similar names to guess
+	Text            string   // License text data
+	Header          string   // License header for source files
+}
+
+func init() {
+	// Allows a user to not use a license.
+	Licenses["none"] = License{"None", []string{"none", "false"}, "", ""}
+
+	initApache2()
+	initMit()
+	initBsdClause3()
+	initBsdClause2()
+	initGpl2()
+	initGpl3()
+	initLgpl()
+	initAgpl()
+}
+
+// getLicense returns license specified by user in flag or in config.
+// If user didn't specify the license, it returns Apache License 2.0.
+//
+// TODO: Inspect project for existing license
+func getLicense() License {
+	// If explicitly flagged, use that.
+	if userLicense != "" {
+		return findLicense(userLicense)
+	}
+
+	// If user wants to have custom license, use that.
+	if viper.IsSet("license.header") || viper.IsSet("license.text") {
+		return License{Header: viper.GetString("license.header"),
+			Text: viper.GetString("license.text")}
+	}
+
+	// If user wants to have built-in license, use that.
+	if viper.IsSet("license") {
+		return findLicense(viper.GetString("license"))
+	}
+
+	// If user didn't set any license, use Apache 2.0 by default.
+	return Licenses["apache"]
+}
+
+func copyrightLine() string {
+	author := viper.GetString("author")
+
+	year := viper.GetString("year") // For tests.
+	if year == "" {
+		year = time.Now().Format("2006")
+	}
+
+	return "Copyright © " + year + " " + author
+}
+
+// findLicense looks for License object of built-in licenses.
+// If it didn't find license, then the app will be terminated and
+// error will be printed.
+func findLicense(name string) License {
+	found := matchLicense(name)
+	if found == "" {
+		er("unknown license: " + name)
+	}
+	return Licenses[found]
+}
+
+// matchLicense compares the given a license name
+// to PossibleMatches of all built-in licenses.
+// It returns blank string, if name is blank string or it didn't find
+// then appropriate match to name.
+func matchLicense(name string) string {
+	if name == "" {
+		return ""
+	}
+
+	for key, lic := range Licenses {
+		for _, match := range lic.PossibleMatches {
+			if strings.EqualFold(name, match) {
+				return key
+			}
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
During import use the file .gitignore to skip processing files and/or directories from placeholder replacement.
Replaces the current hard coded folder names as they are usually specified by the correct language/environment .gitignore files.