### PR TITLE
Use domain if specified

### DIFF
--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -407,11 +407,13 @@ func (options *InstallOptions) Run() error {
 		if options.Flags.Provider == "" {
 			options.Flags.Provider = MINIKUBE
 		}
-		ip, err := options.getCommandOutput("", "minikube", "ip")
-		if err != nil {
-			return errors.Wrap(err, "failed to get the IP from Minikube")
+		if options.Flags.Domain == "" {
+			ip, err := options.getCommandOutput("", "minikube", "ip")
+			if err != nil {
+				return errors.Wrap(err, "failed to get the IP from Minikube")
+			}
+			options.Flags.Domain = ip + ".nip.io"
 		}
-		options.Flags.Domain = ip + ".nip.io"
 	}
 
 	if initOpts.Flags.Domain == "" && options.Flags.Domain != "" {


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Both `create` and `install` were enforcing the use of a `nip.io` address with minikube. My initial PR only fixed the `create` part and not the part where it delegates to `install`.

#### Special notes for the reviewer(s)

#### Which issue this PR fixes

fixes #2162 
