### PR TITLE
`jx upgrade cli` should provide verbose mode

### DIFF
--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -807,7 +807,10 @@ func (o *CommonOptions) installJx(upgrade bool, version string) error {
 	if err != nil {
 		return err
 	}
-	os.Remove(binDir + "/jx")
+	err = os.Remove(binDir + "/jx")
+	if err != nil && o.Verbose {
+		log.Infof("Skipping removal of old jx binary: %s\n", err)
+	}
 	err = util.UnTargz(tarFile, binDir, []string{binary, fileName})
 	if err != nil {
 		return err

--- a/pkg/jx/cmd/upgrade_cli.go
+++ b/pkg/jx/cmd/upgrade_cli.go
@@ -55,6 +55,7 @@ func NewCmdUpgradeCLI(f Factory, out io.Writer, errOut io.Writer) *cobra.Command
 		},
 	}
 	cmd.Flags().StringVarP(&options.Version, "version", "v", "", "The specific version to upgrade to")
+	cmd.Flags().BoolVarP(&options.Verbose, "verbose", "", false, "Enable verbose logging")
 	return cmd
 }
 


### PR DESCRIPTION
We should add verbose flag to `jx upgrade cli` for people interest in more detailed logging during upgrade process.