### PR TITLE
Automatically source <(jx completion bash) from jx shell

### DIFF
--- a/pkg/jx/cmd/shell.go
+++ b/pkg/jx/cmd/shell.go
@@ -32,6 +32,11 @@ fi
 if [ -f ~/.bashrc ]; then
     source ~/.bashrc
 fi
+if type -t dh_bash-completion >/dev/null; then
+    if type -t __start_jx >/dev/null; then true; else
+        source <(jx completion bash)
+    fi
+fi
 `
 
 	zshRcFile = `


### PR DESCRIPTION
I had originally added

```bash
source <(jx completion bash)
```

to my `~/.bashrc`. But this made it slower to start shells for unrelated work, and when I deleted a GKE cluster, I was unpleasantly surprised to find that newly opened shells hung indefinitely, I suppose trying to contact a now-decommissioned API server.

Since there is already a `jx shell` command which sets up a prompt and all that, and this already pays the cost of contacting the API server, it seemed to make sense to automatically install shell completion there as well. I have tried to make this conditional on `bash-completion` being installed and JX completion not already loaded from another source, though the former is tricky to test.

I did not attempt to do the same for zsh as I am not familiar with it.