### PR TITLE
fix for error during cluster creation on AWS:

### DIFF
--- a/pkg/jx/cmd/create_cluster_aws.go
+++ b/pkg/jx/cmd/create_cluster_aws.go
@@ -287,7 +287,7 @@ func (o *CreateClusterAWSOptions) Run() error {
 func (o *CreateClusterAWSOptions) waitForClusterJson(clusterName string) (string, error) {
 	jsonOutput := ""
 	f := func() error {
-		text, err := o.getCommandOutput("", "kops", "get", "cluster", clusterName, "-ojson")
+		text, err := o.getCommandOutput("", "kops", "get", "cluster", "--name", clusterName, "-o", "json")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
when executing the command "jx create cluster aws" the following error occurs and the process hangs: 

retrying after error: Command failed 'kops get cluster CLUSTER_NAME -ojson': cannot mix --name for cluster with positional arguments exit status 1

Full command:
jx create cluster aws \
--zones=eu-west-1a,eu-west-1b,eu-west-1c \
--node-size=m4.xlarge \
--master-size=t2.medium \
--cluster-name=${KOPS_CLUSTER_NAME} \
--state=${KOPS_STATE_STORE} \
--default-admin-password=MY_PASSWORD \
--default-environment-prefix=MY_PREFIX \
--docker-registry=MY_ECR_URL \
--git-private=true \
--domain=MY_DOMAIN \
--namespace=MY_NAMESPACE \
--environment-git-owner=MY_GIT_OWNER

Versions:
KOPS version: 1.10.0
KUBECLT version: 1.11.0
JX version: v1.3.188 jx-linux-amd64

kops accepts the following command: 'kops get cluster --name CLUSTER_NAME -o json'

This PR fixes the issue.