### PR TITLE
Suppressing call to addTeamSettingsCommandsFromTags since it slows down every jx command

### DIFF
--- a/pkg/jx/cmd/edit.go
+++ b/pkg/jx/cmd/edit.go
@@ -59,7 +59,9 @@ func NewCmdEdit(f Factory, in terminal.FileReader, out terminal.FileWriter, errO
 	cmd.AddCommand(NewCmdEditHelmBin(f, in, out, errOut))
 	cmd.AddCommand(NewCmdEditUserRole(f, in, out, errOut))
 	cmd.AddCommand(NewCmdEditExtensionsRepository(f, in, out, errOut))
+	/* TODO cannot be done here as it tries to connect to the API server:
 	addTeamSettingsCommandsFromTags(cmd, in, out, errOut, options)
+        */
 	return cmd
 }
 


### PR DESCRIPTION
I noticed that `jx shell` paused for around a second before giving me every prompt when using my GKE cluster. Clearly `$PS1` was responsible, and in fact it turned out that `jx prompt` pauses. If I switch to an EKS cluster, the pause is a little longer, and when I switch to a Minikuke cluster with the Minikuke VM switched off, it pauses for a couple of _minutes_ until it gets a timeout. A bunch of `strace` tuning later, I found a lot of stack traces like

```
[pid 12737] 09:02:38.003019 <... epoll_ctl resumed> ) = -1 EPERM (Operation not permitted)
 > ~/.jx/bin/jx(runtime.epollctl+0x18) [0x5a048]
 > ~/.jx/bin/jx(internal/poll.runtime_pollClose+0x60) [0x277e0]
 > ~/.jx/bin/jx(internal/poll.(*pollDesc).init+0xb7) [0x84e97]
 > ~/.jx/bin/jx(internal/poll.(*FD).Init+0x5f) [0x85b1f]
 > ~/.jx/bin/jx(os.newFile+0xed) [0x9008d]
 > ~/.jx/bin/jx(os.openFileNolog+0x1aa) [0x9039a]
 > ~/.jx/bin/jx(os.OpenFile+0x5f) [0x8e31f]
 > ~/.jx/bin/jx(os.Open+0x46) [0x8e206]
 > ~/.jx/bin/jx(io/ioutil.ReadFile+0x52) [0xfaa12]
 > ~/.jx/bin/jx(k8s.io/client-go/transport.dataFromSliceOrFile+0x50) [0xb26b50]
 > ~/.jx/bin/jx(k8s.io/client-go/transport.loadTLSFiles+0xcb) [0xb2699b]
 > ~/.jx/bin/jx(k8s.io/client-go/transport.tlsConfigKey+0x6e) [0xb2397e]
 > ~/.jx/bin/jx(k8s.io/client-go/transport.(*tlsTransportCache).get+0x81) [0xb233e1]
 > ~/.jx/bin/jx(k8s.io/client-go/transport.New+0x139) [0xb262a9]
 > ~/.jx/bin/jx(k8s.io/client-go/rest.TransportFor+0x68) [0xb36a28]
 > ~/.jx/bin/jx(k8s.io/client-go/rest.RESTClientFor+0xf3) [0xb2d043]
 > ~/.jx/bin/jx(k8s.io/client-go/kubernetes/typed/networking/v1.NewForConfig+0x81) [0xb97ab1]
 > ~/.jx/bin/jx(k8s.io/client-go/kubernetes.NewForConfig+0x4ca) [0xbb09ca]
 > ~/.jx/bin/jx(github.com/jenkins-x/jx/pkg/jx/cmd.(*factory).CreateClient+0x50) [0x19dc560]
 > ~/.jx/bin/jx(github.com/jenkins-x/jx/pkg/jx/cmd.(*CommonOptions).KubeClient+0x83) [0x18f5d53]
 > ~/.jx/bin/jx(github.com/jenkins-x/jx/pkg/jx/cmd.(*CommonOptions).JXClientAndDevNamespace+0x8f) [0x18f63ff]
 > ~/.jx/bin/jx(github.com/jenkins-x/jx/pkg/jx/cmd.(*CommonOptions).TeamSettings+0x40) [0x191cd10]
 > ~/.jx/bin/jx(github.com/jenkins-x/jx/pkg/jx/cmd.addTeamSettingsCommandsFromTags+0x62) [0x191eb52]
 > ~/.jx/bin/jx(github.com/jenkins-x/jx/pkg/jx/cmd.NewCmdEdit+0x7f4) [0x19cfb44]
 > ~/.jx/bin/jx(github.com/jenkins-x/jx/pkg/jx/cmd.NewJXCommand+0x293) [0x18f2023]
 > ~/.jx/bin/jx(github.com/jenkins-x/jx/cmd/jx/app.Run+0xce) [0x1b547be]
 > ~/.jx/bin/jx(main.main+0x22) [0x1b548a2]
 > ~/.jx/bin/jx(runtime.main+0x207) [0x2cbc7]
 > unexpected_backtracing_error [0xc00005c060]
```

Why would every command be creating a k8s client and attempting to contact the API server? It turns out these are all coming from the creation of the `jx edit` command—even when I am not running that command!—and this call was introduced in @msvticket’s #1821 for #764. I do not pretend to understand what that feature was about, but I presume it cannot be important enough to make every command prompt slower. By comparison, running `time jx prompt` when a GKE cluster is configured as the default context, with my patch:

```
real	0m0.063s
user	0m0.067s
sys	0m0.016s
```

vs. with 1.3.544:

```
real	0m1.772s
user	0m0.437s
sys	0m0.093s
```

Probably there is some proper way to create the client if and when the `jx edit` command is actually being used, but I do not understand the source base well enough to do that, so consider this a hotfix.