### PR TITLE
fix unit test on OS-X

### DIFF
--- a/pkg/util/dirs_test.go
+++ b/pkg/util/dirs_test.go
@@ -16,6 +16,10 @@ func TestJXBinaryLocationSuccess(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "")
 	require.NoError(t, err, "[TEST SETUP] failed to create temp directory for test")
 	defer os.RemoveAll(tempDir)
+	// on OS-X tmp is /tmp but a link to /private/tmp which causes the test to fail!
+	tempDir, err = filepath.EvalSymlinks(tempDir);
+	require.NoError(t, err, "[TEST SETUP] could not resolve symlinks")
+
 	jxpath := filepath.Join(tempDir, "jx")
 	// resolving symlinks requires that the file exists (at least on windows...
 	_ , err = os.Create(jxpath)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

On OS-X the temp directory is defined as /tmp but this is a sym link to
/private/tmp which causes the test to fail.
so resolve symlinks before calling the test as a dirty quick fix

#### Special notes for the reviewer(s)

please test locally on ox-x as I have no access to this environment.

#### Which issue this PR fixes

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
