### PR TITLE
fix(git): Cleanup git URL parsing logic.

### DIFF
--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -147,14 +147,23 @@ func ParseGitURL(text string) (*GitRepositoryInfo, error) {
 }
 
 func parsePath(path string, info *GitRepositoryInfo) (*GitRepositoryInfo, error) {
-	trimPath := strings.TrimSuffix(path, "/")
+
+	// This is necessary for Bitbucket Server in some cases.
+	trimPath := strings.TrimPrefix(path, "/scm")
+
+	// Remove leading and trailing slashes so that splitting on "/" won't result
+	// in empty strings at the beginning & end of the array.
+	trimPath = strings.TrimPrefix(trimPath, "/")
+	trimPath = strings.TrimSuffix(trimPath, "/")
+
 	trimPath = strings.TrimSuffix(trimPath, ".git")
+
 	arr := strings.Split(trimPath, "/")
-	arrayLength := len(arr)
-	if arrayLength >= 2 {
-		info.Organisation = arr[arrayLength-2]
-		info.Project = arr[arrayLength-2]
-		info.Name = arr[arrayLength-1]
+	if len(arr) >= 2 {
+		// We're assuming the beginning of the path is of the form /<org>/<repo>
+		info.Organisation = arr[0]
+		info.Project = arr[0]
+		info.Name = arr[1]
 
 		return info, nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Addresses a bug uncovered by #2175 where pull request URLs are not parsed correctly.

#### Special notes for the reviewer(s)

Holding as WIP until I can test with the right builder image snapshot.
