### PR TITLE
fix:(bitbucket) Handle some more idiosyncratic Bitbucket Server URLs

### DIFF
--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -151,6 +151,10 @@ func parsePath(path string, info *GitRepositoryInfo) (*GitRepositoryInfo, error)
 	// This is necessary for Bitbucket Server in some cases.
 	trimPath := strings.TrimPrefix(path, "/scm")
 
+	// This is necessary for Bitbucket Server in other cases
+	trimPath = strings.Replace(trimPath, "/projects", "", 1)
+	trimPath = strings.Replace(trimPath, "/repos", "", 1)
+
 	// Remove leading and trailing slashes so that splitting on "/" won't result
 	// in empty strings at the beginning & end of the array.
 	trimPath = strings.TrimPrefix(trimPath, "/")

--- a/pkg/gits/git_url_test.go
+++ b/pkg/gits/git_url_test.go
@@ -50,6 +50,9 @@ func TestParseGitURL(t *testing.T) {
 		{
 			"http://test-user@auth.example.com/scm/bar/foo.git", "auth.example.com", "bar", "foo",
 		},
+		{
+			"https://bitbucketserver.com/projects/myproject/repos/foo/pull-requests/1", "bitbucketserver.com", "myproject", "foo",
+		},
 	}
 	for _, data := range testCases {
 		info, err := gits.ParseGitURL(data.url)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We need to handle URLS of the form

```
/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}
```