### PR TITLE
[WIP] Store defaults in team settings

### DIFF
--- a/pkg/apis/jenkins.io/v1/types_environment.go
+++ b/pkg/apis/jenkins.io/v1/types_environment.go
@@ -148,6 +148,7 @@ type TeamSettings struct {
 	Organisation        string               `json:"organisation,omitempty" protobuf:"bytes,14,opt,name=organisation" command:"organisation" commandUsage:"Default git organisation for new repositories"`
 	PipelineUsername    string               `json:"pipelineUsername,omitempty" protobuf:"bytes,15,opt,name=pipelineUsername" command:"pipelineusername" commandUsage:"User used by pipeline. Is given write permission on new repositories."`
 	DockerRegistryOrg   string               `json:"dockerRegistryOrg,omitempty" protobuf:"bytes,16,opt,name=dockerRegistryOrg" command:"dockerregistryorg" commandUsage:"Docker registry organisation used for new projects in Jenkins X."`
+	GitPrivate          bool                 `json:"gitPrivate,omitempty" protobuf:"bytes,17,opt,name=gitPrivate" command:"gitprivate" commandUsage:"Are new repositories private by default"`
 }
 
 // QuickStartLocation

--- a/pkg/apis/jenkins.io/v1/types_environment.go
+++ b/pkg/apis/jenkins.io/v1/types_environment.go
@@ -144,6 +144,10 @@ type TeamSettings struct {
 	PromotionEngine     PromotionEngineType  `json:"promotionEngine,omitempty" protobuf:"bytes,10,opt,name=promotionEngine"`
 	NoTiller            bool                 `json:"noTiller,omitempty" protobuf:"bytes,11,opt,name=noTiller"`
 	HelmTemplate        bool                 `json:"helmTemplate,omitempty" protobuf:"bytes,12,opt,name=helmTemplate"`
+	GitServer           string               `json:"gitServer,omitempty" protobuf:"bytes,13,opt,name=gitServer" command:"gitserver" commandUsage:"Default git server for new repositories"`
+	Organisation        string               `json:"organisation,omitempty" protobuf:"bytes,14,opt,name=organisation" command:"organisation" commandUsage:"Default git organisation for new repositories"`
+	PipelineUsername    string               `json:"pipelineUsername,omitempty" protobuf:"bytes,15,opt,name=pipelineUsername" command:"pipelineusername" commandUsage:"User used by pipeline. Is given write permission on new repositories."`
+	DockerRegistryOrg   string               `json:"dockerRegistryOrg,omitempty" protobuf:"bytes,16,opt,name=dockerRegistryOrg" command:"dockerregistryorg" commandUsage:"Docker registry organisation used for new projects in Jenkins X."`
 }
 
 // QuickStartLocation

