### PR TITLE
fix: disable the new workflow engine unless specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ release: check
 	updatebot push-version --kind docker JX_VERSION $(VERSION)
 	updatebot push-regex -r "\s*release = \"(.*)\"" -v $(VERSION) config.toml
 	updatebot push-regex -r "JX_VERSION=(.*)" -v $(VERSION) install-jx.sh
+	updatebot push-version --kind helm jx $(VERSION)
 	updatebot update-loop
 
 	echo "Updating the JX CLI reference docs"

--- a/charts/jx/templates/deployment.yaml
+++ b/charts/jx/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
 {{- if .Values.restartPolicy }}
       restartPolicy: {{ .Values.restartPolicy }}
 {{- end }}
+{{- if .Values.serviceaccount.enabled }}
+      serviceAccountName: {{ template "jx.fullname" . }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{ if .Values.command -}}

--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -214,7 +214,7 @@ func (o *CommonOptions) JXClientAndDevNamespace() (versioned.Interface, string, 
 
 func (o *CommonOptions) JenkinsClient() (*gojenkins.Jenkins, error) {
 	if o.jenkinsClient == nil {
-		kubeClient, ns, err := o.KubeClient()
+		kubeClient, ns, err := o.KubeClientAndDevNamespace()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/jx/cmd/controller_workflow.go
+++ b/pkg/jx/cmd/controller_workflow.go
@@ -262,9 +262,6 @@ func (o *ControllerWorkflowOptions) onActivity(pipeline *v1.PipelineActivity, jx
 
 	activities := jxClient.JenkinsV1().PipelineActivities(ns)
 
-	if workflowName == "" {
-		workflowName = "default"
-	}
 	if repoName == "" || version == "" || build == "" || pipelineName == "" {
 		if o.Verbose {
 			log.Infof("Ignoring missing data for pipeline: %s repo: %s version: %s status: %s\n", pipeline.Name, repoName, version, string(pipeline.Spec.WorkflowStatus))
@@ -272,6 +269,12 @@ func (o *ControllerWorkflowOptions) onActivity(pipeline *v1.PipelineActivity, jx
 		o.removePipelineActivity(pipeline, activities)
 		return
 	}
+
+	if workflowName == "" {
+		o.removePipelineActivity(pipeline, activities)
+		return
+	}
+
 	if !pipeline.Spec.WorkflowStatus.IsTerminated() {
 		flow := o.workflowMap[workflowName]
 		if flow == nil && workflowName == "default" {
@@ -285,7 +288,6 @@ func (o *ControllerWorkflowOptions) onActivity(pipeline *v1.PipelineActivity, jx
 		}
 
 		if flow == nil {
-			log.Warnf("Cannot process pipeline %s due to workflow name %s not existing\n", pipeline.Name, workflowName)
 			o.removePipelineActivity(pipeline, activities)
 			return
 		}

--- a/pkg/jx/cmd/controller_workflow_integration_test.go
+++ b/pkg/jx/cmd/controller_workflow_integration_test.go
@@ -167,7 +167,7 @@ func TestWorkflowManualPromote(t *testing.T) {
 	production := kube.NewPermanentEnvironmentWithGit("production", "https://github.com/"+testOrgName+"/"+prodRepoName+".git")
 	production.Spec.PromotionStrategy = v1.PromotionStrategyTypeManual
 
-	workflowName := ""
+	workflowName := "default"
 
 	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
 		[]runtime.Object{},

--- a/pkg/jx/cmd/promote.go
+++ b/pkg/jx/cmd/promote.go
@@ -925,7 +925,7 @@ func (o *CommonOptions) getPipelineName(gitInfo *gits.GitRepositoryInfo, pipelin
 		p, b, err := o.getLatestPipelineBuild(pipeline)
 		if err != nil {
 			log.Warnf("Failed to try detect the current Jenkins pipeline for %s due to %s\n", pipeline, err)
-			pipeline = ""
+			build = "1"
 		} else {
 			pipeline = p
 			build = b

--- a/pkg/jx/cmd/promote.go
+++ b/pkg/jx/cmd/promote.go
@@ -399,6 +399,9 @@ func (o *PromoteOptions) Promote(targetNS string, env *v1.Environment, warnIfAut
 					return nil
 				}
 				err = promoteKey.OnPromotePullRequest(o.Activities, startPromotePR)
+				if err != nil {
+					log.Warnf("Failed to update PipelineActivity: %s\n", err)
+				}
 				// lets sleep a little before we try poll for the PR status
 				time.Sleep(waitAfterPullRequestCreated)
 			}


### PR DESCRIPTION
lets use the workflowName on the PipelineActivity to trigger the new
    promotion engine

    we can then make `jx promote` decide to use the new model by setting this
    value or keep things as they are for now while also reusing the workflow
    controller to keep PipelineActivity updated as folks do manual promotions