### PR TITLE
fix:(preview) Try getting CHANGE_URL env variable for PRs, fixes #2174

### DIFF
--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -313,7 +313,11 @@ func (g *GitCLI) Info(dir string) (*GitRepositoryInfo, error) {
 	if err != nil && strings.Contains(text, "Not a git repository") {
 		rUrl = os.Getenv("SOURCE_URL")
 		if rUrl == "" {
-			return nil, fmt.Errorf("you are not in a Git repository - promotion command should be executed from an application directory")
+			// Relevant in a Jenkins pipeline triggered by a PR
+			rUrl = os.Getenv("CHANGE_URL")
+			if rUrl == "" {
+				return nil, fmt.Errorf("you are not in a Git repository - promotion command should be executed from an application directory")
+			}
 		}
 	} else {
 		text, err = g.gitCmdWithOutput(dir, "config", "--get", "remote.origin.url")

--- a/pkg/jx/cmd/preview.go
+++ b/pkg/jx/cmd/preview.go
@@ -685,30 +685,34 @@ func (o *PreviewOptions) defaultValues(ns string, warnMissingName bool) error {
 	if o.SourceURL == "" {
 		o.SourceURL = os.Getenv("SOURCE_URL")
 		if o.SourceURL == "" {
-			// lets discover the git dir
-			if o.Dir == "" {
-				dir, err := os.Getwd()
-				if err != nil {
-					return err
-				}
-				o.Dir = dir
-			}
-			root, gitConf, err := o.Git().FindGitConfigDir(o.Dir)
-			if err != nil {
-				log.Warnf("Could not find a .git directory: %s\n", err)
-			} else {
-				if root != "" {
-					o.Dir = root
-					o.SourceURL, err = o.discoverGitURL(gitConf)
+			// Relevant in a Jenkins pipeline triggered by a PR
+			o.SourceURL = os.Getenv("CHANGE_URL")
+			if o.SourceURL == "" {
+				// lets discover the git dir
+				if o.Dir == "" {
+					dir, err := os.Getwd()
 					if err != nil {
-						log.Warnf("Could not find the remote git source URL:  %s\n", err)
-					} else {
-						if o.SourceRef == "" {
-							o.SourceRef, err = o.Git().Branch(root)
-							if err != nil {
-								log.Warnf("Could not find the remote git source ref:  %s\n", err)
-							}
+						return err
+					}
+					o.Dir = dir
+				}
+				root, gitConf, err := o.Git().FindGitConfigDir(o.Dir)
+				if err != nil {
+					log.Warnf("Could not find a .git directory: %s\n", err)
+				} else {
+					if root != "" {
+						o.Dir = root
+						o.SourceURL, err = o.discoverGitURL(gitConf)
+						if err != nil {
+							log.Warnf("Could not find the remote git source URL:  %s\n", err)
+						} else {
+							if o.SourceRef == "" {
+								o.SourceRef, err = o.Git().Branch(root)
+								if err != nil {
+									log.Warnf("Could not find the remote git source ref:  %s\n", err)
+								}
 
+							}
 						}
 					}
 				}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

For Jenkins pipeline builds triggered by PRs from Bitbucket Cloud, the `discoverGitUrl` logic currently pulls the incorrect repo from the pipeline workspace's git conf. `CHANGE_URL` should always contain the correct repo for git providers that have a Branch Source plugin, such as Bitbucket and GitHub, so pulling that env variable is now part of the git URL discovery logic. 

There's likely a similar gremlin lurking in promotion somewhere.

#### Which issue this PR fixes

fixes #2174 
