### PR TITLE
Correct email value in create docker auth command

### DIFF
--- a/pkg/jx/cmd/create_docker_auth.go
+++ b/pkg/jx/cmd/create_docker_auth.go
@@ -104,7 +104,7 @@ func (o *CreateDockerAuthOptions) Run() error {
 		prompt := &survey.Input{
 			Message: "Please provide email ID for the host: " + o.Host + "  and user: " + o.User,
 		}
-		survey.AskOne(prompt, &secret, nil, surveyOpts)
+		survey.AskOne(prompt, &email, nil, surveyOpts)
 	}
 	kubeClient, currentNs, err := o.KubeClient()
 	if err != nil {


### PR DESCRIPTION
Not setting the e-mail directly when running `jx create docker auth` will not set it in config.json. Not sure it has any impact (I did not see one)