### PR TITLE
Customizing service jxing-nginx-ingress-controller

### DIFF
--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -493,7 +493,7 @@ func (o *InitOptions) initIngress() error {
 		}
 
 		values := []string{"rbac.create=true" /*,"rbac.serviceAccountName="+ingressServiceAccount*/}
-		valuesFiles := []string{}
+		valuesFiles := []string{"./myvalues.yaml"}
 		if o.Flags.Provider == AWS || o.Flags.Provider == EKS {
 			// we can only enable one port for NLBs right now
 			enableHttp := "false"


### PR DESCRIPTION
Allow values to be overriden in myvalues.yaml when creating service jxing-nginx-ingress-controller