### PR TITLE
fix: ask for organisation before replacing placeholders

### DIFF
--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -680,7 +680,7 @@ func (options *ImportOptions) getDockerRegistryOrg() string {
 }
 
 func (options *ImportOptions) getOrganisationOrCurrentUser() string {
-	org := options.getOrganisation()
+	org := options.getOrPickOrganisation()
 	if org == "" {
 		org = options.getCurrentUser()
 	}
@@ -705,7 +705,7 @@ func (options *ImportOptions) getCurrentUser() string {
 	return currentUser
 }
 
-func (options *ImportOptions) getOrganisation() string {
+func (options *ImportOptions) getOrPickOrganisation() string {
 	org := ""
 	gitInfo, err := gits.ParseGitURL(options.RepoURL)
 	if err == nil && gitInfo.Organisation != "" {
@@ -729,7 +729,7 @@ func (options *ImportOptions) CreateNewRemoteRepository() error {
 	dir := options.Dir
 	_, defaultRepoName := filepath.Split(dir)
 
-	options.GitRepositoryOptions.Owner = options.getOrganisation()
+	options.GitRepositoryOptions.Owner = options.getOrPickOrganisation()
 
 	details, err := gits.PickNewGitRepository(options.BatchMode, authConfigSvc, defaultRepoName, &options.GitRepositoryOptions,
 		options.GitServer, options.GitUserAuth, options.Git(), options.In, options.Out, options.Err)

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -710,8 +710,11 @@ func (options *ImportOptions) getOrganisation() string {
 	gitInfo, err := gits.ParseGitURL(options.RepoURL)
 	if err == nil && gitInfo.Organisation != "" {
 		org = gitInfo.Organisation
-	} else {
+	} else if options.Organisation != "" {
 		org = options.Organisation
+	} else if !options.BatchMode {
+		org, err = gits.PickOrganisation(options.GitProvider, options.getCurrentUser(), options.In, options.Out, options.Err)
+		options.Organisation = org
 	}
 	return org
 }


### PR DESCRIPTION
If organisation isn't specified neither as option, in TeamSettings or comes from existing repo it has defaulted to git username.
This created a mismatch if user choosed another organisation upon the question before push.
This is now fixed by asking user earlier.

Fixes #1275