### PR TITLE
Tidy hacking.md

### DIFF
--- a/docs/contributing/hacking.md
+++ b/docs/contributing/hacking.md
@@ -18,12 +18,11 @@ for a note about Go cross-compiling support.
 
 ### Configuring Go
 
-The jx's binary eCLI is  built on your machine in your GO Path. 
+The jx binary CLI is built on your machine in your Go path. 
 
 On macOS, Go can be installed with [Homebrew][]:
 
 ```shell
-
 $ brew install go 
 ```
 
@@ -40,7 +39,7 @@ $ GOOS=linux GOARCH=amd64 ./make.bash --no-clean
 
 ## Fork the Repository
 
-Begin at Github by forking jx, then clone your fork locally. Since jx is a Go package, it
+Begin at GitHub by forking jx, then clone your fork locally. Since jx is a Go package, it
 should be located at `$GOPATH/src/github.com/jenkins-x/jx`.
 
 ```shell
@@ -50,7 +49,7 @@ $ git clone git@github.com:<username>/jx.git
 $ cd jx
 ```
 
-Add the conventional [upstream][] `git` remote in order to fetch changes from jx's main master
+Add the conventional upstream `git` remote in order to fetch changes from jx's main master
 branch and to create pull requests:
 
 ```shell
@@ -65,8 +64,7 @@ source code.
 Run `make` to build the `jx`  binaries:
 
 ```shell
-
-$ make build      # runs dep and builds `jx`  inside the build/
+$ make build      # builds `jx` inside the build/ directory
 ```
 
 ## Testing
@@ -93,43 +91,43 @@ To get a nice HTML report on the tests:
 
 ### Unit Tests
 
-Unit tests should be issolated (see what is an unencapsulated test), and should contain the `t.Parallel()` directive in order to keep things nice and speedy.
+Unit tests should be isolated (see what is an unencapsulated test), and should contain the `t.Parallel()` directive in order to keep things nice and speedy.
 
 If you add a slow running (more than a couple of seconds) test, it needs to be wrapped like so:
-```
+```golang
 if testing.Short() {
 	t.Skip("skipping a_long_running_test")
 } else {
 	// Slow test goes here...
 }
 ```
-Slows tests can (and should) still include `t.Parallel()`
+Slows tests can (and should) still include `t.Parallel()`.
 
 Best practice for unit tests is to define the testing package appending _test to the name of your package, e.g. `mypackage_test` and then import `mypackage` inside your tests.
 This encourages good package design and will enable you to define the exported package API in a composable way.
 
 ### Integration Tests
 
-To add an integration test, create a separate file for your integration tests using the naming convention `mypackage_integration_test.go` Use the same package declaaration as your unit tests: `mypackage_test`. At the very top of the file before the package declaration add this custom build directive:
+To add an integration test, create a separate file for your integration tests using the naming convention `mypackage_integration_test.go` Use the same package declaration as your unit tests: `mypackage_test`. At the very top of the file before the package declaration add this custom build directive:
 
-```
+```golang
 // +build integration
 
 ```
 Note that there needs to be a blank line before you declare the package name. 
 
 This directive will ensure that integration tests are automatically separated from unit tests, and will not be run as part of the normal test suite.
-You should NOT add `t.Parallel()` to an unencapsulated test as it may cause intermittent failures.
+You should **NOT** add `t.Parallel()` to an unencapsulated test as it may cause intermittent failures.
 
 ### What is an unencapsulated test?
-A test is unencapsulated (not issolated) if it cannot be run (with repeatable success) without a certain surrounding state. Relying on external binaries that may not be present, writing or reading from the filesystem without care to specifically avoid collisions, or relying on other tests to run in a specific sequence for your test to pass are all examples of a test that you should carefully consider before committing. If you would like to easily check that your test is issolated before committing simply run: `make docker-test`, or if your test is marked as slow: `make docker-test-slow`. This will mount the jx project folder into a golang docker container that does not include any of your host machines environment. If your test passes here, then you can be happy that the test is encapsulated.
+A test is unencapsulated (not isolated) if it cannot be run (with repeatable success) without a certain surrounding state. Relying on external binaries that may not be present, writing or reading from the filesystem without care to specifically avoid collisions, or relying on other tests to run in a specific sequence for your test to pass are all examples of a test that you should carefully consider before committing. If you would like to easily check that your test is isolated before committing simply run: `make docker-test`, or if your test is marked as slow: `make docker-test-slow`. This will mount the jx project folder into a golang docker container that does not include any of your host machine's environment. If your test passes here, then you can be happy that the test is encapsulated.
 
 ### Mocking / Stubbing
 Mocking or stubbing methods in your unit tests will get you a long way towards test isolation. Coupled with the use of interface based APIs you should be able to make your methods easily testable and useful to other packages that may need to import them.
-https://github.com/petergtz/pegomock Is our current mocking library of choice, mainly because it is very easy to use and doesn't require you to write your own mocks (Yay!)
-We place all interfaces for each package in a file called `interface.go` in the relevant folder. So you can find all interfaces for `github.com/jenkins-x/jx/pkg/util` in `github.com/jenkins-x/jx/pkg/util/interface.go` 
-Generating/Regenerating a mock for a given interface is easy, just go to the `interface.go` file that corresponds with the interface you would like to mock and add a comment directly above your interface definition that will look something like this:
-```
+[Pegomock] is our current mocking library of choice, mainly because it is very easy to use and doesn't require you to write your own mocks. (Yay!)
+We place all interfaces for each package in a file called `interface.go` in the relevant folder. So, you can find all interfaces for `github.com/jenkins-x/jx/pkg/util` in `github.com/jenkins-x/jx/pkg/util/interface.go` 
+Generating/regenerating a mock for a given interface is easy: just go to the `interface.go` file that corresponds with the interface you would like to mock and add a comment directly above your interface definition that will look something like this:
+```golang
 // CommandInterface defines the interface for a Command
 //go:generate pegomock generate github.com/jenkins-x/jx/pkg/util CommandInterface -o mocks/command_interface.go
 type CommandInterface interface {
@@ -145,21 +143,21 @@ type CommandInterface interface {
 	SetExponentialBackOff(*backoff.ExponentialBackOff)
 }
 ```
