### PR TITLE
BitBucketCloudProvider should be automatically detected from server URL

### DIFF
--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -139,16 +139,15 @@ func (pr *GitPullRequest) IsClosed() bool {
 }
 
 func CreateProvider(server *auth.AuthServer, user *auth.UserAuth, git Gitter) (GitProvider, error) {
-	switch server.Kind {
-	case KindBitBucketCloud:
+	if (server.Kind == KindBitBucketCloud) || (server.Kind == "" && strings.HasPrefix(server.URL, "https://bitbucket.org")) {
 		return NewBitbucketCloudProvider(server, user, git)
-	case KindBitBucketServer:
+	} else if server.Kind == KindBitBucketServer {
 		return NewBitbucketServerProvider(server, user, git)
-	case KindGitea:
+	} else if server.Kind == KindGitea {
 		return NewGiteaProvider(server, user, git)
-	case KindGitlab:
+	} else if server.Kind == KindGitlab {
 		return NewGitlabProvider(server, user, git)
-	default:
+	} else {
 		return NewGitHubProvider(server, user, git)
 	}
 }


### PR DESCRIPTION
Right now running `jx install --git-server=https://bitbucket.org ...` fails because Git server kind is undefined. As a result of this jx tries to fall back to GitHub provider, which in turn fails because jx tries to invoke wrong API urls and passes BitBucket token to GitHub API.

`CreateProvider` function should be smart enough to figure out that if server is `https://bitbucket.org`, then BitBucket Cloud provider should be used even if server kind is unspecified. 