### PR TITLE
fix: install command with gitlab provider

### DIFF
--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -169,6 +169,8 @@ func SaasGitKind(gitServiceUrl string) string {
 		return KindGitHub
 	case "https://github.com":
 		return KindGitHub
+	case "https://gitlab.com":
+		return KindGitlab
 	case "http://bitbucket.org":
 		return KindBitBucketCloud
 	case BitbucketCloudURL:

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -951,7 +951,8 @@ func (o *InstallOptions) getGitUser(message string) (*auth.UserAuth, error) {
 	var server *auth.AuthServer
 	gitProvider := o.GitRepositoryOptions.ServerURL
 	if gitProvider != "" {
-		server = config.GetOrCreateServer(gitProvider)
+		kind := gits.SaasGitKind(gitProvider)
+		server = config.GetOrCreateServerName(gitProvider, "", kind)
 	} else {
 		server, err = config.PickServer("Which git provider?", o.BatchMode)
 		if err != nil {


### PR DESCRIPTION
This fixes the: `jx install --git-provider-url=https://gitlab.com` command
