### PR TITLE
chore(tests): Refactored go-expect tests to support better error reporting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/Netflix/go-expect v0.0.0-20180814212900-124a37274874
 	github.com/Pallinder/go-randomdata v0.0.0-20180616180521-15df0648130a
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/alexflint/go-filemutex v0.0.0-20171028004239-d358565f3c3f

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=

--- a/pkg/gits/provider_test.go
+++ b/pkg/gits/provider_test.go
@@ -8,14 +8,12 @@ import (
 	"strings"
 	"testing"
 
-	expect "github.com/Netflix/go-expect"
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/gits"
 	mocks "github.com/jenkins-x/jx/pkg/gits/mocks"
 	utiltests "github.com/jenkins-x/jx/pkg/tests"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type FakeOrgLister struct {
@@ -153,8 +151,8 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 
 	tests := []struct {
 		description  string
-		setup        func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{})
-		cleanup      func(t *testing.T, c *expect.Console, donech chan struct{})
+		setup        func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{})
+		cleanup      func(c *utiltests.ConsoleWrapper, donech chan struct{})
 		Name         string
 		providerKind string
 		hostURL      string
@@ -217,20 +215,20 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			false,
 		},
 		{"create GitHub provider for user from environment",
-			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+			func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{}) {
 				err := setUserAuthInEnv(gits.KindGitHub, "test", "test")
 				assert.NoError(t, err, "should configure the user auth in environment")
-				c, _, term := utiltests.NewTerminal(t)
+				console := utiltests.NewTerminal(t)
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
 				}()
-				return c, term, donech
+				return console, donech
 			},
-			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+			func(c *utiltests.ConsoleWrapper, donech chan struct{}) {
 				err := unsetUserAuthInEnv(gits.KindGitHub)
 				assert.NoError(t, err, "should reset the user auth in environment")
-				err = c.Tty().Close()
+				err = c.Close()
 				assert.NoError(t, err, "should close the tty")
 				<-donech
 			},
@@ -264,28 +262,23 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			true,
 		},
 		{"create GitHub provider in interactive mode",
-			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
-				c, _, term := utiltests.NewTerminal(t)
+			func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{}) {
+				c := utiltests.NewTerminal(t)
 				assert.NotNil(t, c, "console should not be nil")
-				assert.NotNil(t, term, "term should not be nil")
+				assert.NotNil(t, c.Stdio, "term should not be nil")
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
-					_, err := c.ExpectString("github.com user name:")
-					assert.NoError(t, err, "expect user name")
-					_, err = c.SendLine("test")
-					assert.NoError(t, err, "send user name")
-					_, err = c.ExpectString("API Token:")
-					assert.NoError(t, err, "expect API token")
-					_, err = c.SendLine("test")
-					assert.NoError(t, err, "send API token")
-					_, err = c.ExpectEOF()
-					assert.NoError(t, err, "expect EOF")
+					c.ExpectString("github.com user name:")
+					c.SendLine("test")
+					c.ExpectString("API Token:")
+					c.SendLine("test")
+					c.ExpectEOF()
 				}()
-				return c, term, donech
+				return c, donech
 			},
-			func(t *testing.T, c *expect.Console, donech chan struct{}) {
-				err := c.Tty().Close()
+			func(c *utiltests.ConsoleWrapper, donech chan struct{}) {
+				err := c.Close()
 				assert.NoError(t, err, "should close the tty")
 				<-donech
 			},
@@ -335,20 +328,20 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			false,
 		},
 		{"create Gitlab provider for user from environment",
-			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+			func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{}) {
 				err := setUserAuthInEnv(gits.KindGitlab, "test", "test")
 				assert.NoError(t, err, "should configure the user auth in environment")
-				c, _, term := utiltests.NewTerminal(t)
+				c := utiltests.NewTerminal(t)
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
 				}()
-				return c, term, donech
+				return c, donech
 			},
-			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+			func(c *utiltests.ConsoleWrapper, donech chan struct{}) {
 				err := unsetUserAuthInEnv(gits.KindGitlab)
 				assert.NoError(t, err, "should reset the user auth in environment")
-				err = c.Tty().Close()
+				err = c.Close()
 				assert.NoError(t, err, "should close the tty")
 				<-donech
 			},
