### PR TITLE
 Allow for verbose logging on `jx create cluster minikube` 

### DIFF
--- a/pkg/jx/cmd/create_cluster_minikube.go
+++ b/pkg/jx/cmd/create_cluster_minikube.go
@@ -220,6 +220,12 @@ func (o *CreateClusterMinikubeOptions) createClusterMinikube() error {
 	}
 
 	args := []string{"start", "--memory", mem, "--cpus", cpu, "--disk-size", disksize, "--vm-driver", vmDriverValue, "--bootstrapper=kubeadm"}
+	// Show verbose output for minikube cluster creation if verbose flag is set
+	if o.Verbose {
+		args = append(args, "--logtostderr")
+		args = append(args, "--v=3")
+	}
+
 	hyperVVirtualSwitch := o.Flags.HyperVVirtualSwitch
 	if hyperVVirtualSwitch != "" {
 		args = append(args, "--hyperv-virtual-switch", hyperVVirtualSwitch)

--- a/pkg/jx/cmd/create_cluster_minikube.go
+++ b/pkg/jx/cmd/create_cluster_minikube.go
@@ -222,8 +222,7 @@ func (o *CreateClusterMinikubeOptions) createClusterMinikube() error {
 	args := []string{"start", "--memory", mem, "--cpus", cpu, "--disk-size", disksize, "--vm-driver", vmDriverValue, "--bootstrapper=kubeadm"}
 	// Show verbose output for minikube cluster creation if verbose flag is set
 	if o.Verbose {
-		args = append(args, "--logtostderr")
-		args = append(args, "--v=3")
+		args = append(args, "--logtostderr", "--v=3")
 	}
 
 	hyperVVirtualSwitch := o.Flags.HyperVVirtualSwitch


### PR DESCRIPTION
`jx create cluster minikube --verbose` does not currently do anything (although it does accept the option). So I've added a couple lines to create_cluster_minikube.go that check for the flag, and if its set, adds a couple verbose logging flags to the `minikube start` command.

This should help a bunch with debugging if Minikube cluster creation hangs for whatever reason.