### PR TITLE
feat(diagnose): Add a `jx diagnose` command to help with debugging.

### DIFF
--- a/pkg/jx/cmd/cmd.go
+++ b/pkg/jx/cmd/cmd.go
@@ -162,6 +162,7 @@ func NewJXCommand(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 	cmds.Version = version.GetVersion()
 	cmds.SetVersionTemplate("{{printf .Version}}\n")
 	cmds.AddCommand(NewCmdOptions(out))
+	cmds.AddCommand(NewCmdDiagnose(f, in, out, err))
 
 	return cmds
 }

--- a/pkg/jx/cmd/diagnose.go
+++ b/pkg/jx/cmd/diagnose.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"io"
+
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+type DiagnoseOptions struct {
+	CommonOptions
+	Namespace string
+}
+
+func NewCmdDiagnose(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+	options := &DiagnoseOptions{
+		CommonOptions: CommonOptions{
+			Factory: f,
+			In:      in,
+			Out:     out,
+			Err:     errOut,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "diagnose",
+		Short: "Print diagnostic information about the Jenkins-X installation",
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			CheckErr(err)
+		},
+	}
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The namespace to display the kube resources from. If left out, defaults to the current namespace")
+	options.addCommonFlags(cmd)
+	return cmd
+}
+
+func (o *DiagnoseOptions) Run() error {
+	// Get the namespace to run the diagnostics in, and output it
+	ns := o.Namespace
+	if ns == "" {
+		config, _, err := kube.LoadConfig()
+		if err != nil {
+			return err
+		}
+		ns = kube.CurrentNamespace(config)
+	}
+	log.Infof("Running in namespace: %s", util.ColorInfo(ns))
+
+	err := printStatus(o, "Jenkins-X Version", "jx", "version", "--no-version-check")
+	if err != nil {
+		return err
+	}
+
+	err = printStatus(o, "Jenkins-X Status", "jx", "status")
+	if err != nil {
+		return err
+	}
+
+	err = printStatus(o, "Kubernetes PVCs", "kubectl", "get", "pvc", "--namespace", ns)
+	if err != nil {
+		return err
+	}
+
+	err = printStatus(o, "Kubernetes Pods", "kubectl", "get", "po", "--namespace", ns)
+	if err != nil {
+		return err
+	}
+
+	err = printStatus(o, "Kubernetes Ingresses", "kubectl", "get", "ingress", "--namespace", ns)
+	if err != nil {
+		return err
+	}
+
+	err = printStatus(o, "Kubernetes Secrets", "kubectl", "get", "secrets", "--namespace", ns)
+	if err != nil {
+		return err
+	}
+	log.Info("\nPlease visit https://jenkins-x.io/faq/issues/ for any known issues.")
+	log.Info("\nFinished printing diagnostic information.\n")
+	return nil
+}
+
+// Run the specified command (jx status, kubectl get po, etc) and print its output
+func printStatus(o *DiagnoseOptions, header string, command string, options ...string) error {
+	output, err := o.getCommandOutput("", command, options...)
+	if err != nil {
+		log.Errorf("Unable to get the %s", header)
+		return err
+	}
+	// Print the output of the command, and add a little header at the top for formatting / readability
+	log.Infof("\n%s:\n %s\n", header, util.ColorInfo(output))
+	return nil
+}


### PR DESCRIPTION
Fixes https://github.com/jenkins-x/jx/issues/1258

Implements a `jx diagnose` command that users can run when they run into issues. The users can then look at the output (or paste it on a github issue) when they're debugging.

As discussed in the issue, it's a fairly simple command currently, it just outputs the following:
```
Kube namespace
jx version
jx status
kubectl get pvc
kubectl get po
kubectl get ingress
kubcetl get secrets
```
It includes a link to the Jenkins-X known issues page, telling users to check there for any issues they may be hitting. I also added support for a `--namespace` flag, allowing users to get Kube resources from alternate namespaces.

The command can be updated in the future as needed, to add more / less output and to make it "smarter" if needed. For the time being though, this should suffice.