@@ -382,28 +375,23 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			true,
 		},
 		{"create Gitlab provider in interactive mode",
-			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
-				c, _, term := utiltests.NewTerminal(t)
+			func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{}) {
+				c := utiltests.NewTerminal(t)
 				assert.NotNil(t, c, "console should not be nil")
-				assert.NotNil(t, term, "term should not be nil")
+				assert.NotNil(t, c.Stdio, "term should not be nil")
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
-					_, err := c.ExpectString("gitlab.com user name:")
-					assert.NoError(t, err, "expect user name")
-					_, err = c.SendLine("test")
-					assert.NoError(t, err, "send user name")
-					_, err = c.ExpectString("API Token:")
-					assert.NoError(t, err, "expect API token")
-					_, err = c.SendLine("test")
-					assert.NoError(t, err, "send API token")
-					_, err = c.ExpectEOF()
-					assert.NoError(t, err, "expect EOF")
+					c.ExpectString("gitlab.com user name:")
+					c.SendLine("test")
+					c.ExpectString("API Token:")
+					c.SendLine("test")
+					c.ExpectEOF()
 				}()
-				return c, term, donech
+				return c, donech
 			},
-			func(t *testing.T, c *expect.Console, donech chan struct{}) {
-				err := c.Tty().Close()
+			func(c *utiltests.ConsoleWrapper, donech chan struct{}) {
+				err := c.Close()
 				assert.NoError(t, err, "should close the tty")
 				<-donech
 			},
@@ -453,20 +441,20 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			false,
 		},
 		{"create Gitea provider for user from environment",
-			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+			func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{}) {
 				err := setUserAuthInEnv(gits.KindGitea, "test", "test")
 				assert.NoError(t, err, "should configure the user auth in environment")
-				c, _, term := utiltests.NewTerminal(t)
+				c := utiltests.NewTerminal(t)
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
 				}()
-				return c, term, donech
+				return c, donech
 			},
-			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+			func(c *utiltests.ConsoleWrapper, donech chan struct{}) {
 				err := unsetUserAuthInEnv(gits.KindGitea)
 				assert.NoError(t, err, "should reset the user auth in environment")
-				err = c.Tty().Close()
+				err = c.Close()
 				assert.NoError(t, err, "should close the tty")
 				<-donech
 			},
@@ -500,28 +488,23 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			true,
 		},
 		{"create Gitea provider in interactive mode",
-			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
-				c, _, term := utiltests.NewTerminal(t)
+			func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{}) {
+				c := utiltests.NewTerminal(t)
 				assert.NotNil(t, c, "console should not be nil")
-				assert.NotNil(t, term, "term should not be nil")
+				assert.NotNil(t, c.Stdio, "term should not be nil")
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
-					_, err := c.ExpectString("gitea.com user name:")
-					assert.NoError(t, err, "expect user name")
-					_, err = c.SendLine("test")
-					assert.NoError(t, err, "send user name")
-					_, err = c.ExpectString("API Token:")
-					assert.NoError(t, err, "expect API token")
-					_, err = c.SendLine("test")
-					assert.NoError(t, err, "send API token")
-					_, err = c.ExpectEOF()
-					assert.NoError(t, err, "expect EOF")
+					c.ExpectString("gitea.com user name:")
+					c.SendLine("test")
+					c.ExpectString("API Token:")
+					c.SendLine("test")
+					c.ExpectEOF()
 				}()
-				return c, term, donech
+				return c, donech
 			},
-			func(t *testing.T, c *expect.Console, donech chan struct{}) {
-				err := c.Tty().Close()
+			func(c *utiltests.ConsoleWrapper, donech chan struct{}) {
+				err := c.Close()
 				assert.NoError(t, err, "should close the tty")
 				<-donech
 			},
@@ -571,20 +554,20 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			false,
 		},
 		{"create BitbucketServer provider for user from environment",
-			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+			func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{}) {
 				err := setUserAuthInEnv(gits.KindBitBucketServer, "test", "test")
 				assert.NoError(t, err, "should configure the user auth in environment")
-				c, _, term := utiltests.NewTerminal(t)
+				c := utiltests.NewTerminal(t)
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
 				}()
-				return c, term, donech
+				return c, donech
 			},
-			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+			func(c *utiltests.ConsoleWrapper, donech chan struct{}) {
 				err := unsetUserAuthInEnv(gits.KindBitBucketServer)
 				assert.NoError(t, err, "should reset the user auth in environment")
-				err = c.Tty().Close()
+				err = c.Close()
 				assert.NoError(t, err, "should close the tty")
 				<-donech
 			},
