### PR TITLE
fix: allow for downloading quickstarts from other git providers

### DIFF
--- a/pkg/gits/bitbucket_cloud.go
+++ b/pkg/gits/bitbucket_cloud.go
@@ -830,6 +830,10 @@ func (b *BitbucketCloudProvider) ServerURL() string {
 	return b.Server.URL
 }
 
+func (b *BitbucketCloudProvider) BranchArchiveURL(org string, name string, branch string) string {
+	return util.UrlJoin(b.ServerURL(), org, name, "get", branch+".zip")
+}
+
 func (p *BitbucketCloudProvider) CurrentUsername() string {
 	return p.Username
 }

--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -780,6 +780,10 @@ func (b *BitbucketServerProvider) ServerURL() string {
 	return b.Server.URL
 }
 
+func (b *BitbucketServerProvider) BranchArchiveURL(org string, name string, branch string) string {
+	return util.UrlJoin(b.ServerURL(), "rest/api/1.0/projects", org, "repos", name, "archive?format=zip&at="+branch)
+}
+
 func (b *BitbucketServerProvider) CurrentUsername() string {
 	return b.Username
 }
@@ -810,7 +814,7 @@ func (b *BitbucketServerProvider) UpdateRelease(owner string, repo string, tag s
 	return nil
 }
 
-func (p *BitbucketServerProvider) ListReleases(org string, name string) ([]*GitRelease, error) {
+func (b *BitbucketServerProvider) ListReleases(org string, name string) ([]*GitRelease, error) {
 	answer := []*GitRelease{}
 	log.Warn("Bitbucket Server doesn't support releases")
 	return answer, nil

--- a/pkg/gits/gerrit.go
+++ b/pkg/gits/gerrit.go
@@ -158,6 +158,10 @@ func (p *GerritProvider) ServerURL() string {
 	return ""
 }
 
+func (p *GerritProvider) BranchArchiveURL(org string, name string, branch string) string {
+	return ""
+}
+
 func (p *GerritProvider) CurrentUsername() string {
 	return ""
 }

--- a/pkg/gits/gitea.go
+++ b/pkg/gits/gitea.go
@@ -630,6 +630,10 @@ func (p *GiteaProvider) ServerURL() string {
 	return p.Server.URL
 }
 
+func (p *GiteaProvider) BranchArchiveURL(org string, name string, branch string) string {
+	return util.UrlJoin(p.ServerURL(), org, name, "archive", branch+".zip")
+}
+
 func (p *GiteaProvider) UserAuth() auth.UserAuth {
 	return p.User
 }

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -867,6 +867,10 @@ func (p *GitHubProvider) ServerURL() string {
 	return p.Server.URL
 }
 
+func (p *GitHubProvider) BranchArchiveURL(org string, name string, branch string) string {
+	return util.UrlJoin(p.ServerURL(), org, name, "archive", branch+".zip")
+}
+
 func (p *GitHubProvider) CurrentUsername() string {
 	return p.Username
 }

--- a/pkg/gits/gitlab.go
+++ b/pkg/gits/gitlab.go
@@ -565,6 +565,10 @@ func (p *GitlabProvider) ServerURL() string {
 	return p.Server.URL
 }
 
+func (p *GitlabProvider) BranchArchiveURL(org string, name string, branch string) string {
+	return util.UrlJoin(p.ServerURL(), org, name, "-/archive", branch, name+"-"+branch+".zip")
+}
+
 func (p *GitlabProvider) CurrentUsername() string {
 	return p.Username
 }

--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -108,6 +108,9 @@ type GitProvider interface {
 	// ServerURL returns the git server URL
 	ServerURL() string
 
+	// BranchArchiveURL returns a URL to the ZIP archive for the git branch
+	BranchArchiveURL(org string, name string, branch string) string
+
 	// Returns the current username
 	CurrentUsername() string
 

--- a/pkg/gits/provider_fake.go
+++ b/pkg/gits/provider_fake.go
@@ -538,6 +538,10 @@ func (f *FakeProvider) ServerURL() string {
 	return f.Server.URL
 }
 
+func (f *FakeProvider) BranchArchiveURL(org string, name string, branch string) string {
+	return util.UrlJoin(f.ServerURL(), org, name, "archive", branch+".zip")
+}
+
 func (f *FakeProvider) CurrentUsername() string {
 	return f.User.Username
 }

--- a/pkg/quickstarts/model.go
+++ b/pkg/quickstarts/model.go
@@ -16,7 +16,7 @@ const (
 
 // GitQuickstart returns a github based quickstart
 func GitQuickstart(provider gits.GitProvider, owner string, repo string, language string, framework string, tags ...string) *Quickstart {
-	u := util.UrlJoin(provider.ServerURL(), owner, repo+"/archive/master.zip")
+	u := provider.BranchArchiveURL(owner, repo, "master")
 	return &Quickstart{
 		ID:             owner + "/" + repo,
 		Owner:          owner,


### PR DESCRIPTION
Looking for feedback on implementation.  I went with an interface because not all git providers may have a way to download (though I don't have an example of one right now).  The interface allows for checking if the download can even happen before querying for repositories.

An alternative implementation would be to add a method to the `GitProvider` interface and the default implementation would be to return an empty string and log a warning.  Elsewhere when the quickstart is created, it does check for a non-empty download URL, so it would error out there.

Tested all three of these providers: GitHub, Bitbucket Cloud and Bitbucket Server.