### PR TITLE
fix: create cluster eks

### DIFF
--- a/pkg/jx/cmd/common_helm.go
+++ b/pkg/jx/cmd/common_helm.go
@@ -199,7 +199,7 @@ func (o *CommonOptions) helmInit(dir string) error {
 	if o.Helm().HelmBinary() == "helm" {
 		return o.Helm().Init(false, "", "", true)
 	} else {
-		return o.Helm().Init(false, "", "", false)
+		return o.Helm().Init(false, "", "", true)
 	}
 }
 

--- a/pkg/jx/cmd/common_helm.go
+++ b/pkg/jx/cmd/common_helm.go
@@ -199,7 +199,7 @@ func (o *CommonOptions) helmInit(dir string) error {
 	if o.Helm().HelmBinary() == "helm" {
 		return o.Helm().Init(false, "", "", true)
 	} else {
-		return o.Helm().Init(false, "", "", true)
+		return o.Helm().Init(false, "", "", false)
 	}
 }
 

--- a/pkg/jx/cmd/gc_activities.go
+++ b/pkg/jx/cmd/gc_activities.go
@@ -1,18 +1,15 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
+	"sort"
+	"strconv"
+	"strings"
 
+	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"strconv"
-
-	"sort"
-
-	"fmt"
-
-	"strings"
 
 	"github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -68,8 +65,16 @@ func NewCmdGCActivities(f Factory, out io.Writer, errOut io.Writer) *cobra.Comma
 
 // Run implements this command
 func (o *GCActivitiesOptions) Run() error {
-	f := o.Factory
-	client, currentNs, err := f.CreateJXClient()
+	apisClient, err := o.CreateApiExtensionsClient()
+	if err != nil {
+		return err
+	}
+	err = kube.RegisterPipelineActivityCRD(apisClient)
+	if err != nil {
+		return err
+	}
+
+	client, currentNs, err := o.JXClientAndDevNamespace()
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -261,6 +261,11 @@ func (options *InstallOptions) Run() error {
 
 	initOpts.Flags.Provider = options.Flags.Provider
 	initOpts.Flags.Namespace = options.Flags.Namespace
+	exposeController := options.CreateEnvOptions.HelmValuesConfig.ExposeController
+	initOpts.Flags.Http = true
+	if exposeController != nil {
+		initOpts.Flags.Http = exposeController.Config.HTTP == "true"
+	}
 	initOpts.BatchMode = options.BatchMode
 
 	if options.Flags.Provider == AKS {
@@ -303,7 +308,6 @@ func (options *InstallOptions) Run() error {
 	}
 
 	// lets default the helm domain
-	exposeController := options.CreateEnvOptions.HelmValuesConfig.ExposeController
 	if exposeController != nil {
 		ecConfig := &exposeController.Config
 		if ecConfig.Domain == "" && options.Flags.Domain != "" {


### PR DESCRIPTION
lets switch to NLB by default for AWS and EKS so we get stable IP addresses
    for the load balancer so we can use `$IP.nip.io` as the domain name so we
    don't have to use wildcard DNS to kick the tyres