### PR TITLE
feat(aws): add tags flag to tag AWS resource

### DIFF
--- a/pkg/jx/cmd/create_cluster_aws.go
+++ b/pkg/jx/cmd/create_cluster_aws.go
@@ -44,6 +44,7 @@ type CreateClusterAWSFlags struct {
 	NodeSize               string
 	MasterSize             string
 	State                  string
+	Tags                   string
 }
 
 var (
@@ -103,6 +104,7 @@ func NewCmdCreateClusterAWS(f Factory, in terminal.FileReader, out terminal.File
 	cmd.Flags().StringVarP(&options.Flags.NodeSize, "node-size", "", "", "The size of a node in the kops created cluster.")
 	cmd.Flags().StringVarP(&options.Flags.MasterSize, "master-size", "", "", "The size of a master in the kops created cluster.")
 	cmd.Flags().StringVarP(&options.Flags.State, "state", "", "", "The S3 bucket used to store the state of the cluster.")
+	cmd.Flags().StringVarP(&options.Flags.Tags, "tags", "", "", "A list of KV pairs used to tag all instance groups in AWS (eg \"Owner=John Doe,Team=Some Team\").")
 	return cmd
 }
 
@@ -234,6 +236,9 @@ func (o *CreateClusterAWSOptions) Run() error {
 	}
 	if flags.MasterSize != "" {
 		args = append(args, "--master-size", flags.MasterSize)
+	}
+	if flags.Tags != "" {
+		args = append(args, "--cloud-labels", flags.Tags)
 	}
 
 	auth := "RBAC"

--- a/pkg/jx/cmd/create_cluster_eks.go
+++ b/pkg/jx/cmd/create_cluster_eks.go
@@ -35,6 +35,7 @@ type CreateClusterEKSFlags struct {
 	SshPublicKey        string
 	Verbose             int
 	AWSOperationTimeout time.Duration
+	Tags                string
 }
 
 var (
@@ -87,6 +88,7 @@ func NewCmdCreateClusterEKS(f Factory, in terminal.FileReader, out terminal.File
 	cmd.Flags().StringVarP(&options.Flags.Zones, optionZones, "z", "", "Availability Zones. Auto-select if not specified. If provided, this overrides the $EKS_AVAILABILITY_ZONES environment variable")
 	cmd.Flags().StringVarP(&options.Flags.Profile, "profile", "p", "", "AWS profile to use. If provided, this overrides the AWS_PROFILE environment variable")
 	cmd.Flags().StringVarP(&options.Flags.SshPublicKey, "ssh-public-key", "", "", "SSH public key to use for nodes (import from local path, or use existing EC2 key pair) (default \"~/.ssh/id_rsa.pub\")")
+	cmd.Flags().StringVarP(&options.Flags.Tags, "tags", "", "", "A list of KV pairs used to tag all instance groups in AWS (eg \"Owner=John Doe,Team=Some Team\").")
 	return cmd
 }
 
@@ -149,6 +151,9 @@ func (o *CreateClusterEKSOptions) Run() error {
 	}
 	if flags.Verbose >= 0 {
 		args = append(args, "--verbose", strconv.Itoa(flags.Verbose))
+	}
+	if flags.Tags != "" {
+		args = append(args, "--tags", flags.Tags)
 	}
 	args = append(args, "--aws-api-timeout", flags.AWSOperationTimeout.String())
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Add `--tags` flag to `jx create cluster aws` and `jx create cluster eks` commands and pass that onto `eksctl` and `kops`.

#### Special notes for the reviewer(s)

Tested both of these changes by standing up a cluster for each.

#### Which issue this PR fixes

no related issues
