### PR TITLE
fix: ignore error when detecting if prow is enabled

### DIFF
--- a/pkg/jx/cmd/gc_activities.go
+++ b/pkg/jx/cmd/gc_activities.go
@@ -60,6 +60,7 @@ func NewCmdGCActivities(f Factory, out io.Writer, errOut io.Writer) *cobra.Comma
 		},
 	}
 	cmd.Flags().IntVarP(&options.RevisionHistoryLimit, "revision-history-limit", "l", 5, "Minimum number of Activities per application to keep")
+	options.addCommonFlags(cmd)
 	return cmd
 }
 
@@ -97,10 +98,7 @@ func (o *GCActivitiesOptions) Run() error {
 		return nil
 	}
 
-	prowEnabled, err := kube.IsProwEnabled(kubeClient, currentNs)
-	if err != nil {
-		return err
-	}
+	prowEnabled, _ := kube.IsProwEnabled(kubeClient, currentNs)
 
 	var jobNames []string
 	if !prowEnabled {


### PR DESCRIPTION
The error returned ends up being 'error: deployments.apps "prow-build" not found' which is expected when prow is not enabled.