### PR TITLE
Revert "fix:(init) refactor out handling of myvalues.yaml to separate…

### DIFF
--- a/pkg/helm/helm_helpers.go
+++ b/pkg/helm/helm_helpers.go
@@ -5,12 +5,9 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"sort"
-	"os"
 
 	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/util"
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/pkg/errors"
 	"k8s.io/helm/pkg/chartutil"
 )
 
@@ -202,38 +199,4 @@ func LoadChartNameAndVersion(chartFile string) (string, string, error) {
 		return "", "", err
 	}
 	return chart.Name, chart.Version, nil
-}
-
-
-func AppendMyValues(valueFiles []string) error {
-	// Overwrite the values with the content of myvalues.yaml files from the current folder if exists, otherwise
-	// from ~/.jx folder also only if it's present
-	curDir, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "failed to get the current working directory")
-	}
-	myValuesFile := filepath.Join(curDir, "myvalues.yaml")
-	exists, err := util.FileExists(myValuesFile)
-	if err != nil {
-		return errors.Wrap(err, "failed to check if the myvaules.yaml file exists in the current directory")
-	}
-	if exists {
-		valueFiles = append(valueFiles, myValuesFile)
-		log.Infof("Using local value overrides file %s\n", util.ColorInfo(myValuesFile))
-	} else {
-		configDir, err := util.ConfigDir()
-		if err != nil {
-			return err
-		}
-		myValuesFile = filepath.Join(configDir, "myvalues.yaml")
-		exists, err = util.FileExists(myValuesFile)
-		if err != nil {
-			return errors.Wrap(err, "failed to check if the myvaules.yaml file exists in the .jx directory")
-		}
-		if exists {
-			valueFiles = append(valueFiles, myValuesFile)
-			log.Infof("Using local value overrides file %s\n", util.ColorInfo(myValuesFile))
-		}
-	}
-	return nil
 }

--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
-	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -495,10 +494,6 @@ func (o *InitOptions) initIngress() error {
 
 		values := []string{"rbac.create=true" /*,"rbac.serviceAccountName="+ingressServiceAccount*/}
 		valuesFiles := []string{}
-		err = helm.AppendMyValues(valuesFiles)
-		if err != nil {
-			return err
-		}
 		if o.Flags.Provider == AWS || o.Flags.Provider == EKS {
 			// we can only enable one port for NLBs right now
 			enableHttp := "false"

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -21,7 +21,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
-	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
@@ -490,12 +489,34 @@ func (options *InstallOptions) Run() error {
 		return errors.Wrap(err, "failed to update the helm repo")
 	}
 
-	valueFiles := []string{"./secrets.yaml", secretsFileName, adminSecretsFileName, configFileName}
+	valueFiles := []string{"./myvalues.yaml", "./secrets.yaml", secretsFileName, adminSecretsFileName, configFileName}
 
-	err = helm.AppendMyValues(valueFiles)
+	// Overwrite the values with the content of myvaules.yaml files from the current folder if exists, otherwise
+	// from ~/.jx folder also only if is present
+	curDir, err := os.Getwd()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get the current working directory")
 	}
+	myValuesFile := filepath.Join(curDir, "myvalues.yaml")
+	exists, err := util.FileExists(myValuesFile)
+	if err != nil {
+		return errors.Wrap(err, "failed to check if the myvaules.yaml file exists in the current directory")
+	}
+	if exists {
+		valueFiles = append(valueFiles, myValuesFile)
+		log.Infof("Using local value overrides file %s\n", util.ColorInfo(myValuesFile))
+	} else {
+		myValuesFile = filepath.Join(dir, "myvalues.yaml")
+		exists, err = util.FileExists(myValuesFile)
+		if err != nil {
+			return errors.Wrap(err, "failed to check if the myvaules.yaml file exists in the .jx directory")
+		}
+		if exists {
+			valueFiles = append(valueFiles, myValuesFile)
+			log.Infof("Using local value overrides file %s\n", util.ColorInfo(myValuesFile))
+		}
+	}
+
 	options.currentNamespace = ns
 	if options.Flags.Prow {
 		// install prow into the new env


### PR DESCRIPTION
… function and use in both init and install"

This reverts commit b09c61b451d31b1436dce91d58fd105da6088573.

Reverted due to regression in import of myvalues. Please resubmit with
unit tests