### PR TITLE
bug(controller buildnumbers): Encode PipelineActivity names to avoid collisions

### DIFF
--- a/pkg/kube/activity.go
+++ b/pkg/kube/activity.go
@@ -3,10 +3,11 @@ package kube
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/util"
 
 	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
@@ -52,8 +53,6 @@ type PipelineDetails struct {
 	Build         string
 }
 
-var disallowedNameChars = regexp.MustCompile("[^a-z0-9-]")
-
 // PipelineID is an identifier for a Pipeline.
 // A pipeline is typically identified by its owner, repository, and branch with the ID field taking the form
 // `<owner>/>repository>/<branch>`
@@ -68,7 +67,7 @@ type PipelineID struct {
 func NewPipelineIDFromString(id string) PipelineID {
 	pID := PipelineID{
 		ID:   id,
-		Name: disallowedNameChars.ReplaceAllString(id, "-"),
+		Name: util.EncodeKubernetesName(strings.Replace(id, "/", "-", -1)),
 	}
 	return pID
 }

--- a/pkg/kube/activity_test.go
+++ b/pkg/kube/activity_test.go
@@ -240,11 +240,11 @@ func TestPipelineID(t *testing.T) {
 
 	// Upper case allowed in our ID, but not in the K8S 'name'.
 	pID = kube.NewPipelineID("OwNeR1", "rEpO1", "BrAnCh1")
-	validatePipelineID(t, pID, "OwNeR1/rEpO1/BrAnCh1", "owner1-repo1-branch1")
+	validatePipelineID(t, pID, "OwNeR1/rEpO1/BrAnCh1", ".ow.ne.r1-r.ep.o1-.br.an.ch1")
 
 	//Punctuation other than '-' and '.' not allowed in K8S 'name'.
 	pID = kube.NewPipelineID("O/N!R@1", "therepo", "thebranch")
-	validatePipelineID(t, pID, "O/N!R@1/therepo/thebranch", "o-n%21r%401-therepo-thebranch")
+	validatePipelineID(t, pID, "O/N!R@1/therepo/thebranch", ".o-.n.21.r.401-therepo-thebranch")
 }
 
 func validatePipelineID(t *testing.T, pID kube.PipelineID, expectedID string, expectedName string) {

--- a/pkg/kube/activity_test.go
+++ b/pkg/kube/activity_test.go
@@ -232,3 +232,22 @@ func TestCreatePipelineDetails(t *testing.T) {
 		}
 	}
 }
+
+func TestPipelineID(t *testing.T) {
+	// A simple ID.
+	pID := kube.NewPipelineID("o1", "r1", "b1")
+	validatePipelineID(t, pID, "o1/r1/b1", "o1-r1-b1")
+
+	// Upper case allowed in our ID, but not in the K8S 'name'.
+	pID = kube.NewPipelineID("OwNeR1", "rEpO1", "BrAnCh1")
+	validatePipelineID(t, pID, "OwNeR1/rEpO1/BrAnCh1", "owner1-repo1-branch1")
+
+	//Punctuation other than '-' and '.' not allowed in K8S 'name'.
+	pID = kube.NewPipelineID("O/N!R@1", "therepo", "thebranch")
+	validatePipelineID(t, pID, "O/N!R@1/therepo/thebranch", "o-n%21r%401-therepo-thebranch")
+}
+
+func validatePipelineID(t *testing.T, pID kube.PipelineID, expectedID string, expectedName string) {
+	assert.Equal(t, expectedID, pID.ID)
+	assert.Equal(t, expectedName, pID.Name)
+}

