### PR TITLE
fix: using gke as the provider when generating the context name

### DIFF
--- a/pkg/jx/cmd/create_terraform.go
+++ b/pkg/jx/cmd/create_terraform.go
@@ -89,7 +89,7 @@ func (g *GKECluster) SetProvider(provider string) string {
 
 // Context Get the context
 func (g GKECluster) Context() string {
-	return fmt.Sprintf("%s_%s_%s_%s", g.provider, g.ProjectID, g.Zone, g.ClusterName())
+	return fmt.Sprintf("%s_%s_%s_%s", "gke", g.ProjectID, g.Zone, g.ClusterName())
 }
 
 // Region Get the region


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.






fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->