### PR TITLE
Removed duplicated logic from binary installation checking code

### DIFF
--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -281,7 +281,7 @@ func (options *InstallOptions) Run() error {
 		if err != nil {
 			return errors.Wrap(err, "reading jx bin location")
 		}
-		_, install, err := options.shouldInstallBinary(binDir, "tiller")
+		_, install, err := shouldInstallBinary("tiller")
 		if !install && err == nil {
 			confirm := &survey.Confirm{
 				Message: "Uninstalling  existing tiller binary:",
@@ -299,7 +299,7 @@ func (options *InstallOptions) Run() error {
 			}
 		}
 
-		_, install, err = options.shouldInstallBinary(binDir, helmBinary)
+		_, install, err = shouldInstallBinary(helmBinary)
 		if !install && err == nil {
 			confirm := &survey.Confirm{
 				Message: "Uninstalling  existing helm binary:",


### PR DESCRIPTION
I've removed some duplicated logic from `binaryShouldBeInstalled` function, which should be defined in a single place, in particular in `shouldInstallBinary` function.

I've also removed `binDir string` parameter from `shouldInstallBinary`, as we always pass results of `util.JXBinLocation()` invocation as its value anyway.

This is refactoring step towards having binaries checking/downloading/installation logic cleaned and extracted into `binaries` package.