### PR TITLE
All Git options should be copied for 'jx install'

### DIFF
--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -651,8 +651,7 @@ func (options *InstallOptions) Run() error {
 				options.CreateEnvOptions.BatchMode = options.BatchMode
 			}
 			options.CreateEnvOptions.Prow = options.Flags.Prow
-			options.CreateEnvOptions.GitRepositoryOptions.ServerURL = options.GitRepositoryOptions.ServerURL
-			options.CreateEnvOptions.GitRepositoryOptions.Private = options.GitRepositoryOptions.Private
+			options.CreateEnvOptions.GitRepositoryOptions = options.GitRepositoryOptions
 
 			err = options.CreateEnvOptions.Run()
 			if err != nil {


### PR DESCRIPTION
Hi,

Right now jx doesn't copy username and token Git options when creating new environment. That causes `jx install --provider=eks --git-api-token=mySecret --git-username=hekonsek --git-provider-url=https://bitbucket.org` command to fail.

We should simply copy whole `GitRepositoryOptions` struct to avoid this issue.