For some sample output:
```
johns-mbp-3:jx johncollier$ jx diagnose
Running in namespace: jx
Jenkins-X Version:
 Using helmBinary helm, with noTiller false
NAME               VERSION
jx                 1.3.310-dev+1816e6bb
jenkins x platform 0.0.2454
kubernetes cluster v1.11.1+icp-ee
kubectl            v1.9.4
helm client        v2.10.0+g9ad53aa
helm server        v2.10.0+g9ad53aa
git                git version 2.17.1 (Apple Git-112)

Jenkins-X Status:
 Jenkins X checks passed for Cluster(mycluster): 6 nodes, memory 30% of 64949304Ki, cpu 39% of 28. Jenkins is running at http://jenkins.jx.9.42.2.216.nip.io

Kubernetes PVCs:
 NAME                        STATUS    VOLUME         CAPACITY   ACCESS MODES   STORAGECLASS   AGE
jenkins                     Bound     jxpv3          30Gi       RWO                           6d
jenkins-x-docker-registry   Bound     jxpv1          100Gi      RWO                           6d
jenkins-x-mongodb           Bound     jxpv2          8Gi        RWO                           6d
jenkins-x-nexus             Bound     jenkinsslave   8Gi        RWO                           6d

Kubernetes Pods:
 NAME                                             READY     STATUS    RESTARTS   AGE
jenkins-598db5b8b7-4k9pn                         1/1       Running   2          6d
jenkins-x-chartmuseum-55c9598b56-bgzbv           1/1       Running   2          6d
jenkins-x-controller-workflow-64d4d69466-g8k8d   1/1       Running   1          6d
jenkins-x-docker-registry-7b56b4f555-nwr8q       1/1       Running   2          6d
jenkins-x-heapster-65fd697bb-xggh5               2/2       Running   4          6d
jenkins-x-mongodb-6bfd5d9c79-7hwt4               1/1       Running   3          6d
jenkins-x-monocular-api-5c85d647d5-bblkh         1/1       Running   4          6d
jenkins-x-monocular-prerender-5848c74fdc-cwl6z   1/1       Running   2          6d
jenkins-x-monocular-ui-7fb574b54d-9x2rg          1/1       Running   2          6d
jenkins-x-nexus-8655db64f7-7p8s8                 1/1       Running   1          6d
pipelinecontroller-6b5b8d9f47-bdnsb              1/1       Running   1          6d
tester-maven                                     2/2       Running   0          5d

Kubernetes Ingresses:
 NAME                      HOSTS                                                                             ADDRESS      PORTS     AGE
chartmuseum               chartmuseum.jx.9.42.2.216.nip.io                                                  9.42.2.216   80        6d
docker-registry           docker-registry.jx.9.42.2.216.nip.io                                              9.42.2.216   80        6d
jenkins                   jenkins.jx.9.42.2.216.nip.io                                                      9.42.2.216   80        6d
johncollier-go            johncollier-go.jx.9.42.2.216.nip.io,johncollier-go.jx.9.42.2.216.nip.io           9.42.2.216   80        5d
johncollier-maven         johncollier-maven.jx.9.42.2.216.nip.io,johncollier-maven.jx.9.42.2.216.nip.io     9.42.2.216   80        5d
johncollier-maven-theia   johncollier-maven-theia.jx.9.42.2.216.nip.io                                      9.42.2.216   80        5d
johncollier-maven2        johncollier-maven2.jx.9.42.2.216.nip.io,johncollier-maven2.jx.9.42.2.216.nip.io   9.42.2.216   80        5d
monocular                 monocular.jx.9.42.2.216.nip.io                                                    9.42.2.216   80        6d
nexus                     nexus.jx.9.42.2.216.nip.io                                                        9.42.2.216   80        6d
root-go                   root-go.jx.9.42.2.216.nip.io,root-go.jx.9.42.2.216.nip.io                         9.42.2.216   80        5d
root-go-theia             root-go-theia.jx.9.42.2.216.nip.io                                                9.42.2.216   80        5d
root-maven                root-maven.jx.9.42.2.216.nip.io,root-maven.jx.9.42.2.216.nip.io                   9.42.2.216   80        5d
root-maven-theia          root-maven-theia.jx.9.42.2.216.nip.io                                             9.42.2.216   80        5d
root-maven2               root-maven2.jx.9.42.2.216.nip.io,root-maven2.jx.9.42.2.216.nip.io                 9.42.2.216   80        5d
tester-maven              tester-maven.jx.9.42.2.216.nip.io,tester-maven.jx.9.42.2.216.nip.io               9.42.2.216   80        5d
tester-maven-theia        tester-maven-theia.jx.9.42.2.216.nip.io                                           9.42.2.216   80        5d

Kubernetes Secrets:
 NAME                                        TYPE                                  DATA      AGE
artifactory                                 kubernetes.io/dockerconfigjson        1         5d
cleanup-token-t4dqx                         kubernetes.io/service-account-token   3         6d
default-token-nblpv                         kubernetes.io/service-account-token   3         6d
expose-token-plz4s                          kubernetes.io/service-account-token   3         6d
jenkins                                     Opaque                                3         6d
jenkins-docker-cfg                          Opaque                                1         6d
jenkins-git-credentials                     Opaque                                1         6d
jenkins-git-ssh                             Opaque                                2         6d
jenkins-hub-api-token                       Opaque                                1         6d
jenkins-maven-settings                      Opaque                                1         6d
jenkins-npm-token                           Opaque                                1         6d
jenkins-release-gpg                         Opaque                                4         6d
jenkins-ssh-config                          Opaque                                1         6d
jenkins-token-vs6qc                         kubernetes.io/service-account-token   3         6d
jenkins-x-chartmuseum                       Opaque                                2         6d
jenkins-x-controller-workflow-token-tkrkj   kubernetes.io/service-account-token   3         6d
jenkins-x-docker-registry-secret            Opaque                                1         6d
jenkins-x-gc-activities-token-4fshq         kubernetes.io/service-account-token   3         6d
jenkins-x-gc-previews-token-n286g           kubernetes.io/service-account-token   3         6d
jenkins-x-mongodb                           Opaque                                1         6d
jx-basic-auth                               Opaque                                1         6d
jx-install-config                           Opaque                                3         6d
jx-pipeline-git-github-github               Opaque                                2         5d
microclimate-registry-secret                kubernetes.io/dockerconfigjson        1         5d
nexus                                       Opaque                                1         6d
pipelinecontroller-token-jr88c              kubernetes.io/service-account-token   3         6d
sa-jx                                       kubernetes.io/dockerconfigjson        1         5d

Please visit https://jenkins-x.io/faq/issues/ for any known issues.
Finished printing diagnostic information.
```

