### PR TITLE
Add an environment flag to "jx rsh"

### DIFF
--- a/pkg/jx/cmd/rsh.go
+++ b/pkg/jx/cmd/rsh.go
@@ -26,13 +26,14 @@ const (
 type RshOptions struct {
 	CommonOptions
 
-	Container  string
-	Namespace  string
-	Pod        string
-	Executable string
-	ExecCmd    string
-	DevPod     bool
-	Username   string
+	Container   string
+	Namespace   string
+	Pod         string
+	Executable  string
+	ExecCmd     string
+	DevPod      bool
+	Username    string
+	Environment string
 
 	stopCh chan struct{}
 }
@@ -86,6 +87,7 @@ func NewCmdRsh(f Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.DevPod, "devpod", "d", false, "Connect to a DevPod")
 	cmd.Flags().StringVarP(&options.ExecCmd, "execute", "e", defaultRshCommand, "Execute this command on the remote container")
 	cmd.Flags().StringVarP(&options.Username, "username", "", "", "The username to create the DevPod. If not specified defaults to the current operating system user or $USER'")
+	cmd.Flags().StringVarP(&options.Environment, "environment", "", "", "The environment in which to look for the Deployment. Defaults to the current environment")
 
 	return cmd
 }
@@ -101,6 +103,13 @@ func (o *RshOptions) Run() error {
 	ns := o.Namespace
 	if ns == "" {
 		ns = curNs
+	}
+
+	if o.Environment != "" {
+		ns, err = o.findEnvironmentNamespace(o.Environment)
+		if err != nil {
+			return err
+		}
 	}
 
 	if o.ExecCmd == "" {


### PR DESCRIPTION
Fixes https://github.com/jenkins-x/jx/issues/1575

Adds an optional "environment" flag to the `jx rsh` command so that users can select deployments by environment, if they wish.

For an example of it in use, see below. I created a test environment called "tester" and from there,
exec'd into two pods in different environments (one in "johncollier", the other in "dev").
```
Johns-MacBook-Pro-3:jx johncollier$ jx env tester
Using environment 'tester' in team 'jx' on server 'https://9.37.135.251:8001'.
Johns-MacBook-Pro-3:jx johncollier$ jx rsh --environment johncollier
? Pick Pod: microprofile-microprofilex-5bf9b5b6f5-t6lzb
root@microprofile-microprofilex-5bf9b5b6f5-t6lzb:/# exit
exit
Johns-MacBook-Pro-3:jx johncollier$ jx rsh --environment dev
? Pick Pod: jenkins-598db5b8b7-4k9pn
root@jenkins-598db5b8b7-4k9pn:/# exit
exit
```

Additionally, if an invalid environment is selected, the following is shown:
```
Johns-MacBook-Pro-3:jx johncollier$ jx rsh --environment asdfs
error: Invalid option: --env asdfs
Possible values: dev, johncollier, production, root, staging, tester
```

I left the shorthand flag for it blank as -e was already taken for the --execute flag. I assume this is
fine since the username flag has no shorthand either.