### PR TITLE
Correct kind for jira secret

### DIFF
--- a/pkg/jx/cmd/create_tracker_token.go
+++ b/pkg/jx/cmd/create_tracker_token.go
@@ -156,7 +156,7 @@ func (o *CreateTrackerTokenOptions) updateIssueTrackerCredentialsSecret(server *
 	labels := map[string]string{
 		kube.LabelCredentialsType: kube.ValueCredentialTypeUsernamePassword,
 		kube.LabelCreatedBy:       kube.ValueCreatedByJX,
-		kube.LabelKind:            kube.ValueKindChat,
+		kube.LabelKind:            kube.ValueKindIssue,
 		kube.LabelServiceKind:     server.Kind,
 	}
 	annotations := map[string]string{


### PR DESCRIPTION
This seems to have been an search and replace error

The effect of the fix is that the secret for jira is found when creating changelog.