### PR TITLE
Added AWS region resolving logic

### DIFF
--- a/pkg/jx/cmd/delete_aws.go
+++ b/pkg/jx/cmd/delete_aws.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -48,7 +49,17 @@ func NewCmdDeleteAws(f Factory, in terminal.FileReader, out terminal.FileWriter,
 func (o *DeleteAwsOptions) Run() error {
 	vpcid := o.VpcId
 
-	svc := ec2.New(session.New(&aws.Config{Region: aws.String(o.Region)}))
+	region := o.Region
+	if region == "" {
+		region := os.Getenv("AWS_REGION")
+		if region == "" {
+			region = os.Getenv("AWS_DEFAULT_REGION")
+			if region == "" {
+				region = "us-west-2"
+			}
+		}
+	}
+	svc := ec2.New(session.New(&aws.Config{Region: aws.String(region)}))
 
 	// Delete elastic load balancers assigned to VPC
 	elbSvc := elbv2.New(session.New(&aws.Config{Region: aws.String(o.Region)}))


### PR DESCRIPTION
Added AWS region resolving logic to `jx delete aws command`, so user don't have to always specify it via command line flag.