### PR TITLE
Register domain in AWS when using the 'domain' option

### DIFF
--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -699,7 +699,11 @@ func (o *CommonOptions) GetDomain(client kubernetes.Interface, domain string, pr
 	}
 	defaultDomain := address
 
-	if domain == "" && (provider == AWS || provider == EKS) {
+	if provider == AWS || provider == EKS {
+		if domain != "" {
+			err := amazon.RegisterAwsCustomDomain(domain, address)
+			return domain, err
+		}
 		log.Infof("\nOn AWS we recommend using a custom DNS name to access services in your kubernetes cluster to ensure you can use all of your availability zones\n")
 		log.Infof("If you do not have a custom DNS name you can use yet you can register a new one here: %s\n\n", util.ColorInfo("https://console.aws.amazon.com/route53/home?#DomainRegistration:"))
 


### PR DESCRIPTION
We were seeing different behavior when using the `--domain` option in `jx create cluster eks` vs not using it and manually entering it when prompted.  With the option, the domain is not registered with a CNAME whereas when using the prompt, the domain does get a CNAME.

Assuming that the behavior should be the same regardless of where the domain comes from.