### PR TITLE
fix(bitbucket): Issue creation now returns HTML URL for Issue, fixes …

### DIFF
--- a/pkg/gits/bitbucket_cloud.go
+++ b/pkg/gits/bitbucket_cloud.go
@@ -824,6 +824,14 @@ func (b *BitbucketCloudProvider) CreateIssue(owner string, repo string, issue *G
 		b.GitIssueToBitbucketIssue(*issue),
 	)
 
+	// We need to make a second round trip to get the issue's HTML URL.
+	bIssue, _, err = b.Client.IssueTrackerApi.RepositoriesUsernameRepoSlugIssuesIssueIdGet(
+		b.Context,
+		owner,
+		strconv.FormatInt(int64(bIssue.Id), 10),
+		repo,
+	)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
…#1668

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Added an additional round trip after creating a Bitbucket Cloud issue, since the initial POST response doesn't return the HTML URL for the Issue, resulting in a nil pointer dereference when we try to access it.