### PR TITLE
Fixes for AWS (kops) cluster creation

### DIFF
--- a/pkg/jx/cmd/create_cluster_aws.go
+++ b/pkg/jx/cmd/create_cluster_aws.go
@@ -282,7 +282,7 @@ func (o *CreateClusterAWSOptions) Run() error {
 
 	log.Blank()
 	log.Infoln("Validating kops cluster state...")
-	err = o.RunCommand("kops", "validate", "cluster")
+	err = o.runKops("validate", "cluster")
 	if err != nil {
 		return fmt.Errorf("Failed to successfully validate kops cluster state: %s\n", err)
 	}

--- a/pkg/jx/cmd/create_cluster_aws.go
+++ b/pkg/jx/cmd/create_cluster_aws.go
@@ -367,5 +367,5 @@ func (o *CreateClusterAWSOptions) runKops(args ...string) error {
 		args = append(args, "--state", o.Flags.State)
 	}
 	log.Infof("running command: %s\n", util.ColorInfo("kops "+strings.Join(args, " ")))
-	return o.runKops("update", "cluster", "--yes")
+	return o.runCommandVerbose("kops", args...)
 }


### PR DESCRIPTION
1. The `runKops` function was doing an infinite loop.
2. The `kops validate cluster` command needs to go through `runKops` to get the `--state` flag.