### PR TITLE
JXBinaryLocation() function should attempt to lookup for result in env variable

### DIFF
--- a/pkg/util/dirs.go
+++ b/pkg/util/dirs.go
@@ -112,6 +112,10 @@ func JXBinLocation() (string, error) {
 
 // JXBinaryLocation Returns the path to the currently installed JX binary.
 func JXBinaryLocation(commandInterface CommandInterface) (string, error) {
+	jxBinaryFromEnv, found := os.LookupEnv("JX_BINARY")
+	if found {
+		return strings.TrimSuffix(jxBinaryFromEnv, "/jx"), nil
+	}
 	commandInterface.SetName("which")
 	commandInterface.SetArgs([]string{"jx"})
 	out, err := commandInterface.RunWithoutRetry()

--- a/pkg/util/dirs_test.go
+++ b/pkg/util/dirs_test.go
@@ -2,6 +2,7 @@ package util_test
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/jenkins-x/jx/pkg/util"
@@ -28,4 +29,20 @@ func TestJXBinaryLocationFailure(t *testing.T) {
 	res, err := util.JXBinaryLocation(commandInterface)
 	assert.Equal(t, "", res)
 	assert.Error(t, err, "Should error")
+}
+
+func TestJXBinaryLocationFromEnv(t *testing.T) {
+	os.Setenv("JX_BINARY", "/usr/bin")
+	defer os.Unsetenv("JX_BINARY")
+	res, err := util.JXBinaryLocation(&util.Command{})
+	assert.Nil(t, err)
+	assert.Equal(t, "/usr/bin", res)
+}
+
+func TestJXBinaryLocationFromEnvWithPrefix(t *testing.T) {
+	os.Setenv("JX_BINARY", "/usr/bin/jx")
+	defer os.Unsetenv("JX_BINARY")
+	res, err := util.JXBinaryLocation(&util.Command{})
+	assert.Nil(t, err)
+	assert.Equal(t, "/usr/bin", res)
 }


### PR DESCRIPTION
Right now `jx` binary location lookup is practically limited to `which jx` invocation. This is fine for most cases, however I'd like to be able specify `jx` location via env variable. This feature would be primarily useful when user didn't add jx to classpath but still would like to upgrade binary for example. It will also make testing easier, as right now unit testing `CommonOptions#installJx()` is impossible without affecting your existing installation.