-In the example you can see that we pass the generator to use: `pegomock generate` the package path name: `github.com/jenkins-x/jx/pkg/util` the name of the interface: `CommandInterface` and finally an output directive to write the generated file to a mock subfolder. To keep things nice and tidy it's best to write each mocked interface to a separate file in this folder. So in this case: `-o mocks/command_interface.go`
+In the example you can see that we pass the generator to use: `pegomock generate`, the package path name: `github.com/jenkins-x/jx/pkg/util`, the name of the interface: `CommandInterface`, and finally an output directive to write the generated file to a mock sub-folder. To keep things nice and tidy it's best to write each mocked interface to a separate file in this folder. So, in this case: `-o mocks/command_interface.go`
 
 Now simply run:
-```
+```shell
 go generate ./...
 ```
 or
-```
+```shell
 make generate
 ```
 
 You now have a mock to test your new interface!
 The new mock can now be imported into your test file and used for easy mocking/stubbing.
 Here's an example:
-```
+```golang
 package util_test
 
 import (
@@ -183,21 +181,21 @@ func TestJXBinaryLocationSuccess(t *testing.T) {
 }
 ```
 Here we're importing the mock we need in our import declaration:
-```
+```golang
 mocks "github.com/jenkins-x/jx/pkg/util/mocks"
 ```
 Then inside the test we're instantiating `NewMockCommandInterface` which was automatically generated for us by pegomock.
 
-Next we're stubbing something that we don't actually want to run when we execute our test. In this case we don't want to make a call to an external binary as that could break our tests isolation. We're using some handy matchers which are provided by pegomock, and importing using a `.` import to keep the syntax neat (You probably shouldn't do this outside of tests):
-```
+Next we're stubbing something that we don't actually want to run when we execute our test. In this case we don't want to make a call to an external binary as that could break our tests isolation. We're using some handy matchers which are provided by pegomock, and importing using a `.` import to keep the syntax neat. (You probably shouldn't do this outside of tests):
+```golang
 When(commandInterface.RunWithoutRetry()).ThenReturn("/test/something/bin/jx", nil)
 ```
-Now when we can setup our  test using the mock interface and make assertions as normal.
+Now we can set up our test using the mock interface and make assertions as normal.
 
 
 ### Debug logging
 
-Lots of the test have debug output to try figure out when things fail. You can enable verbose debug logging for tests via
+Lots of the test have debug output to try figure out when things fail. You can enable verbose debug logging for tests via:
 
 ```shell 
 export JX_TEST_DEBUG=true
@@ -205,33 +203,30 @@ export JX_TEST_DEBUG=true
 
 ## Debugging
 
-First you need to [install Delve](https://github.com/derekparker/delve/blob/master/Documentation/installation/README.md)
+First you need to [install Delve](https://github.com/derekparker/delve/blob/master/Documentation/installation/README.md).
 
 Then you should be able to run a debug version of a jx command:
 
-```
+```shell
 dlv --listen=:2345 --headless=true --api-version=2 exec ./build/jx -- some arguments
 ```
 
-Then in you IDE you should be able to then set a breakpoint and connect to `2345`.
-
-e.g. in IntellJ you create a new `Go Remote` execution and then hit `Debug`
+Then in you IDE you should be able to then set a breakpoint and connect to `2345` e.g. in IntelliJ you create a new `Go Remote` execution and then hit `Debug`.
 
 ### Debugging jx with stdin
 
 If you want to debug using `jx` with `stdin` to test out terminal interaction, you can start `jx` as usual from the command line then:
 
-* find the `pid` of the jx command via something like `ps -elaf | grep jx`
-* start Delve attaching to the pid:
+1. Find the `pid` of the jx command via something like `ps -elaf | grep jx`
+2. Start Delve, attaching to the pid:
 
-```shell
-
-dlv --listen=:2345 --headless=true --api-version=2 attach SomePID
-```
+	```shell
+	dlv --listen=:2345 --headless=true --api-version=2 attach SomePID
+	```
 
 ### Debugging a unit test
 
-You can run a single unit test via
+You can run a single unit test via:
 
 ```shell
 export TEST="TestSomething"
@@ -245,7 +240,7 @@ export TEST="TestSomething"
 make debugtest1
 ```
 
-Then set breakpoints and debug in your IDE like in the above debugging.
+Then set breakpoints and debug in your IDE as described in [Debugging](#debugging).
 
 ### Using a helper script
 
@@ -265,5 +260,6 @@ Then you can change your `jx someArgs` CLI to `jxDebug someArgs` then debug it!
 [Homebrew]: https://brew.sh/
 [Kubernetes]: https://github.com/kubernetes/kubernetes
 [Minikube]: https://github.com/kubernetes/minikube
+[Pegomock]: https://github.com/petergtz/pegomock
 [upstream]: https://help.github.com/articles/fork-a-repo/
 [upx]: https://upx.github.io


### PR DESCRIPTION
`make build` doesn't run `dep` plus other assorted tidying.

Aside: there's significant overlap between this and https://github.com/jenkins-x/jx-docs/blob/master/content/contribute/development.md