### PR TITLE
`jx upgrade cli` should remove current binary before overwriting it

### DIFF
--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -806,6 +806,7 @@ func (o *CommonOptions) installJx(upgrade bool, version string) error {
 	if err != nil {
 		return err
 	}
+	os.Remove(binDir + "/jx")
 	err = util.UnTargz(tarFile, binDir, []string{binary, fileName})
 	if err != nil {
 		return err


### PR DESCRIPTION
James, I've found another workaround for https://github.com/jenkins-x/jx/pull/1598 . In this documentation http://wiki.wlug.org.nz/ETXTBSY  it is mentioned that:

```
Note, that although you cannot overwrite the file, you can remove it
$ rm example
And then replace it
$ cp /bin/kill ./example
```

So you cannot override or rename running file, but you can remove it and then replace. So actually the right solution would be to add an attempt to remove jx exec before unpacking tarball into it.

Yay! I'm closing https://github.com/jenkins-x/jx/pull/1598 then on behalf of this PR.

CC @rawlingsj 