### PR TITLE
AWS commands should respect --region and --profile flags

### DIFF
--- a/pkg/cloud/amazon/ecr.go
+++ b/pkg/cloud/amazon/ecr.go
@@ -13,9 +13,9 @@ import (
 )
 
 // GetAccountID returns the current account ID
-func GetAccountIDAndRegion() (string, string, error) {
-	sess, err := NewAwsSessionWithoutOptions()
-	region := *sess.Config.Region
+func GetAccountIDAndRegion(profile string, region string) (string, string, error) {
+	sess, err := NewAwsSession(profile, region)
+	region = *sess.Config.Region
 	if err != nil {
 		return "", region, err
 	}
@@ -35,7 +35,7 @@ func GetAccountIDAndRegion() (string, string, error) {
 
 // GetContainerRegistryHost
 func GetContainerRegistryHost() (string, error) {
-	accountId, region, err := GetAccountIDAndRegion()
+	accountId, region, err := GetAccountIDAndRegion("", "")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cloud/amazon/s3.go
+++ b/pkg/cloud/amazon/s3.go
@@ -7,9 +7,9 @@ import (
 
 // CreateS3Bucket creates a new S3 bucket in the default region with the given bucket name
 // returning the location string
-func CreateS3Bucket(bucketName string, region string) (string, error) {
+func CreateS3Bucket(bucketName string, profile string, region string) (string, error) {
 	location := ""
-	sess, err := NewAwsSession("", region)
+	sess, err := NewAwsSession(profile, region)
 	if err != nil {
 		return location, err
 	}

--- a/pkg/jx/cmd/get_aws_info.go
+++ b/pkg/jx/cmd/get_aws_info.go
@@ -59,7 +59,7 @@ func NewCmdGetAWSInfo(f Factory, in terminal.FileReader, out terminal.FileWriter
 
 // Run implements this command
 func (o *GetAWSInfoOptions) Run() error {
-	id, region, err := amazon.GetAccountIDAndRegion()
+	id, region, err := amazon.GetAccountIDAndRegion("", "")
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/get_eks.go
+++ b/pkg/jx/cmd/get_eks.go
@@ -15,6 +15,8 @@ import (
 
 type GetEksOptions struct {
 	GetOptions
+	Profile string
+	Region string
 }
 
 var (
@@ -50,6 +52,8 @@ func NewCmdGetEks(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 			CheckErr(err)
 		},
 	}
+	cmd.Flags().StringVarP(&options.Profile, "profile", "", "", "AWS profile to use.")
+	cmd.Flags().StringVarP(&options.Region, "region", "", "", "AWS region to use. Default: " + amazon.DefaultRegion)
 
 	options.addGetFlags(cmd)
 	return cmd
@@ -71,7 +75,7 @@ func (o *GetEksOptions) Run() error {
 		os.Exit(-1)
 	}
 
-	region, err := amazon.ResolveRegionWithoutOptions()
+	region, err := amazon.ResolveRegion(o.Profile, o.Region)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Right now some AWS-related commands respect `--region` and `--profile` flags and some not. It confuses AWS users, as it is not clear where jx searches for AWS configuration among different commands.

This PR adds support for those flags for `jx get eks` and `jx get aws info` commands.