### PR TITLE
Openshift registry support

### DIFF
--- a/pkg/config/helm_values.go
+++ b/pkg/config/helm_values.go
@@ -50,10 +50,15 @@ type JenkinsGithubServersValuesConfig struct {
 	Url  string `yaml:"Url,omitempty"`
 }
 
+type JenkinsPipelineSecretsValuesConfig struct {
+	DockerConfig string `yaml:"DockerConfig,flow,omitempty"`
+}
+
 type HelmValuesConfig struct {
-	ExposeController *ExposeController   `yaml:"expose,omitempty"`
-	Jenkins          JenkinsValuesConfig `yaml:"jenkins,omitempty"`
-	Prow             ProwValuesConfig    `yaml:"prow,omitempty"`
+	ExposeController *ExposeController                  `yaml:"expose,omitempty"`
+	Jenkins          JenkinsValuesConfig                `yaml:"jenkins,omitempty"`
+	Prow             ProwValuesConfig                   `yaml:"prow,omitempty"`
+	PipelineSecrets  JenkinsPipelineSecretsValuesConfig `yaml:"PipelineSecrets,omitempty"`
 }
 
 type HelmValuesConfigService struct {

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -729,7 +729,7 @@ func (o *InstallOptions) enableOpenShiftRegistryPermissions(ns string, helmConfi
 	if err != nil {
 		return err
 	}
-	helmConfig.PipelineSecrets.DockerConfig = `{"auths": {"` + dockerRegistry + `": {"auth": "` + base64.StdEncoding.EncodeToString([]byte(registryToken)) + `"}}}`
+	helmConfig.PipelineSecrets.DockerConfig = `{"auths": {"` + dockerRegistry + `": {"auth": "` + base64.StdEncoding.EncodeToString([]byte("serviceaccount:"+registryToken)) + `"}}}`
 	return nil
 }
 


### PR DESCRIPTION
The following PR adds support pushing and pulling images from the Openshift registry.

- Registry defaulted to docker-registry.default.svc:5000 for Openshift and Minishift providers
- New serviceaccount is created called jenkins-x-registry
- registry-admin permissions added to the jenkins-x-registry service account
- Docker secret is auto populated using the token from the jenkins-x-registry serviceaccount
- Any authenticated user is granted permissions to pull images from jenkins-x namespace to simplify image pulling for preview namespaces