### PR TITLE
feat(buildlogs): Displays which build it is printing logs for

### DIFF
--- a/pkg/jx/cmd/get_build_logs.go
+++ b/pkg/jx/cmd/get_build_logs.go
@@ -267,6 +267,7 @@ func (o *GetBuildLogsOptions) getProwBuildLog(kubeClient kubernetes.Interface, j
 	}
 
 	lastInitC := initContainers[len(initContainers)-1]
+	log.Infof("Build logs for %s\n", util.ColorInfo(name))
 	return o.getPodLog(ns, pod, lastInitC)
 }
 


### PR DESCRIPTION
This is handy if you do `jx get build logs -p` and there is only one build
pending as otherwise you don't know whether it is for 'your' build, or
'your' build has finished and you are now tailing someone-else's build logs.