### PR TITLE
jenkins-x/jx#1352 Fix create/import jenkinsfile option

### DIFF
--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -414,11 +414,13 @@ func (o *ImportOptions) DraftCreate() error {
 	// https://github.com/Azure/draft/issues/476
 	dir := o.Dir
 
-	tempJenkinsfile := o.Jenkinsfile
-	if tempJenkinsfile == "" {
-		tempJenkinsfile = jenkins.DefaultJenkinsfile
+	defaultJenkinsfile := filepath.Join(dir, jenkins.DefaultJenkinsfile)
+	jenkinsfile := defaultJenkinsfile
+	withRename := false
+	if o.Jenkinsfile != "" {
+		jenkinsfile = filepath.Join(dir, o.Jenkinsfile)
+		withRename = true
 	}
-	jenkinsfile := filepath.Join(dir, tempJenkinsfile)
 	pomName := filepath.Join(dir, "pom.xml")
 	gradleName := filepath.Join(dir, "build.gradle")
 	lpack := ""
@@ -501,6 +503,16 @@ func (o *ImportOptions) DraftCreate() error {
 		if err != nil {
 			return fmt.Errorf("Failed to rename old Jenkinsfile: %s", err)
 		}
+	} else if withRename {
+		defaultJenkinsfileExists, err := util.FileExists(defaultJenkinsfile)
+		if defaultJenkinsfileExists && o.InitialisedGit && !o.DisableJenkinsfileCheck {
+			jenkinsfileBackup = defaultJenkinsfile + jenkinsfileBackupSuffix
+			err = util.RenameFile(defaultJenkinsfile, jenkinsfileBackup)
+			if err != nil {
+				return fmt.Errorf("Failed to rename old Jenkinsfile: %s", err)
+			}
+
+		}
 	}
 
 	err = pack.CreateFrom(dir, lpack)
@@ -509,7 +521,7 @@ func (o *ImportOptions) DraftCreate() error {
 		log.Warnf("Failed to run draft create in %s due to %s", dir, err)
 	}
 
-	unpackedDefaultJenkinsfile := filepath.Join(dir, jenkins.DefaultJenkinsfile)
+	unpackedDefaultJenkinsfile := defaultJenkinsfile
 	if unpackedDefaultJenkinsfile != jenkinsfile {
 		unpackedDefaultJenkinsfileExists := false
 		unpackedDefaultJenkinsfileExists, err = util.FileExists(unpackedDefaultJenkinsfile)
@@ -518,10 +530,14 @@ func (o *ImportOptions) DraftCreate() error {
 			if err != nil {
 				return fmt.Errorf("Failed to rename Jenkinsfile file from '%s' to '%s': %s", unpackedDefaultJenkinsfile, jenkinsfile, err)
 			}
+			if jenkinsfileBackup != "" {
+				err = util.RenameFile(jenkinsfileBackup, defaultJenkinsfile)
+				if err != nil {
+					return fmt.Errorf("Failed to rename Jenkinsfile backup file: %s", err)
+				}
+			}
 		}
-	}
-
-	if jenkinsfileBackup != "" {
+	} else if jenkinsfileBackup != "" {
 		// if there's no Jenkinsfile created then rename it back again!
 		jenkinsfileExists, err = util.FileExists(jenkinsfile)
 		if err != nil {

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -414,7 +414,11 @@ func (o *ImportOptions) DraftCreate() error {
 	// https://github.com/Azure/draft/issues/476
 	dir := o.Dir
 
-	jenkinsfile := filepath.Join(dir, o.Jenkinsfile)
+	tempJenkinsfile := o.Jenkinsfile
+	if tempJenkinsfile == "" {
+		tempJenkinsfile = jenkins.DefaultJenkinsfile
+	}
+	jenkinsfile := filepath.Join(dir, tempJenkinsfile)
 	pomName := filepath.Join(dir, "pom.xml")
 	gradleName := filepath.Join(dir, "build.gradle")
 	lpack := ""
@@ -505,13 +509,15 @@ func (o *ImportOptions) DraftCreate() error {
 		log.Warnf("Failed to run draft create in %s due to %s", dir, err)
 	}
 
-	var unpackedDefaultJenkinsfile = filepath.Join(dir, jenkins.DefaultJenkinsfile)
-	var unpackedDefaultJenkinsfileExists = false
-	unpackedDefaultJenkinsfileExists, err = util.FileExists(unpackedDefaultJenkinsfile)
-	if unpackedDefaultJenkinsfileExists {
-		err = util.RenameFile(unpackedDefaultJenkinsfile, jenkinsfile)
-		if err != nil {
-			return fmt.Errorf("Failed to rename Jenkinsfile file to '%s': %s", unpackedDefaultJenkinsfile, err)
+	unpackedDefaultJenkinsfile := filepath.Join(dir, jenkins.DefaultJenkinsfile)
+	if unpackedDefaultJenkinsfile != jenkinsfile {
+		unpackedDefaultJenkinsfileExists := false
+		unpackedDefaultJenkinsfileExists, err = util.FileExists(unpackedDefaultJenkinsfile)
+		if unpackedDefaultJenkinsfileExists {
+			err = util.RenameFile(unpackedDefaultJenkinsfile, jenkinsfile)
+			if err != nil {
+				return fmt.Errorf("Failed to rename Jenkinsfile file from '%s' to '%s': %s", unpackedDefaultJenkinsfile, jenkinsfile, err)
+			}
 		}
 	}
 

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -414,7 +414,7 @@ func (o *ImportOptions) DraftCreate() error {
 	// https://github.com/Azure/draft/issues/476
 	dir := o.Dir
 
-	jenkinsfile := filepath.Join(dir, "Jenkinsfile")
+	jenkinsfile := filepath.Join(dir, o.Jenkinsfile)
 	pomName := filepath.Join(dir, "pom.xml")
 	gradleName := filepath.Join(dir, "build.gradle")
 	lpack := ""
@@ -503,6 +503,16 @@ func (o *ImportOptions) DraftCreate() error {
 	if err != nil {
 		// lets ignore draft errors as sometimes it can't find a pack - e.g. for environments
 		log.Warnf("Failed to run draft create in %s due to %s", dir, err)
+	}
+
+	var unpackedDefaultJenkinsfile = filepath.Join(dir, jenkins.DefaultJenkinsfile)
+	var unpackedDefaultJenkinsfileExists = false
+	unpackedDefaultJenkinsfileExists, err = util.FileExists(unpackedDefaultJenkinsfile)
+	if unpackedDefaultJenkinsfileExists {
+		err = util.RenameFile(unpackedDefaultJenkinsfile, jenkinsfile)
+		if err != nil {
+			return fmt.Errorf("Failed to rename Jenkinsfile file to '%s': %s", unpackedDefaultJenkinsfile, err)
+		}
 	}
 
 	if jenkinsfileBackup != "" {

--- a/pkg/jx/cmd/import_test.go
+++ b/pkg/jx/cmd/import_test.go
@@ -19,9 +19,9 @@ import (
 
 const (
 	mavenKeepOldJenkinsfile = "maven_keep_old_jenkinsfile"
-	mavenOldJenkinsfile = "maven_old_jenkinsfile"
-	mavenCamel              = "maven-camel"
-	mavenSpringBoot         = "maven-springboot"
+	mavenOldJenkinsfile 	= "maven_old_jenkinsfile"
+	mavenCamel              = "maven_camel"
+	mavenSpringBoot         = "maven_springboot"
 	probePrefix             = "probePath:"
 )
 
@@ -40,20 +40,21 @@ func TestImportProjects(t *testing.T) {
 		if f.IsDir() {
 			name := f.Name()
 			srcDir := filepath.Join(testData, name)
-			testDir := filepath.Join(tempDir, name)
-			util.CopyDir(srcDir, testDir, true)
-
-			err = assertImport(t, testDir, name,false)
-			assert.NoError(t, err, "Importing dir %s from source %s", testDir, srcDir)
-
-			// Now test the same with renamed Jenkinsfiles
-			testDirWithRename := filepath.Join(tempDir, name + "-RenamedJenkinsfile")
-			util.CopyDir(srcDir, testDirWithRename, true)
-
-			err = assertImport(t, testDirWithRename, name,true)
-			assert.NoError(t, err, "Importing dir %s from source %s", testDirWithRename, srcDir)
+			testImportProject(t, tempDir, name, srcDir, false)
+			testImportProject(t, tempDir, name, srcDir, true)
 		}
 	}
+}
+
+func testImportProject(t *testing.T, tempDir string, testcase string, srcDir string, withRename bool) {
+	testDirSuffix := "DefaultJenkinsfile"
+	if withRename {
+		testDirSuffix = "RenamedJenkinsfile"
+	}
+	testDir := filepath.Join(tempDir + "-" + testDirSuffix, testcase)
+	util.CopyDir(srcDir, testDir, true)
+	err := assertImport(t, testDir, testcase, withRename)
+	assert.NoError(t, err, "Importing dir %s from source %s", testDir, srcDir)
 }
 
 func assertImport(t *testing.T, testDir string, testcase string, withRename bool) error {

--- a/pkg/jx/cmd/import_test.go
+++ b/pkg/jx/cmd/import_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/jenkins-x/jx/pkg/jenkins"
 )
 
 const (
@@ -66,7 +67,11 @@ func assertImport(t *testing.T, testDir string) error {
 	err := o.Run()
 	assert.NoError(t, err, "Failed with %s", err)
 	if err == nil {
-		jenkinsfile := filepath.Join(testDir, "Jenkinsfile")
+		tempJenkinsfile := o.Jenkinsfile
+		if tempJenkinsfile == "" {
+			tempJenkinsfile = jenkins.DefaultJenkinsfile
+		}
+		jenkinsfile := filepath.Join(testDir, tempJenkinsfile)
 		tests.AssertFileExists(t, jenkinsfile)
 		tests.AssertFileExists(t, filepath.Join(testDir, "Dockerfile"))
 		tests.AssertFileExists(t, filepath.Join(testDir, "charts", dirName, "Chart.yaml"))

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -79,6 +79,9 @@ func RenameDir(src string, dst string, force bool) (err error) {
 }
 
 func RenameFile(src string, dst string) (err error) {
+	if (src == dst) {
+		return nil
+	}
 	err = CopyFile(src, dst)
 	if err != nil {
 		return fmt.Errorf("failed to copy source file %s to %s: %s", src, dst, err)


### PR DESCRIPTION
As far as I can see the mentioned problem is fixed: Jenkins happily picks up the desired file `Jenkins-XXX` for build. Are any unit/integration tests required?