--- a/pkg/kube/activity_test.go
+++ b/pkg/kube/activity_test.go
@@ -234,6 +234,8 @@ func TestCreatePipelineDetails(t *testing.T) {
 }
 
 func TestPipelineID(t *testing.T) {
+	t.Parallel()
+
 	// A simple ID.
 	pID := kube.NewPipelineID("o1", "r1", "b1")
 	validatePipelineID(t, pID, "o1/r1/b1", "o1-r1-b1")

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// EncodeKubernetesName takes a string and turns it into a form suitable for use as a Kubernetes name.
+// K8S names are lower case, numbers, '-', and '.'. Invalid characters are percent-encoded in a _similar_ way to URL
+// encoding, with a percent followed by the numerical character code. Conversion is:
+//   Upper case letters -> lower case.
+//   'a-z', '0-9', '-', '.' -> left as-is.
+//   Any other characters: percent-encoded ('%' + rune hex code).
+func EncodeKubernetesName(name string) string {
+	name = strings.ToLower(name)
+	encodedName := strings.Builder{}
+
+	for _, ch := range name {
+		if allowedInK8SName(ch) {
+			encodedName.WriteRune(ch)
+		} else {
+			encodedName.WriteString(fmt.Sprintf("%%%X", int(ch)))
+		}
+
+	}
+	return encodedName.String()
+}
+
+func allowedInK8SName(ch rune) bool {
+	return ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9' || ch == '-' || ch == '.'
+}

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -3,29 +3,31 @@ package util
 import (
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 // EncodeKubernetesName takes a string and turns it into a form suitable for use as a Kubernetes name.
+// Note there is no decode functionality provided atm (and things like escaping escape codes aren't handled), so
+// round-tripping is not possible yet.
 // K8S names are lower case, numbers, '-', and '.'. Invalid characters are percent-encoded in a _similar_ way to URL
-// encoding, with a percent followed by the numerical character code. Conversion is:
+// encoding, with a period ('.') followed by the numerical character code. Conversion is:
 //   Upper case letters -> lower case.
 //   'a-z', '0-9', '-', '.' -> left as-is.
-//   Any other characters: percent-encoded ('%' + rune hex code).
+//   Any other characters: percent-encoded ('.' + rune hex code).
 func EncodeKubernetesName(name string) string {
-	name = strings.ToLower(name)
 	encodedName := strings.Builder{}
 
 	for _, ch := range name {
-		if allowedInK8SName(ch) {
+		if ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9' || ch == '-' || ch == '.' {
+			//allowed in name.
 			encodedName.WriteRune(ch)
+		} else if ch >= 'A' && ch <= 'Z' {
+			//Apply toLower encoding.
+			encodedName.WriteString(fmt.Sprintf(".%c", unicode.ToLower(ch)))
 		} else {
-			encodedName.WriteString(fmt.Sprintf("%%%X", int(ch)))
+			//Apply character-code encoding.
+			encodedName.WriteString(fmt.Sprintf(".%X", int(ch)))
 		}
-
 	}
 	return encodedName.String()
-}
-
-func allowedInK8SName(ch rune) bool {
-	return ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9' || ch == '-' || ch == '.'
 }

--- a/pkg/util/k8s_test.go
+++ b/pkg/util/k8s_test.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeKubernetesNameNoEncoding(t *testing.T) {
+	original := "abcdefghijklmnopqrstuvwxyz-.0123456789"
+	assert.Equal(t, original, original, "Didn't expect _any_ encoding to happen.")
+}
+
+func TestEncodeKubernetesNameUpper(t *testing.T) {
+	original := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	expected := strings.ToLower(original)
+	assert.Equal(t, expected, EncodeKubernetesName(original), "Expected upper->lower conversion.")
+}
+
+func TestEncodeKubernetesPunctuationString(t *testing.T) {
+	//Note _valid_ - and . hidden in the string below.
+	original := "!\"£$%^&*()-=_+¬`;'#:@~,./<>?[]{}\\|€"
+	expected := "%21%22%A3%24%25%5E%26%2A%28%29-%3D%5F%2B%AC%60%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F%5B%5D%7B%7D%5C%7C%20AC"
+	assert.Equal(t, expected, EncodeKubernetesName(original), "Expected punctuation to be percent-encoded.")
+}
+
+func TestEncodeKubernetesNameExtendedRunes(t *testing.T) {
+	original := "⌘日本語"
+	expected := "%2318%65E5%672C%8A9E"
+	assert.Equal(t, expected, EncodeKubernetesName(original),
+		"Expected extended characters to be percent-encoded.")
+}

--- a/pkg/util/k8s_test.go
+++ b/pkg/util/k8s_test.go
@@ -8,17 +8,23 @@ import (
 )
 
 func TestEncodeKubernetesNameNoEncoding(t *testing.T) {
+	t.Parallel()
+
 	original := "abcdefghijklmnopqrstuvwxyz-.0123456789"
 	assert.Equal(t, original, original, "Didn't expect _any_ encoding to happen.")
 }
 
 func TestEncodeKubernetesNameUpper(t *testing.T) {
+	t.Parallel()
+
 	original := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	expected := strings.ToLower(".a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z")
 	assert.Equal(t, expected, EncodeKubernetesName(original), "Expected upper->.lower conversion.")
 }
 
 func TestEncodeKubernetesPunctuationString(t *testing.T) {
+	t.Parallel()
+
 	//Note _valid_ - and . hidden in the string below.
 	original := "!\"£$%^&*()-=_+¬`;'#:@~,./<>?[]{}\\|€"
 	expected := ".21.22.A3.24.25.5E.26.2A.28.29-.3D.5F.2B.AC.60.3B.27.23.3A.40.7E.2C..2F.3C.3E.3F.5B.5D.7B.7D.5C.7C.20AC"
@@ -26,6 +32,8 @@ func TestEncodeKubernetesPunctuationString(t *testing.T) {
 }
 
 func TestEncodeKubernetesNameExtendedRunes(t *testing.T) {
+	t.Parallel()
+
 	original := "⌘日本語"
 	expected := ".2318.65E5.672C.8A9E"
 	assert.Equal(t, expected, EncodeKubernetesName(original),

--- a/pkg/util/k8s_test.go
+++ b/pkg/util/k8s_test.go
@@ -14,20 +14,20 @@ func TestEncodeKubernetesNameNoEncoding(t *testing.T) {
 
 func TestEncodeKubernetesNameUpper(t *testing.T) {
 	original := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	expected := strings.ToLower(original)
-	assert.Equal(t, expected, EncodeKubernetesName(original), "Expected upper->lower conversion.")
+	expected := strings.ToLower(".a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z")
+	assert.Equal(t, expected, EncodeKubernetesName(original), "Expected upper->.lower conversion.")
 }
 
 func TestEncodeKubernetesPunctuationString(t *testing.T) {
 	//Note _valid_ - and . hidden in the string below.
 	original := "!\"£$%^&*()-=_+¬`;'#:@~,./<>?[]{}\\|€"
-	expected := "%21%22%A3%24%25%5E%26%2A%28%29-%3D%5F%2B%AC%60%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F%5B%5D%7B%7D%5C%7C%20AC"
-	assert.Equal(t, expected, EncodeKubernetesName(original), "Expected punctuation to be percent-encoded.")
+	expected := ".21.22.A3.24.25.5E.26.2A.28.29-.3D.5F.2B.AC.60.3B.27.23.3A.40.7E.2C..2F.3C.3E.3F.5B.5D.7B.7D.5C.7C.20AC"
+	assert.Equal(t, expected, EncodeKubernetesName(original), "Expected punctuation to be period-encoded.")
 }
 
 func TestEncodeKubernetesNameExtendedRunes(t *testing.T) {
 	original := "⌘日本語"
-	expected := "%2318%65E5%672C%8A9E"
+	expected := ".2318.65E5.672C.8A9E"
 	assert.Equal(t, expected, EncodeKubernetesName(original),
-		"Expected extended characters to be percent-encoded.")
+		"Expected extended characters to be period-encoded.")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Current impl. converts any name-illegal chars into -, which could cause collisions and
therefore two pipelines to share the same build number ID space.
(there is also a bug in the current impl. that won't properly support upper case owner/repo/branch names).


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
