### PR TITLE
fix(cli upgrade): Extract JX tarball to temp folder during cli upgrade.

### DIFF
--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -1131,13 +1131,13 @@ func (o *CommonOptions) installJx(upgrade bool, version string) error {
 	if err != nil {
 		return err
 	}
-	err = os.Remove(binDir + "/jx")
-	if err != nil && o.Verbose {
-		log.Infof("Skipping removal of old jx binary: %s\n", err)
-	}
 	err = os.Remove(tarFile)
 	if err != nil {
 		return err
+	}
+	err = os.Remove(binDir + "/jx")
+	if err != nil && o.Verbose {
+		log.Infof("Skipping removal of old jx binary: %s\n", err)
 	}
 	// Copy over the new binary
 	err = os.Rename(os.TempDir()+"/jx", binDir+"/jx")

--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -1126,19 +1126,25 @@ func (o *CommonOptions) installJx(upgrade bool, version string) error {
 	if err != nil {
 		return err
 	}
+	// Untar the new binary into a temp directory
+	err = util.UnTargz(tarFile, os.TempDir(), []string{binary, fileName})
+	if err != nil {
+		return err
+	}
 	err = os.Remove(binDir + "/jx")
 	if err != nil && o.Verbose {
 		log.Infof("Skipping removal of old jx binary: %s\n", err)
 	}
-	err = util.UnTargz(tarFile, binDir, []string{binary, fileName})
-	if err != nil {
-		return err
-	}
-	log.Infof("Jenkins X client has been installed into %s\n", util.ColorInfo(binDir+"/jx"))
 	err = os.Remove(tarFile)
 	if err != nil {
 		return err
 	}
+	// Copy over the new binary
+	err = os.Rename(os.TempDir()+"/jx", binDir+"/jx")
+	if err != nil {
+		return err
+	}
+	log.Infof("Jenkins X client has been installed into %s\n", util.ColorInfo(binDir+"/jx"))
 	return os.Chmod(fullPath, 0755)
 }
 


### PR DESCRIPTION
Fixes https://github.com/jenkins-x/jx/issues/1893

Updates the JX cli update code in `common_install.go` so that we extract the jx binary into a temp folder first, and only overwrite the old JX binary if it extracted successfully.

Previously we were deleting the old JX binary first, before extracting the tar file. So if a corrupted tarball was downloaded and couldn't be extracted, the user was left without a working JX binary. This is now prevented.

Tested on both macOS and Linux.