### PR TITLE
Deleted duplicate option given at gc example

### DIFF
--- a/pkg/jx/cmd/gc.go
+++ b/pkg/jx/cmd/gc.go
@@ -36,7 +36,6 @@ var (
 `)
 
 	gc_example = templates.Examples(`
-		jx gc previews
 		jx gc activities
 		jx gc helm
 		jx gc gke

--- a/pkg/jx/cmd/gc.go
+++ b/pkg/jx/cmd/gc.go
@@ -37,8 +37,8 @@ var (
 
 	gc_example = templates.Examples(`
 		jx gc activities
-		jx gc helm
 		jx gc gke
+		jx gc helm
 		jx gc previews
 		jx gc releases
 


### PR DESCRIPTION
jx gc outputs this:

....
Examples:
  jx gc previews <- duplicate 
  jx gc activities
  jx gc helm
  jx gc gke <- breaks the alphabetical order
  jx gc previews
  jx gc releases
....