### PR TITLE
Added --skip-installation option to 'create cluster' command

### DIFF
--- a/pkg/jx/cmd/create_cluster.go
+++ b/pkg/jx/cmd/create_cluster.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/log"
 	"io"
 	"sort"
 	"strings"
@@ -15,9 +16,10 @@ type KubernetesProvider string
 // CreateClusterOptions the flags for running create cluster
 type CreateClusterOptions struct {
 	CreateOptions
-	InstallOptions InstallOptions
-	Flags          InitFlags
-	Provider       string
+	InstallOptions   InstallOptions
+	Flags            InitFlags
+	Provider         string
+	SkipInstallation bool
 }
 
 const (
@@ -147,6 +149,10 @@ func createCreateClusterOptions(f Factory, out io.Writer, errOut io.Writer, clou
 }
 
 func (o *CreateClusterOptions) initAndInstall(provider string) error {
+	if o.SkipInstallation {
+		log.Infof("%s cluster created. Skipping Jenkins X installation.\n", o.Provider)
+		return nil
+	}
 	// call jx init
 	o.InstallOptions.BatchMode = o.BatchMode
 	o.InstallOptions.Flags.Provider = provider
@@ -167,4 +173,5 @@ func (o *CreateClusterOptions) Run() error {
 
 func (o *CreateClusterOptions) addCreateClusterFlags(cmd *cobra.Command) {
 	o.InstallOptions.addInstallFlags(cmd, true)
+	cmd.Flags().BoolVarP(&o.SkipInstallation, "skip-installation", "", false, "Provision cluster only, don't install Jenkins X into it")
 }


### PR DESCRIPTION
Hi,

I'd like our devOps team to use Jenkins X to provision Kubernetes cluster on EKS, but I'd like to do it in a dedicated step, without installing actual Jenkins X platform into it. I'd like to achieve something like:

```
jx create cluster eks
jx install --provider=eks
```

I'd like to use such approach, because it is easier to re-provision Jenkins X if needed with Ansible playbooks if we have dedicated playbook for cluster provisioning and Jenkins X installation. 

Would you consider adding `--skip-installation` flag to `create cluster` command? That would solve our issue:

```
jx create cluster eks --skip-installation
jx install --provider=eks
```

Thanks!