@@ -618,28 +601,23 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			true,
 		},
 		{"create BitbucketServer provider in interactive mode",
-			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
-				c, _, term := utiltests.NewTerminal(t)
+			func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{}) {
+				c := utiltests.NewTerminal(t)
 				assert.NotNil(t, c, "console should not be nil")
-				assert.NotNil(t, term, "term should not be nil")
+				assert.NotNil(t, c.Stdio, "term should not be nil")
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
-					_, err := c.ExpectString("bitbucket-server.com user name:")
-					assert.NoError(t, err, "expect user name")
-					_, err = c.SendLine("test")
-					assert.NoError(t, err, "send user name")
-					_, err = c.ExpectString("API Token:")
-					assert.NoError(t, err, "expect API token")
-					_, err = c.SendLine("test")
-					assert.NoError(t, err, "send API token")
-					_, err = c.ExpectEOF()
-					assert.NoError(t, err, "expect EOF")
+					c.ExpectString("bitbucket-server.com user name:")
+					c.SendLine("test")
+					c.ExpectString("API Token:")
+					c.SendLine("test")
+					c.ExpectEOF()
 				}()
-				return c, term, donech
+				return c, donech
 			},
-			func(t *testing.T, c *expect.Console, donech chan struct{}) {
-				err := c.Tty().Close()
+			func(c *utiltests.ConsoleWrapper, donech chan struct{}) {
+				err := c.Close()
 				assert.NoError(t, err, "should close the tty")
 				<-donech
 			},
@@ -689,20 +667,20 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			false,
 		},
 		{"create BitbucketCloud provider for user from environment",
-			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
+			func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{}) {
 				err := setUserAuthInEnv(gits.KindBitBucketCloud, "test", "test")
 				assert.NoError(t, err, "should configure the user auth in environment")
-				c, _, term := utiltests.NewTerminal(t)
+				c := utiltests.NewTerminal(t)
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
 				}()
-				return c, term, donech
+				return c, donech
 			},
-			func(t *testing.T, c *expect.Console, donech chan struct{}) {
+			func(c *utiltests.ConsoleWrapper, donech chan struct{}) {
 				err := unsetUserAuthInEnv(gits.KindBitBucketCloud)
 				assert.NoError(t, err, "should reset the user auth in environment")
-				err = c.Tty().Close()
+				err = c.Close()
 				assert.NoError(t, err, "should close the tty")
 				<-donech
 			},
@@ -736,28 +714,23 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			true,
 		},
 		{"create BitbucketCloud provider in interactive mode",
-			func(t *testing.T) (*expect.Console, *terminal.Stdio, chan struct{}) {
-				c, _, term := utiltests.NewTerminal(t)
+			func(t *testing.T) (*utiltests.ConsoleWrapper, chan struct{}) {
+				c := utiltests.NewTerminal(t)
 				assert.NotNil(t, c, "console should not be nil")
-				assert.NotNil(t, term, "term should not be nil")
+				assert.NotNil(t, c.Stdio, "term should not be nil")
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
-					_, err := c.ExpectString("bitbucket.org user name:")
-					assert.NoError(t, err, "expect user name")
-					_, err = c.SendLine("test")
-					assert.NoError(t, err, "send user name")
-					_, err = c.ExpectString("API Token:")
-					assert.NoError(t, err, "expect API token")
-					_, err = c.SendLine("test")
-					assert.NoError(t, err, "send API token")
-					_, err = c.ExpectEOF()
-					assert.NoError(t, err, "expect EOF")
+					c.ExpectString("bitbucket.org user name:")
+					c.SendLine("test")
+					c.ExpectString("API Token:")
+					c.SendLine("test")
+					c.ExpectEOF()
 				}()
-				return c, term, donech
+				return c, donech
 			},
-			func(t *testing.T, c *expect.Console, donech chan struct{}) {
-				err := c.Tty().Close()
+			func(c *utiltests.ConsoleWrapper, donech chan struct{}) {
+				err := c.Close()
 				assert.NoError(t, err, "should close the tty")
 				<-donech
 			},
@@ -782,14 +755,13 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			assert.NoError(t, err, "should clean the env variables")
 			defer restoreEnviron(t, environ)
 
-			var console *expect.Console
-			var term *terminal.Stdio
+			var console *utiltests.ConsoleWrapper
 			var donech chan struct{}
 			if tc.setup != nil {
-				console, term, donech = tc.setup(t)
+				console, donech = tc.setup(t)
 			}
 
-			users := []*auth.UserAuth{}
+			var users []*auth.UserAuth
 			var currUser *auth.UserAuth
 			var pipelineUser *auth.UserAuth
 			var server *auth.AuthServer
@@ -826,8 +798,8 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			}
 
 			var result gits.GitProvider
-			if term != nil {
-				result, err = gits.CreateProviderForURL(tc.inCluster, *authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, term.In, term.Out, term.Err)
+			if console != nil {
+				result, err = gits.CreateProviderForURL(tc.inCluster, *authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, console.In, console.Out, console.Err)
 			} else {
 				result, err = gits.CreateProviderForURL(tc.inCluster, *authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, nil, nil, nil)
 			}
@@ -849,7 +821,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			}
 
 			if tc.cleanup != nil {
-				tc.cleanup(t, console, donech)
+				tc.cleanup(console, donech)
 			}
 		})
 	}

