### PR TITLE
fix: gc-activities needs permission to get deployments to detect prow

### DIFF
--- a/charts/jx/values.yaml
+++ b/charts/jx/values.yaml
@@ -84,6 +84,12 @@ clusterrole:
     - get
     - delete
     - list
+  - apiGroups:
+    - ""
+    resources:
+    - deployments
+    verbs:
+    - get
 
 activeDeadlineSeconds: 300
 backoffLimit: 5


### PR DESCRIPTION
Hopefully fixes https://github.com/jenkins-x/jx/issues/1705

**WARNING: this change is just a guess, I do not know how to test/verify it!**

`jx gc activities` now calls `kubectl get deployments` here:

https://github.com/jenkins-x/jx/blob/8d7538980cb4887bc9866152732fafd7a62a5830/pkg/kube/namespaces.go#L100

This currently fails due to permissions, example:
```
❯ kubectl logs --tail=100 jenkins-x-gc-activities-1537207200-zwb8m -n jxmt
error: deployments.apps "prow-build" is forbidden: User "system:serviceaccount:jxmt:jenkins-x-gc-activities" cannot get deployments.apps in the namespace "jxmt"
```