### PR TITLE
Add messaging for setup without a custom domain

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,1 @@
+docs/contributing/hacking.md

--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -709,6 +709,8 @@ func (o *CommonOptions) GetDomain(client kubernetes.Interface, domain string, pr
 			return defaultDomain, nil
 		}
 		log.Successf("You can now configure a wildcard DNS pointing to the new loadbalancer address %s", address)
+		log.Info("\nIf you do not have a custom domain setup yet, Ingress rules will be set for magic dns nip.io.")
+		log.Infof("\nOnce you have a customer domain ready, you can update with the command %s", util.ColorInfo(ingressNamespace))
 
 		if provider == AWS || provider == EKS {
 			log.Infof("\nOn AWS we recommend using a custom DNS name to access services in your kubernetes cluster\n")

--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -710,7 +710,7 @@ func (o *CommonOptions) GetDomain(client kubernetes.Interface, domain string, pr
 		}
 		log.Successf("You can now configure a wildcard DNS pointing to the new loadbalancer address %s", address)
 		log.Info("\nIf you do not have a custom domain setup yet, Ingress rules will be set for magic dns nip.io.")
-		log.Infof("\nOnce you have a customer domain ready, you can update with the command %s", util.ColorInfo(ingressNamespace))
+		log.Infof("\nOnce you have a customer domain ready, you can update with the command %s", util.ColorInfo("jx upgrade ingress --cluster"))
 
 		if provider == AWS || provider == EKS {
 			log.Infof("\nOn AWS we recommend using a custom DNS name to access services in your kubernetes cluster\n")


### PR DESCRIPTION
In response to #1316 

* Adds instructions for lacking a custom DNS name *before* inputting anything for AWS

Extra:

* Added a symlink for a top-level `CONTRIBUTING.MD`as the contributing instructions are nested under the docs folder