### PR TITLE
Extracted AWS region resolving logic

### DIFF
--- a/pkg/cloud/amazon/common.go
+++ b/pkg/cloud/amazon/common.go
@@ -1,0 +1,16 @@
+package amazon
+
+import "os"
+
+const DefaultRegion = "us-west-2"
+
+func ResolveRegion() string {
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+		if region == "" {
+			region = DefaultRegion
+		}
+	}
+	return region
+}

--- a/pkg/cloud/amazon/common_test.go
+++ b/pkg/cloud/amazon/common_test.go
@@ -1,0 +1,28 @@
+package amazon_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/cloud/amazon"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolvingDefaultRegion(t *testing.T) {
+	os.Setenv("AWS_REGION", "")
+	os.Setenv("AWS_DEFAULT_REGION", "")
+	region := amazon.ResolveRegion()
+	assert.Equal(t, amazon.DefaultRegion, region)
+}
+
+func TestResolvingRegionFromAwsRegionEnv(t *testing.T) {
+	os.Setenv("AWS_REGION", "us-east-1")
+	region := amazon.ResolveRegion()
+	assert.Equal(t, "us-east-1", region)
+}
+
+func TestResolvingRegionFromAwsDefaultRegionEnv(t *testing.T) {
+	os.Setenv("DEFAULT_AWS_REGION", "us-east-1")
+	region := amazon.ResolveRegion()
+	assert.Equal(t, "us-east-1", region)
+}

--- a/pkg/cloud/amazon/ecr.go
+++ b/pkg/cloud/amazon/ecr.go
@@ -2,7 +2,6 @@ package amazon
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -35,17 +34,11 @@ func GetAccountIDAndRegion() (string, string, error) {
 }
 
 func NewAwsSession() (*session.Session, string, error) {
-	region := os.Getenv("AWS_REGION")
-	if region == "" {
-		region = os.Getenv("AWS_DEFAULT_REGION")
-		if region == "" {
-			region = "us-west-2"
-		}
+	config := aws.Config{
+		Region: aws.String(ResolveRegion()),
 	}
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(region)},
-	)
-	return sess, region, err
+	sess, err := session.NewSession(&config)
+	return sess, *config.Region, err
 }
 
 // GetContainerRegistryHost

--- a/pkg/jx/cmd/delete_aws.go
+++ b/pkg/jx/cmd/delete_aws.go
@@ -2,13 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-	"os"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/jenkins-x/jx/pkg/cloud/amazon"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
+	"io"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/spf13/cobra"
@@ -51,13 +50,7 @@ func (o *DeleteAwsOptions) Run() error {
 
 	region := o.Region
 	if region == "" {
-		region := os.Getenv("AWS_REGION")
-		if region == "" {
-			region = os.Getenv("AWS_DEFAULT_REGION")
-			if region == "" {
-				region = "us-west-2"
-			}
-		}
+		region = amazon.ResolveRegion()
 	}
 	svc := ec2.New(session.New(&aws.Config{Region: aws.String(region)}))
 


### PR DESCRIPTION
Right now we have AWS region resolving logic duplicated in two places. It should be centralized in a single location. Also it will make it easier to add aws profiles support to it, if it is centralized.