### PR TITLE
Fix: Allow non admin to execute various jx commands

### DIFF
--- a/pkg/jx/cmd/common_team_settings.go
+++ b/pkg/jx/cmd/common_team_settings.go
@@ -102,11 +102,6 @@ func (o *CommonOptions) ModifyEnvironment(name string, callback func(env *v1.Env
 
 // defaultModifyDevEnvironment default implementation of modifying the Development environment settings
 func (o *CommonOptions) defaultModifyDevEnvironment(callback func(env *v1.Environment) error) error {
-	err := o.registerEnvironmentCRD()
-	if err != nil {
-		return errors.Wrap(err, "failed to register the environment CRD")
-	}
-
 	jxClient, ns, err := o.JXClientAndDevNamespace()
 	if err != nil {
 		return errors.Wrap(err, "failed to create the jx client")

--- a/pkg/jx/cmd/create_devpod.go
+++ b/pkg/jx/cmd/create_devpod.go
@@ -762,14 +762,6 @@ func (o *CreateDevPodOptions) Run() error {
 
 func (o *CreateDevPodOptions) getOrCreateEditEnvironment() (*v1.Environment, error) {
 	var env *v1.Environment
-	apisClient, err := o.Factory.CreateApiExtensionsClient()
-	if err != nil {
-		return env, err
-	}
-	err = kube.RegisterEnvironmentCRD(apisClient)
-	if err != nil {
-		return env, err
-	}
 
 	kubeClient, _, err := o.KubeClient()
 	if err != nil {

--- a/pkg/jx/cmd/create_quickstart.go
+++ b/pkg/jx/cmd/create_quickstart.go
@@ -116,10 +116,6 @@ func (o *CreateQuickstartOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		err = o.registerEnvironmentCRD()
-		if err != nil {
-			return err
-		}
 
 		locations, err = kube.GetQuickstartLocations(jxClient, ns)
 		if err != nil {

--- a/pkg/jx/cmd/get_activity.go
+++ b/pkg/jx/cmd/get_activity.go
@@ -100,15 +100,6 @@ func (o *GetActivityOptions) Run() error {
 	}
 	kube.SortEnvironments(envList.Items)
 
-	apisClient, err := o.CreateApiExtensionsClient()
-	if err != nil {
-		return err
-	}
-	err = kube.RegisterPipelineActivityCRD(apisClient)
-	if err != nil {
-		return err
-	}
-
 	table := o.CreateTable()
 	table.SetColumnAlign(1, util.ALIGN_RIGHT)
 	table.SetColumnAlign(2, util.ALIGN_RIGHT)

--- a/pkg/jx/cmd/get_env.go
+++ b/pkg/jx/cmd/get_env.go
@@ -80,14 +80,6 @@ func (o *GetEnvOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	apisClient, err := o.CreateApiExtensionsClient()
-	if err != nil {
-		return err
-	}
-	err = kube.RegisterEnvironmentCRD(apisClient)
-	if err != nil {
-		return err
-	}
 
 	args := o.Args
 	if len(args) > 0 {

--- a/pkg/jx/cmd/get_issue.go
+++ b/pkg/jx/cmd/get_issue.go
@@ -93,15 +93,6 @@ func (o *GetIssueOptions) Run() error {
 		return errors.Wrap(err, "cannot create the JX client")
 	}
 
-	apisClient, err := f.CreateApiExtensionsClient()
-	if err != nil {
-		return errors.Wrap(err, "failed to create the Kube API extensions client")
-	}
-	err = kube.RegisterEnvironmentCRD(apisClient)
-	if err != nil {
-		return errors.Wrap(err, "failed to register the Environment API")
-	}
-
 	envList, err := client.JenkinsV1().Environments(ns).List(metav1.ListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "cannot list the environments")

--- a/pkg/jx/cmd/get_preview.go
+++ b/pkg/jx/cmd/get_preview.go
@@ -90,14 +90,6 @@ func (o *GetPreviewOptions) CurrentPreviewUrl() error {
 	if err != nil {
 		return err
 	}
-	apisClient, err := o.CreateApiExtensionsClient()
-	if err != nil {
-		return err
-	}
-	err = kube.RegisterEnvironmentCRD(apisClient)
-	if err != nil {
-		return err
-	}
 
 	envList, err := client.JenkinsV1().Environments(ns).List(metav1.ListOptions{})
 	if err != nil {

--- a/pkg/jx/cmd/get_release.go
+++ b/pkg/jx/cmd/get_release.go
@@ -69,10 +69,6 @@ func NewCmdGetRelease(f Factory, in terminal.FileReader, out terminal.FileWriter
 
 // Run implements this command
 func (o *GetReleaseOptions) Run() error {
-	err := o.registerReleaseCRD()
-	if err != nil {
-		return err
-	}
 	jxClient, curNs, err := o.JXClient()
 	if err != nil {
 		return err

--- a/pkg/jx/cmd/get_user.go
+++ b/pkg/jx/cmd/get_user.go
@@ -62,14 +62,6 @@ func NewCmdGetUser(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 
 // Run implements this command
 func (o *GetUserOptions) Run() error {
-	err := o.registerUserCRD()
-	if err != nil {
-		return err
-	}
-	err = o.registerEnvironmentRoleBindingCRD()
-	if err != nil {
-		return err
-	}
 	jxClient, ns, err := o.JXClientAndAdminNamespace()
 	if err != nil {
 		return err

--- a/pkg/jx/cmd/get_workflow.go
+++ b/pkg/jx/cmd/get_workflow.go
@@ -67,10 +67,6 @@ func NewCmdGetWorkflow(f Factory, in terminal.FileReader, out terminal.FileWrite
 
 // Run implements this command
 func (o *GetWorkflowOptions) Run() error {
-	err := o.registerWorkflowCRD()
-	if err != nil {
-		return err
-	}
 	jxClient, ns, err := o.JXClientAndAdminNamespace()
 	if err != nil {
 		return err

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -229,15 +229,6 @@ func (options *ImportOptions) Run() error {
 			return err
 		}
 
-		apisClient, err := options.CreateApiExtensionsClient()
-		if err != nil {
-			return err
-		}
-		err = kube.RegisterEnvironmentCRD(apisClient)
-		if err != nil {
-			return err
-		}
-
 		isProw, err = options.isProw()
 		if err != nil {
 			return err

--- a/pkg/jx/cmd/step_post_install.go
+++ b/pkg/jx/cmd/step_post_install.go
@@ -80,6 +80,14 @@ func NewCmdStepPostInstall(f Factory, in terminal.FileReader, out terminal.FileW
 
 // Run implements this command
 func (o *StepPostInstallOptions) Run() (err error) {
+	apisClient, err := o.CreateApiExtensionsClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to create the API extensions client")
+	}
+	kube.RegisterAllCRDs(apisClient)
+	if err != nil {
+		return err
+	}
 	jxClient, ns, err := o.JXClientAndDevNamespace()
 	if err != nil {
 		return errors.Wrap(err, "cannot create the JX client")


### PR DESCRIPTION
A jenkins-x user administered with `jx edit userroles` and `jx controller role` doesn't have the
permissions to register CRDs. But the CRDs should have been registerad during install or upgrade anyway.
So the following commands don't register CRD anymore: `create devpod`, `create quickstart`, `import` and all `get`.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is covered by existing or new tests.