--- a/pkg/auth/config_service.go
+++ b/pkg/auth/config_service.go
@@ -76,11 +76,6 @@ func (s *AuthConfigService) SaveUserAuth(url string, userAuth *UserAuth) error {
 	if user != "" {
 		config.DefaultUsername = user
 	}
-	// Set Pipeline user once only.
-	if config.PipeLineUsername == "" {
-		config.PipeLineUsername = user
-		config.PipeLineServer = url
-	}
 
 	config.CurrentServer = url
 	return s.SaveConfig()

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -23,10 +23,8 @@ type UserAuth struct {
 type AuthConfig struct {
 	Servers []*AuthServer
 
-	DefaultUsername  string
-	PipeLineUsername string
-	CurrentServer    string
-	PipeLineServer   string
+	DefaultUsername string
+	CurrentServer   string
 }
 
 // AuthConfigService is a service for handing the config of auth tokens

--- a/pkg/jx/cmd/common_team_settings.go
+++ b/pkg/jx/cmd/common_team_settings.go
@@ -2,6 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+	"io"
 	"os/user"
 	"reflect"
 
@@ -307,4 +312,56 @@ func (o *CommonOptions) getUsername(userName string) (string, error) {
 		userName = u.Username
 	}
 	return userName, nil
+}
+
+func addTeamSettingsCommandsFromTags(baseCmd *cobra.Command, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer, options *EditOptions) error {
+	teamSettings, err := options.TeamSettings()
+	if err != nil {
+		return err
+	}
+	value := reflect.ValueOf(teamSettings).Elem()
+	t := value.Type()
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Field(i)
+		structField := t.Field(i)
+		tag := structField.Tag
+		command, ok := tag.Lookup("command")
+		if !ok {
+			continue
+		}
+		commandUsage, ok := tag.Lookup("commandUsage")
+		if !ok {
+			continue
+		}
+
+		cmd := &cobra.Command{
+			Use:   command,
+			Short: commandUsage,
+			Run: func(cmd *cobra.Command, args []string) {
+				var value string
+				if len(args) > 0 {
+					value = args[0]
+				} else if !options.BatchMode {
+					var err error
+					value, err = util.PickValue(commandUsage+":", field.String(), true, in, out, errOut)
+					CheckErr(err)
+				} else {
+					fatal(fmt.Sprintf("No value to set %s", command), 1)
+				}
+
+				callback := func(env *v1.Environment) error {
+					teamSettings := &env.Spec.TeamSettings
+					if value != "" {
+						reflect.ValueOf(teamSettings).Elem().FieldByName(structField.Name).SetString(value)
+					}
+					log.Infof("Setting the team %s to: %s\n", util.ColorInfo(command), util.ColorInfo(value))
+					return nil
+				}
+				CheckErr(options.ModifyDevEnvironment(callback))
+			},
+		}
+
+		baseCmd.AddCommand(cmd)
+	}
+	return nil
 }

