### PR TITLE
`jx install --provider=eks` should check for binaries dependencies

### DIFF
--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -232,6 +232,23 @@ func (flags *InstallFlags) addCloudEnvOptions(cmd *cobra.Command) {
 
 // Run implements this command
 func (options *InstallOptions) Run() error {
+	if options.Flags.Provider == EKS {
+		var deps []string
+		d := binaryShouldBeInstalled("eksctl")
+		if d != "" {
+			deps = append(deps, d)
+		}
+		d = binaryShouldBeInstalled("heptio-authenticator-aws")
+		if d != "" {
+			deps = append(deps, d)
+		}
+		err := options.installMissingDependencies(deps)
+		if err != nil {
+			log.Errorf("%v\nPlease fix the error or install manually then try again", err)
+			os.Exit(-1)
+		}
+	}
+
 	client, originalNs, err := options.KubeClient()
 	if err != nil {
 		return errors.Wrap(err, "failed to create the kube client")


### PR DESCRIPTION
If you try to install jx with command `jx install --provider=eks` into cluster that has not been created using `jx create cluster eks`, eksctl and heptio-authenticator-aws will not be installed and `jx install` command is gonna to fail.

We should detected required binaries for EKS and perform installation in `jx install` command as well, not only in `jx create cluster eks`.