### PR TITLE
feat(jx) add the OS details to `jx version` output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,9 @@ arm: version
 win: version
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=windows GOARCH=amd64 $(GO) build $(BUILDFLAGS) -o build/$(NAME).exe cmd/jx/jx.go
 
+darwin: version
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=amd64 $(GO) build $(BUILDFLAGS) -o build/darwin/jx cmd/jx/jx.go
+
 bootstrap: vendoring
 
 release: check

--- a/pkg/jx/cmd/version.go
+++ b/pkg/jx/cmd/version.go
@@ -210,7 +210,7 @@ func (o *VersionOptions) UpgradeCli() error {
 	return options.Run()
 }
 
-// returns a human friendly string of the current OS
+// GetOsVersion returns a human friendly string of the current OS
 // in the case of an error this still returns a valid string for the details that can be found.
 func (o *VersionOptions) GetOsVersion() (string, error) {
 	return system.GetOsVersion()

--- a/pkg/jx/cmd/version.go
+++ b/pkg/jx/cmd/version.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/jenkins-x/jx/pkg/util/system"
 	"github.com/jenkins-x/jx/pkg/version"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
@@ -151,6 +152,14 @@ func (o *VersionOptions) Run() error {
 		table.AddRow("git", info(version))
 	}
 
+	// os version
+	version, err = o.GetOsVersion()
+	if err != nil {
+		log.Warnf("Failed to get OS version: %s\n", err)
+	} else {
+		table.AddRow("Operating System", info(version))
+	}
+
 	table.Render()
 
 	if !o.NoVersionCheck {
@@ -199,6 +208,10 @@ func (o *VersionOptions) UpgradeCli() error {
 		},
 	}
 	return options.Run()
+}
+
+func (o *VersionOptions) GetOsVersion() (string, error) {
+	return system.GetOsVersion()
 }
 
 func extractSemVer(text string) string {

--- a/pkg/jx/cmd/version.go
+++ b/pkg/jx/cmd/version.go
@@ -210,6 +210,8 @@ func (o *VersionOptions) UpgradeCli() error {
 	return options.Run()
 }
 
+// returns a human friendly string of the current OS
+// in the case of an error this still returns a valid string for the details that can be found.
 func (o *VersionOptions) GetOsVersion() (string, error) {
 	return system.GetOsVersion()
 }

--- a/pkg/util/system/version.go
+++ b/pkg/util/system/version.go
@@ -1,0 +1,2 @@
+package system
+

--- a/pkg/util/system/version.go
+++ b/pkg/util/system/version.go
@@ -1,2 +1,0 @@
-package system
-

--- a/pkg/util/system/version_darwin.go
+++ b/pkg/util/system/version_darwin.go
@@ -1,0 +1,45 @@
+// +build darwin
+
+package system
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// returns a human friendly string of the current OS
+// in the case of an error this still returns a valid string for the details that can be found.
+func GetOsVersion() (string,  error) {
+	retVal := "unknown OSX version"
+
+	// you can not run the command once to get all this :-(
+	pn, err := runCommand("sw_vers", "-productName")
+	if err != nil {
+		return retVal, err
+	}
+	pv, err := runCommand("sw_vers", "-productVersion")
+	if err != nil {
+		retVal = fmt.Sprintf("%s unknown version", pn)
+	} else {
+		retVal = fmt.Sprintf("%s %s", pn, pv)
+	}
+
+	pb, err := runCommand("sw_vers", "-buildVersion")
+	if err != nil {
+		return fmt.Sprintf("%s unknown build", retVal), err
+	}
+	return fmt.Sprintf("%s build %s", retVal, pb), nil
+}
+
+
+func runCommand(command string, args ...string) (string, error) {
+	e := exec.Command(command, args...)
+	data, err := e.CombinedOutput()
+	text := string(data)
+	text = strings.TrimSpace(text)
+	if err != nil {
+		return "", fmt.Errorf("Command failed '%s %s': %s %s\n", command, strings.Join(args, " "), text, err)
+	}
+	return text, err
+}

--- a/pkg/util/system/version_darwin.go
+++ b/pkg/util/system/version_darwin.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// returns a human friendly string of the current OS
+// GetOsVersion returns a human friendly string of the current OS
 // in the case of an error this still returns a valid string for the details that can be found.
 func GetOsVersion() (string,  error) {
 	retVal := "unknown OSX version"
@@ -39,7 +39,7 @@ func runCommand(command string, args ...string) (string, error) {
 	text := string(data)
 	text = strings.TrimSpace(text)
 	if err != nil {
-		return "", fmt.Errorf("Command failed '%s %s': %s %s\n", command, strings.Join(args, " "), text, err)
+		return "", fmt.Errorf("command failed '%s %s': %s %s\n", command, strings.Join(args, " "), text, err)
 	}
 	return text, err
 }

--- a/pkg/util/system/version_linux.go
+++ b/pkg/util/system/version_linux.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// returns a human friendly string of the current OS
+// GetOsVersion returns a human friendly string of the current OS
 // in the case of an error this still returns a valid string for the details that can be found.
 func GetOsVersion() (string,  error) {
 	// generic LSB compliant Linux
@@ -46,7 +46,7 @@ func runCommand(command string, args ...string) (string, error) {
 	text := string(data)
 	text = strings.TrimSpace(text)
 	if err != nil {
-		return "", fmt.Errorf("Command failed '%s %s': %s %s\n", command, strings.Join(args, " "), text, err)
+		return "", fmt.Errorf("command failed '%s %s': %s %s\n", command, strings.Join(args, " "), text, err)
 	}
 	return text, err
 }

--- a/pkg/util/system/version_linux.go
+++ b/pkg/util/system/version_linux.go
@@ -1,0 +1,60 @@
+// +build linux
+
+package system
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+)
+
+// returns a human friendly string of the current OS
+// in the case of an error this still returns a valid string for the details that can be found.
+func GetOsVersion() (string,  error) {
+	// generic LSB compliant Linux
+	output, err := runCommand("lsb_release", "-d", "-s")
+	if err == nil {
+		return output, nil
+	}
+	// redHat and co these have the OS and version
+	output, err = getFileContents("/etc/redhat-release")
+	if err == nil {
+		return output , nil
+	}
+	// Debian and derivatives this is just the base (Sid) which is not quite enough to say exactly
+	output, err = getFileContents("/etc/debian_version")
+	if err == nil {
+		return fmt.Sprintf("Debian %s based distribution", output), nil
+	}
+	// Alpine Linux
+	output, err = getFileContents("/etc/alpine-release")
+	if err == nil {
+		return fmt.Sprintf("Alpine Linux %s", output), nil
+	}
+	// procfs will tell us the kernel version
+	output, err = getFileContents("/proc/version")
+	if err == nil {
+		return fmt.Sprintf("Unkown Linux distribution %s", output), nil
+	}
+	return "Unknown Linux version", fmt.Errorf("Unknown Linux version")
+}
+
+func runCommand(command string, args ...string) (string, error) {
+	e := exec.Command(command, args...)
+	data, err := e.CombinedOutput()
+	text := string(data)
+	text = strings.TrimSpace(text)
+	if err != nil {
+		return "", fmt.Errorf("Command failed '%s %s': %s %s\n", command, strings.Join(args, " "), text, err)
+	}
+	return text, err
+}
+
+func getFileContents(file string) (string, error) {
+	bytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(string(bytes), "\n"), nil
+}

--- a/pkg/util/system/version_test.go
+++ b/pkg/util/system/version_test.go
@@ -1,0 +1,15 @@
+package system
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetOsVersionReturnsNoError(t *testing.T) {
+	t.Parallel()
+	ver, err := GetOsVersion()
+	assert.NoError(t, err)
+	assert.NotNil(t, ver)
+	assert.NotEmpty(t, ver)
+	//assert.Equal(t, "Windows 10 Pro 1803 build 17134", ver)
+}

--- a/pkg/util/system/version_unknown.go
+++ b/pkg/util/system/version_unknown.go
@@ -1,0 +1,16 @@
+// +build !linux
+// +build !darwin
+// +build !windows
+
+package system
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// returns a human friendly string of the current OS
+func GetOsVersion() (string,  error) {
+	str := fmt.Sprintf("unknown platform %s %s", runtime.GOOS, runtime.GOARCH)
+	return str, fmt.ErrorF(str)
+}

--- a/pkg/util/system/version_unknown.go
+++ b/pkg/util/system/version_unknown.go
@@ -9,7 +9,8 @@ import (
 	"runtime"
 )
 
-// returns a human friendly string of the current OS
+// GetOsVersion returns "unknown platform runtime.GOOS runtime.GOARCH" as a string and error.
+// We don't have support for knowing how to get more details for this platform
 func GetOsVersion() (string,  error) {
 	str := fmt.Sprintf("unknown platform %s %s", runtime.GOOS, runtime.GOARCH)
 	return str, fmt.ErrorF(str)

--- a/pkg/util/system/version_windows.go
+++ b/pkg/util/system/version_windows.go
@@ -31,9 +31,8 @@ func GetOsVersion() (string,  error) {
 		pn, err = getMajorMinorVersion(&regkey)
 		if err != nil {
 			return retVal, err
-		} else {
-			pn = fmt.Sprintf("Windows %s", pn)
 		}
+		pn = fmt.Sprintf("Windows %s", pn)
 	}
 
 	rel, _, err := regkey.GetStringValue("ReleaseId")

--- a/pkg/util/system/version_windows.go
+++ b/pkg/util/system/version_windows.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-// returns a human friendly string of the current OS
+// GetOsVersion returns a human friendly string of the current OS
 // in the case of an error this still returns a valid string for the details that can be found.
 func GetOsVersion() (string,  error) {
 	// we can not use GetVersion as that returns a version that the app sees (from its manifest) and not the current version
@@ -31,6 +31,8 @@ func GetOsVersion() (string,  error) {
 		pn, err = getMajorMinorVersion(&regkey)
 		if err != nil {
 			return retVal, err
+		} else {
+			pn = fmt.Sprintf("Windows %s", pn)
 		}
 	}
 
@@ -47,13 +49,6 @@ func GetOsVersion() (string,  error) {
 	} else {
 		retVal = fmt.Sprintf("%s build %s", retVal, build)
 	}
-
-/*
-	ver, _, err := regkey.GetStringValue("CurrentVersion")
-	if err != nil {
-		log.Fatal(err)
-	}
-*/
 	return retVal, nil
 }
 
@@ -61,7 +56,9 @@ func GetOsVersion() (string,  error) {
 func getMajorMinorVersion(regkey *registry.Key) (string, error) {
 	major, _, err := regkey.GetIntegerValue("CurrentMajorVersionNumber")
 	if err != nil {
-		return "", err
+		// try currentVersion which will only be up to 8.1
+		ver, _, err := regkey.GetStringValue("CurrentVersion")
+		return ver, err
 	}
 	minor, _, err := regkey.GetIntegerValue("CurrentMinorVersionNumber")
 	if err != nil {

--- a/pkg/util/system/version_windows.go
+++ b/pkg/util/system/version_windows.go
@@ -1,0 +1,71 @@
+// +build windows
+
+package system
+
+import (
+	"fmt"
+	//	"fmt"
+	"golang.org/x/sys/windows/registry"
+)
+
+// returns a human friendly string of the current OS
+// in the case of an error this still returns a valid string for the details that can be found.
+func GetOsVersion() (string,  error) {
+	// we can not use GetVersion as that returns a version that the app sees (from its manifest) and not the current version
+	// and is missing some info.  So use the registry e.g.
+	// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentVersion  -> 6.3 (used on older platforms)
+	// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProductName  -> Windows 10 Pro
+	// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NcT\CurrentVersion\ReleaseId  -> 1803
+	// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild -> 17134
+
+	retVal := "unknown windows version"
+
+	regkey, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		return retVal, err
+	}
+	defer regkey.Close()
+
+	pn , _, err := regkey.GetStringValue("ProductName")
+	if err != nil {
+		pn, err = getMajorMinorVersion(&regkey)
+		if err != nil {
+			return retVal, err
+		}
+	}
+
+	rel, _, err := regkey.GetStringValue("ReleaseId")
+	if err != nil {
+		retVal = fmt.Sprintf("%s %s", pn, "unkown release")
+	} else {
+		retVal = fmt.Sprintf("%s %s", pn, rel)
+	}
+
+	build, _, err := regkey.GetStringValue("CurrentBuild")
+	if err != nil {
+		retVal = fmt.Sprintf("%s build %s", retVal, "unknown")
+	} else {
+		retVal = fmt.Sprintf("%s build %s", retVal, build)
+	}
+
+/*
+	ver, _, err := regkey.GetStringValue("CurrentVersion")
+	if err != nil {
+		log.Fatal(err)
+	}
+*/
+	return retVal, nil
+}
+
+
+func getMajorMinorVersion(regkey *registry.Key) (string, error) {
+	major, _, err := regkey.GetIntegerValue("CurrentMajorVersionNumber")
+	if err != nil {
+		return "", err
+	}
+	minor, _, err := regkey.GetIntegerValue("CurrentMinorVersionNumber")
+	if err != nil {
+		return fmt.Sprintf("unknwown windows (%d.unknown)",major), nil
+	}
+	return fmt.Sprintf("unknwown windows (%d.%d)", major, minor), nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

It is useful to know the OS version of the client in reports so this
change addes an "Operating System" column to the details listed by
`jx version`

#### Special notes for the reviewer(s)

tested on `Windows 10 Pro 1803`, `OSX` (some version), `Bash on Ubuntu on Windows` and `centos`, `debian` and `alpine` docker images.

#### Which issue this PR fixes

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
