### PR TITLE
Ensure owner flag is respected by install

### DIFF
--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -704,17 +704,15 @@ func (options *InstallOptions) Run() error {
 			}
 
 			log.Info("Creating default staging and production environments\n")
+			// Common CreateEnv Options
+			options.CreateEnvOptions.GitRepositoryOptions = options.GitRepositoryOptions
+			options.CreateEnvOptions.GitRepositoryOptions.Owner = options.Flags.EnvironmentGitOwner
+			options.CreateEnvOptions.Prefix = options.Flags.DefaultEnvironmentPrefix
+			options.CreateEnvOptions.Prow = options.Flags.Prow
+
 			options.CreateEnvOptions.Options.Name = "staging"
 			options.CreateEnvOptions.Options.Spec.Label = "Staging"
 			options.CreateEnvOptions.Options.Spec.Order = 100
-			options.CreateEnvOptions.GitRepositoryOptions.Owner = options.Flags.EnvironmentGitOwner
-			options.CreateEnvOptions.Prefix = options.Flags.DefaultEnvironmentPrefix
-			if options.BatchMode {
-				options.CreateEnvOptions.BatchMode = options.BatchMode
-			}
-			options.CreateEnvOptions.Prow = options.Flags.Prow
-			options.CreateEnvOptions.GitRepositoryOptions = options.GitRepositoryOptions
-
 			err = options.CreateEnvOptions.Run()
 			if err != nil {
 				return errors.Wrap(err, "failed to create staging environment")
@@ -724,10 +722,6 @@ func (options *InstallOptions) Run() error {
 			options.CreateEnvOptions.Options.Spec.Order = 200
 			options.CreateEnvOptions.Options.Spec.PromotionStrategy = v1.PromotionStrategyTypeManual
 			options.CreateEnvOptions.PromotionStrategy = string(v1.PromotionStrategyTypeManual)
-			options.CreateEnvOptions.GitRepositoryOptions.Owner = options.Flags.EnvironmentGitOwner
-			if options.BatchMode {
-				options.CreateEnvOptions.BatchMode = options.BatchMode
-			}
 
 			err = options.CreateEnvOptions.Run()
 			if err != nil {


### PR DESCRIPTION
Currently, given the order of setting the `CreateEnvOptions` configs, the Owner option is overwritten and therefore not respecting the `environment-git-owner` flag.

This is explained more in #1601 