### PR TITLE
chore remove internal call to docker system prune for releases.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,10 +186,6 @@ release: check
 		git commit --allow-empty -a -m "updated jx commands from $(VERSION)"; \
 		git push origin
 		
-	##### overlayfs2 issue on gke: https://stackoverflow.com/questions/48673513/google-kubernetes-engine-errimagepull-too-many-links ######
-	## NOTE: -a flag seems to intermittently break releases. It only prunes inactive containers so this could point to another issue. 
-	docker system prune -f
-	#####
 
 clean:
 	rm -rf build release cover.out cover.html


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The reason for calling `docker system prune` should be fixed and it was
possibly the cause for failed builds on the node with messages like

```
Step 3/3 : COPY ./build/linux/jx /usr/bin/jx
No such container:
197a16d47ba8cd38249f75fc21d8996a8f1d08e4f358032b047cb6596afab30d
```

As we believe the initial issue is fixed in k8s 1.9 and higher we should
just remove this and see if it fixes the failed builds and that the
initial issue does not come back.


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
