### PR TITLE
When headless mode is set, don't exec into devpod shell after creation.

### DIFF
--- a/pkg/jx/cmd/create_devpod.go
+++ b/pkg/jx/cmd/create_devpod.go
@@ -718,12 +718,16 @@ func (o *CreateDevPodOptions) Run() error {
 			}
 		}
 	}
-	shellCommand := o.ShellCmd
-	if shellCommand == "" {
-		shellCommand = defaultRshCommand
-	}
 
-	rshExec = append(rshExec, shellCommand)
+	// Only want to shell into the DevPod if the headless flag isn't set
+	if !o.Headless {
+		shellCommand := o.ShellCmd
+		if shellCommand == "" {
+			shellCommand = defaultRshCommand
+		}
+
+		rshExec = append(rshExec, shellCommand)
+	}
 
 	options := &RshOptions{
 		CommonOptions: o.CommonOptions,


### PR DESCRIPTION
Since `jx create devpod` accepts the headless flag:
```
      --headless=false: Enable headless operation if using browser automation
```

I've updated create_devpod.go so that if the headless flag has been set, we don't exec into the devpod's shell after creation. We don't want to exec into a shell in headless mode, because access to a TTY shell may not be available.

To do this, I simply added a check for `!o.Headless` around the lines of code that add the shell exec command. 

See below for an example:

```
Johns-MacBook-Pro-3:testmp johncollier$ jx create devpod -l maven --sync --headless
Creating a DevPod of label: maven
Created pod johncollier-maven - waiting for it to be ready...
Updating Helm repository...
Using helmBinary helm with feature flag: none
Helm repository update done.
Pod johncollier-maven is now ready!
You can open other shells into this DevPod via jx create devpod
Port 80 is open on [ ] and forwarded to the devpod
synchronizing directory /Users/johncollier/testmp to DevPod johncollier-maven path /workspace/testmp
Removing old ksync johncollier-maven
Removing old ksync johncollier-maven2
Installing Bash Completion into DevPod
Johns-MacBook-Pro-3:testmp johncollier$
```
```
Johns-MacBook-Pro-3:testmp johncollier$ jx create devpod -l maven --sync
Creating a DevPod of label: maven
Created pod johncollier-maven2 - waiting for it to be ready...
Updating Helm repository...
Using helmBinary helm with feature flag: none
Helm repository update done.
Pod johncollier-maven2 is now ready!
You can open other shells into this DevPod via jx create devpod
Port 80 is open on [ ] and forwarded to the devpod
synchronizing directory /Users/johncollier/testmp to DevPod johncollier-maven2 path /workspace/testmp
Removing old ksync johncollier-maven
Installing Bash Completion into DevPod
[root@johncollier-maven2 testmp]# 
```