### PR TITLE
refactor(auth config): create the building blocks for refactoring the current auth config (updated data model, readers and writers)

### DIFF
--- a/pkg/auth/auth_config.go
+++ b/pkg/auth/auth_config.go
@@ -420,3 +420,8 @@ func (config *AuthConfig) PickOrCreateServer(fallbackServerURL string, serverURL
 	}
 	return config.GetOrCreateServer(name), nil
 }
+
+func (config *AuthConfig) UpdatePipelineServer(server *AuthServer, user *UserAuth) {
+	config.PipeLineServer = server.URL
+	config.PipeLineUsername = user.Username
+}

--- a/pkg/auth/auth_config.go
+++ b/pkg/auth/auth_config.go
@@ -61,8 +61,8 @@ func (c *AuthConfig) FindUserAuth(serverURL string, username string) *UserAuth {
 	return nil
 }
 
-func (config *AuthConfig) IndexOfServerName(name string) int {
-	for i, server := range config.Servers {
+func (c *AuthConfig) IndexOfServerName(name string) int {
+	for i, server := range c.Servers {
 		if server.Name == name {
 			return i
 		}
@@ -303,19 +303,20 @@ func (c *AuthConfig) PickServerUserAuth(server *AuthServer, message string, batc
 		}
 		answer := m[username]
 		if answer == nil {
-			return nil, fmt.Errorf("No username chosen!")
+			return nil, fmt.Errorf("no username chosen")
 		}
 		return answer, nil
 	}
 	return &UserAuth{}, nil
 }
 
+// PrintUserFn prints the use name
 type PrintUserFn func(username string) error
 
 // EditUserAuth Lets the user input/edit the user auth
-func (config *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defaultUserName string, editUser, batchMode bool, fn PrintUserFn, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) error {
+func (c *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defaultUserName string, editUser, batchMode bool, fn PrintUserFn, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) error {
 	// default the user name if its empty
-	defaultUsername := config.DefaultUsername
+	defaultUsername := c.DefaultUsername
 	if defaultUsername == "" {
 		defaultUsername = defaultUserName
 	}
@@ -350,9 +351,10 @@ func (config *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defau
 	return err
 }
 
-func (config *AuthConfig) GetServerNames() []string {
+// GetServerNames returns the name of the server currently in the configuration
+func (c *AuthConfig) GetServerNames() []string {
 	answer := []string{}
-	for _, server := range config.Servers {
+	for _, server := range c.Servers {
 		name := server.Name
 		if name != "" {
 			answer = append(answer, name)
@@ -362,9 +364,10 @@ func (config *AuthConfig) GetServerNames() []string {
 	return answer
 }
 
-func (config *AuthConfig) GetServerURLs() []string {
+// GetServerURLs returns the server URLs currently in the configuration
+func (c *AuthConfig) GetServerURLs() []string {
 	answer := []string{}
-	for _, server := range config.Servers {
+	for _, server := range c.Servers {
 		u := server.URL
 		if u != "" {
 			answer = append(answer, u)
@@ -375,13 +378,13 @@ func (config *AuthConfig) GetServerURLs() []string {
 }
 
 // PickOrCreateServer picks the server to use defaulting to the current server
-func (config *AuthConfig) PickOrCreateServer(fallbackServerURL string, serverURL string, message string, batchMode bool, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (*AuthServer, error) {
-	servers := config.Servers
+func (c *AuthConfig) PickOrCreateServer(fallbackServerURL string, serverURL string, message string, batchMode bool, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (*AuthServer, error) {
+	servers := c.Servers
 	if len(servers) == 0 {
 		if serverURL != "" {
-			return config.GetOrCreateServer(serverURL), nil
+			return c.GetOrCreateServer(serverURL), nil
 		}
-		return config.GetOrCreateServer(fallbackServerURL), nil
+		return c.GetOrCreateServer(fallbackServerURL), nil
 	}
 	// lets let the user pick which server to use defaulting to the current server
 	names := []string{}
@@ -399,29 +402,30 @@ func (config *AuthConfig) PickOrCreateServer(fallbackServerURL string, serverURL
 		names = append(names, serverURL)
 	}
 	if len(names) == 1 {
-		return config.GetOrCreateServer(names[0]), nil
+		return c.GetOrCreateServer(names[0]), nil
 	}
 	defaultValue := serverURL
 	if defaultValue == "" {
-		defaultValue = config.CurrentServer
+		defaultValue = c.CurrentServer
 	}
 	if defaultValue == "" {
 		defaultValue = names[0]
 	}
 	if batchMode {
-		return config.GetOrCreateServer(defaultValue), nil
+		return c.GetOrCreateServer(defaultValue), nil
 	}
 	name, err := util.PickRequiredNameWithDefault(names, message, defaultValue, "", in, out, outErr)
 	if err != nil {
 		return nil, err
 	}
 	if name == "" {
-		return nil, fmt.Errorf("No server URL chosen!")
+		return nil, fmt.Errorf("no server URL chosen")
 	}
-	return config.GetOrCreateServer(name), nil
+	return c.GetOrCreateServer(name), nil
 }
 
-func (config *AuthConfig) UpdatePipelineServer(server *AuthServer, user *UserAuth) {
-	config.PipeLineServer = server.URL
-	config.PipeLineUsername = user.Username
+// UpdatePipelineServer updates the pipeline server in the configuration
+func (c *AuthConfig) UpdatePipelineServer(server *AuthServer, user *UserAuth) {
+	c.PipeLineServer = server.URL
+	c.PipeLineUsername = user.Username
 }

--- a/pkg/auth/auth_config.go
+++ b/pkg/auth/auth_config.go
@@ -1,0 +1,415 @@
+package auth
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/jenkins-x/jx/pkg/util"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+func (c *AuthConfig) FindUserAuths(serverURL string) []*UserAuth {
+	for _, server := range c.Servers {
+		if urlsEqual(server.URL, serverURL) {
+			return server.Users
+		}
+	}
+	return []*UserAuth{}
+}
+
+func (c *AuthConfig) GetOrCreateUserAuth(url string, username string) *UserAuth {
+	user := c.FindUserAuth(url, username)
+	if user != nil {
+		return user
+	}
+	server := c.GetOrCreateServer(url)
+	if server.Users == nil {
+		server.Users = []*UserAuth{}
+	}
+	user = &UserAuth{
+		Username: username,
+	}
+	server.Users = append(server.Users, user)
+	for _, user := range server.Users {
+		if user.Username == username {
+			return user
+		}
+	}
+	return nil
+}
+
+// FindUserAuth finds the auth for the given user name
+// if no username is specified and there is only one auth then return that else nil
+func (c *AuthConfig) FindUserAuth(serverURL string, username string) *UserAuth {
+	auths := c.FindUserAuths(serverURL)
+	if username == "" {
+		if len(auths) == 1 {
+			return auths[0]
+		} else {
+			return nil
+		}
+	}
+	for _, auth := range auths {
+		if auth.Username == username {
+			return auth
+		}
+	}
+	return nil
+}
+
+func (config *AuthConfig) IndexOfServerName(name string) int {
+	for i, server := range config.Servers {
+		if server.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func (c *AuthConfig) SetUserAuth(url string, auth *UserAuth) {
+	username := auth.Username
+	for i, server := range c.Servers {
+		if urlsEqual(server.URL, url) {
+			for j, a := range server.Users {
+				if a.Username == auth.Username {
+					c.Servers[i].Users[j] = auth
+					c.Servers[i].CurrentUser = username
+					return
+				}
+			}
+			c.Servers[i].Users = append(c.Servers[i].Users, auth)
+			c.Servers[i].CurrentUser = username
+			return
+		}
+	}
+	c.Servers = append(c.Servers, &AuthServer{
+		URL:         url,
+		Users:       []*UserAuth{auth},
+		CurrentUser: username,
+	})
+}
+
+func urlsEqual(url1, url2 string) bool {
+	return url1 == url2 || strings.TrimSuffix(url1, "/") == strings.TrimSuffix(url2, "/")
+}
+
+// GetServerByName returns the server for the given URL or null if its not found
+func (c *AuthConfig) GetServer(url string) *AuthServer {
+	for _, s := range c.Servers {
+		if urlsEqual(s.URL, url) {
+			return s
+		}
+	}
+	return nil
+}
+
+// GetServerByName returns the server for the given name or null if its not found
+func (c *AuthConfig) GetServerByName(name string) *AuthServer {
+	for _, s := range c.Servers {
+		if s.Name == name {
+			return s
+		}
+	}
+	return nil
+}
+
+// GetServerByKind returns the server for the given kind or null if its not found
+func (c *AuthConfig) GetServerByKind(kind string) *AuthServer {
+	for _, s := range c.Servers {
+		if s.Kind == kind && s.URL == c.CurrentServer {
+			return s
+		}
+	}
+	return nil
+}
+
+//DeleteServer deletes the server for the given URL and updates the current server
+//if is the same with the deleted server
+func (c *AuthConfig) DeleteServer(url string) {
+	for i, s := range c.Servers {
+		if urlsEqual(s.URL, url) {
+			c.Servers = append(c.Servers[:i], c.Servers[i+1:]...)
+		}
+	}
+	if urlsEqual(c.CurrentServer, url) && len(c.Servers) > 0 {
+		c.CurrentServer = c.Servers[0].URL
+	} else {
+		c.CurrentServer = ""
+	}
+}
+
+func (c *AuthConfig) GetOrCreateServer(url string) *AuthServer {
+	name := ""
+	kind := ""
+	return c.GetOrCreateServerName(url, name, kind)
+}
+
+func (c *AuthConfig) GetOrCreateServerName(url string, name string, kind string) *AuthServer {
+	s := c.GetServer(url)
+	if s == nil {
+		if name == "" {
+			// lets default the name to the server URL
+			name = urlHostName(url)
+		}
+		if c.Servers == nil {
+			c.Servers = []*AuthServer{}
+		}
+		s = &AuthServer{
+			URL:   url,
+			Users: []*UserAuth{},
+			Name:  name,
+			Kind:  kind,
+		}
+		c.Servers = append(c.Servers, s)
+	}
+	if s.Kind == "" {
+		s.Kind = kind
+	}
+	return s
+}
+
+func (c *AuthConfig) AddServer(server *AuthServer) {
+	s := c.GetServer(server.URL)
+	if s == nil {
+		if c.Servers == nil {
+			c.Servers = []*AuthServer{}
+		}
+		c.Servers = append(c.Servers, server)
+	} else {
+		s.Users = append(s.Users, server.Users...)
+	}
+}
+
+func urlHostName(rawUrl string) string {
+	u, err := url.Parse(rawUrl)
+	if err == nil {
+		return u.Host
+	}
+	idx := strings.Index(rawUrl, "://")
+	if idx > 0 {
+		rawUrl = rawUrl[idx+3:]
+	}
+	return strings.TrimSuffix(rawUrl, "/")
+}
+
+func (c *AuthConfig) PickServer(message string, batchMode bool, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (*AuthServer, error) {
+	if c.Servers == nil || len(c.Servers) == 0 {
+		return nil, fmt.Errorf("No servers available!")
+	}
+	if len(c.Servers) == 1 {
+		return c.Servers[0], nil
+	}
+	urls := []string{}
+	for _, s := range c.Servers {
+		urls = append(urls, s.URL)
+	}
+	url := ""
+	if len(urls) > 1 {
+		if batchMode {
+			url = c.CurrentServer
+		} else {
+			prompt := &survey.Select{
+				Message: message,
+				Options: urls,
+			}
+			surveyOpts := survey.WithStdio(in, out, outErr)
+			err := survey.AskOne(prompt, &url, survey.Required, surveyOpts)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, s := range c.Servers {
+		if urlsEqual(s.URL, url) {
+			return s, nil
+		}
+	}
+	return nil, fmt.Errorf("Could not find server for URL %s", url)
+}
+
+// PickServerAuth Pick the servers auth
+func (c *AuthConfig) PickServerUserAuth(server *AuthServer, message string, batchMode bool, org string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (*UserAuth, error) {
+	url := server.URL
+	userAuths := c.FindUserAuths(url)
+	surveyOpts := survey.WithStdio(in, out, errOut)
+	if len(userAuths) == 1 {
+
+		auth := userAuths[0]
+		if batchMode {
+			return auth, nil
+		}
+		confirm := &survey.Confirm{
+			Message: fmt.Sprintf("Do you wish to use %s as the %s", auth.Username, message),
+			Default: true,
+		}
+		flag := false
+		err := survey.AskOne(confirm, &flag, nil, surveyOpts)
+		if err != nil {
+			return auth, err
+		}
+		if flag {
+			return auth, nil
+		}
+
+		// lets create a new user name
+		prompt := &survey.Input{
+			Message: message,
+		}
+		username := ""
+		err = survey.AskOne(prompt, &username, nil, surveyOpts)
+		if err != nil {
+			return auth, err
+		}
+		return c.GetOrCreateUserAuth(url, username), nil
+	}
+	if len(userAuths) > 1 {
+
+		// If in batchmode select the user auth based on the org passed, or default to the first auth.
+		if batchMode {
+			for i, x := range userAuths {
+				if x.Username == org {
+					return userAuths[i], nil
+				}
+			}
+			return userAuths[0], nil
+		}
+
+		usernames := []string{}
+		m := map[string]*UserAuth{}
+		for _, ua := range userAuths {
+			name := ua.Username
+			usernames = append(usernames, name)
+			m[name] = ua
+		}
+		username := ""
+		prompt := &survey.Select{
+			Message: message,
+			Options: usernames,
+		}
+		err := survey.AskOne(prompt, &username, survey.Required, surveyOpts)
+		if err != nil {
+			return &UserAuth{}, err
+		}
+		answer := m[username]
+		if answer == nil {
+			return nil, fmt.Errorf("No username chosen!")
+		}
+		return answer, nil
+	}
+	return &UserAuth{}, nil
+}
+
+type PrintUserFn func(username string) error
+
+// EditUserAuth Lets the user input/edit the user auth
+func (config *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defaultUserName string, editUser, batchMode bool, fn PrintUserFn, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) error {
+	// default the user name if its empty
+	defaultUsername := config.DefaultUsername
+	if defaultUsername == "" {
+		defaultUsername = defaultUserName
+	}
+	if auth.Username == "" {
+		auth.Username = defaultUsername
+	}
+
+	if batchMode {
+		if auth.Username == "" {
+			return fmt.Errorf("Running in batch mode and no default Git username found")
+		}
+		if auth.ApiToken == "" {
+			return fmt.Errorf("Running in batch mode and no default API token found")
+		}
+		return nil
+	}
+	var err error
+
+	if editUser || auth.Username == "" {
+		auth.Username, err = util.PickValue(serverLabel+" user name:", auth.Username, true, "", in, out, outErr)
+		if err != nil {
+			return err
+		}
+	}
+	if fn != nil {
+		err := fn(auth.Username)
+		if err != nil {
+			return err
+		}
+	}
+	auth.ApiToken, err = util.PickPassword("API Token:", "", in, out, outErr)
+	return err
+}
+
+func (config *AuthConfig) GetServerNames() []string {
+	answer := []string{}
+	for _, server := range config.Servers {
+		name := server.Name
+		if name != "" {
+			answer = append(answer, name)
+		}
+	}
+	sort.Strings(answer)
+	return answer
+}
+
+func (config *AuthConfig) GetServerURLs() []string {
+	answer := []string{}
+	for _, server := range config.Servers {
+		u := server.URL
+		if u != "" {
+			answer = append(answer, u)
+		}
+	}
+	sort.Strings(answer)
+	return answer
+}
+
+// PickOrCreateServer picks the server to use defaulting to the current server
+func (config *AuthConfig) PickOrCreateServer(fallbackServerURL string, serverURL string, message string, batchMode bool, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (*AuthServer, error) {
+	servers := config.Servers
+	if len(servers) == 0 {
+		if serverURL != "" {
+			return config.GetOrCreateServer(serverURL), nil
+		}
+		return config.GetOrCreateServer(fallbackServerURL), nil
+	}
+	// lets let the user pick which server to use defaulting to the current server
+	names := []string{}
+	teamServerMissing := true
+	for _, s := range servers {
+		u := s.URL
+		if u != "" {
+			names = append(names, u)
+		}
+		if u == serverURL {
+			teamServerMissing = false
+		}
+	}
+	if teamServerMissing && serverURL != "" {
+		names = append(names, serverURL)
+	}
+	if len(names) == 1 {
+		return config.GetOrCreateServer(names[0]), nil
+	}
+	defaultValue := serverURL
+	if defaultValue == "" {
+		defaultValue = config.CurrentServer
+	}
+	if defaultValue == "" {
+		defaultValue = names[0]
+	}
+	if batchMode {
+		return config.GetOrCreateServer(defaultValue), nil
+	}
+	name, err := util.PickRequiredNameWithDefault(names, message, defaultValue, "", in, out, outErr)
+	if err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, fmt.Errorf("No server URL chosen!")
+	}
+	return config.GetOrCreateServer(name), nil
+}

--- a/pkg/auth/auth_config.go
+++ b/pkg/auth/auth_config.go
@@ -142,6 +142,13 @@ func (c *AuthConfig) DeleteServer(url string) {
 	}
 }
 
+func (c *AuthConfig) CurrentUser(server *AuthServer, inCluster bool) *UserAuth {
+	if urlsEqual(c.PipeLineServer, server.URL) && inCluster {
+		return server.GetUserAuth(c.PipeLineUsername)
+	}
+	return server.CurrentAuth()
+}
+
 func (c *AuthConfig) GetOrCreateServer(url string) *AuthServer {
 	name := ""
 	kind := ""

--- a/pkg/auth/auth_config_test.go
+++ b/pkg/auth/auth_config_test.go
@@ -1,0 +1,174 @@
+package auth_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	url1 = "http://dummy/"
+	url2 = "http://another-jenkins/"
+
+	userDoesNotExist = "doesNotExist"
+	user1            = "someone"
+	user2            = "another"
+	token2v2         = "tokenV2"
+)
+
+func TestAuthConfig(t *testing.T) {
+	t.Parallel()
+	dir, err := ioutil.TempDir("/tmp", "jx-test-jenkins-config-")
+	assertNoError(t, err)
+
+	fileName := filepath.Join(dir, "jenkins.yaml")
+
+	t.Logf("Using config file %s\n", fileName)
+
+	configTest := ConfigTest{
+		t: t,
+	}
+	configTest.svc.FileName = fileName
+
+	config := configTest.Load()
+
+	assert.Equal(t, 0, len(config.Servers), "Should have no servers in config but got %v", config)
+	assertNoAuth(t, config, url1, userDoesNotExist)
+
+	auth1 := auth.UserAuth{
+		Username: user1,
+		ApiToken: "someToken",
+	}
+	config = configTest.SetUserAuth(url1, auth1)
+
+	assert.Equal(t, 1, len(config.Servers), "Number of servers")
+	assert.Equal(t, 1, len(config.Servers[0].Users), "Number of auths")
+	assert.Equal(t, &auth1, config.FindUserAuth(url1, user1), "loaded auth for server %s and user %s", url1, user1)
+	assert.Equal(t, &auth1, config.FindUserAuth(url1, ""), "loaded auth for server %s and no user", url1)
+
+	auth2 := auth.UserAuth{
+		Username: user2,
+		ApiToken: "anotherToken",
+	}
+	config = configTest.SetUserAuth(url1, auth2)
+
+	assert.Equal(t, &auth2, config.FindUserAuth(url1, user2), "Failed to find auth for server %s and user %s", url1, user2)
+	assert.Equal(t, &auth1, config.FindUserAuth(url1, user1), "loaded auth for server %s and user %s", url1, user1)
+	assert.Equal(t, 1, len(config.Servers), "Number of servers")
+	assert.Equal(t, 2, len(config.Servers[0].Users), "Number of auths")
+	assertNoAuth(t, config, url1, userDoesNotExist)
+
+	// lets mutate the auth2
+	auth2.ApiToken = token2v2
+	config = configTest.SetUserAuth(url1, auth2)
+
+	assertNoAuth(t, config, url1, userDoesNotExist)
+	assert.Equal(t, 1, len(config.Servers), "Number of servers")
+	assert.Equal(t, 2, len(config.Servers[0].Users), "Number of auths")
+	assert.Equal(t, &auth1, config.FindUserAuth(url1, user1), "loaded auth for server %s and user %s", url1, user1)
+	assert.Equal(t, &auth2, config.FindUserAuth(url1, user2), "loaded auth for server %s and user %s", url1, user2)
+
+	auth3 := auth.UserAuth{
+		Username: user1,
+		ApiToken: "server2User1Token",
+	}
+	configTest.SetUserAuth(url2, auth3)
+
+	assertNoAuth(t, config, url1, userDoesNotExist)
+	assert.Equal(t, 2, len(config.Servers), "Number of servers")
+	assert.Equal(t, 2, len(config.Servers[0].Users), "Number of auths for server 0")
+	assert.Equal(t, 1, len(config.Servers[1].Users), "Number of auths for server 1")
+	assert.Equal(t, &auth1, config.FindUserAuth(url1, user1), "loaded auth for server %s and user %s", url1, user1)
+	assert.Equal(t, &auth2, config.FindUserAuth(url1, user2), "loaded auth for server %s and user %s", url1, user2)
+	assert.Equal(t, &auth3, config.FindUserAuth(url2, user1), "loaded auth for server %s and user %s", url2, user1)
+}
+
+type ConfigTest struct {
+	t      *testing.T
+	svc    auth.AuthConfigService
+	config *auth.AuthConfig
+}
+
+func (c *ConfigTest) Load() *auth.AuthConfig {
+	config, err := c.svc.LoadConfig()
+	c.config = config
+	c.AssertNoError(err)
+	return c.config
+}
+
+func (c *ConfigTest) SetUserAuth(url string, auth auth.UserAuth) *auth.AuthConfig {
+	copy := auth
+	c.config.SetUserAuth(url, &copy)
+	c.SaveAndReload()
+	return c.config
+}
+
+func (c *ConfigTest) SaveAndReload() *auth.AuthConfig {
+	err := c.svc.SaveConfig()
+	c.AssertNoError(err)
+	return c.Load()
+}
+
+func (c *ConfigTest) AssertNoError(err error) {
+	if err != nil {
+		assert.Fail(c.t, "Should not have received an error but got: %s", err)
+	}
+}
+
+func assertNoAuth(t *testing.T, config *auth.AuthConfig, url string, user string) {
+	found := config.FindUserAuth(url, user)
+	if found != nil {
+		assert.Fail(t, "Found auth when not expecting it for server %s and user %s", url, user)
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	if err != nil {
+		assert.Fail(t, "Should not have received an error but got: %s", err)
+	}
+}
+
+func TestAuthConfigGetsDefaultName(t *testing.T) {
+	t.Parallel()
+	c := &auth.AuthConfig{}
+
+	expectedURL := "https://foo.com"
+	server := c.GetOrCreateServer(expectedURL)
+	assert.NotNil(t, server, "No server found!")
+	assert.True(t, server.Name != "", "Should have a server name!")
+	assert.Equal(t, expectedURL, server.URL, "Server.URL")
+}
+
+func TestDeleteServer(t *testing.T) {
+	t.Parallel()
+	c := &auth.AuthConfig{}
+	url := "https://foo.com"
+	server := c.GetOrCreateServer(url)
+	assert.NotNil(t, server, "Failed to add the server to the configuration")
+	assert.Equal(t, 1, len(c.Servers), "No server found in the configuration")
+
+	c.DeleteServer(url)
+	assert.Equal(t, 0, len(c.Servers), "Failed to remove the server from configuration")
+	assert.Equal(t, "", c.CurrentServer, "Should be no current server")
+}
+
+func TestDeleteServer2(t *testing.T) {
+	t.Parallel()
+	c := &auth.AuthConfig{}
+	url1 := "https://foo1.com"
+	server1 := c.GetOrCreateServer(url1)
+	assert.NotNil(t, server1, "Failed to add the server to the configuration")
+	url2 := "https://foo2.com"
+	server2 := c.GetOrCreateServer(url2)
+	assert.NotNil(t, server2, "Failed to the server to the configuration!")
+	assert.Equal(t, 2, len(c.Servers), "Must have 2 servers in the configuration")
+	c.CurrentServer = url2
+
+	c.DeleteServer(url2)
+	assert.Equal(t, 1, len(c.Servers), "Failed to remove one server from configuration")
+	assert.Equal(t, url1, c.Servers[0].URL, "Failed to remove the right server from the configuration")
+	assert.Equal(t, url1, c.CurrentServer, "Server 1 should be current server")
+}

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -22,7 +22,7 @@ type User struct {
 	Kind        UserKind `yaml:"kind"`
 }
 
-//ServerKind type for server kind
+//ServerKind type of the server
 type ServerKind string
 
 const (

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -1,415 +1,122 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
-	"io"
-	"net/url"
-	"sort"
-	"strings"
-
-	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
-func (c *AuthConfig) FindUserAuths(serverURL string) []*UserAuth {
-	for _, server := range c.Servers {
-		if urlsEqual(server.URL, serverURL) {
-			return server.Users
-		}
-	}
-	return []*UserAuth{}
+//UserKind define for user kind
+type UserKind string
+
+const (
+	UserKindLocal    UserKind = "local"
+	UserKindPipeline UserKind = "pipeline"
+)
+
+//User store the auth infomation for a user
+type User struct {
+	Username    string   `yaml:"username"`
+	ApiToken    string   `yaml:"apitoken"`
+	BearerToken string   `yaml:"bearertoken"`
+	Password    string   `yaml:"password,omitempty" json:"password"`
+	Kind        UserKind `yaml:"kind"`
 }
 
-func (c *AuthConfig) GetOrCreateUserAuth(url string, username string) *UserAuth {
-	user := c.FindUserAuth(url, username)
-	if user != nil {
-		return user
-	}
-	server := c.GetOrCreateServer(url)
-	if server.Users == nil {
-		server.Users = []*UserAuth{}
-	}
-	user = &UserAuth{
-		Username: username,
-	}
-	server.Users = append(server.Users, user)
-	for _, user := range server.Users {
-		if user.Username == username {
-			return user
-		}
-	}
-	return nil
+//ServerKind type of the server
+type ServerKind string
+
+const (
+	ServerKindGit   ServerKind = "git"
+	ServerKindIssue ServerKind = "issue"
+	ServerKindChat  ServerKind = "chat"
+)
+
+//ServerKind type for service used by the server
+type ServiceKind string
+
+const (
+	ServiceKindGithub          ServiceKind = "github"
+	ServiceKindGitlab          ServiceKind = "gitlab"
+	ServiceKindGitea           ServiceKind = "gitea"
+	ServiceKindBitbucketCloud  ServiceKind = "bitbucketcloud"
+	ServiceKindBitbucketServer ServiceKind = "bitbucketserver"
+)
+
+//Server stores the server configuration for a server
+type Server struct {
+	URL         string      `yaml:"url"`
+	Name        string      `yaml:"name"`
+	Kind        ServerKind  `yaml:"kind"`
+	ServiceKind ServiceKind `yaml:"servicekind"`
+	Users       []*User     `yaml:"users"`
 }
 
-// FindUserAuth finds the auth for the given user name
-// if no username is specified and there is only one auth then return that else nil
-func (c *AuthConfig) FindUserAuth(serverURL string, username string) *UserAuth {
-	auths := c.FindUserAuths(serverURL)
-	if username == "" {
-		if len(auths) == 1 {
-			return auths[0]
-		} else {
-			return nil
-		}
-	}
-	for _, auth := range auths {
-		if auth.Username == username {
-			return auth
-		}
-	}
-	return nil
+// Config stores the entire auth configuration for a number of sservers
+type Config struct {
+	Servers []*Server `yaml:"servers"`
 }
 
-func (config *AuthConfig) IndexOfServerName(name string) int {
-	for i, server := range config.Servers {
-		if server.Name == name {
-			return i
-		}
-	}
-	return -1
+// Checker verifies if the configuration is valid
+type Checker interface {
+	Valid() error
 }
 
-func (c *AuthConfig) SetUserAuth(url string, auth *UserAuth) {
-	username := auth.Username
-	for i, server := range c.Servers {
-		if urlsEqual(server.URL, url) {
-			for j, a := range server.Users {
-				if a.Username == auth.Username {
-					c.Servers[i].Users[j] = auth
-					c.Servers[i].CurrentUser = username
-					return
-				}
-			}
-			c.Servers[i].Users = append(c.Servers[i].Users, auth)
-			c.Servers[i].CurrentUser = username
-			return
-		}
-	}
-	c.Servers = append(c.Servers, &AuthServer{
-		URL:         url,
-		Users:       []*UserAuth{auth},
-		CurrentUser: username,
-	})
-}
-
-func urlsEqual(url1, url2 string) bool {
-	return url1 == url2 || strings.TrimSuffix(url1, "/") == strings.TrimSuffix(url2, "/")
-}
-
-// GetServerByName returns the server for the given URL or null if its not found
-func (c *AuthConfig) GetServer(url string) *AuthServer {
-	for _, s := range c.Servers {
-		if urlsEqual(s.URL, url) {
-			return s
-		}
-	}
-	return nil
-}
-
-// GetServerByName returns the server for the given name or null if its not found
-func (c *AuthConfig) GetServerByName(name string) *AuthServer {
-	for _, s := range c.Servers {
-		if s.Name == name {
-			return s
-		}
-	}
-	return nil
-}
-
-// GetServerByKind returns the server for the given kind or null if its not found
-func (c *AuthConfig) GetServerByKind(kind string) *AuthServer {
-	for _, s := range c.Servers {
-		if s.Kind == kind && s.URL == c.CurrentServer {
-			return s
-		}
-	}
-	return nil
-}
-
-//DeleteServer deletes the server for the given URL and updates the current server
-//if is the same with the deleted server
-func (c *AuthConfig) DeleteServer(url string) {
-	for i, s := range c.Servers {
-		if urlsEqual(s.URL, url) {
-			c.Servers = append(c.Servers[:i], c.Servers[i+1:]...)
-		}
-	}
-	if urlsEqual(c.CurrentServer, url) && len(c.Servers) > 0 {
-		c.CurrentServer = c.Servers[0].URL
-	} else {
-		c.CurrentServer = ""
-	}
-}
-
-func (c *AuthConfig) GetOrCreateServer(url string) *AuthServer {
-	name := ""
-	kind := ""
-	return c.GetOrCreateServerName(url, name, kind)
-}
-
-func (c *AuthConfig) GetOrCreateServerName(url string, name string, kind string) *AuthServer {
-	s := c.GetServer(url)
-	if s == nil {
-		if name == "" {
-			// lets default the name to the server URL
-			name = urlHostName(url)
-		}
-		if c.Servers == nil {
-			c.Servers = []*AuthServer{}
-		}
-		s = &AuthServer{
-			URL:   url,
-			Users: []*UserAuth{},
-			Name:  name,
-			Kind:  kind,
-		}
-		c.Servers = append(c.Servers, s)
-	}
-	if s.Kind == "" {
-		s.Kind = kind
-	}
-	return s
-}
-
-func (c *AuthConfig) AddServer(server *AuthServer) {
-	s := c.GetServer(server.URL)
-	if s == nil {
-		if c.Servers == nil {
-			c.Servers = []*AuthServer{}
-		}
-		c.Servers = append(c.Servers, server)
-	} else {
-		s.Users = append(s.Users, server.Users...)
-	}
-}
-
-func urlHostName(rawUrl string) string {
-	u, err := url.Parse(rawUrl)
-	if err == nil {
-		return u.Host
-	}
-	idx := strings.Index(rawUrl, "://")
-	if idx > 0 {
-		rawUrl = rawUrl[idx+3:]
-	}
-	return strings.TrimSuffix(rawUrl, "/")
-}
-
-func (c *AuthConfig) PickServer(message string, batchMode bool, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (*AuthServer, error) {
-	if c.Servers == nil || len(c.Servers) == 0 {
-		return nil, fmt.Errorf("No servers available!")
-	}
-	if len(c.Servers) == 1 {
-		return c.Servers[0], nil
-	}
-	urls := []string{}
-	for _, s := range c.Servers {
-		urls = append(urls, s.URL)
-	}
-	url := ""
-	if len(urls) > 1 {
-		if batchMode {
-			url = c.CurrentServer
-		} else {
-			prompt := &survey.Select{
-				Message: message,
-				Options: urls,
-			}
-			surveyOpts := survey.WithStdio(in, out, outErr)
-			err := survey.AskOne(prompt, &url, survey.Required, surveyOpts)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-	for _, s := range c.Servers {
-		if urlsEqual(s.URL, url) {
-			return s, nil
-		}
-	}
-	return nil, fmt.Errorf("Could not find server for URL %s", url)
-}
-
-// PickServerAuth Pick the servers auth
-func (c *AuthConfig) PickServerUserAuth(server *AuthServer, message string, batchMode bool, org string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (*UserAuth, error) {
-	url := server.URL
-	userAuths := c.FindUserAuths(url)
-	surveyOpts := survey.WithStdio(in, out, errOut)
-	if len(userAuths) == 1 {
-
-		auth := userAuths[0]
-		if batchMode {
-			return auth, nil
-		}
-		confirm := &survey.Confirm{
-			Message: fmt.Sprintf("Do you wish to use %s as the %s", auth.Username, message),
-			Default: true,
-		}
-		flag := false
-		err := survey.AskOne(confirm, &flag, nil, surveyOpts)
-		if err != nil {
-			return auth, err
-		}
-		if flag {
-			return auth, nil
-		}
-
-		// lets create a new user name
-		prompt := &survey.Input{
-			Message: message,
-		}
-		username := ""
-		err = survey.AskOne(prompt, &username, nil, surveyOpts)
-		if err != nil {
-			return auth, err
-		}
-		return c.GetOrCreateUserAuth(url, username), nil
-	}
-	if len(userAuths) > 1 {
-
-		// If in batchmode select the user auth based on the org passed, or default to the first auth.
-		if batchMode {
-			for i, x := range userAuths {
-				if x.Username == org {
-					return userAuths[i], nil
-				}
-			}
-			return userAuths[0], nil
-		}
-
-		usernames := []string{}
-		m := map[string]*UserAuth{}
-		for _, ua := range userAuths {
-			name := ua.Username
-			usernames = append(usernames, name)
-			m[name] = ua
-		}
-		username := ""
-		prompt := &survey.Select{
-			Message: message,
-			Options: usernames,
-		}
-		err := survey.AskOne(prompt, &username, survey.Required, surveyOpts)
-		if err != nil {
-			return &UserAuth{}, err
-		}
-		answer := m[username]
-		if answer == nil {
-			return nil, fmt.Errorf("No username chosen!")
-		}
-		return answer, nil
-	}
-	return &UserAuth{}, nil
-}
-
-type PrintUserFn func(username string) error
-
-// EditUserAuth Lets the user input/edit the user auth
-func (config *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defaultUserName string, editUser, batchMode bool, fn PrintUserFn, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) error {
-	// default the user name if its empty
-	defaultUsername := config.DefaultUsername
-	if defaultUsername == "" {
-		defaultUsername = defaultUserName
-	}
-	if auth.Username == "" {
-		auth.Username = defaultUsername
-	}
-
-	if batchMode {
-		if auth.Username == "" {
-			return fmt.Errorf("Running in batch mode and no default Git username found")
-		}
-		if auth.ApiToken == "" {
-			return fmt.Errorf("Running in batch mode and no default API token found")
-		}
+// Valid checks if the user config is valid
+func (u *User) Valid() error {
+	if u.BearerToken != "" {
 		return nil
 	}
-	var err error
+	if u.Username == "" {
+		return errors.New("Empty username")
+	}
+	if u.ApiToken == "" && u.Password == "" {
+		return errors.New("Empty API token and password")
+	}
+	return nil
 
-	if editUser || auth.Username == "" {
-		auth.Username, err = util.PickValue(serverLabel+" user name:", auth.Username, true, "", in, out, outErr)
+}
+
+// Valid checks if a server config is valid
+func (s *Server) Valid() error {
+	if len(s.Users) == 0 {
+		return fmt.Errorf("%s server has no users", s.Name)
+	}
+	if s.URL == "" {
+		return fmt.Errorf("%s server has an empty URL", s.Name)
+	}
+	for _, u := range s.Users {
+		err := u.Valid()
 		if err != nil {
 			return err
 		}
 	}
-	if fn != nil {
-		err := fn(auth.Username)
+	return nil
+}
+
+// PipelineUser returns the pipeline user, if there is not pipeline user available
+// returns the first user
+func (s *Server) PipelineUser() User {
+	for _, user := range s.Users {
+		if user.Kind == UserKindPipeline {
+			return *user
+		}
+	}
+	if len(s.Users) > 0 {
+		return *s.Users[0]
+	}
+	return User{}
+}
+
+// Valid checks if the config is valid
+func (c *Config) Valid() error {
+	if len(c.Servers) == 0 {
+		return fmt.Errorf("No servers in config")
+	}
+	for _, s := range c.Servers {
+		err := s.Valid()
 		if err != nil {
 			return err
 		}
 	}
-	auth.ApiToken, err = util.PickPassword("API Token:", "", in, out, outErr)
-	return err
-}
-
-func (config *AuthConfig) GetServerNames() []string {
-	answer := []string{}
-	for _, server := range config.Servers {
-		name := server.Name
-		if name != "" {
-			answer = append(answer, name)
-		}
-	}
-	sort.Strings(answer)
-	return answer
-}
-
-func (config *AuthConfig) GetServerURLs() []string {
-	answer := []string{}
-	for _, server := range config.Servers {
-		u := server.URL
-		if u != "" {
-			answer = append(answer, u)
-		}
-	}
-	sort.Strings(answer)
-	return answer
-}
-
-// PickOrCreateServer picks the server to use defaulting to the current server
-func (config *AuthConfig) PickOrCreateServer(fallbackServerURL string, serverURL string, message string, batchMode bool, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (*AuthServer, error) {
-	servers := config.Servers
-	if len(servers) == 0 {
-		if serverURL != "" {
-			return config.GetOrCreateServer(serverURL), nil
-		}
-		return config.GetOrCreateServer(fallbackServerURL), nil
-	}
-	// lets let the user pick which server to use defaulting to the current server
-	names := []string{}
-	teamServerMissing := true
-	for _, s := range servers {
-		u := s.URL
-		if u != "" {
-			names = append(names, u)
-		}
-		if u == serverURL {
-			teamServerMissing = false
-		}
-	}
-	if teamServerMissing && serverURL != "" {
-		names = append(names, serverURL)
-	}
-	if len(names) == 1 {
-		return config.GetOrCreateServer(names[0]), nil
-	}
-	defaultValue := serverURL
-	if defaultValue == "" {
-		defaultValue = config.CurrentServer
-	}
-	if defaultValue == "" {
-		defaultValue = names[0]
-	}
-	if batchMode {
-		return config.GetOrCreateServer(defaultValue), nil
-	}
-	name, err := util.PickRequiredNameWithDefault(names, message, defaultValue, "", in, out, outErr)
-	if err != nil {
-		return nil, err
-	}
-	if name == "" {
-		return nil, fmt.Errorf("No server URL chosen!")
-	}
-	return config.GetOrCreateServer(name), nil
+	return nil
 }

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -172,6 +172,18 @@ func (c *AuthConfig) GetOrCreateServerName(url string, name string, kind string)
 	return s
 }
 
+func (c *AuthConfig) AddServer(server *AuthServer) {
+	s := c.GetServer(server.URL)
+	if s == nil {
+		if c.Servers == nil {
+			c.Servers = []*AuthServer{}
+		}
+		c.Servers = append(c.Servers, server)
+	} else {
+		s.Users = append(s.Users, server.Users...)
+	}
+}
+
 func urlHostName(rawUrl string) string {
 	u, err := url.Parse(rawUrl)
 	if err == nil {

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -22,7 +22,7 @@ type User struct {
 	Kind        UserKind `yaml:"kind"`
 }
 
-//ServerKind type of the server
+//ServerKind type for server kind
 type ServerKind string
 
 const (

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -9,7 +9,9 @@ import (
 type UserKind string
 
 const (
-	UserKindLocal    UserKind = "local"
+	// UserKindLocal indicates a user of type local
+	UserKindLocal UserKind = "local"
+	// UserKindPipeline indicates a user of type pipeline (e.g. used by the build within the pipeline
 	UserKindPipeline UserKind = "pipeline"
 )
 
@@ -28,7 +30,7 @@ type ServerKind string
 const (
 	// ServerKindGit idicates a server configuration for git
 	ServerKindGit ServerKind = "git"
-	// ServerKindChat indicates a server configuration for issue
+	// ServerKindIssue indicates a server configuration for issue
 	ServerKindIssue ServerKind = "issue"
 	// ServerKindChat idicates a server configuration for chat
 	ServerKindChat ServerKind = "chat"

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -26,19 +26,27 @@ type User struct {
 type ServerKind string
 
 const (
-	ServerKindGit   ServerKind = "git"
+	// ServerKindGit idicates a server configuration for git
+	ServerKindGit ServerKind = "git"
+	// ServerKindChat indicates a server configuration for issue
 	ServerKindIssue ServerKind = "issue"
-	ServerKindChat  ServerKind = "chat"
+	// ServerKindChat idicates a server configuration for chat
+	ServerKindChat ServerKind = "chat"
 )
 
-//ServerKind type for service used by the server
+//ServiceKind type for service used by the server
 type ServiceKind string
 
 const (
-	ServiceKindGithub          ServiceKind = "github"
-	ServiceKindGitlab          ServiceKind = "gitlab"
-	ServiceKindGitea           ServiceKind = "gitea"
-	ServiceKindBitbucketCloud  ServiceKind = "bitbucketcloud"
+	// ServiceKindGithub indicates that the git server is using as service GitHub
+	ServiceKindGithub ServiceKind = "github"
+	// ServiceKindGitlab indicates that the git server is using as service Gitlab
+	ServiceKindGitlab ServiceKind = "gitlab"
+	// ServiceKindGitea indicates that the git server is using as service Gitea
+	ServiceKindGitea ServiceKind = "gitea"
+	// ServiceKindBitbucketCloud indicates that the git server is using as service Bitbucket Cloud
+	ServiceKindBitbucketCloud ServiceKind = "bitbucketcloud"
+	// ServiceKindBitbucketServer indicates that the git server is using as service Bitbuckst Server
 	ServiceKindBitbucketServer ServiceKind = "bitbucketserver"
 )
 

--- a/pkg/auth/config_test.go
+++ b/pkg/auth/config_test.go
@@ -1,174 +1,136 @@
 package auth_test
 
 import (
-	"io/ioutil"
-	"path/filepath"
 	"testing"
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	url1 = "http://dummy/"
-	url2 = "http://another-jenkins/"
-
-	userDoesNotExist = "doesNotExist"
-	user1            = "someone"
-	user2            = "another"
-	token2v2         = "tokenV2"
-)
-
-func TestAuthConfig(t *testing.T) {
+func TestValidUser(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir("/tmp", "jx-test-jenkins-config-")
-	assertNoError(t, err)
-
-	fileName := filepath.Join(dir, "jenkins.yaml")
-
-	t.Logf("Using config file %s\n", fileName)
-
-	configTest := ConfigTest{
-		t: t,
+	tests := map[string]struct {
+		user *auth.User
+		err  bool
+	}{
+		"valid user with api token": {
+			user: &auth.User{
+				Username: "test",
+				ApiToken: "test",
+			},
+			err: false,
+		},
+		"valid user with password": {
+			user: &auth.User{
+				Username: "test",
+				Password: "test",
+			},
+			err: false,
+		},
+		"valid user with bearer token": {
+			user: &auth.User{
+				BearerToken: "test",
+			},
+			err: false,
+		},
+		"invalid user": {
+			user: &auth.User{},
+			err:  true,
+		},
+		"invalid user only with username": {
+			user: &auth.User{
+				Username: "test",
+			},
+			err: true,
+		},
+		"invalid user only with api token": {
+			user: &auth.User{
+				ApiToken: "test",
+			},
+			err: true,
+		},
+		"invalid user only with password": {
+			user: &auth.User{
+				Password: "test",
+			},
+			err: true,
+		},
 	}
-	configTest.svc.FileName = fileName
 
-	config := configTest.Load()
-
-	assert.Equal(t, 0, len(config.Servers), "Should have no servers in config but got %v", config)
-	assertNoAuth(t, config, url1, userDoesNotExist)
-
-	auth1 := auth.UserAuth{
-		Username: user1,
-		ApiToken: "someToken",
-	}
-	config = configTest.SetUserAuth(url1, auth1)
-
-	assert.Equal(t, 1, len(config.Servers), "Number of servers")
-	assert.Equal(t, 1, len(config.Servers[0].Users), "Number of auths")
-	assert.Equal(t, &auth1, config.FindUserAuth(url1, user1), "loaded auth for server %s and user %s", url1, user1)
-	assert.Equal(t, &auth1, config.FindUserAuth(url1, ""), "loaded auth for server %s and no user", url1)
-
-	auth2 := auth.UserAuth{
-		Username: user2,
-		ApiToken: "anotherToken",
-	}
-	config = configTest.SetUserAuth(url1, auth2)
-
-	assert.Equal(t, &auth2, config.FindUserAuth(url1, user2), "Failed to find auth for server %s and user %s", url1, user2)
-	assert.Equal(t, &auth1, config.FindUserAuth(url1, user1), "loaded auth for server %s and user %s", url1, user1)
-	assert.Equal(t, 1, len(config.Servers), "Number of servers")
-	assert.Equal(t, 2, len(config.Servers[0].Users), "Number of auths")
-	assertNoAuth(t, config, url1, userDoesNotExist)
-
-	// lets mutate the auth2
-	auth2.ApiToken = token2v2
-	config = configTest.SetUserAuth(url1, auth2)
-
-	assertNoAuth(t, config, url1, userDoesNotExist)
-	assert.Equal(t, 1, len(config.Servers), "Number of servers")
-	assert.Equal(t, 2, len(config.Servers[0].Users), "Number of auths")
-	assert.Equal(t, &auth1, config.FindUserAuth(url1, user1), "loaded auth for server %s and user %s", url1, user1)
-	assert.Equal(t, &auth2, config.FindUserAuth(url1, user2), "loaded auth for server %s and user %s", url1, user2)
-
-	auth3 := auth.UserAuth{
-		Username: user1,
-		ApiToken: "server2User1Token",
-	}
-	configTest.SetUserAuth(url2, auth3)
-
-	assertNoAuth(t, config, url1, userDoesNotExist)
-	assert.Equal(t, 2, len(config.Servers), "Number of servers")
-	assert.Equal(t, 2, len(config.Servers[0].Users), "Number of auths for server 0")
-	assert.Equal(t, 1, len(config.Servers[1].Users), "Number of auths for server 1")
-	assert.Equal(t, &auth1, config.FindUserAuth(url1, user1), "loaded auth for server %s and user %s", url1, user1)
-	assert.Equal(t, &auth2, config.FindUserAuth(url1, user2), "loaded auth for server %s and user %s", url1, user2)
-	assert.Equal(t, &auth3, config.FindUserAuth(url2, user1), "loaded auth for server %s and user %s", url2, user1)
-}
-
-type ConfigTest struct {
-	t      *testing.T
-	svc    auth.AuthConfigService
-	config *auth.AuthConfig
-}
-
-func (c *ConfigTest) Load() *auth.AuthConfig {
-	config, err := c.svc.LoadConfig()
-	c.config = config
-	c.AssertNoError(err)
-	return c.config
-}
-
-func (c *ConfigTest) SetUserAuth(url string, auth auth.UserAuth) *auth.AuthConfig {
-	copy := auth
-	c.config.SetUserAuth(url, &copy)
-	c.SaveAndReload()
-	return c.config
-}
-
-func (c *ConfigTest) SaveAndReload() *auth.AuthConfig {
-	err := c.svc.SaveConfig()
-	c.AssertNoError(err)
-	return c.Load()
-}
-
-func (c *ConfigTest) AssertNoError(err error) {
-	if err != nil {
-		assert.Fail(c.t, "Should not have received an error but got: %s", err)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.user.Valid()
+			if tc.err {
+				assert.Error(t, err, "user should be invalid")
+			} else {
+				assert.NoError(t, err, "user should be valid")
+			}
+		})
 	}
 }
 
-func assertNoAuth(t *testing.T, config *auth.AuthConfig, url string, user string) {
-	found := config.FindUserAuth(url, user)
-	if found != nil {
-		assert.Fail(t, "Found auth when not expecting it for server %s and user %s", url, user)
-	}
-}
-
-func assertNoError(t *testing.T, err error) {
-	if err != nil {
-		assert.Fail(t, "Should not have received an error but got: %s", err)
-	}
-}
-
-func TestAuthConfigGetsDefaultName(t *testing.T) {
+func TestValidServer(t *testing.T) {
 	t.Parallel()
-	c := &auth.AuthConfig{}
+	tests := map[string]struct {
+		server *auth.Server
+		err    bool
+	}{
+		"valid server": {
+			server: &auth.Server{
+				URL:  "https://tests",
+				Name: "test",
+				Users: []*auth.User{
+					&auth.User{
+						Username: "test",
+						ApiToken: "test",
+					},
+				},
+			},
+			err: false,
+		},
+		"invalid server without users": {
+			server: &auth.Server{
+				URL:   "https://tests",
+				Name:  "test",
+				Users: []*auth.User{},
+			},
+			err: true,
+		},
+		"invalid server without URL": {
+			server: &auth.Server{
+				URL:  "",
+				Name: "test",
+				Users: []*auth.User{
+					&auth.User{
+						Username: "test",
+						ApiToken: "test",
+					},
+				},
+			},
+			err: true,
+		},
+		"invalid server with invalid user": {
+			server: &auth.Server{
+				URL:  "https://tests",
+				Name: "test",
+				Users: []*auth.User{
+					&auth.User{
+						Username: "test",
+					},
+				},
+			},
+			err: true,
+		},
+	}
 
-	expectedURL := "https://foo.com"
-	server := c.GetOrCreateServer(expectedURL)
-	assert.NotNil(t, server, "No server found!")
-	assert.True(t, server.Name != "", "Should have a server name!")
-	assert.Equal(t, expectedURL, server.URL, "Server.URL")
-}
-
-func TestDeleteServer(t *testing.T) {
-	t.Parallel()
-	c := &auth.AuthConfig{}
-	url := "https://foo.com"
-	server := c.GetOrCreateServer(url)
-	assert.NotNil(t, server, "Failed to add the server to the configuration")
-	assert.Equal(t, 1, len(c.Servers), "No server found in the configuration")
-
-	c.DeleteServer(url)
-	assert.Equal(t, 0, len(c.Servers), "Failed to remove the server from configuration")
-	assert.Equal(t, "", c.CurrentServer, "Should be no current server")
-}
-
-func TestDeleteServer2(t *testing.T) {
-	t.Parallel()
-	c := &auth.AuthConfig{}
-	url1 := "https://foo1.com"
-	server1 := c.GetOrCreateServer(url1)
-	assert.NotNil(t, server1, "Failed to add the server to the configuration")
-	url2 := "https://foo2.com"
-	server2 := c.GetOrCreateServer(url2)
-	assert.NotNil(t, server2, "Failed to the server to the configuration!")
-	assert.Equal(t, 2, len(c.Servers), "Must have 2 servers in the configuration")
-	c.CurrentServer = url2
-
-	c.DeleteServer(url2)
-	assert.Equal(t, 1, len(c.Servers), "Failed to remove one server from configuration")
-	assert.Equal(t, url1, c.Servers[0].URL, "Failed to remove the right server from the configuration")
-	assert.Equal(t, url1, c.CurrentServer, "Server 1 should be current server")
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.server.Valid()
+			if tc.err {
+				assert.Error(t, err, "user should be invalid")
+			} else {
+				assert.NoError(t, err, "user should be valid")
+			}
+		})
+	}
 }

--- a/pkg/auth/config_test.go
+++ b/pkg/auth/config_test.go
@@ -134,3 +134,73 @@ func TestValidServer(t *testing.T) {
 		})
 	}
 }
+
+func TestPipelineUser(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		server *auth.Server
+		want   auth.User
+	}{
+		"pipeline user": {
+			server: &auth.Server{
+				URL:  "https://test",
+				Name: "test",
+				Users: []*auth.User{
+					&auth.User{
+						Username: "test1",
+						ApiToken: "test",
+						Kind:     auth.UserKindPipeline,
+					},
+					&auth.User{
+						Username: "test2",
+						ApiToken: "test",
+						Kind:     auth.UserKindLocal,
+					},
+				},
+			},
+			want: auth.User{
+				Username: "test1",
+				ApiToken: "test",
+				Kind:     auth.UserKindPipeline,
+			},
+		},
+		"pipeline user when no user available": {
+			server: &auth.Server{
+				URL:   "https://test",
+				Name:  "test",
+				Users: []*auth.User{},
+			},
+			want: auth.User{},
+		},
+		"pipeline user when no pipeline user available": {
+			server: &auth.Server{
+				URL:  "https://test",
+				Name: "test",
+				Users: []*auth.User{
+					&auth.User{
+						Username: "test1",
+						ApiToken: "test",
+						Kind:     auth.UserKindLocal,
+					},
+					&auth.User{
+						Username: "test2",
+						ApiToken: "test",
+						Kind:     auth.UserKindLocal,
+					},
+				},
+			},
+			want: auth.User{
+				Username: "test1",
+				ApiToken: "test",
+				Kind:     auth.UserKindLocal,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tc.server.PipelineUser()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -51,10 +51,12 @@ func (s *AuthServer) GetUsernames() []string {
 	return answer
 }
 
+//HasUserAuths checks if a server has any user auth configured
 func (s *AuthServer) HasUserAuths() bool {
 	return len(s.Users) > 0
 }
 
+// CurrentAuth returns the current user auth, otherwise the first one
 func (s *AuthServer) CurrentAuth() *UserAuth {
 	for _, user := range s.Users {
 		if user.Username == s.CurrentUser {

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -50,3 +50,16 @@ func (s *AuthServer) GetUsernames() []string {
 	sort.Strings(answer)
 	return answer
 }
+
+func (s *AuthServer) HasUserAuths() bool {
+	return len(s.Users) > 0
+}
+
+func (s *AuthServer) CurrentAuth() *UserAuth {
+	for _, user := range s.Users {
+		if user.Username == s.CurrentUser {
+			return user
+		}
+	}
+	return nil
+}

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -61,5 +61,17 @@ func (s *AuthServer) CurrentAuth() *UserAuth {
 			return user
 		}
 	}
+	if len(s.Users) > 0 {
+		return s.Users[0]
+	}
+	return nil
+}
+
+func (s *AuthServer) GetUserAuth(username string) *UserAuth {
+	for _, user := range s.Users {
+		if username == user.Username {
+			return user
+		}
+	}
 	return nil
 }

--- a/pkg/auth/user_auth.go
+++ b/pkg/auth/user_auth.go
@@ -2,23 +2,57 @@ package auth
 
 import (
 	"os"
+	"strings"
 )
+
+const (
+	usernameSuffix    = "_USERNAME"
+	apiTokenSuffix    = "_API_TOKEN"
+	bearerTokenSuffix = "_BEARER_TOKEN"
+	DefaultUsername   = "dummy"
+)
+
+// UsernameEnv builds the username environment variable name
+func UsernameEnv(prefix string) string {
+	prefix = strings.ToUpper(prefix)
+	return prefix + usernameSuffix
+}
+
+// ApiTokenEnv builds the api token environment variable name
+func ApiTokenEnv(prefix string) string {
+	prefix = strings.ToUpper(prefix)
+	return prefix + apiTokenSuffix
+}
+
+// BearerTokenEnv builds the bearer token environment variable name
+func BearerTokenEnv(prefix string) string {
+	prefix = strings.ToUpper(prefix)
+	return prefix + bearerTokenSuffix
+}
 
 // CreateAuthUserFromEnvironment creates a user auth from environment variables
 func CreateAuthUserFromEnvironment(prefix string) UserAuth {
-	answer := UserAuth{
-		Username:    os.Getenv(prefix + "_USERNAME"),
-		ApiToken:    os.Getenv(prefix + "_API_TOKEN"),
-		BearerToken: os.Getenv(prefix + "_BEARER_TOKEN"),
+	user := UserAuth{}
+	username, set := os.LookupEnv(UsernameEnv(prefix))
+	if set {
+		user.Username = username
+	}
+	apiToken, set := os.LookupEnv(ApiTokenEnv(prefix))
+	if set {
+		user.ApiToken = apiToken
+	}
+	bearerToken, set := os.LookupEnv(BearerTokenEnv(prefix))
+	if set {
+		user.BearerToken = bearerToken
 	}
 
-	// lets add a dummy user name if there is an API token defined
-	if answer.ApiToken != "" || answer.Password != "" {
-		if answer.Username == "" {
-			answer.Username = "dummy"
+	if user.ApiToken != "" || user.Password != "" {
+		if user.Username == "" {
+			user.Username = DefaultUsername
 		}
 	}
-	return answer
+
+	return user
 }
 
 // IsInvalid returns true if the user auth has a valid token

--- a/pkg/auth/user_auth_test.go
+++ b/pkg/auth/user_auth_test.go
@@ -1,0 +1,171 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/auth"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func setEnvs(t *testing.T, envs map[string]string) {
+	err := util.RestoreEnviron(envs)
+	assert.NoError(t, err, "should set the environment variables")
+}
+
+func cleanEnvs(t *testing.T, envs []string) {
+	_, err := util.GetAndCleanEnviron(envs)
+	assert.NoError(t, err, "shuold clean the environment variables")
+}
+
+func TestCreateAuthUserFromEnvironment(t *testing.T) {
+	const prefix = "TEST"
+	tests := map[string]struct {
+		prefix  string
+		setup   func(t *testing.T)
+		cleanup func(t *testing.T)
+		want    auth.UserAuth
+	}{
+		"create auth user from environment with api token": {
+			prefix: prefix,
+			setup: func(t *testing.T) {
+				setEnvs(t, map[string]string{
+					auth.UsernameEnv(prefix): "test",
+					auth.ApiTokenEnv(prefix): "test",
+				})
+			},
+			cleanup: func(t *testing.T) {
+				cleanEnvs(t, []string{
+					auth.UsernameEnv(prefix),
+					auth.ApiTokenEnv(prefix),
+				})
+			},
+			want: auth.UserAuth{
+				Username:    "test",
+				ApiToken:    "test",
+				BearerToken: "",
+				Password:    "",
+			},
+		},
+		"create auth user from environment with bearer token": {
+			prefix: prefix,
+			setup: func(t *testing.T) {
+				setEnvs(t, map[string]string{
+					auth.UsernameEnv(prefix):    "test",
+					auth.BearerTokenEnv(prefix): "test",
+				})
+			},
+			cleanup: func(t *testing.T) {
+				cleanEnvs(t, []string{
+					auth.UsernameEnv(prefix),
+					auth.BearerTokenEnv(prefix),
+				})
+			},
+			want: auth.UserAuth{
+				Username:    "test",
+				ApiToken:    "",
+				BearerToken: "test",
+				Password:    "",
+			},
+		},
+		"create auth user from environment with default name": {
+			prefix: prefix,
+			setup: func(t *testing.T) {
+				setEnvs(t, map[string]string{
+					auth.ApiTokenEnv(prefix): "test",
+				})
+			},
+			cleanup: func(t *testing.T) {
+				cleanEnvs(t, []string{
+					auth.ApiTokenEnv(prefix),
+				})
+			},
+			want: auth.UserAuth{
+				Username:    auth.DefaultUsername,
+				ApiToken:    "test",
+				BearerToken: "",
+				Password:    "",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+
+			user := auth.CreateAuthUserFromEnvironment(prefix)
+			assert.Equal(t, tc.want, user)
+
+			if tc.cleanup != nil {
+				tc.cleanup(t)
+			}
+		})
+	}
+}
+
+func TestIsInvalid(t *testing.T) {
+	tests := map[string]struct {
+		user *auth.UserAuth
+		want bool
+	}{
+		"invalid user when empty": {
+			user: &auth.UserAuth{},
+			want: true,
+		},
+		"invalid user with only a username": {
+			user: &auth.UserAuth{
+				Username: "test",
+			},
+			want: true,
+		},
+		"invalid user with only a api token": {
+			user: &auth.UserAuth{
+				ApiToken: "test",
+			},
+			want: true,
+		},
+		"valid user with only a bearer token": {
+			user: &auth.UserAuth{
+				BearerToken: "test",
+			},
+			want: false,
+		},
+		"valid user with api token": {
+			user: &auth.UserAuth{
+				Username: "test",
+				ApiToken: "test",
+			},
+			want: false,
+		},
+		"valid user with bearer token": {
+			user: &auth.UserAuth{
+				Username:    "test",
+				BearerToken: "test",
+			},
+			want: false,
+		},
+		"valid user with api token and bearer token": {
+			user: &auth.UserAuth{
+				Username:    "test",
+				ApiToken:    "test",
+				BearerToken: "test",
+			},
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := tc.user.IsInvalid()
+			msg := ""
+			if tc.want {
+				msg = "user should be invalid"
+			} else {
+				msg = "user should be valid"
+			}
+			assert.Equalf(t, tc.want, result, msg)
+		})
+	}
+}

--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -354,14 +354,15 @@ func CreateProviderForURL(inCluster bool, authConfigSvc auth.AuthConfigService, 
 	userAuth := config.CurrentUser(server, inCluster)
 	if userAuth != nil && !userAuth.IsInvalid() {
 		return CreateProvider(server, userAuth, git)
-	} else {
-		kind := server.Kind
-		if kind != "" {
-			userAuth := auth.CreateAuthUserFromEnvironment(strings.ToUpper(kind))
-			if !userAuth.IsInvalid() {
-				return CreateProvider(server, &userAuth, git)
-			}
+	}
+
+	kind := server.Kind
+	if kind != "" {
+		userAuth := auth.CreateAuthUserFromEnvironment(strings.ToUpper(kind))
+		if !userAuth.IsInvalid() {
+			return CreateProvider(server, &userAuth, git)
 		}
+	} else {
 		userAuth := auth.CreateAuthUserFromEnvironment("GIT")
 		if !userAuth.IsInvalid() {
 			return CreateProvider(server, &userAuth, git)

--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -346,12 +346,18 @@ func (i *GitRepositoryInfo) CreateProvider(authConfigSvc auth.AuthConfigService,
 func CreateProviderForURL(authConfigSvc auth.AuthConfigService, gitKind string, hostUrl string, git Gitter, batchMode bool, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (GitProvider, error) {
 	config := authConfigSvc.Config()
 	server := config.GetOrCreateServer(hostUrl)
-	url := server.URL
 	if gitKind != "" {
 		server.Kind = gitKind
 	}
-	userAuths := authConfigSvc.Config().FindUserAuths(url)
-	if len(userAuths) == 0 {
+
+	var userAuth *auth.UserAuth
+	if server != nil {
+		userAuth = server.CurrentAuth()
+	}
+
+	if userAuth != nil && !userAuth.IsInvalid() {
+		return CreateProvider(server, userAuth, git)
+	} else {
 		kind := server.Kind
 		if kind != "" {
 			userAuth := auth.CreateAuthUserFromEnvironment(strings.ToUpper(kind))
@@ -364,16 +370,11 @@ func CreateProviderForURL(authConfigSvc auth.AuthConfigService, gitKind string, 
 			return CreateProvider(server, &userAuth, git)
 		}
 	}
-	if len(userAuths) > 0 {
-		// TODO use default user???
-		auth := userAuths[0]
-		return CreateProvider(server, auth, git)
-	}
-	auth, err := createUserForServer(batchMode, authConfigSvc, server, git, in, out, errOut)
+	userAuth, err := createUserForServer(batchMode, authConfigSvc, server, git, in, out, errOut)
 	if err != nil {
 		return nil, err
 	}
-	return CreateProvider(server, auth, git)
+	return CreateProvider(server, userAuth, git)
 }
 
 func createUserForServer(batchMode bool, authConfigSvc auth.AuthConfigService, server *auth.AuthServer,
@@ -385,7 +386,6 @@ func createUserForServer(batchMode bool, authConfigSvc auth.AuthConfigService, s
 		return nil
 	}
 
-	// TODO could we guess this based on the users ~/.git for github?
 	defaultUserName := ""
 	err := authConfigSvc.Config().EditUserAuth(server.Label(), userAuth, defaultUserName, false, batchMode, f, in, out, errOut)
 	if err != nil {

--- a/pkg/gits/provider_test.go
+++ b/pkg/gits/provider_test.go
@@ -2,10 +2,20 @@ package gits_test
 
 import (
 	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
 
+	expect "github.com/Netflix/go-expect"
+	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/gits"
+	mocks "github.com/jenkins-x/jx/pkg/gits/mocks"
+	utiltests "github.com/jenkins-x/jx/pkg/tests"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type FakeOrgLister struct {
@@ -44,4 +54,731 @@ func Test_getOrganizations(t *testing.T) {
 			assert.Equal(t, tt.want, result)
 		})
 	}
+}
+
+func createAuthConfigSvc(authConfig *auth.AuthConfig, fileName string) *auth.AuthConfigService {
+	authConfigSvc := &auth.AuthConfigService{
+		FileName: fileName,
+	}
+	authConfigSvc.SetConfig(authConfig)
+	return authConfigSvc
+}
+
+func createAuthConfig(currentServer *auth.AuthServer, servers ...*auth.AuthServer) *auth.AuthConfig {
+	servers = append(servers, currentServer)
+	return &auth.AuthConfig{
+		Servers:       servers,
+		CurrentServer: currentServer.URL,
+	}
+}
+
+func createAuthServer(url string, name string, kind string, currentUser *auth.UserAuth, users ...*auth.UserAuth) *auth.AuthServer {
+	users = append(users, currentUser)
+	return &auth.AuthServer{
+		URL:         url,
+		Name:        name,
+		Kind:        kind,
+		Users:       users,
+		CurrentUser: currentUser.Username,
+	}
+}
+
+func createGitProvider(t *testing.T, kind string, server *auth.AuthServer, user *auth.UserAuth, git gits.Gitter) gits.GitProvider {
+	switch kind {
+	case gits.KindGitHub:
+		gitHubProvider, err := gits.NewGitHubProvider(server, user, git)
+		assert.NoError(t, err, "should create GitHub provider without error")
+		return gitHubProvider
+	case gits.KindGitlab:
+		gitlabProvider, err := gits.NewGitlabProvider(server, user, git)
+		assert.NoError(t, err, "should create Gitlab provider without error")
+		return gitlabProvider
+	case gits.KindGitea:
+		giteaProvider, err := gits.NewGiteaProvider(server, user, git)
+		assert.NoError(t, err, "should create Gitea provider without error")
+		return giteaProvider
+	case gits.KindBitBucketServer:
+		bitbucketServerProvider, err := gits.NewBitbucketServerProvider(server, user, git)
+		assert.NoError(t, err, "should create Bitbucket server  provider without error")
+		return bitbucketServerProvider
+	case gits.KindBitBucketCloud:
+		bitbucketCloudProvider, err := gits.NewBitbucketCloudProvider(server, user, git)
+		assert.NoError(t, err, "should create Bitbucket cloud  provider without error")
+		return bitbucketCloudProvider
+	default:
+		return nil
+	}
+}
+
+func setUserAuthInEnv(kind string, username string, apiToken string) error {
+	prefix := strings.ToUpper(kind)
+	err := os.Setenv(prefix+"_USERNAME", username)
+	if err != nil {
+		return err
+	}
+	return os.Setenv(prefix+"_API_TOKEN", apiToken)
+}
+
+func unsetUserAuthInEnv(kind string) error {
+	prefix := strings.ToUpper(kind)
+	err := os.Unsetenv(prefix + "_USERNAME")
+	if err != nil {
+		return err
+	}
+	return os.Unsetenv(prefix + "_API_TOKEN")
+}
+
+func getAndCleanEnviron(kind string) (map[string]string, error) {
+	prefix := strings.ToUpper(kind)
+	keys := []string{
+		prefix + "_USERNAME",
+		prefix + "_API_TOKEN",
+		"GIT_USERNAME",
+		"GIT_API_TOKEN",
+	}
+	return util.GetAndCleanEnviron(keys)
+}
+
+func restoreEnviron(t *testing.T, environ map[string]string) {
+	err := util.RestoreEnviron(environ)
+	assert.NoError(t, err, "should restore the env variable")
+}
+
+func TestCreateGitProviderFromURL(t *testing.T) {
+	t.Parallel()
+
+	git := mocks.NewMockGitter()
+
+	tests := []struct {
+		description  string
+		setup        func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{})
+		cleanup      func(t *testing.T, c *expect.Console, donech chan struct{})
+		Name         string
+		providerKind string
+		hostURL      string
+		git          gits.Gitter
+		numUsers     int
+		currUser     int
+		username     string
+		apiToken     string
+		batchMode    bool
+		wantError    bool
+	}{
+		{"create GitHub provider for one user",
+			nil,
+			nil,
+			"GitHub",
+			gits.KindGitHub,
+			"https://github.com",
+			git,
+			1,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create GitHub provider for multiple users",
+			nil,
+			nil,
+			"GitHub",
+			gits.KindGitHub,
+			"https://github.com",
+			git,
+			2,
+			1,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create GitHub provider for user from environment",
+			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+				err := setUserAuthInEnv(gits.KindGitHub, "test", "test")
+				assert.NoError(t, err, "should configure the user auth in environment")
+				c, _, term := utiltests.NewTerminal(t)
+				donech := make(chan struct{})
+				go func() {
+					defer close(donech)
+				}()
+				return c, term, donech
+			},
+			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+				err := unsetUserAuthInEnv(gits.KindGitHub)
+				assert.NoError(t, err, "should reset the user auth in environment")
+				err = c.Tty().Close()
+				assert.NoError(t, err, "should close the tty")
+				<-donech
+			},
+			"GitHub",
+			gits.KindGitHub,
+			"https://github.com",
+			git,
+			0,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create GitHub provider in barch mode ",
+			nil,
+			nil,
+			"GitHub",
+			gits.KindGitHub,
+			"https://github.com",
+			git,
+			0,
+			0,
+			"",
+			"",
+			true,
+			true,
+		},
+		{"create GitHub provider in interactive mode",
+			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+				c, _, term := utiltests.NewTerminal(t)
+				assert.NotNil(t, c, "console should not be nil")
+				assert.NotNil(t, term, "term should not be nil")
+				donech := make(chan struct{})
+				go func() {
+					defer close(donech)
+					_, err := c.ExpectString("github.com user name:")
+					assert.NoError(t, err, "expect user name")
+					_, err = c.SendLine("test")
+					assert.NoError(t, err, "send user name")
+					_, err = c.ExpectString("API Token:")
+					assert.NoError(t, err, "expect API token")
+					_, err = c.SendLine("test")
+					assert.NoError(t, err, "send API token")
+					_, err = c.ExpectEOF()
+					assert.NoError(t, err, "expect EOF")
+				}()
+				return c, term, donech
+			},
+			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+				err := c.Tty().Close()
+				assert.NoError(t, err, "should close the tty")
+				<-donech
+			},
+			"GitHub",
+			gits.KindGitHub,
+			"https://github.com",
+			git,
+			0,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create Gitlab provider for one user",
+			nil,
+			nil,
+			"Gitlab",
+			gits.KindGitlab,
+			"https://gitlab.com",
+			git,
+			1,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create Gitlab provider for multiple users",
+			nil,
+			nil,
+			"Gitlab",
+			gits.KindGitHub,
+			"https://gitlab.com",
+			git,
+			2,
+			1,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create Gitlab provider for user from environment",
+			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+				err := setUserAuthInEnv(gits.KindGitlab, "test", "test")
+				assert.NoError(t, err, "should configure the user auth in environment")
+				c, _, term := utiltests.NewTerminal(t)
+				donech := make(chan struct{})
+				go func() {
+					defer close(donech)
+				}()
+				return c, term, donech
+			},
+			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+				err := unsetUserAuthInEnv(gits.KindGitlab)
+				assert.NoError(t, err, "should reset the user auth in environment")
+				err = c.Tty().Close()
+				assert.NoError(t, err, "should close the tty")
+				<-donech
+			},
+			"Gitlab",
+			gits.KindGitlab,
+			"https://gitlab.com",
+			git,
+			0,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create Gitlab provider in barch mode ",
+			nil,
+			nil,
+			"Gitlab",
+			gits.KindGitlab,
+			"https://gitlab.com",
+			git,
+			0,
+			0,
+			"",
+			"",
+			true,
+			true,
+		},
+		{"create Gitlab provider in interactive mode",
+			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+				c, _, term := utiltests.NewTerminal(t)
+				assert.NotNil(t, c, "console should not be nil")
+				assert.NotNil(t, term, "term should not be nil")
+				donech := make(chan struct{})
+				go func() {
+					defer close(donech)
+					_, err := c.ExpectString("gitlab.com user name:")
+					assert.NoError(t, err, "expect user name")
+					_, err = c.SendLine("test")
+					assert.NoError(t, err, "send user name")
+					_, err = c.ExpectString("API Token:")
+					assert.NoError(t, err, "expect API token")
+					_, err = c.SendLine("test")
+					assert.NoError(t, err, "send API token")
+					_, err = c.ExpectEOF()
+					assert.NoError(t, err, "expect EOF")
+				}()
+				return c, term, donech
+			},
+			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+				err := c.Tty().Close()
+				assert.NoError(t, err, "should close the tty")
+				<-donech
+			},
+			"Gitlab",
+			gits.KindGitlab,
+			"https://gitlab.com",
+			git,
+			0,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create Gitea provider for one user",
+			nil,
+			nil,
+			"Gitea",
+			gits.KindGitea,
+			"https://gitea.com",
+			git,
+			1,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create Gitea provider for multiple users",
+			nil,
+			nil,
+			"Gitea",
+			gits.KindGitea,
+			"https://gitea.com",
+			git,
+			2,
+			1,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create Gitea provider for user from environment",
+			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+				err := setUserAuthInEnv(gits.KindGitea, "test", "test")
+				assert.NoError(t, err, "should configure the user auth in environment")
+				c, _, term := utiltests.NewTerminal(t)
+				donech := make(chan struct{})
+				go func() {
+					defer close(donech)
+				}()
+				return c, term, donech
+			},
+			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+				err := unsetUserAuthInEnv(gits.KindGitea)
+				assert.NoError(t, err, "should reset the user auth in environment")
+				err = c.Tty().Close()
+				assert.NoError(t, err, "should close the tty")
+				<-donech
+			},
+			"Gitea",
+			gits.KindGitea,
+			"https://gitea.com",
+			git,
+			0,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create Gitea provider in barch mode ",
+			nil,
+			nil,
+			"Gitea",
+			gits.KindGitea,
+			"https://gitea.com",
+			git,
+			0,
+			0,
+			"",
+			"",
+			true,
+			true,
+		},
+		{"create Gitea provider in interactive mode",
+			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+				c, _, term := utiltests.NewTerminal(t)
+				assert.NotNil(t, c, "console should not be nil")
+				assert.NotNil(t, term, "term should not be nil")
+				donech := make(chan struct{})
+				go func() {
+					defer close(donech)
+					_, err := c.ExpectString("gitea.com user name:")
+					assert.NoError(t, err, "expect user name")
+					_, err = c.SendLine("test")
+					assert.NoError(t, err, "send user name")
+					_, err = c.ExpectString("API Token:")
+					assert.NoError(t, err, "expect API token")
+					_, err = c.SendLine("test")
+					assert.NoError(t, err, "send API token")
+					_, err = c.ExpectEOF()
+					assert.NoError(t, err, "expect EOF")
+				}()
+				return c, term, donech
+			},
+			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+				err := c.Tty().Close()
+				assert.NoError(t, err, "should close the tty")
+				<-donech
+			},
+			"Gitea",
+			gits.KindGitea,
+			"https://gitea.com",
+			git,
+			0,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create BitbucketServer provider for one user",
+			nil,
+			nil,
+			"BitbucketServer",
+			gits.KindBitBucketServer,
+			"https://bitbucket-server.com",
+			git,
+			1,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create BitbucketServer provider for multiple users",
+			nil,
+			nil,
+			"BitbucketServer",
+			gits.KindBitBucketServer,
+			"https://bitbucket-server.com",
+			git,
+			2,
+			1,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create BitbucketServer provider for user from environment",
+			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+				err := setUserAuthInEnv(gits.KindBitBucketServer, "test", "test")
+				assert.NoError(t, err, "should configure the user auth in environment")
+				c, _, term := utiltests.NewTerminal(t)
+				donech := make(chan struct{})
+				go func() {
+					defer close(donech)
+				}()
+				return c, term, donech
+			},
+			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+				err := unsetUserAuthInEnv(gits.KindBitBucketServer)
+				assert.NoError(t, err, "should reset the user auth in environment")
+				err = c.Tty().Close()
+				assert.NoError(t, err, "should close the tty")
+				<-donech
+			},
+			"BitbucketServer",
+			gits.KindBitBucketServer,
+			"https://bitbucket-server.com",
+			git,
+			0,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create BitbucketServer provider in barch mode ",
+			nil,
+			nil,
+			"BitbucketServer",
+			gits.KindBitBucketServer,
+			"https://bitbucket-server.com",
+			git,
+			0,
+			0,
+			"",
+			"",
+			true,
+			true,
+		},
+		{"create BitbucketServer provider in interactive mode",
+			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+				c, _, term := utiltests.NewTerminal(t)
+				assert.NotNil(t, c, "console should not be nil")
+				assert.NotNil(t, term, "term should not be nil")
+				donech := make(chan struct{})
+				go func() {
+					defer close(donech)
+					_, err := c.ExpectString("bitbucket-server.com user name:")
+					assert.NoError(t, err, "expect user name")
+					_, err = c.SendLine("test")
+					assert.NoError(t, err, "send user name")
+					_, err = c.ExpectString("API Token:")
+					assert.NoError(t, err, "expect API token")
+					_, err = c.SendLine("test")
+					assert.NoError(t, err, "send API token")
+					_, err = c.ExpectEOF()
+					assert.NoError(t, err, "expect EOF")
+				}()
+				return c, term, donech
+			},
+			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+				err := c.Tty().Close()
+				assert.NoError(t, err, "should close the tty")
+				<-donech
+			},
+			"BitbucketServer",
+			gits.KindBitBucketServer,
+			"https://bitbucket-server.com",
+			git,
+			0,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create BitbucketCloud provider for one user",
+			nil,
+			nil,
+			"BitbucketCloud",
+			gits.KindBitBucketCloud,
+			"https://bitbucket.org",
+			git,
+			1,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create BitbucketCloud provider for multiple users",
+			nil,
+			nil,
+			"BitbucketCloud",
+			gits.KindBitBucketCloud,
+			"https://bitbucket.org",
+			git,
+			2,
+			1,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create BitbucketCloud provider for user from environment",
+			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+				err := setUserAuthInEnv(gits.KindBitBucketCloud, "test", "test")
+				assert.NoError(t, err, "should configure the user auth in environment")
+				c, _, term := utiltests.NewTerminal(t)
+				donech := make(chan struct{})
+				go func() {
+					defer close(donech)
+				}()
+				return c, term, donech
+			},
+			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+				err := unsetUserAuthInEnv(gits.KindBitBucketCloud)
+				assert.NoError(t, err, "should reset the user auth in environment")
+				err = c.Tty().Close()
+				assert.NoError(t, err, "should close the tty")
+				<-donech
+			},
+			"BitbucketCloud",
+			gits.KindBitBucketCloud,
+			"https://bitbucket.org",
+			git,
+			0,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+		{"create BitbucketCloud provider in barch mode ",
+			nil,
+			nil,
+			"BitbucketCloud",
+			gits.KindBitBucketCloud,
+			"https://bitbucket.org",
+			git,
+			0,
+			0,
+			"",
+			"",
+			true,
+			true,
+		},
+		{"create BitbucketCloud provider in interactive mode",
+			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+				c, _, term := utiltests.NewTerminal(t)
+				assert.NotNil(t, c, "console should not be nil")
+				assert.NotNil(t, term, "term should not be nil")
+				donech := make(chan struct{})
+				go func() {
+					defer close(donech)
+					_, err := c.ExpectString("bitbucket.org user name:")
+					assert.NoError(t, err, "expect user name")
+					_, err = c.SendLine("test")
+					assert.NoError(t, err, "send user name")
+					_, err = c.ExpectString("API Token:")
+					assert.NoError(t, err, "expect API token")
+					_, err = c.SendLine("test")
+					assert.NoError(t, err, "send API token")
+					_, err = c.ExpectEOF()
+					assert.NoError(t, err, "expect EOF")
+				}()
+				return c, term, donech
+			},
+			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+				err := c.Tty().Close()
+				assert.NoError(t, err, "should close the tty")
+				<-donech
+			},
+			"BitbucketCloud",
+			gits.KindBitBucketCloud,
+			"https://bitbucket.org",
+			git,
+			0,
+			0,
+			"test",
+			"test",
+			false,
+			false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			environ, err := getAndCleanEnviron(tc.providerKind)
+			assert.NoError(t, err, "should clean the env variables")
+			defer restoreEnviron(t, environ)
+
+			var console *expect.Console
+			var term *terminal.Stdio
+			var donech chan struct{}
+			if tc.setup != nil {
+				console, term, donech = tc.setup(t)
+			}
+
+			users := []*auth.UserAuth{}
+			var currUser *auth.UserAuth
+			var server *auth.AuthServer
+			var authSvc *auth.AuthConfigService
+			configFile, err := ioutil.TempFile("", "test-config")
+			defer os.Remove(configFile.Name())
+			if tc.numUsers > 0 {
+				for u := 1; u <= tc.numUsers; u++ {
+					user := &auth.UserAuth{
+						Username: fmt.Sprintf("%s-%d", tc.username, u),
+						ApiToken: fmt.Sprintf("%s-%d", tc.apiToken, u),
+					}
+					users = append(users, user)
+				}
+				assert.True(t, len(users) > tc.currUser, "current user index should be smaller than number of users")
+				currUser = users[tc.currUser]
+				if len(users) > 1 {
+					users = append(users[:tc.currUser], users[tc.currUser+1:]...)
+				} else {
+					users = []*auth.UserAuth{}
+				}
+				server = createAuthServer(tc.hostURL, tc.Name, tc.providerKind, currUser, users...)
+				authSvc = createAuthConfigSvc(createAuthConfig(server), configFile.Name())
+			} else {
+				currUser = &auth.UserAuth{
+					Username: tc.username,
+					ApiToken: tc.apiToken,
+				}
+				server = createAuthServer(tc.hostURL, tc.Name, tc.providerKind, currUser, users...)
+				authSvc = &auth.AuthConfigService{
+					FileName: configFile.Name(),
+				}
+			}
+
+			var result gits.GitProvider
+			if term != nil {
+				result, err = gits.CreateProviderForURL(*authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, term.In, term.Out, term.Err)
+			} else {
+				result, err = gits.CreateProviderForURL(*authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, nil, nil, nil)
+			}
+			if tc.wantError {
+				assert.Error(t, err, "should fail to create provider")
+				assert.Nil(t, result, "created provider should be nil")
+			} else {
+				assert.NoError(t, err, "should create provider without error")
+				assert.NotNil(t, result, "created provider should not be nil")
+				want := createGitProvider(t, tc.providerKind, server, currUser, tc.git)
+				assert.NotNil(t, want, "expected provider should not be nil")
+				assertProvider(t, want, result)
+			}
+
+			if tc.cleanup != nil {
+				tc.cleanup(t, console, donech)
+			}
+		})
+	}
+}
+
+func assertProvider(t *testing.T, want gits.GitProvider, result gits.GitProvider) {
+	assert.Equal(t, want.Kind(), result.Kind())
+	assert.Equal(t, want.ServerURL(), result.ServerURL())
+	assert.Equal(t, want.UserAuth(), result.UserAuth())
 }

--- a/pkg/gits/provider_test.go
+++ b/pkg/gits/provider_test.go
@@ -64,11 +64,13 @@ func createAuthConfigSvc(authConfig *auth.AuthConfig, fileName string) *auth.Aut
 	return authConfigSvc
 }
 
-func createAuthConfig(currentServer *auth.AuthServer, servers ...*auth.AuthServer) *auth.AuthConfig {
+func createAuthConfig(currentServer *auth.AuthServer, piplineServer, pipelineUser string, servers ...*auth.AuthServer) *auth.AuthConfig {
 	servers = append(servers, currentServer)
 	return &auth.AuthConfig{
-		Servers:       servers,
-		CurrentServer: currentServer.URL,
+		Servers:          servers,
+		CurrentServer:    currentServer.URL,
+		PipeLineServer:   piplineServer,
+		PipeLineUsername: pipelineUser,
 	}
 }
 
@@ -159,9 +161,11 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 		git          gits.Gitter
 		numUsers     int
 		currUser     int
+		pipelineUser int
 		username     string
 		apiToken     string
 		batchMode    bool
+		inCluster    bool
 		wantError    bool
 	}{
 		{"create GitHub provider for one user",
@@ -173,8 +177,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			1,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -187,9 +193,27 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			2,
 			1,
+			1,
 			"test",
 			"test",
 			false,
+			false,
+			false,
+		},
+		{"create GitHub provider for pipline user when in cluster ",
+			nil,
+			nil,
+			"GitHub",
+			gits.KindGitHub,
+			"https://github.com",
+			git,
+			2,
+			1,
+			0,
+			"test",
+			"test",
+			false,
+			true,
 			false,
 		},
 		{"create GitHub provider for user from environment",
@@ -216,8 +240,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -230,9 +256,11 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"",
 			"",
 			true,
+			false,
 			true,
 		},
 		{"create GitHub provider in interactive mode",
@@ -267,8 +295,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -281,8 +311,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			1,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -295,8 +327,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			2,
 			1,
+			1,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -324,8 +358,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -338,9 +374,11 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"",
 			"",
 			true,
+			false,
 			true,
 		},
 		{"create Gitlab provider in interactive mode",
@@ -375,8 +413,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -389,8 +429,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			1,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -403,8 +445,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			2,
 			1,
+			1,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -432,8 +476,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -446,9 +492,11 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"",
 			"",
 			true,
+			false,
 			true,
 		},
 		{"create Gitea provider in interactive mode",
@@ -483,8 +531,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -497,8 +547,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			1,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -511,8 +563,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			2,
 			1,
+			1,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -540,8 +594,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -554,9 +610,11 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"",
 			"",
 			true,
+			false,
 			true,
 		},
 		{"create BitbucketServer provider in interactive mode",
@@ -591,8 +649,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -605,8 +665,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			1,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -619,8 +681,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			2,
 			1,
+			1,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -648,8 +712,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -662,9 +728,11 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"",
 			"",
 			true,
+			false,
 			true,
 		},
 		{"create BitbucketCloud provider in interactive mode",
@@ -699,8 +767,10 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			git,
 			0,
 			0,
+			0,
 			"test",
 			"test",
+			false,
 			false,
 			false,
 		},
@@ -721,6 +791,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 
 			users := []*auth.UserAuth{}
 			var currUser *auth.UserAuth
+			var pipelineUser *auth.UserAuth
 			var server *auth.AuthServer
 			var authSvc *auth.AuthConfigService
 			configFile, err := ioutil.TempFile("", "test-config")
@@ -735,13 +806,14 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 				}
 				assert.True(t, len(users) > tc.currUser, "current user index should be smaller than number of users")
 				currUser = users[tc.currUser]
+				pipelineUser = users[tc.pipelineUser]
 				if len(users) > 1 {
 					users = append(users[:tc.currUser], users[tc.currUser+1:]...)
 				} else {
 					users = []*auth.UserAuth{}
 				}
 				server = createAuthServer(tc.hostURL, tc.Name, tc.providerKind, currUser, users...)
-				authSvc = createAuthConfigSvc(createAuthConfig(server), configFile.Name())
+				authSvc = createAuthConfigSvc(createAuthConfig(server, server.URL, pipelineUser.Username), configFile.Name())
 			} else {
 				currUser = &auth.UserAuth{
 					Username: tc.username,
@@ -755,9 +827,9 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 
 			var result gits.GitProvider
 			if term != nil {
-				result, err = gits.CreateProviderForURL(*authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, term.In, term.Out, term.Err)
+				result, err = gits.CreateProviderForURL(tc.inCluster, *authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, term.In, term.Out, term.Err)
 			} else {
-				result, err = gits.CreateProviderForURL(*authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, nil, nil, nil)
+				result, err = gits.CreateProviderForURL(tc.inCluster, *authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, nil, nil, nil)
 			}
 			if tc.wantError {
 				assert.Error(t, err, "should fail to create provider")
@@ -765,9 +837,15 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			} else {
 				assert.NoError(t, err, "should create provider without error")
 				assert.NotNil(t, result, "created provider should not be nil")
-				want := createGitProvider(t, tc.providerKind, server, currUser, tc.git)
-				assert.NotNil(t, want, "expected provider should not be nil")
-				assertProvider(t, want, result)
+				if tc.inCluster {
+					want := createGitProvider(t, tc.providerKind, server, pipelineUser, tc.git)
+					assert.NotNil(t, want, "expected provider should not be nil")
+					assertProvider(t, want, result)
+				} else {
+					want := createGitProvider(t, tc.providerKind, server, currUser, tc.git)
+					assert.NotNil(t, want, "expected provider should not be nil")
+					assertProvider(t, want, result)
+				}
 			}
 
 			if tc.cleanup != nil {

--- a/pkg/io/config_readers.go
+++ b/pkg/io/config_readers.go
@@ -1,0 +1,173 @@
+package io
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+
+	"github.com/jenkins-x/jx/pkg/auth"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/util"
+	yaml "gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type ConfigReader interface {
+	Read() (*auth.AuthConfig, error)
+}
+
+type FileConfigReader struct {
+	filename string
+}
+
+func NewFileConfigReader(filename string) *FileConfigReader {
+	return &FileConfigReader{
+		filename: filename,
+	}
+}
+
+func (f *FileConfigReader) Read() (*auth.AuthConfig, error) {
+	config := &auth.AuthConfig{}
+	if f.filename == "" {
+		return nil, errors.New("No config file name defined")
+	}
+	exists, err := util.FileExists(f.filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "checking if the file config file '%s' exits", f.filename)
+	}
+	if !exists {
+		return nil, fmt.Errorf("Config file '%s' does not exist", f.filename)
+	}
+	content, err := ioutil.ReadFile(f.filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading the content of config file '%s'", f.filename)
+	}
+	err = yaml.Unmarshal(content, config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unmarshaling the content of config file '%s'", f.filename)
+	}
+	return config, nil
+}
+
+type ServerRetrieverFn func() (name string, url string, kind string)
+
+type EnvConfigReader struct {
+	prefix          string
+	serverRetriever ServerRetrieverFn
+}
+
+func NewEnvConfigReader(envPrefix string, serverRetriever ServerRetrieverFn) *EnvConfigReader {
+	return &EnvConfigReader{
+		prefix:          envPrefix,
+		serverRetriever: serverRetriever,
+	}
+}
+
+func (e *EnvConfigReader) Read() (*auth.AuthConfig, error) {
+	if e.serverRetriever == nil {
+		return nil, errors.New("No server retriever function provider in env config reader")
+	}
+	config := &auth.AuthConfig{}
+	userAuth := auth.CreateAuthUserFromEnvironment(e.prefix)
+	if userAuth.IsInvalid() {
+		return nil, errors.New("Invalid user found in the environment variables")
+	}
+	servername, url, kind := e.serverRetriever()
+	config.Servers = []*auth.AuthServer{{
+		Name:  servername,
+		URL:   url,
+		Kind:  kind,
+		Users: []*auth.UserAuth{&userAuth},
+	}}
+	return config, nil
+}
+
+type KubeSecretsConfigReader struct {
+	client      kubernetes.Interface
+	namespace   string
+	kind        string
+	serviceKind string
+}
+
+func NewKubeSecretsConfigReader(client kubernetes.Interface, namespace string,
+	kind string, serviceKind string) *KubeSecretsConfigReader {
+	return &KubeSecretsConfigReader{
+		client:      client,
+		namespace:   namespace,
+		kind:        kind,
+		serviceKind: serviceKind,
+	}
+}
+
+func (k *KubeSecretsConfigReader) Read() (*auth.AuthConfig, error) {
+	secrets, err := k.secrets()
+	if err != nil {
+		return nil, errors.Wrap(err, "retrieving config from k8s secrets")
+	}
+	if secrets == nil {
+		return nil, errors.New("No secrets found with config")
+	}
+	config := &auth.AuthConfig{}
+	for _, secret := range secrets.Items {
+		labels := secret.Labels
+		annotations := secret.Annotations
+		if labels != nil && annotations != nil {
+			url := annotations[kube.AnnotationURL]
+			name := annotations[kube.AnnotationName]
+			serviceKind := labels[kube.LabelServiceKind]
+			if url != "" {
+				user, err := k.userAuthFromSecret(secret)
+				if err != nil {
+					continue
+				}
+				if user.IsInvalid() {
+					continue
+				}
+				server := &auth.AuthServer{
+					URL:  url,
+					Name: name,
+					Kind: serviceKind,
+					Users: []*auth.UserAuth{
+						user,
+					},
+				}
+				config.AddServer(server)
+			}
+		}
+	}
+	return config, nil
+}
+
+func (k *KubeSecretsConfigReader) userAuthFromSecret(secret corev1.Secret) (*auth.UserAuth, error) {
+	data := secret.Data
+	if data == nil {
+		return nil, fmt.Errorf("No user auth credentials found in secret '%s'", secret.Name)
+	}
+	username, ok := data[kube.SecretDataUsername]
+	if !ok || len(username) == 0 {
+		return nil, fmt.Errorf("No usernmae found in secret '%s'", secret.Name)
+	}
+	password, ok := data[kube.SecretDataPassword]
+	if !ok || len(password) == 0 {
+		return nil, fmt.Errorf("No password found in secret '%s'", secret.Name)
+	}
+
+	return &auth.UserAuth{
+		Username: string(username),
+		ApiToken: string(password),
+	}, nil
+}
+
+func (k *KubeSecretsConfigReader) secrets() (*corev1.SecretList, error) {
+	selector := kube.LabelKind + "=" + k.kind
+	if k.serviceKind != "" {
+		selector = kube.LabelServiceKind + "=" + k.serviceKind
+	}
+	opts := metav1.ListOptions{
+		LabelSelector: selector,
+	}
+	return k.client.CoreV1().Secrets(k.namespace).List(opts)
+}

--- a/pkg/io/config_readers.go
+++ b/pkg/io/config_readers.go
@@ -223,6 +223,7 @@ func (k *KubeSecretsConfigReader) userFromSecret(secret corev1.Secret) (*auth.Us
 	return &auth.User{
 		Username: string(username),
 		ApiToken: string(password),
+		Kind:     auth.UserKindPipeline,
 	}, nil
 }
 

--- a/pkg/io/config_readers.go
+++ b/pkg/io/config_readers.go
@@ -73,7 +73,7 @@ const (
 	usernameSuffix    = "_USERNAME"
 	apiTokenSuffix    = "_API_TOKEN"
 	bearerTokenSuffix = "_BEARER_TOKEN"
-	DefaultUsername   = "dummy"
+	defaultUsername   = "dummy"
 )
 
 // UsernameEnv builds the username environment variable name
@@ -142,7 +142,7 @@ func (e *EnvConfigReader) userFromEnv(prefix string) auth.User {
 
 	if user.ApiToken != "" || user.Password != "" {
 		if user.Username == "" {
-			user.Username = DefaultUsername
+			user.Username = defaultUsername
 		}
 	}
 	return user

--- a/pkg/io/config_readers.go
+++ b/pkg/io/config_readers.go
@@ -15,20 +15,24 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+//ConfigReader interface for reading auth configuration
 type ConfigReader interface {
 	Read() (*auth.AuthConfig, error)
 }
 
+//FileConfigReader keeps the path to the configration file
 type FileConfigReader struct {
 	filename string
 }
 
+//NewFileConfigReader creates a new file config reader
 func NewFileConfigReader(filename string) *FileConfigReader {
 	return &FileConfigReader{
 		filename: filename,
 	}
 }
 
+//Read reads the configuration from a file
 func (f *FileConfigReader) Read() (*auth.AuthConfig, error) {
 	config := &auth.AuthConfig{}
 	if f.filename == "" {
@@ -52,13 +56,17 @@ func (f *FileConfigReader) Read() (*auth.AuthConfig, error) {
 	return config, nil
 }
 
+//ServerRetrieverFn retrives the server config
 type ServerRetrieverFn func() (name string, url string, kind string)
 
+//EventConfigReader keeps the prefix of the env variables where the user auth config is stored
+// and also a server config retriever
 type EnvConfigReader struct {
 	prefix          string
 	serverRetriever ServerRetrieverFn
 }
 
+//NewEnvConfigReader creates a new environment config reader
 func NewEnvConfigReader(envPrefix string, serverRetriever ServerRetrieverFn) *EnvConfigReader {
 	return &EnvConfigReader{
 		prefix:          envPrefix,
@@ -66,6 +74,7 @@ func NewEnvConfigReader(envPrefix string, serverRetriever ServerRetrieverFn) *En
 	}
 }
 
+//Read reads the configuration from environment
 func (e *EnvConfigReader) Read() (*auth.AuthConfig, error) {
 	if e.serverRetriever == nil {
 		return nil, errors.New("No server retriever function provider in env config reader")
@@ -85,6 +94,7 @@ func (e *EnvConfigReader) Read() (*auth.AuthConfig, error) {
 	return config, nil
 }
 
+//NewKubeSecretsConfigReader config reader for Kubernetes secrets
 type KubeSecretsConfigReader struct {
 	client      kubernetes.Interface
 	namespace   string
@@ -92,6 +102,7 @@ type KubeSecretsConfigReader struct {
 	serviceKind string
 }
 
+//NewKubeSecretsConfigReader creates a new Kubernetes config reader
 func NewKubeSecretsConfigReader(client kubernetes.Interface, namespace string,
 	kind string, serviceKind string) *KubeSecretsConfigReader {
 	return &KubeSecretsConfigReader{
@@ -102,6 +113,7 @@ func NewKubeSecretsConfigReader(client kubernetes.Interface, namespace string,
 	}
 }
 
+//Read reads the config from Kuberntes secrets
 func (k *KubeSecretsConfigReader) Read() (*auth.AuthConfig, error) {
 	secrets, err := k.secrets()
 	if err != nil {

--- a/pkg/io/config_readers.go
+++ b/pkg/io/config_readers.go
@@ -148,7 +148,7 @@ func (e *EnvConfigReader) userFromEnv(prefix string) auth.User {
 	return user
 }
 
-//NewKubeSecretsConfigReader config reader for Kubernetes secrets
+//KubeSecretsConfigReader config reader for Kubernetes secrets
 type KubeSecretsConfigReader struct {
 	client      kubernetes.Interface
 	namespace   string

--- a/pkg/io/config_readers.go
+++ b/pkg/io/config_readers.go
@@ -62,7 +62,7 @@ func (f *FileConfigReader) Read() (*auth.Config, error) {
 type ServerRetrieverFn func() (name string, url string,
 	kind auth.ServerKind, serviceKind auth.ServiceKind)
 
-//EventConfigReader keeps the prefix of the env variables where the user auth config is stored
+//EnvConfigReader keeps the prefix of the env variables where the user auth config is stored
 // and also a server config retriever
 type EnvConfigReader struct {
 	prefix          string

--- a/pkg/io/config_readers_test.go
+++ b/pkg/io/config_readers_test.go
@@ -244,6 +244,7 @@ func TestKubeSecretsConfigReader(t *testing.T) {
 							&auth.User{
 								Username: "test",
 								ApiToken: "test",
+								Kind:     auth.UserKindPipeline,
 							},
 						},
 						Name: "GitHub",
@@ -269,6 +270,7 @@ func TestKubeSecretsConfigReader(t *testing.T) {
 							&auth.User{
 								Username: "test",
 								ApiToken: "test",
+								Kind:     auth.UserKindPipeline,
 							},
 						},
 						Name: "GitHub",
@@ -294,6 +296,7 @@ func TestKubeSecretsConfigReader(t *testing.T) {
 							&auth.User{
 								Username: "test",
 								ApiToken: "test",
+								Kind:     auth.UserKindPipeline,
 							},
 						},
 						Name: "GitHub",
@@ -363,6 +366,7 @@ func TestKubeSecretsConfigReader(t *testing.T) {
 							&auth.User{
 								Username: "test",
 								ApiToken: "test",
+								Kind:     auth.UserKindPipeline,
 							},
 						},
 						Name: "",

--- a/pkg/io/config_readers_test.go
+++ b/pkg/io/config_readers_test.go
@@ -1,0 +1,414 @@
+package io_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/auth"
+	"github.com/jenkins-x/jx/pkg/io"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestFileConfigReader(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		config     string
+		createFile bool
+		err        bool
+		want       auth.AuthConfig
+	}{
+		"read config from file": {
+			config: `
+servers:
+- url: https://github.com
+  users:
+  - username: test
+    apitoken: test
+    bearertoken: ""
+  name: GitHub
+  kind: github
+  currentuser: test`,
+			createFile: true,
+			err:        false,
+			want: auth.AuthConfig{
+				Servers: []*auth.AuthServer{
+					&auth.AuthServer{
+						URL: "https://github.com",
+						Users: []*auth.UserAuth{
+							&auth.UserAuth{
+								Username: "test",
+								ApiToken: "test",
+							},
+						},
+						Name:        "GitHub",
+						Kind:        "github",
+						CurrentUser: "test",
+					},
+				},
+			},
+		},
+		"read config from empty file": {
+			config:     "",
+			createFile: true,
+			err:        false,
+			want:       auth.AuthConfig{},
+		},
+		"read config from a file which does not exist": {
+			config:     "",
+			createFile: false,
+			err:        true,
+			want:       auth.AuthConfig{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			configFile := "test"
+			if tc.createFile {
+				file, err := ioutil.TempFile("", "test-config")
+				assert.NoError(t, err, "should create a temporary config file")
+				defer os.Remove(file.Name())
+				_, err = file.Write([]byte(tc.config))
+				assert.NoError(t, err, "should write the test config into file")
+				configFile = file.Name()
+			}
+			configReader := io.NewFileConfigReader(configFile)
+			config, err := configReader.Read()
+			if tc.err {
+				assert.Error(t, err, "should read config from file with an error")
+			} else {
+				assert.NoError(t, err, "should read config from file without error")
+				if config == nil {
+					t.Fatal("should read a config object which is not nil")
+				}
+				assert.Equal(t, tc.want, *config)
+			}
+		})
+	}
+}
+
+func setEnvs(t *testing.T, envs map[string]string) {
+	err := util.RestoreEnviron(envs)
+	assert.NoError(t, err, "should set the environment variables")
+}
+
+func cleanEnvs(t *testing.T, envs []string) {
+	_, err := util.GetAndCleanEnviron(envs)
+	assert.NoError(t, err, "shuold clean the environment variables")
+}
+
+func TestEnvConfigReader(t *testing.T) {
+	t.Parallel()
+
+	const prefix = "TEST"
+	tests := map[string]struct {
+		prefix          string
+		serverRetriever io.ServerRetrieverFn
+		setup           func(t *testing.T)
+		cleanup         func(t *testing.T)
+		err             bool
+		want            auth.AuthConfig
+	}{
+		"read config from environment variables": {
+			prefix: prefix,
+			serverRetriever: func() (string, string, string) {
+				return "GitHub", "https://github.com", "github"
+			},
+			setup: func(t *testing.T) {
+				setEnvs(t, map[string]string{
+					auth.UsernameEnv(prefix): "test",
+					auth.ApiTokenEnv(prefix): "test",
+				})
+			},
+			cleanup: func(t *testing.T) {
+				cleanEnvs(t, []string{
+					auth.UsernameEnv(prefix),
+					auth.ApiTokenEnv(prefix),
+				})
+			},
+			want: auth.AuthConfig{
+				Servers: []*auth.AuthServer{
+					&auth.AuthServer{
+						URL: "https://github.com",
+						Users: []*auth.UserAuth{
+							&auth.UserAuth{
+								Username: "test",
+								ApiToken: "test",
+							},
+						},
+						Name: "GitHub",
+						Kind: "github",
+					},
+				},
+			},
+			err: false,
+		},
+		"read config from empty environment variables": {
+			prefix: prefix,
+			serverRetriever: func() (string, string, string) {
+				return "GitHub", "https://github.com", "github"
+			},
+			want: auth.AuthConfig{},
+			err:  true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+			configReader := io.NewEnvConfigReader(tc.prefix, tc.serverRetriever)
+			config, err := configReader.Read()
+			if tc.err {
+				assert.Error(t, err, "should read config from env with error")
+			} else {
+				assert.NoError(t, err, "should read config from env with error")
+				if config == nil {
+					t.Fatal("should read a config object which is not nil")
+				}
+				assert.Equal(t, tc.want, *config)
+			}
+			if tc.cleanup != nil {
+				tc.cleanup(t)
+			}
+		})
+	}
+}
+
+func secret(name string, kind string, serviceKind string, serviceName string, url string, username string, password string) *corev1.Secret {
+	labels := map[string]string{}
+	if kind != "" {
+		labels[kube.LabelKind] = kind
+	}
+	if serviceKind != "" {
+		labels[kube.LabelServiceKind] = serviceKind
+	}
+	annotations := map[string]string{
+		kube.AnnotationName: serviceName,
+	}
+	if url != "" {
+		annotations[kube.AnnotationURL] = url
+	}
+	data := map[string][]byte{}
+	if username != "" {
+		data[kube.SecretDataUsername] = []byte(username)
+	}
+	if password != "" {
+		data[kube.SecretDataPassword] = []byte(password)
+	}
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Data: data,
+	}
+	return s
+}
+
+func TestKubeSecretsConfigReader(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		name        string
+		namespace   string
+		kind        string
+		serviceKind string
+		url         string
+		username    string
+		password    string
+		want        auth.AuthConfig
+		err         bool
+	}{
+		"read config from k8s secret": {
+			name:        "GitHub",
+			namespace:   "test",
+			kind:        "git",
+			serviceKind: "github",
+			url:         "https://github.com",
+			username:    "test",
+			password:    "test",
+			want: auth.AuthConfig{
+				Servers: []*auth.AuthServer{
+					&auth.AuthServer{
+						URL: "https://github.com",
+						Users: []*auth.UserAuth{
+							&auth.UserAuth{
+								Username: "test",
+								ApiToken: "test",
+							},
+						},
+						Name: "GitHub",
+						Kind: "github",
+					},
+				},
+			},
+			err: false,
+		},
+		"read config from k8s secret without service kind": {
+			name:        "GitHub",
+			namespace:   "test",
+			kind:        "git",
+			serviceKind: "",
+			url:         "https://github.com",
+			username:    "test",
+			password:    "test",
+			want: auth.AuthConfig{
+				Servers: []*auth.AuthServer{
+					&auth.AuthServer{
+						URL: "https://github.com",
+						Users: []*auth.UserAuth{
+							&auth.UserAuth{
+								Username: "test",
+								ApiToken: "test",
+							},
+						},
+						Name: "GitHub",
+						Kind: "",
+					},
+				},
+			},
+			err: false,
+		},
+		"read config from k8s secret without kind": {
+			name:        "GitHub",
+			namespace:   "test",
+			kind:        "",
+			serviceKind: "github",
+			url:         "https://github.com",
+			username:    "test",
+			password:    "test",
+			want: auth.AuthConfig{
+				Servers: []*auth.AuthServer{
+					&auth.AuthServer{
+						URL: "https://github.com",
+						Users: []*auth.UserAuth{
+							&auth.UserAuth{
+								Username: "test",
+								ApiToken: "test",
+							},
+						},
+						Name: "GitHub",
+						Kind: "github",
+					},
+				},
+			},
+			err: false,
+		},
+		"read config from k8s secret without kind labels": {
+			name:        "GitHub",
+			namespace:   "test",
+			kind:        "",
+			serviceKind: "",
+			url:         "https://github.com",
+			username:    "test",
+			password:    "test",
+			want:        auth.AuthConfig{},
+			err:         false,
+		},
+		"read config from k8s secret without username": {
+			name:        "GitHub",
+			namespace:   "test",
+			kind:        "git",
+			serviceKind: "github",
+			url:         "https://github.com",
+			username:    "",
+			password:    "test",
+			want:        auth.AuthConfig{},
+			err:         false,
+		},
+		"read config from k8s secret without password": {
+			name:        "GitHub",
+			namespace:   "test",
+			kind:        "git",
+			serviceKind: "github",
+			url:         "https://github.com",
+			username:    "test",
+			password:    "",
+			want:        auth.AuthConfig{},
+			err:         false,
+		},
+		"read config from k8s secret without URL": {
+			name:        "GitHub",
+			namespace:   "test",
+			kind:        "git",
+			serviceKind: "github",
+			url:         "",
+			username:    "test",
+			password:    "test",
+			want:        auth.AuthConfig{},
+			err:         false,
+		},
+		"read config from k8s secret without name": {
+			name:        "",
+			namespace:   "test",
+			kind:        "git",
+			serviceKind: "github",
+			url:         "https://github.com",
+			username:    "test",
+			password:    "test",
+			want: auth.AuthConfig{
+				Servers: []*auth.AuthServer{
+					&auth.AuthServer{
+						URL: "https://github.com",
+						Users: []*auth.UserAuth{
+							&auth.UserAuth{
+								Username: "test",
+								ApiToken: "test",
+							},
+						},
+						Name: "",
+						Kind: "github",
+					},
+				},
+			},
+			err: false,
+		},
+		"read config from k8s secret without labels and annotations": {
+			name:        "",
+			namespace:   "test",
+			kind:        "",
+			serviceKind: "",
+			url:         "",
+			username:    "",
+			password:    "",
+			want:        auth.AuthConfig{},
+			err:         false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := k8sfake.NewSimpleClientset()
+			const secretName = "config-test"
+			secret := secret(secretName, tc.kind, tc.serviceKind, tc.name, tc.url, tc.username, tc.password)
+			_, err := client.CoreV1().Secrets(tc.namespace).Create(secret)
+			assert.NoError(t, err, "should create secret without error")
+
+			configReader := io.NewKubeSecretsConfigReader(client, tc.namespace, tc.kind, tc.serviceKind)
+			config, err := configReader.Read()
+			if tc.err {
+				assert.Error(t, err, "should read config from secrete with error")
+			} else {
+				assert.NoError(t, err, "should read config from secret without error")
+				if config == nil {
+					t.Fatal("should read a config object which is not nil")
+				}
+				assert.Equal(t, tc.want, *config)
+			}
+			err = client.CoreV1().Secrets(tc.namespace).Delete(secretName, &metav1.DeleteOptions{})
+			assert.NoError(t, err, "should delete the secret")
+		})
+	}
+
+}

--- a/pkg/io/config_writers.go
+++ b/pkg/io/config_writers.go
@@ -14,7 +14,7 @@ const (
 
 //ConfigWriter interface for writing auth configuration
 type ConfigWriter interface {
-	Write(config *auth.AuthConfig) error
+	Write(config *auth.Config) error
 }
 
 //FileConfigWriter file config write which keeps the path to the configuration file
@@ -30,7 +30,7 @@ func NewFileConfigWriter(filename string) *FileConfigWriter {
 }
 
 //Write writes the auth configuration into a file
-func (f *FileConfigWriter) Write(config *auth.AuthConfig) error {
+func (f *FileConfigWriter) Write(config *auth.Config) error {
 	if f.filename == "" {
 		return errors.New("No config file name defined")
 	}

--- a/pkg/io/config_writers.go
+++ b/pkg/io/config_writers.go
@@ -1,0 +1,43 @@
+package io
+
+import (
+	"io/ioutil"
+
+	"github.com/jenkins-x/jx/pkg/auth"
+	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
+)
+
+const (
+	defaultWritePermissions = 0640
+)
+
+//ConfigWriter interface for writing auth configuration
+type ConfigWriter interface {
+	Write(config *auth.AuthConfig) error
+}
+
+//FileConfigWriter file config write which keeps the path to the configuration file
+type FileConfigWriter struct {
+	filename string
+}
+
+//NewFileConfigWriter creates a new file config writer
+func NewFileConfigWriter(filename string) *FileConfigWriter {
+	return &FileConfigWriter{
+		filename: filename,
+	}
+}
+
+//Write writes the auth configuration into a file
+func (f *FileConfigWriter) Write(config *auth.AuthConfig) error {
+	if f.filename == "" {
+		return errors.New("No config file name defined")
+	}
+	content, err := yaml.Marshal(config)
+	if err != nil {
+		return errors.Wrap(err, "marshaling the config to yaml")
+	}
+	err = ioutil.WriteFile(f.filename, content, defaultWritePermissions)
+	return nil
+}

--- a/pkg/io/config_writers.go
+++ b/pkg/io/config_writers.go
@@ -1,11 +1,17 @@
 package io
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/jenkins-x/jx/pkg/auth"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -23,7 +29,7 @@ type FileConfigWriter struct {
 }
 
 //NewFileConfigWriter creates a new file config writer
-func NewFileConfigWriter(filename string) *FileConfigWriter {
+func NewFileConfigWriter(filename string) ConfigWriter {
 	return &FileConfigWriter{
 		filename: filename,
 	}
@@ -40,4 +46,87 @@ func (f *FileConfigWriter) Write(config *auth.Config) error {
 	}
 	err = ioutil.WriteFile(f.filename, content, defaultWritePermissions)
 	return nil
+}
+
+const (
+	usernameKey = "username"
+	passwordKey = "password"
+)
+
+// KubeSecretsConfigWriter config writer into Kubernetes secrets
+type KubeSecretsConfigWriter struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+// NewKubeSecretsConfigWriter creates a new Kubernetes secrets config writer
+func NewKubeSecretsConfigWriter(client kubernetes.Interface, namespace string) ConfigWriter {
+	return &KubeSecretsConfigWriter{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+// Write write the config into Kuberntes secrets, it will one secret per server configuration
+func (k *KubeSecretsConfigWriter) Write(config *auth.Config) error {
+	for _, server := range config.Servers {
+		name := k.secretName(server)
+		labels := k.labels(server)
+		annotations := k.annotations(server)
+		secret, err := k.client.CoreV1().Secrets(k.namespace).Get(name, metav1.GetOptions{})
+		create := false
+		if err != nil {
+			create = true
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Labels:      labels,
+					Annotations: annotations,
+				},
+				Data: map[string][]byte{},
+			}
+		} else {
+			secret.Labels = util.MergeMaps(secret.Labels, labels)
+			secret.Annotations = util.MergeMaps(secret.Annotations, annotations)
+		}
+		user := server.PipelineUser()
+		if err := user.Valid(); err != nil {
+			return errors.Wrapf(err, "validating user '%s' of server '%s'", user.Username, server.Name)
+		}
+		secret.Data[usernameKey] = []byte(user.Username)
+		secret.Data[passwordKey] = []byte(user.ApiToken)
+		if create {
+			_, err := k.client.CoreV1().Secrets(k.namespace).Create(secret)
+			if err != nil {
+				return errors.Wrapf(err, "creating secret '%s'", name)
+			}
+		} else {
+			_, err := k.client.CoreV1().Secrets(k.namespace).Update(secret)
+			if err != nil {
+				return errors.Wrapf(err, "updating secret '%s'", name)
+			}
+		}
+	}
+	return nil
+}
+
+func (k *KubeSecretsConfigWriter) secretName(server *auth.Server) string {
+	return kube.ToValidName(kube.SecretJenkinsPipelinePrefix + string(server.Kind) + "-" + string(server.ServiceKind) + "-" + server.Name)
+}
+
+func (k *KubeSecretsConfigWriter) labels(server *auth.Server) map[string]string {
+	return map[string]string{
+		kube.LabelCredentialsType: kube.ValueCredentialTypeUsernamePassword,
+		kube.LabelCreatedBy:       kube.ValueCreatedByJX,
+		kube.LabelKind:            string(server.Kind),
+		kube.LabelServiceKind:     string(server.ServiceKind),
+	}
+}
+
+func (k *KubeSecretsConfigWriter) annotations(server *auth.Server) map[string]string {
+	return map[string]string{
+		kube.AnnotationCredentialsDescription: fmt.Sprintf("Configuration and credentials for server %s", server.URL),
+		kube.AnnotationURL:                    server.URL,
+		kube.AnnotationName:                   server.Name,
+	}
 }

--- a/pkg/io/config_writers_test.go
+++ b/pkg/io/config_writers_test.go
@@ -1,13 +1,19 @@
 package io_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/io"
+	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestFileConfigWriter(t *testing.T) {
@@ -28,8 +34,8 @@ func TestFileConfigWriter(t *testing.T) {
 								ApiToken: "test",
 							},
 						},
-						Name: "GitHub",
-						Kind: "github",
+						Name:        "GitHub",
+						ServiceKind: "github",
 					},
 				},
 			},
@@ -66,4 +72,270 @@ func TestFileConfigWriter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKubeSecretsConfigWriter(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		namespace string
+		config    *auth.Config
+		setup     func(t *testing.T, client kubernetes.Interface, ns string)
+		err       bool
+		want      []*corev1.Secret
+	}{
+		"store config into kubernetes secret": {
+			namespace: "test",
+			config: &auth.Config{
+				Servers: []*auth.Server{
+					&auth.Server{
+						URL: "https://github.com",
+						Users: []*auth.User{
+							&auth.User{
+								Username: "test1",
+								ApiToken: "test1",
+								Kind:     auth.UserKindPipeline,
+							},
+							&auth.User{
+								Username: "test2",
+								ApiToken: "test2",
+								Kind:     auth.UserKindLocal,
+							},
+						},
+						Name:        "GitHub",
+						Kind:        auth.ServerKindGit,
+						ServiceKind: auth.ServiceKindGithub,
+					},
+				},
+			},
+			err: false,
+			want: []*corev1.Secret{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "jx-pipeline-git-github-github",
+						Namespace: "test",
+						Labels: map[string]string{
+							kube.LabelCredentialsType: kube.ValueCredentialTypeUsernamePassword,
+							kube.LabelCreatedBy:       kube.ValueCreatedByJX,
+							kube.LabelKind:            "git",
+							kube.LabelServiceKind:     "github",
+						},
+						Annotations: map[string]string{
+							kube.AnnotationCredentialsDescription: fmt.Sprintf("Configuration and credentials for server https://github.com"),
+							kube.AnnotationURL:                    "https://github.com",
+							kube.AnnotationName:                   "GitHub",
+						},
+					},
+					Data: map[string][]byte{
+						"username": []byte("test1"),
+						"password": []byte("test1"),
+					},
+				},
+			},
+		},
+		"store config into multiple kubernetes secrets": {
+			namespace: "test",
+			config: &auth.Config{
+				Servers: []*auth.Server{
+					&auth.Server{
+						URL: "https://github.com",
+						Users: []*auth.User{
+							&auth.User{
+								Username: "test1",
+								ApiToken: "test1",
+								Kind:     auth.UserKindPipeline,
+							},
+							&auth.User{
+								Username: "test2",
+								ApiToken: "test2",
+								Kind:     auth.UserKindLocal,
+							},
+						},
+						Name:        "GitHub",
+						Kind:        auth.ServerKindGit,
+						ServiceKind: auth.ServiceKindGithub,
+					},
+					&auth.Server{
+						URL: "https://gitlab.com",
+						Users: []*auth.User{
+							&auth.User{
+								Username: "test1",
+								ApiToken: "test1",
+								Kind:     auth.UserKindPipeline,
+							},
+							&auth.User{
+								Username: "test2",
+								ApiToken: "test2",
+								Kind:     auth.UserKindLocal,
+							},
+						},
+						Name:        "Gitlab",
+						Kind:        auth.ServerKindGit,
+						ServiceKind: auth.ServiceKindGitlab,
+					},
+				},
+			},
+			err: false,
+			want: []*corev1.Secret{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "jx-pipeline-git-github-github",
+						Namespace: "test",
+						Labels: map[string]string{
+							kube.LabelCredentialsType: kube.ValueCredentialTypeUsernamePassword,
+							kube.LabelCreatedBy:       kube.ValueCreatedByJX,
+							kube.LabelKind:            "git",
+							kube.LabelServiceKind:     "github",
+						},
+						Annotations: map[string]string{
+							kube.AnnotationCredentialsDescription: fmt.Sprintf("Configuration and credentials for server https://github.com"),
+							kube.AnnotationURL:                    "https://github.com",
+							kube.AnnotationName:                   "GitHub",
+						},
+					},
+					Data: map[string][]byte{
+						"username": []byte("test1"),
+						"password": []byte("test1"),
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "jx-pipeline-git-gitlab-gitlab",
+						Namespace: "test",
+						Labels: map[string]string{
+							kube.LabelCredentialsType: kube.ValueCredentialTypeUsernamePassword,
+							kube.LabelCreatedBy:       kube.ValueCreatedByJX,
+							kube.LabelKind:            "git",
+							kube.LabelServiceKind:     "gitlab",
+						},
+						Annotations: map[string]string{
+							kube.AnnotationCredentialsDescription: fmt.Sprintf("Configuration and credentials for server https://gitlab.com"),
+							kube.AnnotationURL:                    "https://gitlab.com",
+							kube.AnnotationName:                   "Gitlab",
+						},
+					},
+					Data: map[string][]byte{
+						"username": []byte("test1"),
+						"password": []byte("test1"),
+					},
+				},
+			},
+		},
+		"store config with invalid user into kubernetes secret": {
+			namespace: "test",
+			config: &auth.Config{
+				Servers: []*auth.Server{
+					&auth.Server{
+						URL:         "https://github.com",
+						Users:       []*auth.User{},
+						Name:        "GitHub",
+						Kind:        auth.ServerKindGit,
+						ServiceKind: auth.ServiceKindGithub,
+					},
+				},
+			},
+			err: true,
+		},
+		"update config into kubernetes secret": {
+			namespace: "test",
+			setup: func(t *testing.T, client kubernetes.Interface, ns string) {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "jx-pipeline-git-github-github",
+						Namespace: "test",
+						Labels: map[string]string{
+							kube.LabelCredentialsType: kube.ValueCredentialTypeUsernamePassword,
+							kube.LabelCreatedBy:       kube.ValueCreatedByJX,
+							kube.LabelKind:            "git",
+							kube.LabelServiceKind:     "github",
+						},
+						Annotations: map[string]string{
+							kube.AnnotationCredentialsDescription: fmt.Sprintf("Configuration and credentials for server https://github.com"),
+							kube.AnnotationURL:                    "https://github.com",
+							kube.AnnotationName:                   "GitHub",
+						},
+					},
+					Data: map[string][]byte{
+						"username": []byte("test"),
+						"password": []byte("test"),
+					},
+				}
+
+				_, err := client.CoreV1().Secrets(ns).Create(secret)
+				assert.NoError(t, err, "should setup a secret without error")
+			},
+			config: &auth.Config{
+				Servers: []*auth.Server{
+					&auth.Server{
+						URL: "https://github.com",
+						Users: []*auth.User{
+							&auth.User{
+								Username: "test1",
+								ApiToken: "test1",
+								Kind:     auth.UserKindPipeline,
+							},
+							&auth.User{
+								Username: "test2",
+								ApiToken: "test2",
+								Kind:     auth.UserKindLocal,
+							},
+						},
+						Name:        "GitHub",
+						Kind:        auth.ServerKindGit,
+						ServiceKind: auth.ServiceKindGithub,
+					},
+				},
+			},
+			err: false,
+			want: []*corev1.Secret{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "jx-pipeline-git-github-github",
+						Namespace: "test",
+						Labels: map[string]string{
+							kube.LabelCredentialsType: kube.ValueCredentialTypeUsernamePassword,
+							kube.LabelCreatedBy:       kube.ValueCreatedByJX,
+							kube.LabelKind:            "git",
+							kube.LabelServiceKind:     "github",
+						},
+						Annotations: map[string]string{
+							kube.AnnotationCredentialsDescription: fmt.Sprintf("Configuration and credentials for server https://github.com"),
+							kube.AnnotationURL:                    "https://github.com",
+							kube.AnnotationName:                   "GitHub",
+						},
+					},
+					Data: map[string][]byte{
+						"username": []byte("test1"),
+						"password": []byte("test1"),
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := k8sfake.NewSimpleClientset()
+			if tc.setup != nil {
+				tc.setup(t, client, tc.namespace)
+			}
+			configWriter := io.NewKubeSecretsConfigWriter(client, tc.namespace)
+			err := configWriter.Write(tc.config)
+			if tc.err {
+				assert.Error(t, err, "should generate an error when writing the config")
+			} else {
+				assert.NoError(t, err, "should not generate an error when writing the confiig")
+				for _, wantSecret := range tc.want {
+					gotSecret, err := client.CoreV1().Secrets(tc.namespace).Get(wantSecret.Name, metav1.GetOptions{})
+					assert.NoErrorf(t, err, "should find secret '%s'", wantSecret.Name)
+					if gotSecret == nil {
+						t.Fatalf("created secret '%s' should not be nil", wantSecret.Name)
+					}
+					assert.Equal(t, *wantSecret, *gotSecret)
+				}
+			}
+
+		})
+	}
+
 }

--- a/pkg/io/config_writers_test.go
+++ b/pkg/io/config_writers_test.go
@@ -1,0 +1,70 @@
+package io_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/auth"
+	"github.com/jenkins-x/jx/pkg/io"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileConfigWriter(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		config auth.AuthConfig
+		err    bool
+	}{
+		"write config to file": {
+			config: auth.AuthConfig{
+				Servers: []*auth.AuthServer{
+					&auth.AuthServer{
+						URL: "https://github.com",
+						Users: []*auth.UserAuth{
+							&auth.UserAuth{
+								Username: "test",
+								ApiToken: "test",
+							},
+						},
+						Name:        "GitHub",
+						Kind:        "github",
+						CurrentUser: "test",
+					},
+				},
+			},
+			err: false,
+		},
+		"write empty config to file": {
+			config: auth.AuthConfig{
+				Servers: []*auth.AuthServer{},
+			},
+			err: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			file, err := ioutil.TempFile("", "test-config")
+			assert.NoError(t, err, "should create a temporary config file")
+			defer os.Remove(file.Name())
+
+			configWriter := io.NewFileConfigWriter(file.Name())
+			err = configWriter.Write(&tc.config)
+			if tc.err {
+				assert.Error(t, err, "should write config into a file with an error")
+			} else {
+				assert.NoError(t, err, "should write config into a file without error")
+
+				configReader := io.NewFileConfigReader(file.Name())
+				config, err := configReader.Read()
+				assert.NoError(t, err, "should read the written file without error")
+				if config == nil {
+					t.Fatal("should read a config object which is not nil")
+				}
+				assert.Equal(t, tc.config, *config)
+			}
+		})
+	}
+}

--- a/pkg/io/config_writers_test.go
+++ b/pkg/io/config_writers_test.go
@@ -14,31 +14,30 @@ func TestFileConfigWriter(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		config auth.AuthConfig
+		config auth.Config
 		err    bool
 	}{
 		"write config to file": {
-			config: auth.AuthConfig{
-				Servers: []*auth.AuthServer{
-					&auth.AuthServer{
+			config: auth.Config{
+				Servers: []*auth.Server{
+					&auth.Server{
 						URL: "https://github.com",
-						Users: []*auth.UserAuth{
-							&auth.UserAuth{
+						Users: []*auth.User{
+							&auth.User{
 								Username: "test",
 								ApiToken: "test",
 							},
 						},
-						Name:        "GitHub",
-						Kind:        "github",
-						CurrentUser: "test",
+						Name: "GitHub",
+						Kind: "github",
 					},
 				},
 			},
 			err: false,
 		},
 		"write empty config to file": {
-			config: auth.AuthConfig{
-				Servers: []*auth.AuthServer{},
+			config: auth.Config{
+				Servers: []*auth.Server{},
 			},
 			err: false,
 		},

--- a/pkg/jx/cmd/common_git.go
+++ b/pkg/jx/cmd/common_git.go
@@ -108,8 +108,8 @@ func (o *CommonOptions) updatePipelineGitCredentialsSecret(server *auth.AuthServ
 			Data: map[string][]byte{},
 		}
 	} else {
-		secret.Annotations = kube.MergeMaps(secret.Annotations, annotations)
-		secret.Labels = kube.MergeMaps(secret.Labels, labels)
+		secret.Annotations = util.MergeMaps(secret.Annotations, annotations)
+		secret.Labels = util.MergeMaps(secret.Labels, labels)
 	}
 	if userAuth.Username != "" {
 		secret.Data["username"] = []byte(userAuth.Username)

--- a/pkg/jx/cmd/common_git.go
+++ b/pkg/jx/cmd/common_git.go
@@ -57,7 +57,7 @@ func (o *CommonOptions) createGitProvider(dir string) (*gits.GitRepositoryInfo, 
 		return gitInfo, nil, nil, err
 	}
 	gitKind, err := o.GitServerKind(gitInfo)
-	gitProvider, err := gitInfo.CreateProvider(authConfigSvc, gitKind, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+	gitProvider, err := gitInfo.CreateProvider(o.Factory.IsInCluster(), authConfigSvc, gitKind, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
 	if err != nil {
 		return gitInfo, gitProvider, nil, err
 	}
@@ -312,5 +312,5 @@ func (o *CommonOptions) gitProviderForGitServerURL(gitServiceUrl string, gitKind
 	if err != nil {
 		return nil, err
 	}
-	return gits.CreateProviderForURL(authConfigSvc, gitKind, gitServiceUrl, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+	return gits.CreateProviderForURL(o.Factory.IsInCluster(), authConfigSvc, gitKind, gitServiceUrl, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
 }

--- a/pkg/jx/cmd/create_chat_token.go
+++ b/pkg/jx/cmd/create_chat_token.go
@@ -180,8 +180,8 @@ func (o *CreateChatTokenOptions) updateChatCredentialsSecret(server *auth.AuthSe
 			Data: map[string][]byte{},
 		}
 	} else {
-		secret.Annotations = kube.MergeMaps(secret.Annotations, annotations)
-		secret.Labels = kube.MergeMaps(secret.Labels, labels)
+		secret.Annotations = util.MergeMaps(secret.Annotations, annotations)
+		secret.Labels = util.MergeMaps(secret.Labels, labels)
 	}
 	if userAuth.Username != "" {
 		secret.Data["username"] = []byte(userAuth.Username)

--- a/pkg/jx/cmd/create_token_addon.go
+++ b/pkg/jx/cmd/create_token_addon.go
@@ -190,8 +190,8 @@ func (o *CreateTokenAddonOptions) updateAddonCredentialsSecret(server *auth.Auth
 			Data: map[string][]byte{},
 		}
 	} else {
-		secret.Annotations = kube.MergeMaps(secret.Annotations, annotations)
-		secret.Labels = kube.MergeMaps(secret.Labels, labels)
+		secret.Annotations = util.MergeMaps(secret.Annotations, annotations)
+		secret.Labels = util.MergeMaps(secret.Labels, labels)
 	}
 	if userAuth.Username != "" {
 		secret.Data["username"] = []byte(userAuth.Username)

--- a/pkg/jx/cmd/create_tracker_token.go
+++ b/pkg/jx/cmd/create_tracker_token.go
@@ -179,8 +179,8 @@ func (o *CreateTrackerTokenOptions) updateIssueTrackerCredentialsSecret(server *
 			Data: map[string][]byte{},
 		}
 	} else {
-		secret.Annotations = kube.MergeMaps(secret.Annotations, annotations)
-		secret.Labels = kube.MergeMaps(secret.Labels, labels)
+		secret.Annotations = util.MergeMaps(secret.Annotations, annotations)
+		secret.Labels = util.MergeMaps(secret.Labels, labels)
 	}
 	if userAuth.Username != "" {
 		secret.Data["username"] = []byte(userAuth.Username)

--- a/pkg/jx/cmd/factory.go
+++ b/pkg/jx/cmd/factory.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/kube/services"
 	"io"
 	"net/url"
 	"os"
 	"path/filepath"
 
 	"github.com/jenkins-x/jx/pkg/helm"
+	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/jenkins-x/jx/pkg/log"
 
 	"github.com/heptio/sonobuoy/pkg/client"
@@ -258,12 +258,17 @@ func (f *factory) AuthMergePipelineSecrets(config *auth.AuthConfig, secrets *cor
 						username := data[kube.SecretDataUsername]
 						pwd := data[kube.SecretDataPassword]
 						if len(username) > 0 && isCDPipeline {
-							userAuth := config.GetOrCreateUserAuth(u, string(username))
-							if userAuth != nil {
-								if len(pwd) > 0 {
-									userAuth.ApiToken = string(pwd)
+							userAuth := config.FindUserAuth(u, string(username))
+							if userAuth == nil {
+								userAuth = &auth.UserAuth{
+									Username: string(username),
+									ApiToken: string(pwd),
 								}
+							} else if len(pwd) > 0 {
+								userAuth.ApiToken = string(pwd)
 							}
+							config.SetUserAuth(u, userAuth)
+							config.UpdatePipelineServer(server, userAuth)
 						}
 					}
 				}

--- a/pkg/jx/cmd/gc_previews.go
+++ b/pkg/jx/cmd/gc_previews.go
@@ -107,7 +107,7 @@ func (o *GCPreviewsOptions) Run() error {
 				return err
 			}
 
-			gitProvider, err := gitInfo.CreateProvider(authConfigSvc, gitKind, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+			gitProvider, err := gitInfo.CreateProvider(o.Factory.IsInCluster(), authConfigSvc, gitKind, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
 			if err != nil {
 				return err
 			}

--- a/pkg/jx/cmd/preview.go
+++ b/pkg/jx/cmd/preview.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/kube/services"
 	"io"
 	"io/ioutil"
 	"os"
@@ -10,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/kube/services"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/config"
@@ -224,7 +225,7 @@ func (o *PreviewOptions) Run() error {
 			return err
 		}
 
-		gitProvider, err := o.Factory.CreateGitProvider(o.GitInfo.URL, "message", authConfigSvc, gitKind, o.BatchMode, o.Git(), o.In, o.Out, o.Err)
+		gitProvider, err := o.Factory.CreateGitProvider(o.Factory.IsInCluster(), o.GitInfo.URL, "message", authConfigSvc, gitKind, o.BatchMode, o.Git(), o.In, o.Out, o.Err)
 		if err != nil {
 			return fmt.Errorf("cannot create Git provider %v", err)
 		}

--- a/pkg/jx/cmd/preview.go
+++ b/pkg/jx/cmd/preview.go
@@ -225,7 +225,7 @@ func (o *PreviewOptions) Run() error {
 			return err
 		}
 
-		gitProvider, err := o.Factory.CreateGitProvider(o.Factory.IsInCluster(), o.GitInfo.URL, "message", authConfigSvc, gitKind, o.BatchMode, o.Git(), o.In, o.Out, o.Err)
+		gitProvider, err := o.Factory.CreateGitProvider(o.GitInfo.URL, "message", authConfigSvc, gitKind, o.BatchMode, o.Git(), o.In, o.Out, o.Err)
 		if err != nil {
 			return fmt.Errorf("cannot create Git provider %v", err)
 		}

--- a/pkg/jx/cmd/step_changelog.go
+++ b/pkg/jx/cmd/step_changelog.go
@@ -296,7 +296,7 @@ func (o *StepChangelogOptions) Run() error {
 
 	gitKind, err := o.GitServerKind(gitInfo)
 	foundGitProvider := true
-	gitProvider, err := o.State.GitInfo.CreateProvider(authConfigSvc, gitKind, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+	gitProvider, err := o.State.GitInfo.CreateProvider(o.Factory.IsInCluster(), authConfigSvc, gitKind, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
 	if err != nil {
 		foundGitProvider = false
 		log.Warnf("Could not create GitProvide so cannot update the release notes: %s\n", err)

--- a/pkg/jx/cmd/step_split_monorepo.go
+++ b/pkg/jx/cmd/step_split_monorepo.go
@@ -317,7 +317,7 @@ func (o *CommonOptions) createGitProviderForURL(gitKind string, gitUrl string) (
 	if err != nil {
 		return nil, err
 	}
-	return gits.CreateProviderForURL(authConfigSvc, gitKind, gitUrl, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+	return gits.CreateProviderForURL(o.Factory.IsInCluster(), authConfigSvc, gitKind, gitUrl, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
 }
 
 func (o *CommonOptions) createGitProviderForURLWithoutKind(gitUrl string) (gits.GitProvider, *gits.GitRepositoryInfo, error) {
@@ -333,7 +333,7 @@ func (o *CommonOptions) createGitProviderForURLWithoutKind(gitUrl string) (gits.
 	if err != nil {
 		return nil, gitInfo, err
 	}
-	gitProvider, err := gits.CreateProviderForURL(authConfigSvc, gitKind, gitInfo.HostURL(), o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+	gitProvider, err := gits.CreateProviderForURL(o.Factory.IsInCluster(), authConfigSvc, gitKind, gitInfo.HostURL(), o.Git(), o.BatchMode, o.In, o.Out, o.Err)
 	return gitProvider, gitInfo, err
 }
 

--- a/pkg/kube/constants.go
+++ b/pkg/kube/constants.go
@@ -70,6 +70,9 @@ const (
 	// SecretJenkinsReleaseGPG the GPG secrets for doing releases
 	SecretJenkinsReleaseGPG = "jenkins-release-gpg"
 
+	// SecretJenkinsPipelinePrefix prefix for a jenkins pipeline secret name
+	SecretJenkinsPipelinePrefix = "jx-pipeline-"
+
 	// SecretJenkinsPipelineAddonCredentials the chat credentials secret
 	SecretJenkinsPipelineAddonCredentials = "jx-pipeline-addon-"
 

--- a/pkg/kube/metadata.go
+++ b/pkg/kube/metadata.go
@@ -2,20 +2,6 @@ package kube
 
 import "strconv"
 
-// MergeMaps merges all the maps together with the entries in the last map overwriting any earlier values
-//
-// so if you want to add some annotations to a resource you can do
-// resource.Annotations = kube.MergeMaps(resource.Annotations, myAnnotations)
-func MergeMaps(maps ...map[string]string) map[string]string {
-	answer := map[string]string{}
-	for _, m := range maps {
-		for k, v := range m {
-			answer[k] = v
-		}
-	}
-	return answer
-}
-
 // IsResourceVersionNewer returns true if the first resource version is newer than the second
 func IsResourceVersionNewer(v1 string, v2 string) bool {
 	if v1 == v2 || v1 == "" {

--- a/pkg/util/environ.go
+++ b/pkg/util/environ.go
@@ -1,0 +1,28 @@
+package util
+
+import "os"
+
+func GetAndCleanEnviron(keys []string) (map[string]string, error) {
+	environ := map[string]string{}
+	for _, key := range keys {
+		value, set := os.LookupEnv(key)
+		if set {
+			environ[key] = value
+			err := os.Unsetenv(key)
+			if err != nil {
+				return environ, err
+			}
+		}
+	}
+	return environ, nil
+}
+
+func RestoreEnviron(environ map[string]string) error {
+	for key, value := range environ {
+		err := os.Setenv(key, value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/util/environ.go
+++ b/pkg/util/environ.go
@@ -2,6 +2,7 @@ package util
 
 import "os"
 
+// GetAndCleanEnviron cleans the provided env variables and returns their current value
 func GetAndCleanEnviron(keys []string) (map[string]string, error) {
 	environ := map[string]string{}
 	for _, key := range keys {
@@ -17,6 +18,7 @@ func GetAndCleanEnviron(keys []string) (map[string]string, error) {
 	return environ, nil
 }
 
+// RestoreEnviron sets the in the environment the environment variables provided as input
 func RestoreEnviron(environ map[string]string) error {
 	for key, value := range environ {
 		err := os.Setenv(key, value)

--- a/pkg/util/environ_test.go
+++ b/pkg/util/environ_test.go
@@ -1,0 +1,130 @@
+package util_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAndCleanEnviron(t *testing.T) {
+	tests := map[string]struct {
+		setEnvs   map[string]string
+		unsetEnvs []string
+		want      map[string]string
+		wantErr   bool
+	}{
+
+		"get and clean no env variables": {
+			setEnvs: map[string]string{},
+			want:    map[string]string{},
+			wantErr: false,
+		},
+		"get and clean one env variables": {
+			setEnvs: map[string]string{
+				"TEST1": "value1",
+			},
+			want: map[string]string{
+				"TEST1": "value1",
+			},
+			wantErr: false,
+		},
+		"get and clean multiple env variables": {
+			setEnvs: map[string]string{
+				"TEST1": "value1",
+				"TEST2": "value2",
+			},
+			want: map[string]string{
+				"TEST1": "value1",
+				"TEST2": "value2",
+			},
+			wantErr: false,
+		},
+		"get and clean only set env variables": {
+			setEnvs: map[string]string{
+				"TEST1": "value1",
+			},
+			unsetEnvs: []string{
+				"TEST2",
+			},
+			want: map[string]string{
+				"TEST1": "value1",
+			},
+			wantErr: false,
+		},
+	}
+
+	for description, tc := range tests {
+		t.Run(description, func(t *testing.T) {
+			for key, value := range tc.setEnvs {
+				err := os.Setenv(key, value)
+				assert.NoErrorf(t, err, "should set env variable '%s'='%s'", key, value)
+			}
+			envNames := append(tc.unsetEnvs, util.MapKeys(tc.setEnvs)...)
+			envs, err := util.GetAndCleanEnviron(envNames)
+			if tc.wantErr {
+				assert.Error(t, err, "should return an error")
+			} else {
+				assert.NoError(t, err, "should not return an error")
+			}
+			assert.Equal(t, tc.want, envs, "should contained the expected cleaned keys")
+			for key, _ := range envs {
+				_, set := os.LookupEnv(key)
+				assert.Falsef(t, set, "env variable '%s' should not be set", key)
+			}
+		})
+	}
+}
+
+func TestRetoreEnviron(t *testing.T) {
+	tests := map[string]struct {
+		environ map[string]string
+		want    map[string]string
+		wantErr bool
+	}{
+		"restore nonenv variable": {
+			environ: map[string]string{},
+			want:    map[string]string{},
+			wantErr: false,
+		},
+		"restore one env variable": {
+			environ: map[string]string{
+				"TEST1": "value1",
+			},
+			want: map[string]string{
+				"TEST1": "value1",
+			},
+			wantErr: false,
+		},
+		"restore multiple env variables": {
+			environ: map[string]string{
+				"TEST1": "value1",
+				"TEST2": "value2",
+			},
+			want: map[string]string{
+				"TEST1": "value1",
+				"TEST2": "value2",
+			},
+			wantErr: false,
+		},
+	}
+
+	for description, tc := range tests {
+		t.Run(description, func(t *testing.T) {
+			err := util.RestoreEnviron(tc.environ)
+			if tc.wantErr {
+				assert.Error(t, err, "should retun and error")
+			} else {
+				assert.NoError(t, err, "should not reutnr an error")
+			}
+			for wantKey, wantValue := range tc.want {
+				value, set := os.LookupEnv(wantKey)
+				assert.Truef(t, set, "should set env vairable '%s'", wantKey)
+				assert.Equalf(t, wantValue, value, "should set env variable '%s'='%s'", wantKey, wantValue)
+				err := os.Unsetenv(wantKey)
+				assert.NoError(t, err, "should unset the envariable '%s", wantKey)
+			}
+		})
+	}
+}

--- a/pkg/util/environ_test.go
+++ b/pkg/util/environ_test.go
@@ -69,7 +69,7 @@ func TestGetAndCleanEnviron(t *testing.T) {
 				assert.NoError(t, err, "should not return an error")
 			}
 			assert.Equal(t, tc.want, envs, "should contained the expected cleaned keys")
-			for key, _ := range envs {
+			for key := range envs {
 				_, set := os.LookupEnv(key)
 				assert.Falsef(t, set, "env variable '%s' should not be set", key)
 			}

--- a/pkg/util/maps.go
+++ b/pkg/util/maps.go
@@ -16,7 +16,7 @@ func StringMapHasValue(m map[string]string, value string) bool {
 // MapKeys returns the keys of a given map
 func MapKeys(m map[string]string) []string {
 	keys := []string{}
-	for key, _ := range m {
+	for key := range m {
 		keys = append(keys, key)
 	}
 	return keys

--- a/pkg/util/maps.go
+++ b/pkg/util/maps.go
@@ -12,3 +12,12 @@ func StringMapHasValue(m map[string]string, value string) bool {
 	}
 	return false
 }
+
+// MapKeys returns the keys of a given map
+func MapKeys(m map[string]string) []string {
+	keys := []string{}
+	for key, _ := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/pkg/util/maps.go
+++ b/pkg/util/maps.go
@@ -21,3 +21,17 @@ func MapKeys(m map[string]string) []string {
 	}
 	return keys
 }
+
+// MergeMaps merges all the maps together with the entries in the last map overwriting any earlier values
+//
+// so if you want to add some annotations to a resource you can do
+// resource.Annotations = kube.MergeMaps(resource.Annotations, myAnnotations)
+func MergeMaps(maps ...map[string]string) map[string]string {
+	answer := map[string]string{}
+	for _, m := range maps {
+		for k, v := range m {
+			answer[k] = v
+		}
+	}
+	return answer
+}

--- a/pkg/util/urls.go
+++ b/pkg/util/urls.go
@@ -45,3 +45,8 @@ func UrlHostNameWithoutPort(rawUri string) (string, error) {
 	}
 	return rawUri, nil
 }
+
+// UrlEqual verifies if URLs are equal
+func UrlEqual(url1, url2 string) bool {
+	return url1 == url2 || strings.TrimSuffix(url1, "/") == strings.TrimSuffix(url2, "/")
+}

--- a/pkg/util/urls.go
+++ b/pkg/util/urls.go
@@ -46,7 +46,7 @@ func UrlHostNameWithoutPort(rawUri string) (string, error) {
 	return rawUri, nil
 }
 
-// UrlEqual verifies if URLs are equal
-func UrlEqual(url1, url2 string) bool {
+// URLEqual verifies if URLs are equal
+func URLEqual(url1, url2 string) bool {
 	return url1 == url2 || strings.TrimSuffix(url1, "/") == strings.TrimSuffix(url2, "/")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Implements some building blocks for refactoring the current auth config, such as:
- Updates the config data model to reflect the current type of users and servers
- Implements readers for getting the config from a local file, environment variables and Kubernetes secrets
- Implements writers to store the config into a local file or Kubernetes secrets
- Tests which cover the added functionality

Also it implements  a fix for Git providers when created in the cluster with pipeline user 
and adds tests for git provider creation.

#### Special notes for the reviewer(s)

The Git provider fix is in the last commit.

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->