### PR TITLE
Fix typo in command line doc

### DIFF
--- a/pkg/jx/cmd/get_build.go
+++ b/pkg/jx/cmd/get_build.go
@@ -25,7 +25,7 @@ var (
 `)
 
 	get_build_example = templates.Examples(`
-		# List all pipeines
+		# List all pipelines
 		jx get pipeline
 
 		# List all URLs for services in the current namespace


### PR DESCRIPTION
Just fixing a small typo in the command line examples for jx get command.