### PR TITLE
`jx upgrade platform` should not perform upgrade if given version is installed

### DIFF
--- a/pkg/jx/cmd/upgrade_platform.go
+++ b/pkg/jx/cmd/upgrade_platform.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"io"
+	"strings"
 
 	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -76,7 +77,7 @@ func NewCmdUpgradePlatform(f Factory, in terminal.FileReader, out terminal.FileW
 
 // Run implements the command
 func (o *UpgradePlatformOptions) Run() error {
-	version := o.Version
+	targetVersion := o.Version
 	err := o.Helm().UpdateRepo()
 	if err != nil {
 		return err
@@ -88,7 +89,7 @@ func (o *UpgradePlatformOptions) Run() error {
 			return err
 		}
 	}
-	if version == "" {
+	if targetVersion == "" {
 		io := &InstallOptions{}
 		io.CommonOptions = o.CommonOptions
 		io.Flags = o.InstallFlags
@@ -96,13 +97,40 @@ func (o *UpgradePlatformOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		version, err = LoadVersionFromCloudEnvironmentsDir(wrkDir)
+		targetVersion, err = LoadVersionFromCloudEnvironmentsDir(wrkDir)
 		if err != nil {
 			return err
 		}
 	}
-	if version != "" {
-		log.Infof("Upgrading to version %s\n", util.ColorInfo(version))
+
+	// Current version
+	var currentVersion string
+	output, err := o.Helm().ListCharts()
+	if err != nil {
+		log.Warnf("Failed to find helm installs: %s\n", err)
+		return err
+	} else {
+		for _, line := range strings.Split(output, "\n") {
+			fields := strings.Split(line, "\t")
+			if len(fields) > 4 && strings.TrimSpace(fields[0]) == "jenkins-x" {
+				for _, f := range fields[4:] {
+					f = strings.TrimSpace(f)
+					if strings.HasPrefix(f, jxChartPrefix) {
+						currentVersion = strings.TrimPrefix(f, jxChartPrefix)
+					}
+				}
+			}
+		}
+	}
+	if currentVersion == "" {
+		return errors.New("Jenkins X platform helm chart in not installed.")
+	}
+
+	if targetVersion != currentVersion {
+		log.Infof("Upgrading platform from version %s to version %s\n", util.ColorInfo(currentVersion), util.ColorInfo(targetVersion))
+	} else {
+		log.Infof("Already installed platform version %s. Skipping upgrade process.\n", util.ColorInfo(targetVersion))
+		return nil
 	}
 
 	valueFiles := []string{}
@@ -115,5 +143,5 @@ func (o *UpgradePlatformOptions) Run() error {
 	if o.Set != "" {
 		values = append(values, o.Set)
 	}
-	return o.Helm().UpgradeChart(o.Chart, o.ReleaseName, ns, &version, false, nil, false, false, values, valueFiles)
+	return o.Helm().UpgradeChart(o.Chart, o.ReleaseName, ns, &targetVersion, false, nil, false, false, values, valueFiles)
 }


### PR DESCRIPTION
Right now `jx upgrade platform` attempts to upgrade version of platform no matter if the proper version is installed or not. We should detect which version of platform is installed, which is requested and then upgrade platform or just display information that proper version is already installed.

Even when upgrading we should display information that we are `upgrading from X to Y`,  not only `upgrading to Y`.