### PR TITLE
Avoid prompting when creating from quickstart in batch mode

### DIFF
--- a/pkg/jx/cmd/create_quickstart.go
+++ b/pkg/jx/cmd/create_quickstart.go
@@ -50,7 +50,7 @@ var (
 	`)
 )
 
-// CreateQuickstartOptions the options for the create spring command
+// CreateQuickstartOptions the options for the create quickstart command
 type CreateQuickstartOptions struct {
 	CreateProjectOptions
 

--- a/pkg/quickstarts/model.go
+++ b/pkg/quickstarts/model.go
@@ -106,8 +106,13 @@ func (model *QuickstartModel) CreateSurvey(filter *QuickstartFilter, batchMode b
 	}
 	answer := ""
 	if len(names) == 1 {
+		// if there's only a single option, use it
 		answer = names[0]
+	} else if batchMode {
+		// should not prompt for selection in batch mode so return an error
+		return nil, fmt.Errorf("More than one quickstart matches the current filter options. Try filtering based on other criteria (eg. Owner or Text)")
 	} else {
+		// if no single answer after filtering and we're not in batch mode then prompt
 		prompt := &survey.Select{
 			Message: "select the quickstart you wish to create",
 			Options: names,
@@ -117,6 +122,7 @@ func (model *QuickstartModel) CreateSurvey(filter *QuickstartFilter, batchMode b
 			return nil, err
 		}
 	}
+
 	if answer == "" {
 		return nil, fmt.Errorf("No quickstart chosen")
 	}


### PR DESCRIPTION
Proposed fix for https://github.com/jenkins-x/jx/issues/1953

The `jx create quickstart` command prompts for selection even if the batch mode `-b` option is specified. This causes scripts to hang. This PR simply adds a check for batch mode and returns an error to avoid prompting.