### PR TITLE
fix: prow installation should support gcp configurations

### DIFF
--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -1199,7 +1199,7 @@ func (o *CommonOptions) GetClusterUserName() (string, error) {
 	username, _ := o.getCommandOutput("", "gcloud", "config", "get-value", "core/account")
 
 	if username != "" {
-		return username, nil
+		return GetSafeUsername(username), nil
 	}
 
 	config, _, err := kube.LoadConfig()
@@ -1220,6 +1220,13 @@ func (o *CommonOptions) GetClusterUserName() (string, error) {
 	username = context.AuthInfo
 
 	return username, nil
+}
+
+func GetSafeUsername(username string) string {
+	if strings.Contains(username, "Your active configuration is") {
+		return strings.Split(username, "\n")[1]
+	}
+	return username
 }
 
 func (o *CommonOptions) installProw() error {

--- a/pkg/jx/cmd/install_test.go
+++ b/pkg/jx/cmd/install_test.go
@@ -22,6 +22,16 @@ func TestInstall(t *testing.T) {
 }
 
 func TestGenerateProwSecret(t *testing.T) {
-
 	fmt.Println(util.RandStringBytesMaskImprSrc(41))
 }
+
+func TestGetSafeUsername(t *testing.T) {
+	username := `Your active configuration is: [cloudshell-16392]
+tutorial@bamboo-depth-206411.iam.gserviceaccount.com`
+	assert.Equal(t, GetSafeUsername(username) , "tutorial@bamboo-depth-206411.iam.gserviceaccount.com")
+
+	username = `tutorial@bamboo-depth-206411.iam.gserviceaccount.com`
+	assert.Equal(t, GetSafeUsername(username) , "tutorial@bamboo-depth-206411.iam.gserviceaccount.com")
+}
+
+


### PR DESCRIPTION
Cloudshell uses GCP configurations when activating a user account.  This
leads to an extra line of text stating which configuration is active when 
trying to access 'core/account'.  This currently breaks the prow installation