### PR TITLE
Fixes to adding pipeline user as collaborator

### DIFF
--- a/pkg/gits/bitbucket_cloud.go
+++ b/pkg/gits/bitbucket_cloud.go
@@ -904,7 +904,7 @@ func (p *BitbucketCloudProvider) ListReleases(org string, name string) ([]*GitRe
 	return answer, nil
 }
 
-func (b *BitbucketCloudProvider) AddCollaborator(user string, repo string) error {
+func (b *BitbucketCloudProvider) AddCollaborator(user string, organisation string, repo string) error {
 	log.Infof("Automatically adding the pipeline user as a collaborator is currently not implemented for bitbucket. Please add user: %v as a collaborator to this project.\n", user)
 	return nil
 }

--- a/pkg/gits/bitbucket_cloud_test.go
+++ b/pkg/gits/bitbucket_cloud_test.go
@@ -411,7 +411,7 @@ func (suite *BitbucketCloudProviderTestSuite) TestUserInfo() {
 }
 
 func (suite *BitbucketCloudProviderTestSuite) TestAddCollaborator() {
-	err := suite.provider.AddCollaborator("derek", "repo")
+	err := suite.provider.AddCollaborator("derek", orgName, "repo")
 	suite.Require().Nil(err)
 }
 

--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -821,7 +821,7 @@ func (b *BitbucketServerProvider) ListReleases(org string, name string) ([]*GitR
 	return answer, nil
 }
 
-func (b *BitbucketServerProvider) AddCollaborator(user string, repo string) error {
+func (b *BitbucketServerProvider) AddCollaborator(user string, organisation string, repo string) error {
 	log.Infof("Automatically adding the pipeline user as a collaborator is currently not implemented for bitbucket. Please add user: %v as a collaborator to this project.\n", user)
 	return nil
 }

--- a/pkg/gits/bitbucket_server_test.go
+++ b/pkg/gits/bitbucket_server_test.go
@@ -304,7 +304,7 @@ func (suite *BitbucketServerProviderTestSuite) TestUserInfo() {
 }
 
 func (suite *BitbucketServerProviderTestSuite) TestAddCollaborator() {
-	err := suite.provider.AddCollaborator("derek", "repo")
+	err := suite.provider.AddCollaborator("derek", orgname, "repo")
 	suite.Require().Nil(err)
 }
 

--- a/pkg/gits/gerrit.go
+++ b/pkg/gits/gerrit.go
@@ -176,7 +176,7 @@ func (p *GerritProvider) UserInfo(username string) *GitUser {
 	return nil
 }
 
-func (p *GerritProvider) AddCollaborator(user string, repo string) error {
+func (p *GerritProvider) AddCollaborator(user string, organisation string, repo string) error {
 	log.Infof("Automatically adding the pipeline user as a collaborator is currently not implemented for gerrit. Please add user: %v as a collaborator to this project.\n", user)
 	return nil
 }

--- a/pkg/gits/gitea.go
+++ b/pkg/gits/gitea.go
@@ -660,7 +660,7 @@ func (p *GiteaProvider) UserInfo(username string) *GitUser {
 	}
 }
 
-func (p *GiteaProvider) AddCollaborator(user string, repo string) error {
+func (p *GiteaProvider) AddCollaborator(user string, organisation string, repo string) error {
 	log.Infof("Automatically adding the pipeline user as a collaborator is currently not implemented for gitea. Please add user: %v as a collaborator to this project.\n", user)
 	return nil
 }

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -895,9 +895,9 @@ func (p *GitHubProvider) UserInfo(username string) *GitUser {
 	}
 }
 
-func (p *GitHubProvider) AddCollaborator(user string, repo string) error {
+func (p *GitHubProvider) AddCollaborator(user string, organisation string, repo string) error {
 	log.Infof("Automatically adding the pipeline user: %v as a collaborator.\n", user)
-	_, err := p.Client.Repositories.AddCollaborator(p.Context, p.Username, repo, user, &github.RepositoryAddCollaboratorOptions{})
+	_, err := p.Client.Repositories.AddCollaborator(p.Context, organisation, repo, user, &github.RepositoryAddCollaboratorOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/gits/gitlab.go
+++ b/pkg/gits/gitlab.go
@@ -605,7 +605,7 @@ func (p *GitlabProvider) IssueURL(org string, name string, number int, isPull bo
 	return ""
 }
 
-func (p *GitlabProvider) AddCollaborator(user string, repo string) error {
+func (p *GitlabProvider) AddCollaborator(user string, organisation string, repo string) error {
 	log.Infof("Automatically adding the pipeline user as a collaborator is currently not implemented for gitlab. Please add user: %v as a collaborator to this project.\n", user)
 	return nil
 }

--- a/pkg/gits/gitlab_test.go
+++ b/pkg/gits/gitlab_test.go
@@ -155,7 +155,7 @@ func (suite *GitlabProviderSuite) TestGetRepository() {
 }
 
 func (suite *GitlabProviderSuite) TestAddCollaborator() {
-	err := suite.provider.AddCollaborator("derek", "repo")
+	err := suite.provider.AddCollaborator("derek", orgName, "repo")
 	suite.Require().Nil(err)
 }
 

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -122,7 +122,7 @@ type GitProvider interface {
 	// Returns user info, if possible
 	UserInfo(username string) *GitUser
 
-	AddCollaborator(string, string) error
+	AddCollaborator(string, string, string) error
 	// TODO Refactor to remove bespoke types when we implement another provider
 	ListInvitations() ([]*github.RepositoryInvitation, *github.Response, error)
 	// TODO Refactor to remove bespoke types when we implement another provider

--- a/pkg/gits/mocks/git_provider.go
+++ b/pkg/gits/mocks/git_provider.go
@@ -39,11 +39,11 @@ func (mock *MockGitProvider) AcceptInvitation(_param0 int64) (*github.Response, 
 	return ret0, ret1
 }
 
-func (mock *MockGitProvider) AddCollaborator(_param0 string, _param1 string) error {
+func (mock *MockGitProvider) AddCollaborator(_param0 string, _param1 string, _param2 string) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitProvider().")
 	}
-	params := []pegomock.Param{_param0, _param1}
+	params := []pegomock.Param{_param0, _param1, _param2}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("AddCollaborator", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
@@ -771,8 +771,8 @@ func (c *GitProvider_AcceptInvitation_OngoingVerification) GetAllCapturedArgumen
 	return
 }
 
-func (verifier *VerifierGitProvider) AddCollaborator(_param0 string, _param1 string) *GitProvider_AddCollaborator_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1}
+func (verifier *VerifierGitProvider) AddCollaborator(_param0 string, _param1 string, _param2 string) *GitProvider_AddCollaborator_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "AddCollaborator", params)
 	return &GitProvider_AddCollaborator_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -782,12 +782,12 @@ type GitProvider_AddCollaborator_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *GitProvider_AddCollaborator_OngoingVerification) GetCapturedArguments() (string, string) {
-	_param0, _param1 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+func (c *GitProvider_AddCollaborator_OngoingVerification) GetCapturedArguments() (string, string, string) {
+	_param0, _param1, _param2 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1]
 }
 
-func (c *GitProvider_AddCollaborator_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
+func (c *GitProvider_AddCollaborator_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(params[0]))
@@ -797,6 +797,10 @@ func (c *GitProvider_AddCollaborator_OngoingVerification) GetAllCapturedArgument
 		_param1 = make([]string, len(params[1]))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
+		}
+		_param2 = make([]string, len(params[2]))
+		for u, param := range params[2] {
+			_param2[u] = param.(string)
 		}
 	}
 	return

--- a/pkg/gits/provider_fake.go
+++ b/pkg/gits/provider_fake.go
@@ -560,7 +560,7 @@ func (f *FakeProvider) UserInfo(username string) *GitUser {
 	return nil
 }
 
-func (f *FakeProvider) AddCollaborator(user string, repo string) error {
+func (f *FakeProvider) AddCollaborator(user string, organisation string, repo string) error {
 	log.Infof("Automatically adding the pipeline user as a collaborator is currently not implemented for git fake. Please add user: %v as a collaborator to this project.\n", user)
 	return nil
 }

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -744,42 +744,49 @@ func (options *ImportOptions) CreateNewRemoteRepository() error {
 	config := authConfigSvc.Config()
 	if config.PipeLineUsername != options.GitUserAuth.Username && config.CurrentServer == config.PipeLineServer {
 		// Make the invitation
-		err := options.GitProvider.AddCollaborator(config.PipeLineUsername, details.RepoName)
+		err := options.GitProvider.AddCollaborator(config.PipeLineUsername, details.Organisation, details.RepoName)
 		if err != nil {
 			return err
 		}
 
+		// If repo is put in an organisation that the pipeline user is not part of an invitation needs to be accepted.
 		// Create a new provider for the pipeline user
 		pipelineUserAuth := config.FindUserAuth(config.CurrentServer, config.PipeLineUsername)
-		pipelineServerAuth := config.GetServer(config.CurrentServer)
-		pipelineUserProvider, err := gits.CreateProvider(pipelineServerAuth, pipelineUserAuth, options.Git())
-		if err != nil {
-			return err
-		}
-
-		// Get all invitations for the pipeline user
-		// Wrapped in retry to not immediately fail the quickstart creation if APIs are flaky.
-		f := func() error {
-			invites, _, err := pipelineUserProvider.ListInvitations()
+		if pipelineUserAuth == nil {
+			log.Warnf("Pipeline git user credentials not found. %s will need to accept the invitation to collaborate\n"+
+				"on %s if %s is not part of %s.\n\n",
+				config.PipeLineUsername, details.RepoName, config.PipeLineUsername, details.Organisation)
+		} else {
+			pipelineServerAuth := config.GetServer(config.CurrentServer)
+			pipelineUserProvider, err := gits.CreateProvider(pipelineServerAuth, pipelineUserAuth, options.Git())
 			if err != nil {
 				return err
 			}
-			for _, x := range invites {
-				// Accept all invitations for the pipeline user
-				_, err = pipelineUserProvider.AcceptInvitation(*x.ID)
+
+			// Get all invitations for the pipeline user
+			// Wrapped in retry to not immediately fail the quickstart creation if APIs are flaky.
+			f := func() error {
+				invites, _, err := pipelineUserProvider.ListInvitations()
 				if err != nil {
 					return err
 				}
+				for _, x := range invites {
+					// Accept all invitations for the pipeline user
+					_, err = pipelineUserProvider.AcceptInvitation(*x.ID)
+					if err != nil {
+						return err
+					}
+				}
+				return nil
 			}
-			return nil
-		}
-		exponentialBackOff := backoff.NewExponentialBackOff()
-		timeout := 20 * time.Second
-		exponentialBackOff.MaxElapsedTime = timeout
-		exponentialBackOff.Reset()
-		err = backoff.Retry(f, exponentialBackOff)
-		if err != nil {
-			return err
+			exponentialBackOff := backoff.NewExponentialBackOff()
+			timeout := 20 * time.Second
+			exponentialBackOff.MaxElapsedTime = timeout
+			exponentialBackOff.Reset()
+			err = backoff.Retry(f, exponentialBackOff)
+			if err != nil {
+				return err
+			}
 		}
 
 	}


### PR DESCRIPTION
Add pipeline user as collaborator in organisation so it works if it's different from user. Previously 404 was returned by github.

Skip accepting invitation as pipeline user if credentials are missing. Previously we got "panic: runtime error: invalid memory address or nil pointer dereference"
If pipeline user is part of organisation the acceptance step isn't needed anyway.