### PR TITLE
Migrated installChart() calls to installChartOptions()

### DIFF
--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -703,7 +703,14 @@ func (o *CommonOptions) runExposecontroller(devNamespace, targetNamespace string
 	}
 
 	helmRelease := "expose-" + strings.ToLower(randomdata.SillyName())
-	err := o.installChart(helmRelease, exposecontrollerChart, exposecontrollerVersion, targetNamespace, true, exValues)
+	err := o.installChartOptions(InstallChartOptions{
+		ReleaseName: helmRelease,
+		Chart: exposecontrollerChart,
+		Version: exposecontrollerVersion,
+		Ns: targetNamespace,
+		HelmUpdate: true,
+		SetValues: exValues,
+	})
 	if err != nil {
 		return fmt.Errorf("exposecontroller deployment failed: %v", err)
 	}

--- a/pkg/jx/cmd/common_cert_manager.go
+++ b/pkg/jx/cmd/common_cert_manager.go
@@ -17,7 +17,14 @@ func (o *CommonOptions) ensureCertmanager() error {
 		if ok {
 
 			values := []string{"rbac.create=true", "ingressShim.extraArgs='{--default-issuer-name=letsencrypt-staging,--default-issuer-kind=Issuer}'"}
-			err = o.installChart("cert-manager", "stable/cert-manager", "", CertManagerNamespace, true, values)
+			err = o.installChartOptions(InstallChartOptions{
+				ReleaseName: "cert-manager",
+				Chart: "stable/cert-manager",
+				Version: "",
+				Ns: CertManagerNamespace,
+				HelmUpdate: true,
+				SetValues: values,
+			})
 			if err != nil {
 				return fmt.Errorf("CertManager deployment failed: %v", err)
 			}

--- a/pkg/jx/cmd/create_devpod.go
+++ b/pkg/jx/cmd/create_devpod.go
@@ -769,7 +769,14 @@ func (o *CreateDevPodOptions) getOrCreateEditEnvironment() (*v1.Environment, err
 	if !flag || err != nil {
 		log.Infof("Installing the ExposecontrollerService in the namespace: %s\n", util.ColorInfo(editNs))
 		releaseName := editNs + "-es"
-		err = o.installChart(releaseName, kube.ChartExposecontrollerService, "", editNs, true, nil)
+		err = o.installChartOptions(InstallChartOptions{
+			ReleaseName: releaseName,
+			Chart: kube.ChartExposecontrollerService,
+			Version: "",
+			Ns: editNs,
+			HelmUpdate: true,
+			SetValues: nil,
+		})
 	}
 	return env, err
 }


### PR DESCRIPTION
Migrated a couple of `installChart()` calls to `installChartOptions()` function introduced in #1741. We should prefer using `installChartOptions()` as it doesn't require refactoring when we add new arguments to the function definition.

This is the same PR as #1772 but created from dedicated branch.