### PR TITLE
`upgrade platform` should use platform version from cloud-env

### DIFF
--- a/pkg/jx/cmd/upgrade_platform.go
+++ b/pkg/jx/cmd/upgrade_platform.go
@@ -115,5 +115,5 @@ func (o *UpgradePlatformOptions) Run() error {
 	if o.Set != "" {
 		values = append(values, o.Set)
 	}
-	return o.Helm().UpgradeChart(o.Chart, o.ReleaseName, ns, nil, false, nil, false, false, values, valueFiles)
+	return o.Helm().UpgradeChart(o.Chart, o.ReleaseName, ns, &version, false, nil, false, false, values, valueFiles)
 }


### PR DESCRIPTION
`jx upgrade platform` should use the version of platform read from cloud-env or passed via `--version` option. Right now we're ignoring that version and upgrade platform to the latest version anyway.