### PR TITLE
fix: typo "Examples: jx create pullRequest" at "jx create pullrequest…

### DIFF
--- a/pkg/jx/cmd/create_pullrequest.go
+++ b/pkg/jx/cmd/create_pullrequest.go
@@ -23,11 +23,11 @@ var (
 
 	createPullRequestExample = templates.Examples(`
 		# Create a Pull Request in the current project
-		jx create pullRequest -t "my PR title"
+		jx create pullrequest -t "my PR title"
 
 
 		# Create a Pull Request with a title and a body
-		jx create pullRequest -t "my PR title" --body "	
+		jx create pullrequest -t "my PR title" --body "	
 		some more
 		text
 		goes
@@ -85,10 +85,10 @@ func NewCmdCreatePullRequest(f Factory, in terminal.FileReader, out terminal.Fil
 	}
 
 	cmd.Flags().StringVarP(&options.Dir, "dir", "", "", "The source directory used to detect the Git repository. Defaults to the current directory")
-	cmd.Flags().StringVarP(&options.Title, optionTitle, "t", "", "The title of the pullRequest to create")
-	cmd.Flags().StringVarP(&options.Body, "body", "", "", "The body of the pullRequest")
+	cmd.Flags().StringVarP(&options.Title, optionTitle, "t", "", "The title of the pullrequest to create")
+	cmd.Flags().StringVarP(&options.Body, "body", "", "", "The body of the pullrequest")
 	cmd.Flags().StringVarP(&options.Base, "base", "", "master", "The base branch to create the pull request into")
-	cmd.Flags().StringArrayVarP(&options.Labels, "label", "l", []string{}, "The labels to add to the pullRequest")
+	cmd.Flags().StringArrayVarP(&options.Labels, "label", "l", []string{}, "The labels to add to the pullrequest")
 
 	options.addCommonFlags(cmd)
 	return cmd


### PR DESCRIPTION
… --help" command

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

There is a typo at "jx create pullrequest --help" command's output.

"pullRequest" should be fixed as "pullrequest" in Examples.

```
jx create pullrequest --help
Creates a Pull Request in a the git project of the current directory

Aliases:
pullrequest, pr, pull request
Examples:
  # Create a Pull Request in the current project
  jx create pullRequest -t "my PR title"


  # Create a Pull Request with a title and a body
  jx create pullRequest -t "my PR title" --body "
  some more
  text
  goes
  here
  ""
  "
Options:
      --base='master': The base branch to create the pull request into
  -b, --batch-mode=false: In batch mode the command never prompts for user input
      --body='': The body of the pullRequest
      --dir='': The source directory used to detect the Git repository. Defaults to the current directory
      --headless=false: Enable headless operation if using browser automation
      --install-dependencies=false: Should any required dependencies be installed automatically
  -l, --label=[]: The labels to add to the pullRequest
      --log-level='info': Logging level. Possible values - panic, fatal, error, warning, info, debug.
      --no-brew=false: Disables the use of brew on macOS to install or upgrade command line dependencies
      --pull-secrets='': The pull secrets the service account created should have (useful when deploying to your own private registry): provide multiple pull secrets by providing them in a singular block of quotes e.g. --pull-secrets "foo, bar, baz"
      --skip-auth-secrets-merge=false: Skips merging a local git auth yaml file with any pipeline secrets that are found
  -t, --title='': The title of the pullRequest to create
      --verbose=false: Enable verbose logging
Usage:
  jx create pullrequest [flags] [options]
Use "jx options" for a list of global command-line options (applies to all commands).
```

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2261