### PR TITLE
fix: correct url for chart museum

### DIFF
--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -73,7 +73,7 @@ const (
 	// INGRESS_SERVICE_NAME service name for ingress controller
 	INGRESS_SERVICE_NAME = "jxing-nginx-ingress-controller"
 	// DEFAULT_CHARTMUSEUM_URL default URL for Jenkins X ChartMuseum
-	DEFAULT_CHARTMUSEUM_URL = "https://chartmuseum.build.cd.jenkins-x.io"
+	DEFAULT_CHARTMUSEUM_URL = "https://chartmuseum.jx.cd.jenkins-x.io"
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Correct the URL for Chartmuseum

#### Special notes for the reviewer(s)
Since the changes to the chartmuseum layout last week, .build no longer has jenkins-x-platform updates in it

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
