### PR TITLE
Add --git-private flag to make private repositories

### DIFF
--- a/pkg/gits/git_repo.go
+++ b/pkg/gits/git_repo.go
@@ -24,6 +24,7 @@ type GitRepositoryOptions struct {
 	Username  string
 	ApiToken  string
 	Owner     string
+	Private   bool
 }
 
 // GetRepository returns the repository if it already exists
@@ -181,13 +182,12 @@ func PickNewOrExistingGitRepository(out io.Writer, batchMode bool, authConfigSvc
 	}
 	fullName := git.RepoName(owner, repoName)
 	fmt.Fprintf(out, "\n\nCreating repository %s\n", util.ColorInfo(fullName))
-	privateRepo := false
 
 	return &CreateRepoData{
 		Organisation: owner,
 		RepoName:     repoName,
 		FullName:     fullName,
-		PrivateRepo:  privateRepo,
+		PrivateRepo:  repoOptions.Private,
 		User:         userAuth,
 		GitProvider:  provider,
 	}, err

--- a/pkg/jx/cmd/common_git.go
+++ b/pkg/jx/cmd/common_git.go
@@ -232,6 +232,7 @@ func addGitRepoOptionsArguments(cmd *cobra.Command, repositoryOptions *gits.GitR
 	cmd.Flags().StringVarP(&repositoryOptions.ServerURL, "git-provider-url", "", "", "The git server URL to create new git repositories inside")
 	cmd.Flags().StringVarP(&repositoryOptions.Username, "git-username", "", "", "The git username to use for creating new git repositories")
 	cmd.Flags().StringVarP(&repositoryOptions.ApiToken, "git-api-token", "", "", "The git API token to use for creating new git repositories")
+	cmd.Flags().BoolVarP(&repositoryOptions.Private, "git-private", "", false, "Create new git repositories as private")
 }
 
 func (o *CommonOptions) GitServerKind(gitInfo *gits.GitRepositoryInfo) (string, error) {

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -652,6 +652,7 @@ func (options *InstallOptions) Run() error {
 			}
 			options.CreateEnvOptions.Prow = options.Flags.Prow
 			options.CreateEnvOptions.GitRepositoryOptions.ServerURL = options.GitRepositoryOptions.ServerURL
+			options.CreateEnvOptions.GitRepositoryOptions.Private = options.GitRepositoryOptions.Private
 
 			err = options.CreateEnvOptions.Run()
 			if err != nil {


### PR DESCRIPTION
This allows for the creation of private git repositories.

I tested creating private repositories with Bitbucket Cloud via `jx create cluster eks`.  I realize there are several other commands that also get this flag and other git providers, but I haven't tested those individually.

I was a little surprised by the change I had to make in `pkg/jx/cmd/install.go`, unsure if other options need to be mapped over?  Like Username or ApiToken?