--- a/pkg/jx/cmd/common_commands_test.go
+++ b/pkg/jx/cmd/common_commands_test.go
@@ -52,10 +52,10 @@ func TestVerboseOutput(t *testing.T) {
 func TestNonVerboseOutput(t *testing.T) {
 	tests.SkipForWindows(t, "go-expect does not work on windows")
 	t.Parallel()
-	c, state, term := tests.NewTerminal(t)
-	defer c.Close()
-	o := cmd.CommonOptions{Out: term.Out}
+	console := tests.NewTerminal(t)
+	defer console.Close()
+	o := cmd.CommonOptions{Out: console.Out}
 	err := o.RunCommand("echo", "foo")
 	assert.NoError(t, err, "Should not error")
-	assert.Empty(t, expect.StripTrailingEmptyLines(state.String()))
+	assert.Empty(t, expect.StripTrailingEmptyLines(console.CurrentState()))
 }

--- a/pkg/jx/cmd/common_import_test.go
+++ b/pkg/jx/cmd/common_import_test.go
@@ -46,15 +46,15 @@ func TestImportProject(t *testing.T) {
 	factory := cmd_mocks.NewMockFactory()
 
 	// mock terminal
-	c, state, term := tests.NewTerminal(t)
+	console := tests.NewTerminal(t)
 
 	// Test interactive IO
 	donec := make(chan struct{})
 	go func() {
 		defer close(donec)
-		c.ExpectString("Do you wish to use jx-testing-user as the user name for the Jenkins Pipeline")
-		c.SendLine("Y")
-		c.ExpectEOF()
+		console.ExpectString("Do you wish to use jx-testing-user as the user name for the Jenkins Pipeline")
+		console.SendLine("Y")
+		console.ExpectEOF()
 	}()
 
 	// mock Kubernetes interface
@@ -83,9 +83,9 @@ func TestImportProject(t *testing.T) {
 	o := &cmd.ImportOptions{
 		CommonOptions: cmd.CommonOptions{
 			Factory: factory,
-			In:      term.In,
-			Out:     term.Out,
-			Err:     term.Err,
+			In:      console.In,
+			Out:     console.Out,
+			Err:     console.Err,
 		},
 	}
 
@@ -114,11 +114,11 @@ func TestImportProject(t *testing.T) {
 	)
 
 	// Close the slave end of the pty, and read the remaining bytes from the master end.
-	c.Tty().Close()
+	console.Close()
 	<-donec
 
 	assert.NoError(t, err, "Should not error")
 
 	// Dump the terminal's screen.
-	t.Logf(expect.StripTrailingEmptyLines(state.String()))
+	t.Logf(expect.StripTrailingEmptyLines(console.CurrentState()))
 }

--- a/pkg/jx/cmd/create_env_test.go
+++ b/pkg/jx/cmd/create_env_test.go
@@ -91,33 +91,34 @@ func TestCreateEnvRun(t *testing.T) {
 	When(jenkinsClientInterface.GetJob(AnyString())).ThenReturn(jenkinsJob, nil)
 
 	// Mock terminal
-	c, state, term := tests.NewTerminal(t)
+	console := tests.NewTerminal(t)
 
 	// Test interactive IO
 	donec := make(chan struct{})
+	//noinspection GoUnhandledErrorResult
 	go func() {
 		defer close(donec)
-		c.ExpectString("Name:")
-		c.SendLine("testing")
-		c.ExpectString("Label:")
-		c.SendLine("Testing")
-		c.ExpectString("Namespace:")
-		c.SendLine("jx-testing")
-		c.ExpectString("Cluster URL:")
-		c.SendLine("http://good.looking.com")
-		c.ExpectString("Promotion Strategy:")
-		c.SendLine("A")
-		c.ExpectString("Order:")
-		c.SendLine("1")
-		c.ExpectString("We will now create a Git repository to store your testing environment, ok? :")
-		c.SendLine("N")
-		c.ExpectString("Git URL for the Environment source code:")
-		c.SendLine("https://github.com/jx-testing-user/testing-env")
-		c.ExpectString("Git branch for the Environment source code:")
-		c.SendLine("master")
-		c.ExpectString("Do you wish to use jx-testing-user as the user name for the Jenkins Pipeline")
-		c.SendLine("Y")
-		c.ExpectEOF()
+		console.ExpectString("Name:")
+		console.SendLine("testing")
+		console.ExpectString("Label:")
+		console.SendLine("Testing")
+		console.ExpectString("Namespace:")
+		console.SendLine("jx-testing")
+		console.ExpectString("Cluster URL:")
+		console.SendLine("http://good.looking.com")
+		console.ExpectString("Promotion Strategy:")
+		console.SendLine("A")
+		console.ExpectString("Order:")
+		console.SendLine("1")
+		console.ExpectString("We will now create a Git repository to store your testing environment, ok? :")
+		console.SendLine("N")
+		console.ExpectString("Git URL for the Environment source code:")
+		console.SendLine("https://github.com/jx-testing-user/testing-env")
+		console.ExpectString("Git branch for the Environment source code:")
+		console.SendLine("master")
+		console.ExpectString("Do you wish to use jx-testing-user as the user name for the Jenkins Pipeline")
+		console.SendLine("Y")
+		console.ExpectEOF()
 	}()
 
 	a := make(map[string]string)
@@ -137,9 +138,9 @@ func TestCreateEnvRun(t *testing.T) {
 		CreateOptions: cmd.CreateOptions{
 			CommonOptions: cmd.CommonOptions{
 				Factory: factory,
-				In:      term.In,
-				Out:     term.Out,
-				Err:     term.Err,
+				In:      console.In,
+				Out:     console.Out,
+				Err:     console.Err,
 			},
 		},
 	}
@@ -147,11 +148,11 @@ func TestCreateEnvRun(t *testing.T) {
 	err := options.Run()
 
 	// Close the slave end of the pty, and read the remaining bytes from the master end.
-	c.Tty().Close()
+	console.Close()
 	<-donec
 
 	assert.NoError(t, err, "Should not error")
 
 	// Dump the terminal's screen.
-	t.Logf(expect.StripTrailingEmptyLines(state.String()))
+	t.Logf(expect.StripTrailingEmptyLines(console.CurrentState()))
 }

--- a/pkg/jx/cmd/uninstall.go
+++ b/pkg/jx/cmd/uninstall.go
@@ -83,7 +83,7 @@ func (o *UninstallOptions) Run() error {
 			targetContext = o.Context
 		} else {
 			targetContext, err = util.PickValue(fmt.Sprintf("Enter the current context name to confirm "+
-				"uninstalllation of the Jenkins X platform from the %s namespace:", util.ColorInfo(namespace)),
+				"uninstallation of the Jenkins X platform from the %s namespace:", util.ColorInfo(namespace)),
 				"", true,
 				"To prevent accidental uninstallation from the wrong cluster, you must enter the current "+
 					"kubernetes context. This can be found with `kubectl config current-context`",
@@ -124,7 +124,7 @@ func (o *UninstallOptions) Run() error {
 	o.Helm().DeleteRelease(namespace, "jx-prow", true)
 	err = o.Helm().DeleteRelease(namespace, "jenkins-x", true)
 	if err != nil {
-		errs = append(errs, fmt.Errorf("failed to uninstall the jenkins-x helm chart in namespace %s: %s", namespace ,err))
+		errs = append(errs, fmt.Errorf("failed to uninstall the jenkins-x helm chart in namespace %s: %s", namespace, err))
 	}
 	err = jxClient.JenkinsV1().Environments(namespace).DeleteCollection(&meta_v1.DeleteOptions{}, meta_v1.ListOptions{})
 	if err != nil {

--- a/pkg/kube/env_test.go
+++ b/pkg/kube/env_test.go
@@ -168,31 +168,31 @@ func TestCreateEnvironmentSurvey(t *testing.T) {
 	// Override CreateApiExtensionsClient to return mock apiextensions interface
 	When(factory.CreateApiExtensionsClient()).ThenReturn(apiextensionsInterface, nil)
 
-	c, state, term := tests.NewTerminal(t)
-	defer c.Close()
+	console := tests.NewTerminal(t)
+	defer console.Close()
 
 	donec := make(chan struct{})
 	go func() {
 		defer close(donec)
-		c.ExpectString("Name:")
-		c.SendLine("staging")
-		c.ExpectString("Label:")
-		c.SendLine("Staging")
-		c.ExpectString("Namespace:")
-		c.SendLine("jx-testing")
-		c.ExpectString("Cluster URL:")
-		c.SendLine("http://good.looking.com")
-		c.ExpectString("Promotion Strategy:")
-		c.SendLine("A")
-		c.ExpectString("Order:")
-		c.SendLine("1")
-		c.ExpectString("We will now create a Git repository to store your staging environment, ok? :")
-		c.SendLine("N")
-		c.ExpectString("Git URL for the Environment source code:")
-		c.SendLine("https://github.com/derekzoolanderreallyreallygoodlooking/staging-env")
-		c.ExpectString("Git branch for the Environment source code:")
-		c.SendLine("master")
-		c.ExpectEOF()
+		console.ExpectString("Name:")
+		console.SendLine("staging")
+		console.ExpectString("Label:")
+		console.SendLine("Staging")
+		console.ExpectString("Namespace:")
+		console.SendLine("jx-testing")
+		console.ExpectString("Cluster URL:")
+		console.SendLine("http://good.looking.com")
+		console.ExpectString("Promotion Strategy:")
+		console.SendLine("A")
+		console.ExpectString("Order:")
+		console.SendLine("1")
+		console.ExpectString("We will now create a Git repository to store your staging environment, ok? :")
+		console.SendLine("N")
+		console.ExpectString("Git URL for the Environment source code:")
+		console.SendLine("https://github.com/derekzoolanderreallyreallygoodlooking/staging-env")
+		console.ExpectString("Git branch for the Environment source code:")
+		console.SendLine("master")
+		console.ExpectEOF()
 	}()
 
 	batchMode := false
@@ -229,17 +229,17 @@ func TestCreateEnvironmentSurvey(t *testing.T) {
 		helmValues,
 		prefix,
 		gitter,
-		term.In,
-		term.Out,
-		term.Err,
+		console.In,
+		console.Out,
+		console.Err,
 	)
 
 	// Close the slave end of the pty, and read the remaining bytes from the master end.
-	c.Tty().Close()
+	console.Close()
 	<-donec
 
 	assert.NoError(t, err, "Should not error")
 
 	// Dump the terminal's screen.
-	t.Log(expect.StripTrailingEmptyLines(state.String()))
+	t.Log(expect.StripTrailingEmptyLines(console.CurrentState()))
 }

--- a/pkg/tests/console_wrapper.go
+++ b/pkg/tests/console_wrapper.go
@@ -1,0 +1,47 @@
+package tests
+
+import (
+	"github.com/Netflix/go-expect"
+	"github.com/acarl005/stripansi"
+	"github.com/hinshun/vt10x"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+	"testing"
+)
+
+// ConsoleWrapper is a wrapper around the go-expect Console that takes a test object and will report failures
+// This prevents users having to manually detect and report errors during the tests
+type ConsoleWrapper struct {
+	tester  *testing.T
+	console *expect.Console
+	state   *vt10x.State
+	terminal.Stdio
+}
+
+// ExpectString expects a string to be present on the console and fails the test if it is not
+func (c *ConsoleWrapper) ExpectString(s string) {
+	out, err := c.console.ExpectString(s)
+	assert.NoError(c.tester, err, "Expected string: %q\nActual string: %q", s, stripansi.Strip(out))
+}
+
+// SendLine sends a string to the console and fails the test if something goes wrong
+func (c *ConsoleWrapper) SendLine(s string) {
+	_, err := c.console.SendLine(s)
+	assert.NoError(c.tester, err, "Error sending line %s", s)
+}
+
+// ExpectEOF expects an EOF to be present on the console and reports an error if it is not
+func (c *ConsoleWrapper) ExpectEOF() {
+	out, err := c.console.ExpectEOF()
+	assert.NoError(c.tester, err, "Expected EOF. Got %q", stripansi.Strip(out))
+}
+
+// Close closes the console
+func (c *ConsoleWrapper) Close() error {
+	return c.console.Tty().Close()
+}
+
+// CurrentState gets the last line of text currently on the console
+func (c *ConsoleWrapper) CurrentState() string {
+	return c.state.String()
+}

--- a/pkg/tests/helpers.go
+++ b/pkg/tests/helpers.go
@@ -2,7 +2,8 @@ package tests
 
 import (
 	"bytes"
-	"fmt"
+	"github.com/acarl005/stripansi"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"runtime"
@@ -11,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	expect "github.com/Netflix/go-expect"
+	"github.com/Netflix/go-expect"
 	"github.com/hinshun/vt10x"
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -87,11 +88,10 @@ func newTerminal(c *expect.Console) *terminal.Stdio {
 }
 
 // NewTerminal mock terminal to control stdin and stdout
-func NewTerminal(t *testing.T) (*expect.Console, *vt10x.State, *terminal.Stdio) {
+func NewTerminal(t *testing.T) *ConsoleWrapper {
 	buf := new(bytes.Buffer)
 	timeout := time.Second * 1
 	opts := []expect.ConsoleOpt{
-		expectNoTimeoutError(t),
 		sendNoError(t),
 		expect.WithStdout(buf),
 		expect.WithDefaultTimeout(timeout),
@@ -101,8 +101,12 @@ func NewTerminal(t *testing.T) (*expect.Console, *vt10x.State, *terminal.Stdio) 
 	if err != nil {
 		panic(err)
 	}
-	term := newTerminal(c)
-	return c, state, term
+	return &ConsoleWrapper{
+		tester:  t,
+		console: c,
+		state:   state,
+		Stdio:   *newTerminal(c),
+	}
 }
 
 // TestCloser closes io
@@ -111,20 +115,6 @@ func TestCloser(t *testing.T, closer io.Closer) {
 		t.Errorf("Close failed: %s", err)
 		debug.PrintStack()
 	}
-}
-
-func expectNoTimeoutError(t *testing.T) expect.ConsoleOpt {
-	return expect.WithExpectObserver(
-		func(matcher expect.Matcher, buf string, err error) {
-			if err != nil {
-				if e, ok := err.(*os.PathError); ok {
-					if e.Timeout() {
-						panic("Test: " + t.Name() + " Timeout waiting for Terminal output: " + fmt.Sprintf("%q", buf))
-					}
-				}
-			}
-		},
-	)
 }
 
 func sendNoError(t *testing.T) expect.ConsoleOpt {
@@ -146,4 +136,10 @@ func SkipForWindows(t *testing.T, reason string) {
 	if runtime.GOOS == "windows" {
 		t.Skipf("Test skipped on windows. Reason: %s", reason)
 	}
+}
+
+// ExpectString does the same as the go-expect console.ExpectString method, but also reports failures to the testing object in a sensible format
+func ExpectString(t *testing.T, console *expect.Console, s string) {
+	out, err := console.ExpectString(s)
+	assert.NoError(t, err, "Expected string: %q\nActual string: %q", s, stripansi.Strip(out))
 }

--- a/pkg/vault/vaultselector_test.go
+++ b/pkg/vault/vaultselector_test.go
@@ -67,8 +67,8 @@ func Test_GetVault_PromptsUserIfMoreThanOneVaultInNamespace(t *testing.T) {
 	tests.SkipForWindows(t, "go-expect does not work on windows")
 
 	// mock terminal
-	console, state, term := tests.NewTerminal(t)
-	vaultOperatorClient, factory, err, kubeClient := setupMocks(t, term)
+	console := tests.NewTerminal(t)
+	vaultOperatorClient, factory, err, kubeClient := setupMocks(t, &console.Stdio)
 	createMockedVault("vault1", "myVaultNamespace", "one.ah.ah.ah", "Count", vaultOperatorClient, kubeClient)
 	createMockedVault("vault2", "myVaultNamespace", "two.ah.ah.ah", "Von-Count", vaultOperatorClient, kubeClient)
 
@@ -85,11 +85,11 @@ func Test_GetVault_PromptsUserIfMoreThanOneVaultInNamespace(t *testing.T) {
 
 	vault, err := selector.GetVault("", "myVaultNamespace")
 
-	console.Tty().Close()
+	console.Close()
 	<-donec
 
 	// Dump the terminal's screen.
-	t.Logf(expect.StripTrailingEmptyLines(state.String()))
+	t.Logf(expect.StripTrailingEmptyLines(console.CurrentState()))
 
 	assert.Equal(t, "vault2", vault.Name)
 	assert.Equal(t, "myVaultNamespace", vault.Namespace)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
This refactors the `go-expect` tests by hiding the actual `console` behind a wrapper. The wrapper will automatically assert that there are no errors as a result of the `Expect` clauses (previously almost-all errors were not assigned to any variable and just discarded).

Previously, if a `go-expect` test failed, the output would be:
```
panic: Test: TestUninstallOptions_Run_ContextSpecifiedViaCli_FailsWhenContextNamesDoNotMatch Timeout waiting for Terminal output: "\x1b[0G\x1b[2K\x1b[1;92m? \x1b[0m\x1b[1;99mEnter the current context name to confirm uninstalllation of the Jenkins X platform from the ns namespace: \x1b[0m\x1b[36m[? for help]\x1b[0m \x1b[?25l\x1b7\x1b[999;999f\x1b[6n\x1b8\x1b[?25h"

goroutine 56 [running]:
github.com/jenkins-x/jx/pkg/tests.expectNoTimeoutError.func1(0x0, 0x0, 0xc0005543c0, 0xbf, 0x204d4c0, 0xc000177b60)
        /home/steve/code/jx/jx/pkg/tests/helpers.go:122 +0x1e3
github.com/Netflix/go-expect.(*Console).Expect.func1(0xc000582840, 0xc000603ea0, 0xc000276000, 0xc000603eb0)
        /home/steve/go/pkg/mod/github.com/!netflix/go-expect@v0.0.0-20180814212900-124a37274874/expect.go:72 +0x8a
github.com/Netflix/go-expect.(*Console).Expect(0xc000582840, 0xc0000d1f70, 0x1, 0x1, 0xc000554300, 0xbf, 0x204d4c0, 0xc000177b60)
        /home/steve/go/pkg/mod/github.com/!netflix/go-expect@v0.0.0-20180814212900-124a37274874/expect.go:92 +0x85a
github.com/Netflix/go-expect.(*Console).ExpectString(0xc000582840, 0x1dc9d52, 0x1d, 0x0, 0x0, 0x0, 0x0)
        /home/steve/go/pkg/mod/github.com/!netflix/go-expect@v0.0.0-20180814212900-124a37274874/expect.go:35 +0xac
command-line-arguments_test.TestUninstallOptions_Run_ContextSpecifiedViaCli_FailsWhenContextNamesDoNotMatch.func1(0xc000538960, 0xc000582840)
        /home/steve/code/jx/jx/pkg/jx/cmd/uninstall_test.go:105 +0x6a
created by command-line-arguments_test.TestUninstallOptions_Run_ContextSpecifiedViaCli_FailsWhenContextNamesDoNotMatch
        /home/steve/code/jx/jx/pkg/jx/cmd/uninstall_test.go:103 +0xc6
```

With this PR, the output is now:
```
--- FAIL: TestUninstallOptions_Run_ContextSpecifiedViaCli_FailsWhenContextNamesDoNotMatch (1.01s)
    console_wrapper.go:24:
                Error Trace:    console_wrapper.go:24
                                                        uninstall_test.go:103
                                                        asm_amd64.s:1333
                Error:          Received unexpected error:
                                read |0: i/o timeout
                Test:           TestUninstallOptions_Run_ContextSpecifiedViaCli_FailsWhenContextNamesDoNotMatch
                Messages:       Expected string: "Expected text defined in test"
                                Actual string: "This is the actual text on the command line as returned by the jx executable"

```

#### Special notes for the reviewer(s)
The `expectNoTimeoutError` method has been removed because because it's no longer needed.


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
