### PR TITLE
External Jenkins URL

### DIFF
--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -45,20 +45,21 @@ const (
 
 // CommonOptions contains common options and helper methods
 type CommonOptions struct {
-	Factory              Factory
-	In                   terminal.FileReader
-	Out                  terminal.FileWriter
-	Err                  io.Writer
-	Cmd                  *cobra.Command
-	Args                 []string
-	BatchMode            bool
-	Verbose              bool
-	Headless             bool
-	NoBrew               bool
-	InstallDependencies  bool
-	SkipAuthSecretsMerge bool
-	ServiceAccount       string
-	Username             string
+	Factory                Factory
+	In                     terminal.FileReader
+	Out                    terminal.FileWriter
+	Err                    io.Writer
+	Cmd                    *cobra.Command
+	Args                   []string
+	BatchMode              bool
+	Verbose                bool
+	Headless               bool
+	NoBrew                 bool
+	InstallDependencies    bool
+	SkipAuthSecretsMerge   bool
+	ServiceAccount         string
+	Username               string
+	ExternalJenkinsBaseURL string
 
 	// common cached clients
 	KubeClientCached    kubernetes.Interface

--- a/pkg/jx/cmd/common_import.go
+++ b/pkg/jx/cmd/common_import.go
@@ -193,7 +193,11 @@ func (o *CommonOptions) ImportProject(gitURL string, dir string, jenkinsfile str
 
 	// register the webhook
 	suffix := gitProvider.JenkinsWebHookPath(gitURL, "")
-	webhookUrl := util.UrlJoin(jenk.BaseURL(), suffix)
+	jenkBaseURL := o.ExternalJenkinsBaseURL
+	if jenkBaseURL == "" {
+		jenkBaseURL = jenk.BaseURL()
+	}
+	webhookUrl := util.UrlJoin(jenkBaseURL, suffix)
 	webhook := &gits.GitWebHookArguments{
 		Owner: gitInfo.Organisation,
 		Repo:  gitInfo,

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -191,6 +191,7 @@ func (options *ImportOptions) addImportFlags(cmd *cobra.Command, createProject b
 	cmd.Flags().StringVarP(&options.DraftPack, "pack", "", "", "The name of the pack to use")
 	cmd.Flags().StringVarP(&options.DefaultOwner, "default-owner", "", "someone", "The default user/organisation used if no user is found for the current Git repository being imported")
 	cmd.Flags().StringVarP(&options.DockerRegistryOrg, "docker-registry-org", "", "", "The name of the docker registry organisation to use. If not specified then the Git provider organisation will be used")
+	cmd.Flags().StringVarP(&options.ExternalJenkinsBaseURL, "external-jenkins-url", "", "", "The jenkins url that an external git provider needs to use")
 
 	options.addCommonFlags(cmd)
 	addGitRepoOptionsArguments(cmd, &options.GitRepositoryOptions)


### PR DESCRIPTION
Support separate external url for git web hooks.
Typically needed when having a private kubernetes cluster on an internal domain.