### PR TITLE
Fail the build if there are uncommitted modifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
                     sh "echo building Pull Request for preview ${TEAM}"
 
                     sh "make linux"
+                    sh 'test `git status --short | tee /dev/stderr | wc --bytes` -eq 0'
                     sh "make test-slow-integration"
                     sh "./build/linux/jx --help"
 


### PR DESCRIPTION
Copied from https://github.com/jenkinsci/jenkins/commit/9d269168a59f2863467bf17ebe1ed8800da04bd2. This would have failed on #2167, for example, as building that touches `go.mod` + `go.sum` to register new modules. The build succeeds, but is presumably nondeterministic as Go is just guessing at the versions to use each time. We want the author of the PR to commit these files and have that commit be tested.