### PR TITLE
Upgraded eksctl version

### DIFF
--- a/pkg/binaries/binaries.go
+++ b/pkg/binaries/binaries.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 )
 
+const EksctlVersion = "0.1.3"
+
 func BinaryWithExtension(binary string) string {
 	if runtime.GOOS == "windows" {
 		return binary + ".exe"

--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -34,8 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const eksctlVersion = "0.1.1"
-
 var (
 	groovy = `
 // imports
@@ -1244,7 +1242,7 @@ func (o *CommonOptions) installAws() error {
 }
 
 func (o *CommonOptions) installEksCtl(skipPathScan bool) error {
-	return o.installEksCtlWithVersion(eksctlVersion, skipPathScan)
+	return o.installEksCtlWithVersion(binaries.EksctlVersion, skipPathScan)
 }
 
 func (o *CommonOptions) installEksCtlWithVersion(version string, skipPathScan bool) error {


### PR DESCRIPTION
Upgraded eksctl version to 1.1.3. You can upgrade eksctl version managed by jx by executing `jx upgrade binaries`.

@jstrachan This is so cool to start having binaries version under control finally. I can now go to out devOps team and tell them to execute `jx upgrade binaries` as soon as this PR is merged. This is exactly what we needed. I will proceed with migrated other binaries to be controlled via this mechanism.