### PR TITLE
Use default-environment-prefix if provided

### DIFF
--- a/pkg/jx/cmd/common_gke.go
+++ b/pkg/jx/cmd/common_gke.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
-	survey "gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 // asks to chose from existing projects or optionally creates one if none exist
@@ -22,7 +22,7 @@ func (o *CommonOptions) getGoogleProjectId() (string, error) {
 	lines := strings.Split(string(out), "\n")
 	var existingProjects []string
 	for _, l := range lines {
-		if strings.Contains(l, CLUSTER_LIST_HEADER) {
+		if strings.Contains(l, clusterListHeader) {
 			continue
 		}
 		fields := strings.Fields(l)

--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"strings"
 
-	os_user "os/user"
+	osUser "os/user"
 
 	"regexp"
 
@@ -44,7 +44,7 @@ type CreateClusterGKEFlags struct {
 	Labels          string
 }
 
-const CLUSTER_LIST_HEADER = "PROJECT_ID"
+const clusterListHeader = "PROJECT_ID"
 
 var (
 	createClusterGKELong = templates.LongDesc(`
@@ -70,7 +70,7 @@ var (
 	disallowedLabelCharacters = regexp.MustCompile("[^a-z0-9-]")
 )
 
-// NewCmdGet creates a command object for the generic "init" action, which
+// NewCmdCreateClusterGKE creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
 func NewCmdCreateClusterGKE(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
 	options := CreateClusterGKEOptions{
@@ -248,7 +248,7 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 	}
 
 	labels := o.Flags.Labels
-	user, err := os_user.Current()
+	user, err := osUser.Current()
 	if err == nil && user != nil {
 		username := sanitizeLabel(user.Username)
 		if username != "" {
@@ -270,7 +270,9 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 	}
 
 	log.Info("Initialising cluster ...\n")
-	o.InstallOptions.Flags.DefaultEnvironmentPrefix = o.Flags.ClusterName
+	if o.InstallOptions.Flags.DefaultEnvironmentPrefix == "" {
+		o.InstallOptions.Flags.DefaultEnvironmentPrefix = o.Flags.ClusterName
+	}
 	err = o.initAndInstall(GKE)
 	if err != nil {
 		return err

--- a/pkg/jx/cmd/create_cluster_gke_terraform.go
+++ b/pkg/jx/cmd/create_cluster_gke_terraform.go
@@ -8,7 +8,7 @@ import (
 
 	"errors"
 
-	os_user "os/user"
+	osUser "os/user"
 
 	"io/ioutil"
 	"os"
@@ -71,14 +71,9 @@ var (
 
 `)
 
-	requiredServiceAccountRoles = []string{"roles/compute.instanceAdmin.v1",
-		"roles/iam.serviceAccountActor",
-		"roles/container.clusterAdmin",
-		"roles/container.admin",
-		"roles/container.developer"}
 )
 
-// NewCmdGet creates a command object for the generic "init" action, which
+// NewCmdCreateClusterGKETerraform creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
 func NewCmdCreateClusterGKETerraform(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
 	options := CreateClusterGKETerraformOptions{
@@ -271,7 +266,7 @@ func (o *CreateClusterGKETerraformOptions) createClusterGKETerraform() error {
 		})
 	}
 
-	user, err := os_user.Current()
+	user, err := osUser.Current()
 	if err != nil {
 		return err
 	}
@@ -366,7 +361,9 @@ func (o *CreateClusterGKETerraformOptions) createClusterGKETerraform() error {
 	log.Info(output)
 
 	log.Info("Initialising cluster ...\n")
-	o.InstallOptions.Flags.DefaultEnvironmentPrefix = o.Flags.ClusterName
+	if o.InstallOptions.Flags.DefaultEnvironmentPrefix == "" {
+		o.InstallOptions.Flags.DefaultEnvironmentPrefix = o.Flags.ClusterName
+	}
 	err = o.initAndInstall(GKE)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

For GKE, use the `default-environment-prefix` in preference to `cluster-name` if given. Also, clean up linter warnings.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2233 
