### PR TITLE
Upgrade to Anchore chart 0.2.3 by default

### DIFF
--- a/pkg/jx/cmd/create_addon_anchore.go
+++ b/pkg/jx/cmd/create_addon_anchore.go
@@ -23,7 +23,7 @@ const (
 	defaultAnchoreName        = "anchore"
 	defaultAnchoreNamespace   = "anchore"
 	defaultAnchoreReleaseName = "anchore"
-	defaultAnchoreVersion     = "0.1.7"
+	defaultAnchoreVersion     = "0.2.3"
 	defaultAnchorePassword    = "anchore"
 	defaultAnchoreConfigDir   = "/anchore_service_dir"
 	anchoreDeploymentName     = "anchore-anchore-engine-core"


### PR DESCRIPTION
The latest version of Anchore brings a lot of improvements. Most useful to me, this also enables the NVD feed by default so that my projects' jars, gems, etc., can also be scanned for CVEs in addition to the existing operating system package checks.