### PR TITLE
Update minimum Go version mentioned in Contributing.MD

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -9,7 +9,7 @@ development environment for working on the jx source code.
 To compile and test jx binaries you will need:
 
  - [git][]
- - [Go][] 1.9 or later, with support for compiling to `linux/amd64`
+ - [Go][] 1.11 or later, with support for compiling to `linux/amd64`
  - [dep](https://github.com/golang/dep)
  
 


### PR DESCRIPTION
With the change to using Go modules in Jenkins X (introduced in Go 1.11), JX builds using a version of Go <= 1.10 now fail. So I've updated the contributing docs to mention a minimum of Go 1.11 required to build