### PR TITLE
standardize casing for Environment

### DIFF
--- a/pkg/jx/cmd/delete_env.go
+++ b/pkg/jx/cmd/delete_env.go
@@ -46,7 +46,7 @@ func NewCmdDeleteEnv(f Factory, in terminal.FileReader, out terminal.FileWriter,
 
 	cmd := &cobra.Command{
 		Use:     "environment",
-		Short:   "Deletes one or more environments",
+		Short:   "Deletes one or more Environments",
 		Aliases: []string{"env"},
 		Long:    delete_env_long,
 		Example: delete_env_example,

--- a/pkg/jx/cmd/promote.go
+++ b/pkg/jx/cmd/promote.go
@@ -130,7 +130,7 @@ func NewCmdPromote(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 	}
 	cmd := &cobra.Command{
 		Use:     "promote [application]",
-		Short:   "Promotes a version of an application to an environment",
+		Short:   "Promotes a version of an application to an Environment",
 		Long:    promote_long,
 		Example: promote_example,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
all other references for Environment for delete help has upper case