### PR TITLE
fix(controller): Move build number controller under 'jx controllers'

### DIFF
--- a/pkg/jx/cmd/cmd.go
+++ b/pkg/jx/cmd/cmd.go
@@ -149,7 +149,6 @@ func NewJXCommand(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 			Commands: []*cobra.Command{
 				NewCmdController(f, in, out, err),
 				NewCmdGC(f, in, out, err),
-				NewCmdServeBuildNumbers(f, in, out, err),
 			},
 		},
 	}

--- a/pkg/jx/cmd/controller.go
+++ b/pkg/jx/cmd/controller.go
@@ -36,7 +36,7 @@ func NewCmdController(f Factory, in terminal.FileReader, out terminal.FileWriter
 	}
 
 	cmd := &cobra.Command{
-		Use:     "controller [flags]",
+		Use:     "controller <command> [flags]",
 		Short:   "Runs a controller",
 		Long:    controllerLong,
 		Example: controllerExample,
@@ -54,6 +54,7 @@ func NewCmdController(f Factory, in terminal.FileReader, out terminal.FileWriter
 	cmd.AddCommand(NewCmdControllerTeam(f, in, out, errOut))
 	cmd.AddCommand(NewCmdControllerWorkflow(f, in, out, errOut))
 	cmd.AddCommand(NewCmdControllerCommitStatus(f, in, out, errOut))
+	cmd.AddCommand(NewCmdSControllerBuildNumbers(f, in, out, errOut))
 	return cmd
 }
 

--- a/pkg/jx/cmd/serve_buildnumbers.go
+++ b/pkg/jx/cmd/serve_buildnumbers.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	command    = "serve-buildnumbers"
+	command    = "buildnumbers"
 	optionPort = "port"
 	optionBind = "bind"
 )
@@ -24,13 +24,14 @@ type ServeBuildNumbersOptions struct {
 }
 
 var (
-	serveBuildNumbersLong = templates.LongDesc("Generates the next build unique number for a pipeline")
+	serveBuildNumbersLong = templates.LongDesc(`Runs the build number controller that serves sequential build 
+		numbers over an HTTP interface.`)
 
 	serveBuildNumbersExample = templates.Examples("jx " + command)
 )
 
-// NewCmdServeBuildNumbers builds a new command to serving build numbers over an HTTP interface.
-func NewCmdServeBuildNumbers(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+// NewCmdSControllerBuildNumbers builds a new command to serving build numbers over an HTTP interface.
+func NewCmdSControllerBuildNumbers(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
 	options := ServeBuildNumbersOptions{
 		CommonOptions: CommonOptions{
 			Factory: f,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

I previously added the new build numbers http endpoint at the top level cmd - its actually another controller, so just moving it underneath
that command to avoid cluttering the top level help/overview.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->