### PR TITLE
CLI upgrade should show final binary path

### DIFF
--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -810,6 +810,7 @@ func (o *CommonOptions) installJx(upgrade bool, version string) error {
 	if err != nil {
 		return err
 	}
+	log.Infof("Jenkins X client has been installed into %s\n", util.ColorInfo(binDir + "/jx"))
 	err = os.Remove(tarFile)
 	if err != nil {
 		return err


### PR DESCRIPTION
Right now `jx upgrade cli` displays the following output:

```jx upgrade cli
Downloading https://github.com/jenkins-x/jx/releases/download/v1.3.191/jx-linux-amd64.tar.gz to /home/hekonsek/.jx/bin/jx.tgz...
Downloaded /home/hekonsek/.jx/bin/jx.tgz
```

What is kinda confusing for end user as it looks like jx client tar has been downloaded by not extracted and that I'm supposed to do it by myself as manual step.

So I've added extra line of message to stress that `jx upgrade cli` command does extract and install jx and no other action is needed:

```jx upgrade cli
Downloading https://github.com/jenkins-x/jx/releases/download/v1.3.191/jx-linux-amd64.tar.gz to /home/hekonsek/.jx/bin/jx.tgz...
Downloaded /home/hekonsek/.jx/bin/jx.tgz
Jenkins X client has been installed into /home/hekonsek/.jx/bin/jx
```