### PR TITLE
Revert "fix: ask for organisation before replacing placeholders"

### DIFF
--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -710,11 +710,8 @@ func (options *ImportOptions) getOrPickOrganisation() string {
 	gitInfo, err := gits.ParseGitURL(options.RepoURL)
 	if err == nil && gitInfo.Organisation != "" {
 		org = gitInfo.Organisation
-	} else if options.Organisation != "" {
+	} else {
 		org = options.Organisation
-	} else if !options.BatchMode {
-		org, err = gits.PickOrganisation(options.GitProvider, options.getCurrentUser(), options.In, options.Out, options.Err)
-		options.Organisation = org
 	}
 	return org
 }


### PR DESCRIPTION
This reverts commit 49ca8896dfbd9051ddd763223633c8dc9771a081.