### PR TITLE
fix: Update all roles, not only viewer

### DIFF
--- a/pkg/jx/cmd/controller_role.go
+++ b/pkg/jx/cmd/controller_role.go
@@ -141,8 +141,8 @@ func (o *ControllerRoleOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	for _, binding := range bindings.Items {
-		o.upsertEnvironmentRoleBinding(&binding)
+	for i := range bindings.Items {
+		o.upsertEnvironmentRoleBinding(&bindings.Items[i])
 	}
 	envList, err := jxClient.JenkinsV1().Environments(ns).List(metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
Since binding was updated for each item &binding point to the last item
after going through the loop. This meant only viewer got updated, but several times.

```
Creating RoleBinding viewer in namespace jx
Updating RoleBinding viewer in namespace jx
Updating RoleBinding viewer in namespace jx
Creating Role viewer in namespace jx-production
Creating RoleBinding viewer in namespace jx-production
Updating RoleBinding viewer in namespace jx-production
Updating RoleBinding viewer in namespace jx-production
Creating Role viewer in namespace jx-staging
Creating RoleBinding viewer in namespace jx-staging
Updating RoleBinding viewer in namespace jx-staging
Updating RoleBinding viewer in namespace jx-staging
```

With this fix the pointer given to upsertEnvironmentRoleBinding is to the propper place in the Items array.