--- a/pkg/jx/cmd/edit.go
+++ b/pkg/jx/cmd/edit.go
@@ -58,6 +58,7 @@ func NewCmdEdit(f Factory, in terminal.FileReader, out terminal.FileWriter, errO
 	cmd.AddCommand(NewCmdEditEnv(f, in, out, errOut))
 	cmd.AddCommand(NewCmdEditHelmBin(f, in, out, errOut))
 	cmd.AddCommand(NewCmdEditUserRole(f, in, out, errOut))
+	addTeamSettingsCommandsFromTags(cmd, in, out, errOut, options)
 	return cmd
 }
 

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -91,7 +91,6 @@ type ImportOptions struct {
 	ImportGitCommitMessage  string
 	ListDraftPacks          bool
 	DraftPack               string
-	DefaultOwner            string
 	DockerRegistryOrg       string
 
 	DisableDotGitSearch   bool
@@ -103,6 +102,8 @@ type ImportOptions struct {
 	GitProvider           gits.GitProvider
 	PostDraftPackCallback CallbackFn
 	DisableMaven          bool
+	PipelineUserName      string
+	PipelineServer        string
 }
 
 var (
@@ -189,7 +190,6 @@ func (options *ImportOptions) addImportFlags(cmd *cobra.Command, createProject b
 	cmd.Flags().StringVarP(&options.BranchPattern, "branches", "", "", "The branch pattern for branches to trigger CI/CD pipelines on")
 	cmd.Flags().BoolVarP(&options.ListDraftPacks, "list-packs", "", false, "list available draft packs")
 	cmd.Flags().StringVarP(&options.DraftPack, "pack", "", "", "The name of the pack to use")
-	cmd.Flags().StringVarP(&options.DefaultOwner, "default-owner", "", "someone", "The default user/organisation used if no user is found for the current Git repository being imported")
 	cmd.Flags().StringVarP(&options.DockerRegistryOrg, "docker-registry-org", "", "", "The name of the docker registry organisation to use. If not specified then the Git provider organisation will be used")
 
 	options.addCommonFlags(cmd)
@@ -247,6 +247,10 @@ func (options *ImportOptions) Run() error {
 			}
 		}
 	}
+	err = options.DefaultsFromTeamSettings()
+	if err != nil {
+		return err
+	}
 
 	var userAuth *auth.UserAuth
 	if options.GitProvider == nil {
@@ -264,7 +268,7 @@ func (options *ImportOptions) Run() error {
 			serverURL := gitInfo.HostURLWithoutUser()
 			server = config.GetOrCreateServer(serverURL)
 		} else {
-			server, err = config.PickOrCreateServer(gits.GitHubURL, "Which Git service do you wish to use", options.BatchMode, options.In, options.Out, options.Err)
+			server, err = config.PickOrCreateServer(gits.GitHubURL, options.GitRepositoryOptions.ServerURL, "Which Git service do you wish to use", options.BatchMode, options.In, options.Out, options.Err)
 			if err != nil {
 				return err
 			}
@@ -664,10 +668,9 @@ func (options *ImportOptions) getDockerRegistryOrg() string {
 }
 
 func (options *ImportOptions) getOrganisationOrCurrentUser() string {
-	currentUser := options.getCurrentUser()
 	org := options.getOrganisation()
 	if org == "" {
-		org = currentUser
+		org = options.getCurrentUser()
 	}
 	return org
 }
@@ -675,9 +678,6 @@ func (options *ImportOptions) getOrganisationOrCurrentUser() string {
 func (options *ImportOptions) getCurrentUser() string {
 	//walk through every file in the given dir and update the placeholders
 	var currentUser string
-	if options.Organisation != "" {
-		return options.Organisation
-	}
 	if options.GitServer != nil {
 		currentUser = options.GitServer.CurrentUser
 		if currentUser == "" {
@@ -688,7 +688,7 @@ func (options *ImportOptions) getCurrentUser() string {
 	}
 	if currentUser == "" {
 		log.Warn("No username defined for the current Git server!")
-		currentUser = options.DefaultOwner
+		currentUser = options.GitRepositoryOptions.Username
 	}
 	return currentUser
 }
@@ -714,9 +714,8 @@ func (options *ImportOptions) CreateNewRemoteRepository() error {
 	dir := options.Dir
 	_, defaultRepoName := filepath.Split(dir)
 
-	if options.Organisation != "" {
-		options.GitRepositoryOptions.Owner = options.Organisation
-	}
+	options.GitRepositoryOptions.Owner = options.getOrganisation()
+
 	details, err := gits.PickNewGitRepository(options.BatchMode, authConfigSvc, defaultRepoName, &options.GitRepositoryOptions,
 		options.GitServer, options.GitUserAuth, options.Git(), options.In, options.Out, options.Err)
 	if err != nil {
@@ -744,23 +743,26 @@ func (options *ImportOptions) CreateNewRemoteRepository() error {
 	log.Infof("Pushed Git repository to %s\n\n", util.ColorInfo(repo.HTMLURL))
 
 	// If the user creating the repo is not the pipeline user, add the pipeline user as a contributor to the repo
-	config := authConfigSvc.Config()
-	if config.PipeLineUsername != options.GitUserAuth.Username && config.CurrentServer == config.PipeLineServer {
+	if options.PipelineUserName != options.GitUserAuth.Username && options.GitServer.URL == options.PipelineServer {
 		// Make the invitation
-		err := options.GitProvider.AddCollaborator(config.PipeLineUsername, details.Organisation, details.RepoName)
+		err := options.GitProvider.AddCollaborator(options.PipelineUserName, details.Organisation, details.RepoName)
 		if err != nil {
 			return err
 		}
 
 		// If repo is put in an organisation that the pipeline user is not part of an invitation needs to be accepted.
 		// Create a new provider for the pipeline user
-		pipelineUserAuth := config.FindUserAuth(config.CurrentServer, config.PipeLineUsername)
+		authConfig := authConfigSvc.Config()
+		if err != nil {
+			return err
+		}
+		pipelineUserAuth := authConfig.FindUserAuth(options.GitServer.URL, options.PipelineUserName)
 		if pipelineUserAuth == nil {
 			log.Warnf("Pipeline Git user credentials not found. %s will need to accept the invitation to collaborate\n"+
 				"on %s if %s is not part of %s.\n\n",
-				config.PipeLineUsername, details.RepoName, config.PipeLineUsername, details.Organisation)
+				options.PipelineUserName, details.RepoName, options.PipelineUserName, details.Organisation)
 		} else {
-			pipelineServerAuth := config.GetServer(config.CurrentServer)
+			pipelineServerAuth := authConfig.GetServer(authConfig.CurrentServer)
 			pipelineUserProvider, err := gits.CreateProvider(pipelineServerAuth, pipelineUserAuth, options.Git())
 			if err != nil {
 				return err
@@ -1365,6 +1367,25 @@ func (options *ImportOptions) fixMaven() error {
 			}
 		}
 	}
+	return nil
+}
+
+func (options *ImportOptions) DefaultsFromTeamSettings() error {
+	settings, err := options.TeamSettings()
+	if err != nil {
+		return err
+	}
+	if options.Organisation == "" {
+		options.Organisation = settings.Organisation
+	}
+	if options.DockerRegistryOrg == "" {
+		options.DockerRegistryOrg = settings.DockerRegistryOrg
+	}
+	if options.GitRepositoryOptions.ServerURL == "" {
+		options.GitRepositoryOptions.ServerURL = settings.GitServer
+	}
+	options.PipelineServer = settings.GitServer
+	options.PipelineUserName = settings.PipelineUsername
 	return nil
 }
 

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -1384,6 +1384,7 @@ func (options *ImportOptions) DefaultsFromTeamSettings() error {
 	if options.GitRepositoryOptions.ServerURL == "" {
 		options.GitRepositoryOptions.ServerURL = settings.GitServer
 	}
+	options.GitRepositoryOptions.Private = settings.GitPrivate || options.GitRepositoryOptions.Private
 	options.PipelineServer = settings.GitServer
 	options.PipelineUserName = settings.PipelineUsername
 	return nil

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1144,6 +1144,17 @@ func (options *InstallOptions) getGitUser(message string) (*auth.UserAuth, error
 		if userAuth.IsInvalid() {
 			return userAuth, fmt.Errorf("you did not properly define the user authentication")
 		}
+		callback := func(env *v1.Environment) error {
+			teamSettings := &env.Spec.TeamSettings
+			teamSettings.GitServer = url
+			teamSettings.PipelineUsername = userAuth.Username
+			teamSettings.Organisation = options.Owner
+			return nil
+		}
+		err = options.ModifyDevEnvironment(callback)
+		if err != nil {
+			return userAuth, fmt.Errorf("failed to save team settings %s", err)
+		}
 	}
 	// TODO This API should be refactored/rethought as mixing OO and functional styles is error prone. If choosing an OO style, mutations should be carried out on the object data and then that data should be introspected as the source of truth in the operation. Alternatively, remove object state and pass values in a functional style.
 	options.GitRepositoryOptions.Username = userAuth.Username

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1149,6 +1149,7 @@ func (options *InstallOptions) getGitUser(message string) (*auth.UserAuth, error
 			teamSettings.GitServer = url
 			teamSettings.PipelineUsername = userAuth.Username
 			teamSettings.Organisation = options.Owner
+			teamSettings.GitPrivate = options.GitRepositoryOptions.Private
 			return nil
 		}
 		err = options.ModifyDevEnvironment(callback)

--- a/pkg/tests/helpers.go
+++ b/pkg/tests/helpers.go
@@ -68,11 +68,9 @@ func CreateAuthConfigService() auth.AuthConfigService {
 		Name:        "jx-testing-server",
 	}
 	authConfig := auth.AuthConfig{
-		Servers:          []*auth.AuthServer{&authServer},
-		DefaultUsername:  userAuth.Username,
-		PipeLineUsername: userAuth.Username,
-		CurrentServer:    authServer.URL,
-		PipeLineServer:   authServer.URL,
+		Servers:         []*auth.AuthServer{&authServer},
+		DefaultUsername: userAuth.Username,
+		CurrentServer:   authServer.URL,
 	}
 	authConfigSvc.SetConfig(&authConfig)
 	return authConfigSvc


### PR DESCRIPTION
Add git server, organisation, pipeline git user name and docker registry
organisation to team settings. Set git server, organisation and pipeline
git user name on jx install. The values are used during import.
Transferring team settings to options to avid fetching team settings multiple times.
Removing option default-owner since it overlaps and is confused with git-provider-url and org.
Removing PipelineUSer and PipeLineServer from AuthConfig since they now is placed in TeamSettings

Fixes #764 

This is not properly tested manually yet. Also I don't know how to run the integration tests.