### PR TITLE
fix: service-linker chart names

### DIFF
--- a/charts/service-linker/Makefile
+++ b/charts/service-linker/Makefile
@@ -1,6 +1,6 @@
 OS := $(shell uname)
 
-gc-previews:
+service-linker:
 	helm init --client-only
 	helm repo add chartmuseum http://jenkins-x-chartmuseum:8080
 	helm repo add chartmuseum https://chartmuseum.build.cd.jenkins-x.io

--- a/charts/service-linker/values.yaml
+++ b/charts/service-linker/values.yaml
@@ -1,4 +1,4 @@
-gc-activities:
+service-linker:
   serviceaccount:
     enabled: true
   cronjob:


### PR DESCRIPTION
See https://github.com/jenkins-x/jx/pull/1735#issuecomment-423260358 and https://github.com/jenkins-x/jx/pull/1735#issuecomment-423766524

Not sure how to test this change and only making it because @rawlingsj thought it was a good idea.

Cheers!