### PR TITLE
WIP bug (options): Make global CommonOptions available on all commands.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test-integration-report-html: get-test-deps test-integration
 	@gocov convert cover.out | gocov-html > cover.html && open cover.html
 
 test-slow-integration:
-	@CGO_ENABLED=$(CGO_ENABLED) $(GO) test -v -v -memprofile mem.out -count=1 -tags=integration -coverprofile=cover.out ./...
+	@CGO_ENABLED=$(CGO_ENABLED) $(GO) test -v -count=1 -tags=integration -coverprofile=cover.out ./...
 
 test-slow-integration-report: get-test-deps test-slow-integration
 	@gocov convert cover.out | gocov report

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test-integration-report-html: get-test-deps test-integration
 	@gocov convert cover.out | gocov-html > cover.html && open cover.html
 
 test-slow-integration:
-	@CGO_ENABLED=$(CGO_ENABLED) $(GO) test -count=1 -tags=integration -coverprofile=cover.out ./...
+	@CGO_ENABLED=$(CGO_ENABLED) $(GO) test -v -v -memprofile mem.out -count=1 -tags=integration -coverprofile=cover.out ./...
 
 test-slow-integration-report: get-test-deps test-slow-integration
 	@gocov convert cover.out | gocov report

--- a/pkg/jx/cmd/add.go
+++ b/pkg/jx/cmd/add.go
@@ -1,17 +1,14 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 // AddOptions contains the command line options
 type AddOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	DisableImport bool
 	OutDir        string
@@ -31,14 +28,9 @@ var (
 )
 
 // NewCmdAdd creates a command object for the "add" command
-func NewCmdAdd(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdAdd(commonOpts *CommonOptions) *cobra.Command {
 	options := &AddOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -52,7 +44,7 @@ func NewCmdAdd(f Factory, in terminal.FileReader, out terminal.FileWriter, errOu
 			CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdAddApp(f, in, out, errOut))
+	cmd.AddCommand(NewCmdAddApp(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/add_app.go
+++ b/pkg/jx/cmd/add_app.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -16,7 +15,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // AddAppOptions the options for the create spring command
@@ -46,15 +44,10 @@ type AddAppOptions struct {
 }
 
 // NewCmdAddApp creates a command object for the "create" command
-func NewCmdAddApp(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdAddApp(commonOpts *CommonOptions) *cobra.Command {
 	options := &AddAppOptions{
 		AddOptions: AddOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/add_app.go
+++ b/pkg/jx/cmd/add_app.go
@@ -80,8 +80,6 @@ func (o *AddAppOptions) addFlags(cmd *cobra.Command, defaultNamespace string, de
 		"The username for the repository")
 	cmd.Flags().StringVarP(&o.Password, "password", "", "",
 		"The password for the repository")
-	cmd.Flags().BoolVarP(&o.BatchMode, optionBatchMode, "b", false, "In batch mode the command never prompts for user input")
-	cmd.Flags().BoolVarP(&o.Verbose, optionVerbose, "", false, "Enable verbose logging")
 	if o.GitOps {
 		// GitOps specific flags go here
 		cmd.Flags().StringVarP(&o.Alias, "alias", "", "", "An alias to use for the app")

--- a/pkg/jx/cmd/add_app_test.go
+++ b/pkg/jx/cmd/add_app_test.go
@@ -22,7 +22,7 @@ func TestAddAppForGitOps(t *testing.T) {
 
 	o := &cmd.AddAppOptions{
 		AddOptions: cmd.AddOptions{
-			CommonOptions: *testEnv.CommonOptions,
+			CommonOptions: testEnv.CommonOptions,
 		},
 		FakePullRequests: testEnv.FakePullRequests,
 		Version:          "0.0.1",
@@ -62,6 +62,9 @@ func prepareDevEnv(t *testing.T, gitOps bool) (*AddAppTestEnv, error) {
 
 	o := cmd.AddAppOptions{
 		FakePullRequests: cmd.NewCreateEnvPullRequestFn(fakeGitProvider),
+		AddOptions: cmd.AddOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 	}
 
 	devEnv := kube.NewPermanentEnvironmentWithGit("dev", fmt.Sprintf("https://github.com/%s/%s.git", testOrgName,
@@ -71,7 +74,7 @@ func prepareDevEnv(t *testing.T, gitOps bool) (*AddAppTestEnv, error) {
 		devEnv.Spec.Source.Ref = "master"
 	}
 
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{},
 		[]runtime.Object{
 			devEnv,
@@ -81,7 +84,7 @@ func prepareDevEnv(t *testing.T, gitOps bool) (*AddAppTestEnv, error) {
 	)
 	return &AddAppTestEnv{
 		FakePullRequests: o.FakePullRequests,
-		CommonOptions:    &o.CommonOptions,
+		CommonOptions:    o.CommonOptions,
 		FakeGitProvider:  fakeGitProvider,
 		DevRepo:          fakeRepo,
 		DevEnvRepo:       devEnvRepo,

--- a/pkg/jx/cmd/cloudbees.go
+++ b/pkg/jx/cmd/cloudbees.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/kube/services"
-	"io"
 
+	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
@@ -15,7 +13,7 @@ import (
 )
 
 type CloudBeesOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	OnlyViewURL bool
 }
@@ -36,14 +34,9 @@ var (
 		jx console -u`)
 )
 
-func NewCmdCloudBees(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCloudBees(commonOpts *CommonOptions) *cobra.Command {
 	options := &CloudBeesOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "cloudbees",
@@ -58,7 +51,7 @@ func NewCmdCloudBees(f Factory, in terminal.FileReader, out terminal.FileWriter,
 			CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdCloudBeesPipeline(f, in, out, errOut))
+	cmd.AddCommand(NewCmdCloudBeesPipeline(commonOpts))
 	cmd.Flags().BoolVarP(&options.OnlyViewURL, "url", "u", false, "Only displays and the URL and does not open the browser")
 	return cmd
 }

--- a/pkg/jx/cmd/cloudbees_pipeline.go
+++ b/pkg/jx/cmd/cloudbees_pipeline.go
@@ -2,14 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
 )
 
 type CloudBeesPipelineOptions struct {
@@ -32,15 +29,10 @@ var (
 		jx cloudbees pipeline -u`)
 )
 
-func NewCmdCloudBeesPipeline(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCloudBeesPipeline(commonOpts *CommonOptions) *cobra.Command {
 	options := &CloudBeesPipelineOptions{
 		CloudBeesOptions: CloudBeesOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/cmd.go
+++ b/pkg/jx/cmd/cmd.go
@@ -60,25 +60,34 @@ func NewJXCommand(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 		*/
 	}
 
-	addCommands := NewCmdAdd(f, in, out, err)
-	createCommands := NewCmdCreate(f, in, out, err)
-	deleteCommands := NewCmdDelete(f, in, out, err)
-	getCommands := NewCmdGet(f, in, out, err)
-	editCommands := NewCmdEdit(f, in, out, err)
-	updateCommands := NewCmdUpdate(f, in, out, err)
+	commonOpts := &CommonOptions{
+		Factory: f,
+		In:      in,
+		Out:     out,
+		Err:     err,
+	}
+	// commonOpts holds the global flags and will be shared/inherited by all sub-commands created below.
+	commonOpts.addCommonFlags(cmds)
+
+	addCommands := NewCmdAdd(commonOpts)
+	createCommands := NewCmdCreate(commonOpts)
+	deleteCommands := NewCmdDelete(commonOpts)
+	getCommands := NewCmdGet(commonOpts)
+	editCommands := NewCmdEdit(commonOpts)
+	updateCommands := NewCmdUpdate(commonOpts)
 
 	installCommands := []*cobra.Command{
-		NewCmdInstall(f, in, out, err),
-		NewCmdUninstall(f, in, out, err),
-		NewCmdUpgrade(f, in, out, err),
+		NewCmdInstall(commonOpts),
+		NewCmdUninstall(commonOpts),
+		NewCmdUpgrade(commonOpts),
 	}
 	installCommands = append(installCommands, findCommands("cluster", createCommands, deleteCommands)...)
 	installCommands = append(installCommands, findCommands("cluster", updateCommands)...)
 	installCommands = append(installCommands, findCommands("jenkins token", createCommands, deleteCommands)...)
-	installCommands = append(installCommands, NewCmdInit(f, in, out, err))
+	installCommands = append(installCommands, NewCmdInit(commonOpts))
 
 	addProjectCommands := []*cobra.Command{
-		NewCmdImport(f, in, out, err),
+		NewCmdImport(commonOpts),
 	}
 	addProjectCommands = append(addProjectCommands, findCommands("create archetype", createCommands, deleteCommands)...)
 	addProjectCommands = append(addProjectCommands, findCommands("create spring", createCommands, deleteCommands)...)
@@ -89,15 +98,15 @@ func NewJXCommand(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 	gitCommands := []*cobra.Command{}
 	gitCommands = append(gitCommands, findCommands("git server", createCommands, deleteCommands)...)
 	gitCommands = append(gitCommands, findCommands("git token", createCommands, deleteCommands)...)
-	gitCommands = append(gitCommands, NewCmdRepo(f, in, out, err))
+	gitCommands = append(gitCommands, NewCmdRepo(commonOpts))
 
 	addonCommands := []*cobra.Command{}
 	addonCommands = append(addonCommands, findCommands("addon", createCommands, deleteCommands)...)
 	addonCommands = append(addonCommands, findCommands("app", createCommands, deleteCommands, addCommands)...)
 
 	environmentsCommands := []*cobra.Command{
-		NewCmdPreview(f, in, out, err),
-		NewCmdPromote(f, in, out, err),
+		NewCmdPreview(commonOpts),
+		NewCmdPromote(commonOpts),
 	}
 	environmentsCommands = append(environmentsCommands, findCommands("environment", createCommands, deleteCommands, editCommands, getCommands)...)
 
@@ -121,33 +130,33 @@ func NewJXCommand(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 		{
 			Message: "Working with Kubernetes:",
 			Commands: []*cobra.Command{
-				NewCompliance(f, in, out, err),
-				NewCmdCompletion(f, in, out, err),
-				NewCmdContext(f, in, out, err),
-				NewCmdEnvironment(f, in, out, err),
-				NewCmdTeam(f, in, out, err),
-				NewCmdNamespace(f, in, out, err),
-				NewCmdPrompt(f, in, out, err),
-				NewCmdScan(f, in, out, err),
-				NewCmdShell(f, in, out, err),
-				NewCmdStatus(f, in, out, err),
+				NewCompliance(commonOpts),
+				NewCmdCompletion(commonOpts),
+				NewCmdContext(commonOpts),
+				NewCmdEnvironment(commonOpts),
+				NewCmdTeam(commonOpts),
+				NewCmdNamespace(commonOpts),
+				NewCmdPrompt(commonOpts),
+				NewCmdScan(commonOpts),
+				NewCmdShell(commonOpts),
+				NewCmdStatus(commonOpts),
 			},
 		},
 		{
 			Message: "Working with Applications:",
 			Commands: []*cobra.Command{
-				NewCmdConsole(f, in, out, err),
-				NewCmdLogs(f, in, out, err),
-				NewCmdOpen(f, in, out, err),
-				NewCmdRsh(f, in, out, err),
-				NewCmdSync(f, in, out, err),
+				NewCmdConsole(commonOpts),
+				NewCmdLogs(commonOpts),
+				NewCmdOpen(commonOpts),
+				NewCmdRsh(commonOpts),
+				NewCmdSync(commonOpts),
 			},
 		},
 		{
 			Message: "Working with CloudBees application:",
 			Commands: []*cobra.Command{
-				NewCmdCloudBees(f, in, out, err),
-				NewCmdLogin(f, in, out, err),
+				NewCmdCloudBees(commonOpts),
+				NewCmdLogin(commonOpts),
 			},
 		},
 		{
@@ -163,21 +172,21 @@ func NewJXCommand(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 				updateCommands,
 				deleteCommands,
 				addCommands,
-				NewCmdStart(f, in, out, err),
-				NewCmdStop(f, in, out, err),
+				NewCmdStart(commonOpts),
+				NewCmdStop(commonOpts),
 			},
 		},
 		{
 			Message: "Jenkins X Pipeline Commands:",
 			Commands: []*cobra.Command{
-				NewCmdStep(f, in, out, err),
+				NewCmdStep(commonOpts),
 			},
 		},
 		{
 			Message: "Jenkins X services:",
 			Commands: []*cobra.Command{
-				NewCmdController(f, in, out, err),
-				NewCmdGC(f, in, out, err),
+				NewCmdController(commonOpts),
+				NewCmdGC(commonOpts),
 			},
 		},
 	}
@@ -186,30 +195,24 @@ func NewJXCommand(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 
 	filters := []string{"options"}
 
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-		Out:     out,
-		Err:     err,
-	}
 	verifier := &extensions.CommandOverrideVerifier{
 		Root:        cmds,
 		SeenPlugins: make(map[string]string, 0),
 	}
-	pluginCommandGroups, managedPluginsEnabled, err1 := commonOptions.getPluginCommandGroups(verifier)
+	pluginCommandGroups, managedPluginsEnabled, err1 := commonOpts.getPluginCommandGroups(verifier)
 	if err1 != nil {
 		log.Errorf("%v\n", err1)
 	}
 	templates.ActsAsRootCommand(cmds, filters, pluginCommandGroups, groups...)
-	cmds.AddCommand(NewCmdDocs(f, in, out, err))
-	cmds.AddCommand(NewCmdVersion(f, in, out, err))
+	cmds.AddCommand(NewCmdDocs())
+	cmds.AddCommand(NewCmdVersion(commonOpts))
 	cmds.Version = version.GetVersion()
 	cmds.SetVersionTemplate("{{printf .Version}}\n")
 	cmds.AddCommand(NewCmdOptions(out))
-	cmds.AddCommand(NewCmdDiagnose(f, in, out, err))
+	cmds.AddCommand(NewCmdDiagnose(commonOpts))
 
 	managedPlugins := &managedPluginHandler{
-		CommonOptions: commonOptions,
+		CommonOptions: commonOpts,
 	}
 	localPlugins := &localPluginHandler{}
 	args := os.Args
@@ -288,7 +291,7 @@ type PluginHandler interface {
 }
 
 type managedPluginHandler struct {
-	CommonOptions
+	*CommonOptions
 	localPluginHandler
 }
 

--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -140,15 +140,14 @@ func (o *CommonOptions) Debugf(format string, a ...interface{}) {
 }
 
 func (options *CommonOptions) addCommonFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVarP(&options.BatchMode, optionBatchMode, "b", false, "In batch mode the command never prompts for user input")
-	cmd.Flags().BoolVarP(&options.Verbose, optionVerbose, "", false, "Enable verbose logging")
-	cmd.Flags().StringVarP(&options.LogLevel, optionLogLevel, "", logrus.InfoLevel.String(), "Logging level. Possible values - panic, fatal, error, warning, info, debug.")
-	cmd.Flags().BoolVarP(&options.Headless, optionHeadless, "", false, "Enable headless operation if using browser automation")
-	cmd.Flags().BoolVarP(&options.NoBrew, optionNoBrew, "", false, "Disables the use of brew on macOS to install or upgrade command line dependencies")
-	cmd.Flags().BoolVarP(&options.InstallDependencies, optionInstallDeps, "", false, "Should any required dependencies be installed automatically")
-	cmd.Flags().BoolVarP(&options.SkipAuthSecretsMerge, optionSkipAuthSecMerge, "", false, "Skips merging a local git auth yaml file with any pipeline secrets that are found")
-	cmd.Flags().StringVarP(&options.PullSecrets, optionPullSecrets, "", "", "The pull secrets the service account created should have (useful when deploying to your own private registry): provide multiple pull secrets by providing them in a singular block of quotes e.g. --pull-secrets \"foo, bar, baz\"")
-
+	cmd.PersistentFlags().BoolVarP(&options.BatchMode, optionBatchMode, "", false, "In batch mode the command never prompts for user input")
+	cmd.PersistentFlags().BoolVarP(&options.Verbose, optionVerbose, "", false, "Enable verbose logging")
+	cmd.PersistentFlags().StringVarP(&options.LogLevel, optionLogLevel, "", logrus.InfoLevel.String(), "Logging level. Possible values - panic, fatal, error, warning, info, debug.")
+	cmd.PersistentFlags().BoolVarP(&options.Headless, optionHeadless, "", false, "Enable headless operation if using browser automation")
+	cmd.PersistentFlags().BoolVarP(&options.NoBrew, optionNoBrew, "", false, "Disables the use of brew on macOS to install or upgrade command line dependencies")
+	cmd.PersistentFlags().BoolVarP(&options.InstallDependencies, optionInstallDeps, "", false, "Should any required dependencies be installed automatically")
+	cmd.PersistentFlags().BoolVarP(&options.SkipAuthSecretsMerge, optionSkipAuthSecMerge, "", false, "Skips merging a local git auth yaml file with any pipeline secrets that are found")
+	cmd.PersistentFlags().StringVarP(&options.PullSecrets, optionPullSecrets, "", "", "The pull secrets the service account created should have (useful when deploying to your own private registry): provide multiple pull secrets by providing them in a singular block of quotes e.g. --pull-secrets \"foo, bar, baz\"")
 	options.Cmd = cmd
 }
 
@@ -855,7 +854,7 @@ func (o *CommonOptions) GetWebHookEndpoint() (string, error) {
 //This is analogous to running `jx namespace cheese`.
 func (o *CommonOptions) ChangeNamespace(ns string) {
 	nsOptions := &NamespaceOptions{
-		CommonOptions: *o,
+		CommonOptions: o,
 	}
 	nsOptions.BatchMode = true
 	nsOptions.Args = []string{ns}

--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -140,7 +140,7 @@ func (o *CommonOptions) Debugf(format string, a ...interface{}) {
 }
 
 func (options *CommonOptions) addCommonFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().BoolVarP(&options.BatchMode, optionBatchMode, "", false, "In batch mode the command never prompts for user input")
+	cmd.PersistentFlags().BoolVarP(&options.BatchMode, optionBatchMode, "b", false, "In batch mode the command never prompts for user input")
 	cmd.PersistentFlags().BoolVarP(&options.Verbose, optionVerbose, "", false, "Enable verbose logging")
 	cmd.PersistentFlags().StringVarP(&options.LogLevel, optionLogLevel, "", logrus.InfoLevel.String(), "Logging level. Possible values - panic, fatal, error, warning, info, debug.")
 	cmd.PersistentFlags().BoolVarP(&options.Headless, optionHeadless, "", false, "Enable headless operation if using browser automation")

--- a/pkg/jx/cmd/common_helm.go
+++ b/pkg/jx/cmd/common_helm.go
@@ -400,7 +400,7 @@ func (o *CommonOptions) ensureHelm() error {
 		return errors.Wrap(err, "failed to install Helm")
 	}
 	initOpts := InitOptions{
-		CommonOptions: *o,
+		CommonOptions: o,
 	}
 	return initOpts.initHelm()
 }

--- a/pkg/jx/cmd/common_import_test.go
+++ b/pkg/jx/cmd/common_import_test.go
@@ -81,7 +81,7 @@ func TestImportProject(t *testing.T) {
 	When(jenkinsClientInterface.GetJob(AnyString())).ThenReturn(jenkinsJob, nil)
 
 	o := &cmd.ImportOptions{
-		CommonOptions: cmd.CommonOptions{
+		CommonOptions: &cmd.CommonOptions{
 			Factory: factory,
 			In:      console.In,
 			Out:     console.Out,

--- a/pkg/jx/cmd/common_install_test.go
+++ b/pkg/jx/cmd/common_install_test.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInstallEksctl(t *testing.T) {

--- a/pkg/jx/cmd/completion.go
+++ b/pkg/jx/cmd/completion.go
@@ -7,7 +7,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const boilerPlate = ""
@@ -48,13 +47,7 @@ var (
 	}
 )
 
-func NewCmdCompletion(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	options := &CommonOptions{
-		Factory: f,
-		In:      in,
-		Out:     out,
-		Err:     errOut,
-	}
+func NewCmdCompletion(commonOpts *CommonOptions) *cobra.Command {
 
 	shells := []string{}
 	for s := range completion_shells {
@@ -66,9 +59,9 @@ func NewCmdCompletion(f Factory, in terminal.FileReader, out terminal.FileWriter
 		Short: "Output shell completion code for the given shell (bash or zsh)",
 		Long:  completion_long,
 		Run: func(cmd *cobra.Command, args []string) {
-			options.Cmd = cmd
-			options.Args = args
-			err := options.Run()
+			commonOpts.Cmd = cmd
+			commonOpts.Args = args
+			err := commonOpts.Run()
 			CheckErr(err)
 		},
 		ValidArgs: shells,

--- a/pkg/jx/cmd/compliance.go
+++ b/pkg/jx/cmd/compliance.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/heptio/sonobuoy/pkg/buildinfo"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // TODO change the name of the namespace to something more jx specific (e.g. jx-compliance), but
@@ -20,19 +17,14 @@ var complianceImage = "gcr.io/heptio-images/sonobuoy:" + buildinfo.Version
 
 // ComplianceOptions options for compliance command
 type ComplianceOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCompliance creates a command object for the generic "compliance" action, which
 // executes the compliance tests against a Kubernetes cluster
-func NewCompliance(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCompliance(commonOpts *CommonOptions) *cobra.Command {
 	options := &ComplianceOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -46,11 +38,11 @@ func NewCompliance(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 		},
 	}
 
-	cmd.AddCommand(NewCmdComplianceStatus(f, in, out, errOut))
-	cmd.AddCommand(NewCmdComplianceResults(f, in, out, errOut))
-	cmd.AddCommand(NewCmdComplianceRun(f, in, out, errOut))
-	cmd.AddCommand(NewCmdComplianceDelete(f, in, out, errOut))
-	cmd.AddCommand(NewCmdComplianceLogs(f, in, out, errOut))
+	cmd.AddCommand(NewCmdComplianceStatus(commonOpts))
+	cmd.AddCommand(NewCmdComplianceResults(commonOpts))
+	cmd.AddCommand(NewCmdComplianceRun(commonOpts))
+	cmd.AddCommand(NewCmdComplianceDelete(commonOpts))
+	cmd.AddCommand(NewCmdComplianceLogs(commonOpts))
 
 	return cmd
 }

--- a/pkg/jx/cmd/compliance_delete.go
+++ b/pkg/jx/cmd/compliance_delete.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/heptio/sonobuoy/pkg/client"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -23,20 +20,14 @@ var (
 
 // ComplianceDeleteOptions options for "compliance delete" command
 type ComplianceDeleteOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCmdComplianceDeletecreates a command object for the "compliance delete" action, which
 // delete the Kubernetes resources allocated by the compliance tests
-func NewCmdComplianceDelete(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdComplianceDelete(commonOpts *CommonOptions) *cobra.Command {
 	options := &ComplianceDeleteOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/compliance_logs.go
+++ b/pkg/jx/cmd/compliance_logs.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -29,21 +28,16 @@ var (
 
 // ComplianceLogsOptions options for "compliance logs" command
 type ComplianceLogsOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Follow bool
 }
 
 // NewCmdComplianceLogs creates a command object for the "compliance logs" action, which
 // prints the logs of compliance tests
-func NewCmdComplianceLogs(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdComplianceLogs(commonOpts *CommonOptions) *cobra.Command {
 	options := &ComplianceLogsOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/compliance_results.go
+++ b/pkg/jx/cmd/compliance_results.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -34,20 +33,14 @@ var (
 
 // ComplianceResultsOptions options for "compliance results" command
 type ComplianceResultsOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCmdComplianceResults creates a command object for the "compliance results" action, which
 // shows the results of E2E compliance tests
-func NewCmdComplianceResults(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdComplianceResults(commonOpts *CommonOptions) *cobra.Command {
 	options := &ComplianceResultsOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/compliance_run.go
+++ b/pkg/jx/cmd/compliance_run.go
@@ -1,14 +1,11 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/heptio/sonobuoy/pkg/client"
 	"github.com/heptio/sonobuoy/pkg/config"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/api/core/v1"
 )
 
@@ -25,19 +22,14 @@ var (
 
 // ComplianceRuntOptions options for "compliance run" command
 type ComplianceRunOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCmdComplianceRun creates a command object for the "compliance run" action, which
 // starts the E2E compliance tests
-func NewCmdComplianceRun(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdComplianceRun(commonOpts *CommonOptions) *cobra.Command {
 	options := &ComplianceRunOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/compliance_status.go
+++ b/pkg/jx/cmd/compliance_status.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/heptio/sonobuoy/pkg/plugin/aggregation"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -10,7 +9,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -26,19 +24,14 @@ var (
 
 // ComplianceStatusOptions options for "compliance status" command
 type ComplianceStatusOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCmdComplianceStatus creates a command object for the "compliance status" action, which
 // retrieve the status of E2E compliance tests
-func NewCmdComplianceStatus(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdComplianceStatus(commonOpts *CommonOptions) *cobra.Command {
 	options := &ComplianceStatusOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/console.go
+++ b/pkg/jx/cmd/console.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
@@ -39,16 +37,11 @@ var (
 		jx console --classic`)
 )
 
-func NewCmdConsole(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdConsole(commonOpts *CommonOptions) *cobra.Command {
 	options := &ConsoleOptions{
 		GetURLOptions: GetURLOptions{
 			GetOptions: GetOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/context.go
+++ b/pkg/jx/cmd/context.go
@@ -2,22 +2,21 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/kube"
-	"io"
 	"sort"
 	"strings"
+
+	"github.com/jenkins-x/jx/pkg/kube"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 type ContextOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Filter string
 }
@@ -39,15 +38,9 @@ var (
 		jx ctx minikube`)
 )
 
-func NewCmdContext(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdContext(commonOpts *CommonOptions) *cobra.Command {
 	options := &ContextOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "context",
@@ -63,7 +56,6 @@ func NewCmdContext(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 		},
 	}
 	cmd.Flags().StringVarP(&options.Filter, "filter", "f", "", "Filter the list of contexts to switch between using the given text")
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/controller.go
+++ b/pkg/jx/cmd/controller.go
@@ -1,17 +1,14 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 // ControllerOptions contains the CLI options
 type ControllerOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 var (
@@ -25,14 +22,9 @@ var (
 )
 
 // NewCmdController creates the edit command
-func NewCmdController(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdController(commonOpts *CommonOptions) *cobra.Command {
 	options := &ControllerOptions{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -48,13 +40,13 @@ func NewCmdController(f Factory, in terminal.FileReader, out terminal.FileWriter
 		},
 	}
 
-	cmd.AddCommand(NewCmdControllerBackup(f, in, out, errOut))
-	cmd.AddCommand(NewCmdControllerBuild(f, in, out, errOut))
-	cmd.AddCommand(NewCmdControllerRole(f, in, out, errOut))
-	cmd.AddCommand(NewCmdControllerTeam(f, in, out, errOut))
-	cmd.AddCommand(NewCmdControllerWorkflow(f, in, out, errOut))
-	cmd.AddCommand(NewCmdControllerCommitStatus(f, in, out, errOut))
-	cmd.AddCommand(NewCmdSControllerBuildNumbers(f, in, out, errOut))
+	cmd.AddCommand(NewCmdControllerBackup(commonOpts))
+	cmd.AddCommand(NewCmdControllerBuild(commonOpts))
+	cmd.AddCommand(NewCmdControllerRole(commonOpts))
+	cmd.AddCommand(NewCmdControllerTeam(commonOpts))
+	cmd.AddCommand(NewCmdControllerWorkflow(commonOpts))
+	cmd.AddCommand(NewCmdControllerCommitStatus(commonOpts))
+	cmd.AddCommand(NewCmdControllerBuildNumbers(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/controller_backup.go
+++ b/pkg/jx/cmd/controller_backup.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -14,7 +13,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -33,15 +31,10 @@ type ControllerBackupOptions struct {
 
 // NewCmdControllerBackup creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdControllerBackup(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdControllerBackup(commonOpts *CommonOptions) *cobra.Command {
 	options := &ControllerBackupOptions{
 		ControllerOptions: ControllerOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -60,7 +53,6 @@ func NewCmdControllerBackup(f Factory, in terminal.FileReader, out terminal.File
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The namespace to watch or defaults to the current namespace")
 	cmd.Flags().StringVarP(&options.Organisation, "organisation", "o", "", "The organisation to backup")
 
-	options.addCommonFlags(cmd)
 
 	return cmd
 }

--- a/pkg/jx/cmd/controller_build.go
+++ b/pkg/jx/cmd/controller_build.go
@@ -59,8 +59,6 @@ func NewCmdControllerBuild(commonOpts *CommonOptions) *cobra.Command {
 		Aliases: []string{"builds"},
 	}
 
-	options.addCommonFlags(cmd)
-
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The namespace to watch or defaults to the current namespace")
 	cmd.Flags().BoolVarP(&options.InitGitCredentials, "git-credentials", "", false, "If enable then lets run the 'jx step git credentials' step to initialise git credentials")
 	return cmd

--- a/pkg/jx/cmd/controller_build.go
+++ b/pkg/jx/cmd/controller_build.go
@@ -2,10 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/gits"
-	"io"
 	"io/ioutil"
-	"k8s.io/client-go/kubernetes"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,13 +10,15 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/jenkins-x/jx/pkg/gits"
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/builds"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -41,15 +40,10 @@ type ControllerBuildOptions struct {
 
 // NewCmdControllerBuild creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdControllerBuild(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdControllerBuild(commonOpts *CommonOptions) *cobra.Command {
 	options := &ControllerBuildOptions{
 		ControllerOptions: ControllerOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -104,7 +98,7 @@ func (o *ControllerBuildOptions) Run() error {
 		// lets validate we have git configured
 		_, _, err = gits.EnsureUserAndEmailSetup(o.Git())
 		if err != nil {
-		  return err
+			return err
 		}
 
 		err := o.runCommandVerbose("git", "config", "--global", "credential.helper", "store")
@@ -368,7 +362,7 @@ func (o *CommonOptions) generateBuildLogURL(podInterface typedcorev1.PodInterfac
 
 	if initGitCredentials {
 		gc := &StepGitCredentialsOptions{}
-		gc.CommonOptions = *o
+		gc.CommonOptions = o
 		gc.BatchMode = true
 		log.Info("running: jx step git credentials\n")
 		err = gc.Run()

--- a/pkg/jx/cmd/controller_commitstatus.go
+++ b/pkg/jx/cmd/controller_commitstatus.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -37,7 +36,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // ControllerCommitStatusOptions the options for the controller
@@ -46,15 +44,10 @@ type ControllerCommitStatusOptions struct {
 }
 
 // NewCmdControllerCommitStatus creates a command object for the "create" command
-func NewCmdControllerCommitStatus(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdControllerCommitStatus(commonOpts *CommonOptions) *cobra.Command {
 	options := &ControllerCommitStatusOptions{
 		ControllerOptions: ControllerOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/controller_commitstatus.go
+++ b/pkg/jx/cmd/controller_commitstatus.go
@@ -61,7 +61,6 @@ func NewCmdControllerCommitStatus(commonOpts *CommonOptions) *cobra.Command {
 			CheckErr(err)
 		},
 	}
-	cmd.Flags().BoolVarP(&options.Verbose, "verbose", "v", false, "Enable verbose logging")
 	return cmd
 }
 

--- a/pkg/jx/cmd/controller_role.go
+++ b/pkg/jx/cmd/controller_role.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"reflect"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -64,15 +62,10 @@ var (
 `)
 )
 
-func NewCmdControllerRole(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdControllerRole(commonOpts *CommonOptions) *cobra.Command {
 	options := ControllerRoleOptions{
 		ControllerOptions: ControllerOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/controller_role_test.go
+++ b/pkg/jx/cmd/controller_role_test.go
@@ -2,10 +2,11 @@ package cmd_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
-	"testing"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -23,6 +24,9 @@ import (
 func TestEnvironmentRoleBinding(t *testing.T) {
 	t.Parallel()
 	o := &cmd.ControllerRoleOptions{
+		ControllerOptions: cmd.ControllerOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		NoWatch: true,
 	}
 	roleName := "myrole"
@@ -87,7 +91,7 @@ func TestEnvironmentRoleBinding(t *testing.T) {
 		},
 	}
 
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{
 			role,
 			roleWithLabel,

--- a/pkg/jx/cmd/controller_team.go
+++ b/pkg/jx/cmd/controller_team.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"io/ioutil"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -32,17 +30,12 @@ type ControllerTeamOptions struct {
 
 // NewCmdControllerTeam creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdControllerTeam(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdControllerTeam(commonOpts *CommonOptions) *cobra.Command {
 	options := &ControllerTeamOptions{
 		ControllerOptions: ControllerOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
-		InstallOptions: CreateInstallOptions(f, in, out, errOut),
+		InstallOptions: CreateInstallOptions(commonOpts),
 	}
 
 	cmd := &cobra.Command{
@@ -57,7 +50,6 @@ func NewCmdControllerTeam(f Factory, in terminal.FileReader, out terminal.FileWr
 		Aliases: []string{"team"},
 	}
 
-	options.ControllerOptions.addCommonFlags(cmd)
 	options.InstallOptions.addInstallFlags(cmd, true)
 
 	return cmd

--- a/pkg/jx/cmd/controller_workflow.go
+++ b/pkg/jx/cmd/controller_workflow.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"reflect"
 	"strconv"
 	"strings"
@@ -18,7 +17,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/workflow"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -50,15 +48,10 @@ type ControllerWorkflowOptions struct {
 
 // NewCmdControllerWorkflow creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdControllerWorkflow(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdControllerWorkflow(commonOpts *CommonOptions) *cobra.Command {
 	options := &ControllerWorkflowOptions{
 		ControllerOptions: ControllerOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -74,7 +67,6 @@ func NewCmdControllerWorkflow(f Factory, in terminal.FileReader, out terminal.Fi
 		Aliases: []string{"workflows"},
 	}
 
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The namespace to watch or defaults to the current namespace")
 	cmd.Flags().StringVarP(&options.LocalHelmRepoName, "helm-repo-name", "r", kube.LocalHelmRepoName, "The name of the helm repository that contains the app")

--- a/pkg/jx/cmd/controller_workflow_integration_test.go
+++ b/pkg/jx/cmd/controller_workflow_integration_test.go
@@ -3,6 +3,8 @@
 package cmd_test
 
 import (
+	"testing"
+
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/helm"
@@ -12,7 +14,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/workflow"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 )
 
 func TestSequentialWorkflow(t *testing.T) {
@@ -28,6 +29,9 @@ func TestSequentialWorkflow(t *testing.T) {
 	fakeGitProvider := gits.NewFakeProvider(fakeRepo, stagingRepo, prodRepo)
 
 	o := &cmd.ControllerWorkflowOptions{
+		ControllerOptions: cmd.ControllerOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		NoWatch:          true,
 		FakePullRequests: cmd.NewCreateEnvPullRequestFn(fakeGitProvider),
 		FakeGitProvider:  fakeGitProvider,
@@ -43,7 +47,7 @@ func TestSequentialWorkflow(t *testing.T) {
 	step1 := workflow.CreateWorkflowPromoteStep("staging")
 	step2 := workflow.CreateWorkflowPromoteStep("production", step1)
 
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{},
 		[]runtime.Object{
 			staging,
@@ -148,6 +152,9 @@ func TestWorkflowManualPromote(t *testing.T) {
 	fakeGitProvider := gits.NewFakeProvider(fakeRepo, stagingRepo, prodRepo)
 
 	o := &cmd.ControllerWorkflowOptions{
+		ControllerOptions: cmd.ControllerOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		NoWatch:          true,
 		FakePullRequests: cmd.NewCreateEnvPullRequestFn(fakeGitProvider),
 		FakeGitProvider:  fakeGitProvider,
@@ -159,7 +166,7 @@ func TestWorkflowManualPromote(t *testing.T) {
 
 	workflowName := "default"
 
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{},
 		[]runtime.Object{
 			staging,
@@ -297,6 +304,9 @@ func TestParallelWorkflow(t *testing.T) {
 	fakeGitProvider := gits.NewFakeProvider(fakeRepo, repoA, repoB, repoC)
 
 	o := &cmd.ControllerWorkflowOptions{
+		ControllerOptions: cmd.ControllerOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		NoWatch:          true,
 		FakePullRequests: cmd.NewCreateEnvPullRequestFn(fakeGitProvider),
 		FakeGitProvider:  fakeGitProvider,
@@ -312,7 +322,7 @@ func TestParallelWorkflow(t *testing.T) {
 	step2 := workflow.CreateWorkflowPromoteStep(envNameB)
 	step3 := workflow.CreateWorkflowPromoteStep(envNameC, step1, step2)
 
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{},
 		[]runtime.Object{
 			envA,
@@ -442,6 +452,9 @@ func TestNewVersionWhileExistingWorkflow(t *testing.T) {
 	fakeGitProvider := gits.NewFakeProvider(fakeRepo, stagingRepo, prodRepo)
 
 	o := &cmd.ControllerWorkflowOptions{
+		ControllerOptions: cmd.ControllerOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		NoWatch:          true,
 		FakePullRequests: cmd.NewCreateEnvPullRequestFn(fakeGitProvider),
 		FakeGitProvider:  fakeGitProvider,
@@ -457,7 +470,7 @@ func TestNewVersionWhileExistingWorkflow(t *testing.T) {
 	step1 := workflow.CreateWorkflowPromoteStep("staging")
 	step2 := workflow.CreateWorkflowPromoteStep("production", step1)
 
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{},
 		[]runtime.Object{
 			staging,

--- a/pkg/jx/cmd/create.go
+++ b/pkg/jx/cmd/create.go
@@ -1,17 +1,14 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 // CreateOptions contains the command line options
 type CreateOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	DisableImport bool
 	OutDir        string
@@ -43,59 +40,50 @@ var (
 )
 
 // NewCmdCreate creates a command object for the "create" command
-func NewCmdCreate(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	options := &CreateOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
-	}
-
+func NewCmdCreate(commonOpts *CommonOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new resource",
 		Long:  create_long,
 		Run: func(cmd *cobra.Command, args []string) {
-			options.Cmd = cmd
-			options.Args = args
-			err := options.Run()
+			commonOpts.Cmd = cmd
+			commonOpts.Args = args
+			err := commonOpts.Run()
 			CheckErr(err)
 		},
 	}
 
-	cmd.AddCommand(NewCmdCreateAddon(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateArchetype(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateBranchPattern(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateCamel(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateChat(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateCodeship(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateCluster(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateDevPod(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateDockerAuth(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateDocs(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateEnv(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateEtcHosts(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateGkeServiceAccount(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateGit(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateIssue(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateJenkins(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateJHipster(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateLile(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateMicro(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreatePostPreviewJob(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateProject(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreatePullRequest(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateQuickstart(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateQuickstartLocation(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateSpring(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateTeam(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateTerraform(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateToken(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateTracker(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateUser(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateVault(f, in, out, errOut))
+	cmd.AddCommand(NewCmdCreateAddon(commonOpts))
+	cmd.AddCommand(NewCmdCreateArchetype(commonOpts))
+	cmd.AddCommand(NewCmdCreateBranchPattern(commonOpts))
+	cmd.AddCommand(NewCmdCreateCamel(commonOpts))
+	cmd.AddCommand(NewCmdCreateChat(commonOpts))
+	cmd.AddCommand(NewCmdCreateCodeship(commonOpts))
+	cmd.AddCommand(NewCmdCreateCluster(commonOpts))
+	cmd.AddCommand(NewCmdCreateDevPod(commonOpts))
+	cmd.AddCommand(NewCmdCreateDockerAuth(commonOpts))
+	cmd.AddCommand(NewCmdCreateDocs(commonOpts))
+	cmd.AddCommand(NewCmdCreateEnv(commonOpts))
+	cmd.AddCommand(NewCmdCreateEtcHosts(commonOpts))
+	cmd.AddCommand(NewCmdCreateGkeServiceAccount(commonOpts))
+	cmd.AddCommand(NewCmdCreateGit(commonOpts))
+	cmd.AddCommand(NewCmdCreateIssue(commonOpts))
+	cmd.AddCommand(NewCmdCreateJenkins(commonOpts))
+	cmd.AddCommand(NewCmdCreateJHipster(commonOpts))
+	cmd.AddCommand(NewCmdCreateLile(commonOpts))
+	cmd.AddCommand(NewCmdCreateMicro(commonOpts))
+	cmd.AddCommand(NewCmdCreatePostPreviewJob(commonOpts))
+	cmd.AddCommand(NewCmdCreateProject(commonOpts))
+	cmd.AddCommand(NewCmdCreatePullRequest(commonOpts))
+	cmd.AddCommand(NewCmdCreateQuickstart(commonOpts))
+	cmd.AddCommand(NewCmdCreateQuickstartLocation(commonOpts))
+	cmd.AddCommand(NewCmdCreateSpring(commonOpts))
+	cmd.AddCommand(NewCmdCreateTeam(commonOpts))
+	cmd.AddCommand(NewCmdCreateTerraform(commonOpts))
+	cmd.AddCommand(NewCmdCreateToken(commonOpts))
+	cmd.AddCommand(NewCmdCreateTracker(commonOpts))
+	cmd.AddCommand(NewCmdCreateUser(commonOpts))
+	cmd.AddCommand(NewCmdCreateVault(commonOpts))
 
 	return cmd
 }

--- a/pkg/jx/cmd/create_addon.go
+++ b/pkg/jx/cmd/create_addon.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,15 +24,10 @@ type CreateAddonOptions struct {
 }
 
 // NewCmdCreateAddon creates a command object for the "create" command
-func NewCmdCreateAddon(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddon(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -43,26 +36,26 @@ func NewCmdCreateAddon(f Factory, in terminal.FileReader, out terminal.FileWrite
 		Short:   "Creates an addon",
 		Aliases: []string{"scm"},
 		Run: func(cmd *cobra.Command, args []string) {
-			options.Cmd = cmd
-			options.Args = args
-			err := options.Run()
+			commonOpts.Cmd = cmd
+			commonOpts.Args = args
+			err := commonOpts.Run()
 			CheckErr(err)
 		},
 	}
 
-	cmd.AddCommand(NewCmdCreateAddonAmbassador(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonAnchore(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonCloudBees(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonGitea(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonIstio(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonKnativeBuild(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonKubeless(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonOwasp(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonPipelineEvents(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonPrometheus(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonProw(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonSSO(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateAddonVault(f, in, out, errOut))
+	cmd.AddCommand(NewCmdCreateAddonAmbassador(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonAnchore(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonCloudBees(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonGitea(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonIstio(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonKnativeBuild(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonKubeless(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonOwasp(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonPipelineEvents(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonPrometheus(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonProw(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonSSO(commonOpts))
+	cmd.AddCommand(NewCmdCreateAddonVault(commonOpts))
 
 	options.addFlags(cmd, kube.DefaultNamespace, "", "")
 	return cmd

--- a/pkg/jx/cmd/create_addon_ambassador.go
+++ b/pkg/jx/cmd/create_addon_ambassador.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
@@ -42,16 +40,11 @@ type CreateAddonAmbassadorOptions struct {
 }
 
 // NewCmdCreateAddonAmbassador creates a command object for the "create" command
-func NewCmdCreateAddonAmbassador(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonAmbassador(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonAmbassadorOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -70,7 +63,6 @@ func NewCmdCreateAddonAmbassador(f Factory, in terminal.FileReader, out terminal
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, "", defaultAmbassadorReleaseName, defaultAmbassadorVersion)
 
 	cmd.Flags().StringVarP(&options.Chart, optionChart, "c", kube.ChartAmbassador, "The name of the chart to use")

--- a/pkg/jx/cmd/create_addon_anchore.go
+++ b/pkg/jx/cmd/create_addon_anchore.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/kube/services"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"fmt"
@@ -55,16 +53,11 @@ type CreateAddonAnchoreOptions struct {
 }
 
 // NewCmdCreateAddonAnchore creates a command object for the "create" command
-func NewCmdCreateAddonAnchore(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonAnchore(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonAnchoreOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -83,7 +76,6 @@ func NewCmdCreateAddonAnchore(f Factory, in terminal.FileReader, out terminal.Fi
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, defaultAnchoreNamespace, defaultAnchoreReleaseName, defaultAnchoreVersion)
 
 	cmd.Flags().StringVarP(&options.Password, "password", "p", defaultAnchorePassword, "The default password to use for Anchore")

--- a/pkg/jx/cmd/create_addon_cloudbees.go
+++ b/pkg/jx/cmd/create_addon_cloudbees.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/util"
@@ -13,7 +12,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -50,16 +48,11 @@ type CreateAddonCloudBeesOptions struct {
 }
 
 // NewCmdCreateAddonCloudBees creates a command object for the "create" command
-func NewCmdCreateAddonCloudBees(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonCloudBees(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonCloudBeesOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -81,7 +74,6 @@ func NewCmdCreateAddonCloudBees(f Factory, in terminal.FileReader, out terminal.
 	cmd.Flags().BoolVarP(&options.Sso, "sso", "", false, "Enable single sign-on")
 	cmd.Flags().BoolVarP(&options.Basic, "basic", "", false, "Enable basic auth")
 	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "Password to access UI when using basic auth.  Defaults to default Jenkins X admin password.")
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, defaultCloudBeesNamespace, defaultCloudBeesReleaseName, defaultCloudBeesVersion)
 	return cmd
 }

--- a/pkg/jx/cmd/create_addon_gitea.go
+++ b/pkg/jx/cmd/create_addon_gitea.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -12,7 +11,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -48,16 +46,11 @@ type CreateAddonGiteaOptions struct {
 }
 
 // NewCmdCreateAddonGitea creates a command object for the "create" command
-func NewCmdCreateAddonGitea(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonGitea(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonGiteaOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -76,7 +69,6 @@ func NewCmdCreateAddonGitea(f Factory, in terminal.FileReader, out terminal.File
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, "", defaultGiteaReleaseName, defaultGiteaVersion)
 
 	cmd.Flags().StringVarP(&options.Username, "username", "u", "", "The name for the user to create in Gitea. Note that Gitea tends to reject 'admin'")

--- a/pkg/jx/cmd/create_addon_istio.go
+++ b/pkg/jx/cmd/create_addon_istio.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -16,7 +15,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -53,16 +51,11 @@ type CreateAddonIstioOptions struct {
 }
 
 // NewCmdCreateAddonIstio creates a command object for the "create" command
-func NewCmdCreateAddonIstio(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonIstio(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonIstioOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -81,7 +74,6 @@ func NewCmdCreateAddonIstio(f Factory, in terminal.FileReader, out terminal.File
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, defaultIstioNamespace, defaultIstioReleaseName, defaultIstioVersion)
 
 	cmd.Flags().StringVarP(&options.Password, "password", "p", defaultIstioPassword, "The default password to use for Istio")

--- a/pkg/jx/cmd/create_addon_knative_build.go
+++ b/pkg/jx/cmd/create_addon_knative_build.go
@@ -2,15 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/kube"
-	"io"
 	"strings"
+
+	"github.com/jenkins-x/jx/pkg/kube"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -30,16 +29,11 @@ type CreateAddonKnativeBuildOptions struct {
 	token    string
 }
 
-func NewCmdCreateAddonKnativeBuild(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonKnativeBuild(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonKnativeBuildOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/create_addon_kubeless.go
+++ b/pkg/jx/cmd/create_addon_kubeless.go
@@ -1,16 +1,13 @@
 package cmd
 
 import (
-	"io"
 	"strings"
-
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -41,16 +38,11 @@ type CreateAddonKubelessOptions struct {
 }
 
 // NewCmdCreateAddonKubeless creates a command object for the "create" command
-func NewCmdCreateAddonKubeless(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonKubeless(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonKubelessOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -69,7 +61,6 @@ func NewCmdCreateAddonKubeless(f Factory, in terminal.FileReader, out terminal.F
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, defaultKubelessNamespace, defaultKubelessReleaseName, defaultKubelessVersion)
 
 	cmd.Flags().StringVarP(&options.Chart, optionChart, "c", kube.ChartKubeless, "The name of the chart to use")

--- a/pkg/jx/cmd/create_addon_owasp.go
+++ b/pkg/jx/cmd/create_addon_owasp.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,16 +30,11 @@ type CreateAddonOwaspOptions struct {
 	Image        string
 }
 
-func NewCmdCreateAddonOwasp(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonOwasp(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonOwaspOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/create_addon_pipeline_events.go
+++ b/pkg/jx/cmd/create_addon_pipeline_events.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 	"time"
 
@@ -9,7 +8,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"fmt"
@@ -51,17 +49,11 @@ type CreateAddonPipelineEventsOptions struct {
 }
 
 // NewCmdCreateAddonPipelineEvents creates a command object for the "create" command
-func NewCmdCreateAddonPipelineEvents(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonPipelineEvents(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonPipelineEventsOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-
-					Out: out,
-					Err: errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -80,7 +72,6 @@ func NewCmdCreateAddonPipelineEvents(f Factory, in terminal.FileReader, out term
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, defaultPENamespace, defaultPEReleaseName, defaultPEVersion)
 
 	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "Password to access pipeline-events services such as Kibana and Elasticsearch.  Defaults to default Jenkins X admin password.")

--- a/pkg/jx/cmd/create_addon_prometheus.go
+++ b/pkg/jx/cmd/create_addon_prometheus.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -13,7 +12,6 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,16 +29,10 @@ type CreateAddonPrometheusOptions struct {
 	Password    string
 }
 
-func NewCmdCreateAddonPrometheus(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonPrometheus(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonPrometheusOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/create_addon_prow.go
+++ b/pkg/jx/cmd/create_addon_prow.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"fmt"
 
@@ -38,17 +35,11 @@ type CreateAddonProwOptions struct {
 }
 
 // NewCmdCreateAddonProw creates a command object for the "create" command
-func NewCmdCreateAddonProw(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateAddonProw(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonProwOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-
-					Out: out,
-					Err: errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -66,7 +57,6 @@ func NewCmdCreateAddonProw(f Factory, in terminal.FileReader, out terminal.FileW
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, "", kube.DefaultProwReleaseName, defaultProwVersion)
 
 	cmd.Flags().StringVarP(&options.Prow.Chart, optionChart, "c", kube.ChartProw, "The name of the chart to use")

--- a/pkg/jx/cmd/create_addon_sso.go
+++ b/pkg/jx/cmd/create_addon_sso.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	survey "gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -51,22 +49,16 @@ type CreateAddonSSOOptions struct {
 }
 
 // NewCmdCreateAddonSSO creates a command object for the "create addon sso" command
-func NewCmdCreateAddonSSO(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-		Out:     out,
-		Err:     errOut,
-	}
+func NewCmdCreateAddonSSO(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonSSOOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: commonOptions,
+				CommonOptions: commonOpts,
 			},
 		},
 		UpgradeIngressOptions: UpgradeIngressOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: commonOptions,
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -84,7 +76,6 @@ func NewCmdCreateAddonSSO(f Factory, in terminal.FileReader, out terminal.FileWr
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	cmd.Flags().StringVarP(&options.DexVersion, "dex-version", "", defaultDexVersion, "The dex chart version to install)")
 	options.addFlags(cmd, defaultSSONamesapce, defaultSSOReleaseNamePrefix, defaultOperatorVersion)
 	options.UpgradeIngressOptions.addFlags(cmd)

--- a/pkg/jx/cmd/create_addon_vault.go
+++ b/pkg/jx/cmd/create_addon_vault.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -42,17 +40,11 @@ type CreateAddonVaultOptions struct {
 }
 
 // NewCmdCreateAddonVault creates a command object for the "create addon vault-opeator" command
-func NewCmdCreateAddonVault(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-		Out:     out,
-		Err:     errOut,
-	}
+func NewCmdCreateAddonVault(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateAddonVaultOptions{
 		CreateAddonOptions: CreateAddonOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: commonOptions,
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -70,14 +62,13 @@ func NewCmdCreateAddonVault(f Factory, in terminal.FileReader, out terminal.File
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, defaultVaultNamesapce, kube.DefaultVaultOperatorReleaseName, defaultVaultOperatorVersion)
 	return cmd
 }
 
 // Run implements the command
 func (o *CreateAddonVaultOptions) Run() error {
-	return InstallVaultOperator(&o.CommonOptions, o.Namespace)
+	return InstallVaultOperator(o.CommonOptions, o.Namespace)
 }
 
 // InstallVaultOperator installs a vault operator in the namespace provided

--- a/pkg/jx/cmd/create_archetype.go
+++ b/pkg/jx/cmd/create_archetype.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"os"
 	"path/filepath"
@@ -47,17 +45,11 @@ type CreateArchetypeOptions struct {
 }
 
 // NewCmdCreateArchetype creates a command object for the "create" command
-func NewCmdCreateArchetype(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateArchetype(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateArchetypeOptions{
 		CreateProjectOptions: CreateProjectOptions{
 			ImportOptions: ImportOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-
-					Out: out,
-					Err: errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/create_branch_pattern.go
+++ b/pkg/jx/cmd/create_branch_pattern.go
@@ -2,12 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -37,16 +35,10 @@ type CreateBranchPatternOptions struct {
 }
 
 // NewCmdCreateBranchPattern creates a command object for the "create" command
-func NewCmdCreateBranchPattern(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateBranchPattern(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateBranchPatternOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -64,7 +56,6 @@ func NewCmdCreateBranchPattern(f Factory, in terminal.FileReader, out terminal.F
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_camel.go
+++ b/pkg/jx/cmd/create_camel.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
@@ -32,18 +29,12 @@ type CreateCamelOptions struct {
 }
 
 // NewCmdCreateCamel creates a command object for the "create" command
-func NewCmdCreateCamel(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateCamel(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateCamelOptions{
 		CreateArchetypeOptions{
 			CreateProjectOptions: CreateProjectOptions{
 				ImportOptions: ImportOptions{
-					CommonOptions: CommonOptions{
-						Factory: f,
-						In:      in,
-
-						Out: out,
-						Err: errOut,
-					},
+					CommonOptions: commonOpts,
 				},
 			},
 		},

--- a/pkg/jx/cmd/create_chat.go
+++ b/pkg/jx/cmd/create_chat.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateChatOptions the options for the create spring command
@@ -13,15 +10,10 @@ type CreateChatOptions struct {
 }
 
 // NewCmdCreateChat creates a command object for the "create" command
-func NewCmdCreateChat(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateChat(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateChatOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -37,8 +29,8 @@ func NewCmdCreateChat(f Factory, in terminal.FileReader, out terminal.FileWriter
 		},
 	}
 
-	cmd.AddCommand(NewCmdCreateChatServer(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateChatToken(f, in, out, errOut))
+	cmd.AddCommand(NewCmdCreateChatServer(commonOpts))
+	cmd.AddCommand(NewCmdCreateChatToken(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_chat_server.go
+++ b/pkg/jx/cmd/create_chat_server.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -30,15 +28,10 @@ type CreateChatServerOptions struct {
 }
 
 // NewCmdCreateChatServer creates a command object for the "create" command
-func NewCmdCreateChatServer(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateChatServer(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateChatServerOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/create_chat_token.go
+++ b/pkg/jx/cmd/create_chat_token.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/chats"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,16 +40,10 @@ type CreateChatTokenOptions struct {
 }
 
 // NewCmdCreateChatToken creates a command
-func NewCmdCreateChatToken(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateChatToken(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateChatTokenOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -68,7 +60,6 @@ func NewCmdCreateChatToken(f Factory, in terminal.FileReader, out terminal.FileW
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	options.ServerFlags.addGitServerFlags(cmd)
 	cmd.Flags().StringVarP(&options.ApiToken, "api-token", "t", "", "The API Token for the user")
 	cmd.Flags().StringVarP(&options.Timeout, "timeout", "", "", "The timeout if using browser automation to generate the API token (by passing username and password)")

--- a/pkg/jx/cmd/create_cluster.go
+++ b/pkg/jx/cmd/create_cluster.go
@@ -2,12 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/log"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
@@ -112,8 +110,8 @@ func KubernetesProviderOptions() string {
 
 // NewCmdCreateCluster creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
-func NewCmdCreateCluster(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	options := createCreateClusterOptions(f, in, out, errOut, "")
+func NewCmdCreateCluster(commonOpts *CommonOptions) *cobra.Command {
+	options := createCreateClusterOptions(commonOpts, "")
 
 	cmd := &cobra.Command{
 		Use:     "cluster [kubernetes provider]",
@@ -128,14 +126,14 @@ func NewCmdCreateCluster(f Factory, in terminal.FileReader, out terminal.FileWri
 		},
 	}
 
-	cmd.AddCommand(NewCmdCreateClusterAKS(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateClusterAWS(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateClusterEKS(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateClusterGKE(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateClusterMinikube(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateClusterMinishift(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateClusterOKE(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateClusterIKS(f, in, out, errOut))
+	cmd.AddCommand(NewCmdCreateClusterAKS(commonOpts))
+	cmd.AddCommand(NewCmdCreateClusterAWS(commonOpts))
+	cmd.AddCommand(NewCmdCreateClusterEKS(commonOpts))
+	cmd.AddCommand(NewCmdCreateClusterGKE(commonOpts))
+	cmd.AddCommand(NewCmdCreateClusterMinikube(commonOpts))
+	cmd.AddCommand(NewCmdCreateClusterMinishift(commonOpts))
+	cmd.AddCommand(NewCmdCreateClusterOKE(commonOpts))
+	cmd.AddCommand(NewCmdCreateClusterIKS(commonOpts))
 
 	return cmd
 }
@@ -145,20 +143,13 @@ func (o *CreateClusterOptions) addCreateClusterFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&o.SkipInstallation, "skip-installation", "", false, "Provision cluster only, don't install Jenkins X into it")
 }
 
-func createCreateClusterOptions(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer, cloudProvider string) CreateClusterOptions {
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-
-		Out: out,
-		Err: errOut,
-	}
+func createCreateClusterOptions(commonOpts *CommonOptions, cloudProvider string) CreateClusterOptions {
 	options := CreateClusterOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: commonOptions,
+			CommonOptions: commonOpts,
 		},
 		Provider:       cloudProvider,
-		InstallOptions: CreateInstallOptions(f, in, out, errOut),
+		InstallOptions: CreateInstallOptions(commonOpts),
 	}
 	return options
 }

--- a/pkg/jx/cmd/create_cluster_aks.go
+++ b/pkg/jx/cmd/create_cluster_aks.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"os"
 	"strings"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateClusterOptions the flags for running create cluster
@@ -80,9 +78,9 @@ var (
 
 // NewCmdGet creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
-func NewCmdCreateClusterAKS(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateClusterAKS(commonOpts *CommonOptions) *cobra.Command {
 	options := CreateClusterAKSOptions{
-		CreateClusterOptions: createCreateClusterOptions(f, in, out, errOut, AKS),
+		CreateClusterOptions: createCreateClusterOptions(commonOpts, AKS),
 	}
 	cmd := &cobra.Command{
 		Use:     "aks",

--- a/pkg/jx/cmd/create_cluster_aws.go
+++ b/pkg/jx/cmd/create_cluster_aws.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -16,7 +15,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
@@ -72,9 +70,9 @@ var (
 )
 
 // NewCmdCreateClusterAWS creates the command
-func NewCmdCreateClusterAWS(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateClusterAWS(commonOpts *CommonOptions) *cobra.Command {
 	options := CreateClusterAWSOptions{
-		CreateClusterOptions: createCreateClusterOptions(f, in, out, errOut, AKS),
+		CreateClusterOptions: createCreateClusterOptions(commonOpts, AKS),
 	}
 	cmd := &cobra.Command{
 		Use:     "aws",
@@ -90,7 +88,6 @@ func NewCmdCreateClusterAWS(f Factory, in terminal.FileReader, out terminal.File
 	}
 
 	options.addCreateClusterFlags(cmd)
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Flags.Profile, "profile", "", "", "AWS profile to use.")
 	cmd.Flags().StringVarP(&options.Flags.Region, "region", "", "", "AWS region to use. Default: "+amazon.DefaultRegion)

--- a/pkg/jx/cmd/create_cluster_eks.go
+++ b/pkg/jx/cmd/create_cluster_eks.go
@@ -1,19 +1,18 @@
 package cmd
 
 import (
-	"github.com/jenkins-x/jx/pkg/cloud/amazon"
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/jenkins-x/jx/pkg/util"
-	"io"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/jenkins-x/jx/pkg/cloud/amazon"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateClusterEKSOptions contains the CLI flags
@@ -57,9 +56,9 @@ var (
 )
 
 // NewCmdCreateClusterEKS creates the command
-func NewCmdCreateClusterEKS(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateClusterEKS(commonOpts *CommonOptions) *cobra.Command {
 	options := CreateClusterEKSOptions{
-		CreateClusterOptions: createCreateClusterOptions(f, in, out, errOut, AKS),
+		CreateClusterOptions: createCreateClusterOptions(commonOpts, AKS),
 	}
 	cmd := &cobra.Command{
 		Use:     "eks",
@@ -75,7 +74,6 @@ func NewCmdCreateClusterEKS(f Factory, in terminal.FileReader, out terminal.File
 	}
 
 	options.addCreateClusterFlags(cmd)
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Flags.ClusterName, optionClusterName, "n", "", "The name of this cluster.")
 	cmd.Flags().StringVarP(&options.Flags.NodeType, "node-type", "", "m5.large", "node instance type")

--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
+
 	"strings"
 
-	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"github.com/pkg/errors"
+
+	"github.com/jenkins-x/jx/pkg/io/secrets"
 
 	osUser "os/user"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateClusterOptions the flags for running create cluster
@@ -47,7 +47,7 @@ type CreateClusterGKEFlags struct {
 	Namespace       string
 	Labels          string
 	Scopes          []string
-	Preemptible 	bool
+	Preemptible     bool
 }
 
 const clusterListHeader = "PROJECT_ID"
@@ -78,9 +78,9 @@ var (
 
 // NewCmdCreateClusterGKE creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
-func NewCmdCreateClusterGKE(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateClusterGKE(commonOpts *CommonOptions) *cobra.Command {
 	options := CreateClusterGKEOptions{
-		CreateClusterOptions: createCreateClusterOptions(f, in, out, errOut, GKE),
+		CreateClusterOptions: createCreateClusterOptions(commonOpts, GKE),
 	}
 	cmd := &cobra.Command{
 		Use:     "gke",
@@ -96,7 +96,6 @@ func NewCmdCreateClusterGKE(f Factory, in terminal.FileReader, out terminal.File
 	}
 
 	options.addCreateClusterFlags(cmd)
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Flags.ClusterName, optionClusterName, "n", "", "The name of this cluster, default is a random generated name")
 	cmd.Flags().StringVarP(&options.Flags.ClusterIpv4Cidr, "cluster-ipv4-cidr", "", "", "The IP address range for the pods in this cluster in CIDR notation (e.g. 10.0.0.0/14)")
@@ -115,7 +114,7 @@ func NewCmdCreateClusterGKE(f Factory, in terminal.FileReader, out terminal.File
 	cmd.Flags().StringArrayVarP(&options.Flags.Scopes, "scope", "", []string{}, "The OAuth scopes to be added to the cluster")
 	cmd.Flags().BoolVarP(&options.Flags.Preemptible, "preemptible", "", false, "Use preemptible VMs in the node-pool")
 
-	cmd.AddCommand(NewCmdCreateClusterGKETerraform(f, in, out, errOut))
+	cmd.AddCommand(NewCmdCreateClusterGKETerraform(commonOpts))
 
 	return cmd
 }
@@ -325,7 +324,7 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 	// TODO - Reenable vault for GitOpsMode
 	//o.CreateClusterOptions.InstallOptions.GitOpsMode || o.CreateClusterOptions.InstallOptions.Vault {
 	if o.CreateClusterOptions.InstallOptions.Vault {
-		if err = InstallVaultOperator(&o.CommonOptions, ""); err != nil {
+		if err = InstallVaultOperator(o.CommonOptions, ""); err != nil {
 			return err
 		}
 		err = secrets.NewSecretLocation(kubeClient, ns).SetInVault(true)

--- a/pkg/jx/cmd/create_cluster_gke_terraform.go
+++ b/pkg/jx/cmd/create_cluster_gke_terraform.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"fmt"
@@ -23,7 +22,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"gopkg.in/src-d/go-git.v4"
 )
 
@@ -74,9 +72,9 @@ var (
 
 // NewCmdCreateClusterGKETerraform creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
-func NewCmdCreateClusterGKETerraform(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateClusterGKETerraform(commonOpts *CommonOptions) *cobra.Command {
 	options := CreateClusterGKETerraformOptions{
-		CreateClusterOptions: createCreateClusterOptions(f, in, out, errOut, GKE),
+		CreateClusterOptions: createCreateClusterOptions(commonOpts, GKE),
 	}
 	cmd := &cobra.Command{
 		Use:     "terraform",
@@ -93,7 +91,6 @@ func NewCmdCreateClusterGKETerraform(f Factory, in terminal.FileReader, out term
 
 	options.addAuthFlags(cmd)
 	options.addCreateClusterFlags(cmd)
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Flags.ClusterName, optionClusterName, "n", "", "The name of this cluster, default is a random generated name")
 	//cmd.Flags().StringVarP(&options.Flags.ClusterIpv4Cidr, "cluster-ipv4-cidr", "", "", "The IP address range for the pods in this cluster in CIDR notation (e.g. 10.0.0.0/14)")

--- a/pkg/jx/cmd/create_cluster_iks.go
+++ b/pkg/jx/cmd/create_cluster_iks.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"math"
 	"os"
 	"regexp"
@@ -20,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	survey "gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateClusterOptions the flags for running create cluster
@@ -99,9 +97,9 @@ func (s byNumberIndex) Less(i, j int) bool {
 
 // NewCmdGet creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a kubernetes cluster.
-func NewCmdCreateClusterIKS(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateClusterIKS(commonOpts *CommonOptions) *cobra.Command {
 	options := CreateClusterIKSOptions{
-		CreateClusterOptions: createCreateClusterOptions(f, in, out, errOut, OKE),
+		CreateClusterOptions: createCreateClusterOptions(commonOpts, OKE),
 	}
 	cmd := &cobra.Command{
 		Use:     "iks",

--- a/pkg/jx/cmd/create_cluster_minikube.go
+++ b/pkg/jx/cmd/create_cluster_minikube.go
@@ -57,9 +57,9 @@ var (
 
 // NewCmdGet creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
-func NewCmdCreateClusterMinikube(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateClusterMinikube(commonOpts *CommonOptions) *cobra.Command {
 	options := CreateClusterMinikubeOptions{
-		CreateClusterOptions: createCreateClusterOptions(f, in, out, errOut, MINIKUBE),
+		CreateClusterOptions: createCreateClusterOptions(commonOpts, MINIKUBE),
 	}
 	cmd := &cobra.Command{
 		Use:     "minikube",
@@ -75,7 +75,6 @@ func NewCmdCreateClusterMinikube(f Factory, in terminal.FileReader, out terminal
 	}
 
 	options.addCreateClusterFlags(cmd)
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Flags.Memory, "memory", "m", "", fmt.Sprintf("Amount of RAM allocated to the Minikube VM in MB. Defaults to %s MB.", MinikubeDefaultMemory))
 	cmd.Flags().StringVarP(&options.Flags.CPU, "cpu", "c", "", fmt.Sprintf("Number of CPUs allocated to the Minikube VM. Defaults to %s.", MinikubeDefaultCpu))

--- a/pkg/jx/cmd/create_cluster_minishift.go
+++ b/pkg/jx/cmd/create_cluster_minishift.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -13,7 +12,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateClusterMinishiftOptions the flags for running create cluster
@@ -51,9 +49,9 @@ var (
 
 // NewCmdGet creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
-func NewCmdCreateClusterMinishift(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateClusterMinishift(commonOpts *CommonOptions) *cobra.Command {
 	options := CreateClusterMinishiftOptions{
-		CreateClusterOptions: createCreateClusterOptions(f, in, out, errOut, MINISHIFT),
+		CreateClusterOptions: createCreateClusterOptions(commonOpts, MINISHIFT),
 	}
 	cmd := &cobra.Command{
 		Use:     "minishift",
@@ -69,7 +67,6 @@ func NewCmdCreateClusterMinishift(f Factory, in terminal.FileReader, out termina
 	}
 
 	options.addCreateClusterFlags(cmd)
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Flags.Memory, "memory", "m", "4096", "Amount of RAM allocated to the Minishift VM in MB")
 	cmd.Flags().StringVarP(&options.Flags.CPU, "cpu", "c", "3", "Number of CPUs allocated to the Minishift VM")

--- a/pkg/jx/cmd/create_cluster_oke.go
+++ b/pkg/jx/cmd/create_cluster_oke.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -18,7 +17,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateClusterOptions the flags for running create cluster
@@ -77,9 +75,9 @@ var (
 
 // NewCmdGet creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
-func NewCmdCreateClusterOKE(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateClusterOKE(commonOpts *CommonOptions) *cobra.Command {
 	options := CreateClusterOKEOptions{
-		CreateClusterOptions: createCreateClusterOptions(f, in, out, errOut, OKE),
+		CreateClusterOptions: createCreateClusterOptions(commonOpts, OKE),
 	}
 	cmd := &cobra.Command{
 		Use:     "oke",
@@ -95,7 +93,6 @@ func NewCmdCreateClusterOKE(f Factory, in terminal.FileReader, out terminal.File
 	}
 
 	options.addCreateClusterFlags(cmd)
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Flags.ClusterName, "name", "", "", "The name of the cluster. Avoid entering confidential information.")
 	cmd.Flags().StringVarP(&options.Flags.CompartmentId, "compartmentId", "", "", "The OCID of the compartment in which to create the cluster.")

--- a/pkg/jx/cmd/create_codeship.go
+++ b/pkg/jx/cmd/create_codeship.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"context"
 	"errors"
@@ -10,6 +9,8 @@ import (
 	"os"
 	"path"
 	"strings"
+
+	"strconv"
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/codeship/codeship-go"
@@ -21,8 +22,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/version"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"strconv"
 )
 
 type CreateCodeshipFlags struct {
@@ -57,35 +56,20 @@ var (
 )
 
 // NewCmdCreateCodeship creates a command object for the "create" command
-func NewCmdCreateCodeship(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateCodeship(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateCodeshipOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 		CreateTerraformOptions: CreateTerraformOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
-			InstallOptions: CreateInstallOptions(f, in, out, errOut),
+			InstallOptions: CreateInstallOptions(commonOpts),
 		},
 		CreateGkeServiceAccountOptions: CreateGkeServiceAccountOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -102,7 +86,6 @@ func NewCmdCreateCodeship(f Factory, in terminal.FileReader, out terminal.FileWr
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd)
 	options.CreateTerraformOptions.InstallOptions.addInstallFlags(cmd, true)
 

--- a/pkg/jx/cmd/create_devpod.go
+++ b/pkg/jx/cmd/create_devpod.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,18 +10,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jenkins-x/jx/pkg/kube/serviceaccount"
+	"github.com/jenkins-x/jx/pkg/kube/services"
+
 	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
-	"github.com/jenkins-x/jx/pkg/kube/serviceaccount"
-	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,24 +87,14 @@ type CreateDevPodOptions struct {
 }
 
 // NewCmdCreateDevPod creates a command object for the "create" command
-func NewCmdCreateDevPod(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateDevPod(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateDevPodOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 		GitCredentials: StepGitCredentialsOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -141,7 +130,6 @@ func NewCmdCreateDevPod(f Factory, in terminal.FileReader, out terminal.FileWrit
 	cmd.Flags().StringVarP(&options.TillerNamespace, "tiller-namespace", "", "", "The optional tiller namespace to use within the DevPod.")
 	cmd.Flags().StringVarP(&options.ServiceAccount, "service-account", "", "", "The ServiceAccount name used for the DevPod")
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_docker_auth.go
+++ b/pkg/jx/cmd/create_docker_auth.go
@@ -3,13 +3,11 @@ package cmd
 import (
 	b64 "encoding/base64"
 	"encoding/json"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -49,16 +47,10 @@ type CreateDockerAuthOptions struct {
 }
 
 // NewCmdCreateIssue creates a command object for the "create" command
-func NewCmdCreateDockerAuth(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateDockerAuth(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateDockerAuthOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -79,7 +71,6 @@ func NewCmdCreateDockerAuth(f Factory, in terminal.FileReader, out terminal.File
 	cmd.Flags().StringVarP(&options.User, username, "u", "", "The user to associate auth component of config.json")
 	cmd.Flags().StringVarP(&options.Secret, "secret", "s", "", "The secret to associate auth component of config.json")
 	cmd.Flags().StringVarP(&options.Email, "email", "e", "", "The email to associate auth component of config.json")
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_docs.go
+++ b/pkg/jx/cmd/create_docs.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -13,7 +12,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -45,15 +43,10 @@ type CreateDocsOptions struct {
 }
 
 // NewCmdCreateDocs creates a command object for the "create" command
-func NewCmdCreateDocs(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateDocs(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateDocsOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/create_env.go
+++ b/pkg/jx/cmd/create_env.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/jenkins-x/jx/pkg/kube/serviceaccount"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
-
-	"fmt"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/config"
@@ -61,18 +59,13 @@ type CreateEnvOptions struct {
 }
 
 // NewCmdCreateEnv creates a command object for the "create" command
-func NewCmdCreateEnv(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateEnv(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateEnvOptions{
 		HelmValuesConfig: config.HelmValuesConfig{
 			ExposeController: &config.ExposeController{},
 		},
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -114,7 +107,6 @@ func NewCmdCreateEnv(f Factory, in terminal.FileReader, out terminal.FileWriter,
 	addGitRepoOptionsArguments(cmd, &options.GitRepositoryOptions)
 	options.HelmValuesConfig.AddExposeControllerValues(cmd, false)
 
-	options.addCommonFlags(cmd)
 
 	return cmd
 }
@@ -238,7 +230,6 @@ func (o *CreateEnvOptions) Run() error {
 				log.Warnf("Namespace %s does not exist for jx to patch the service account for, you should patch the service account manually with your pull secret(s) \n", env.Spec.Namespace)
 			}
 		}
-		// It's a common option, see addCommonFlags in common.go
 		imagePullSecrets := o.GetImagePullSecrets()
 		saName := "default"
 		//log.Infof("Patching the secrets %s for the service account %s\n", imagePullSecrets, saName)

--- a/pkg/jx/cmd/create_env_test.go
+++ b/pkg/jx/cmd/create_env_test.go
@@ -136,7 +136,7 @@ func TestCreateEnvRun(t *testing.T) {
 	options := cmd.CreateEnvOptions{
 		HelmValuesConfig: helmValuesConfig,
 		CreateOptions: cmd.CreateOptions{
-			CommonOptions: cmd.CommonOptions{
+			CommonOptions: &cmd.CommonOptions{
 				Factory: factory,
 				In:      console.In,
 				Out:     console.Out,

--- a/pkg/jx/cmd/create_etc_hosts.go
+++ b/pkg/jx/cmd/create_etc_hosts.go
@@ -2,17 +2,16 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/kube/services"
-	"io"
 	"io/ioutil"
 	"net/url"
 	"strings"
+
+	"github.com/jenkins-x/jx/pkg/kube/services"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -39,15 +38,10 @@ type CreateEtcHostsOptions struct {
 }
 
 // NewCmdCreateEtcHosts creates a command object for the "create" command
-func NewCmdCreateEtcHosts(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateEtcHosts(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateEtcHostsOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/create_git.go
+++ b/pkg/jx/cmd/create_git.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateGitOptions the options for the create spring command
@@ -13,15 +10,10 @@ type CreateGitOptions struct {
 }
 
 // NewCmdCreateGit creates a command object for the "create" command
-func NewCmdCreateGit(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateGit(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateGitOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -37,9 +29,9 @@ func NewCmdCreateGit(f Factory, in terminal.FileReader, out terminal.FileWriter,
 		},
 	}
 
-	cmd.AddCommand(NewCmdCreateGitServer(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateGitToken(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateGitUser(f, in, out, errOut))
+	cmd.AddCommand(NewCmdCreateGitServer(commonOpts))
+	cmd.AddCommand(NewCmdCreateGitToken(commonOpts))
+	cmd.AddCommand(NewCmdCreateGitUser(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_git_api_token.go
+++ b/pkg/jx/cmd/create_git_api_token.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/chromedp/cdproto/cdp"
@@ -15,7 +14,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/nodes"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
@@ -52,15 +50,10 @@ type CreateGitTokenOptions struct {
 }
 
 // NewCmdCreateGitToken creates a command
-func NewCmdCreateGitToken(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateGitToken(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateGitTokenOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -77,7 +70,6 @@ func NewCmdCreateGitToken(f Factory, in terminal.FileReader, out terminal.FileWr
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	options.ServerFlags.addGitServerFlags(cmd)
 	cmd.Flags().StringVarP(&options.ApiToken, "api-token", "t", "", "The API Token for the user")
 	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "The User password to try automatically create a new API Token")

--- a/pkg/jx/cmd/create_git_server.go
+++ b/pkg/jx/cmd/create_git_server.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -42,16 +40,10 @@ type CreateGitServerOptions struct {
 }
 
 // NewCmdCreateGitServer creates a command object for the "create" command
-func NewCmdCreateGitServer(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateGitServer(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateGitServerOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/create_git_user.go
+++ b/pkg/jx/cmd/create_git_user.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -38,15 +36,10 @@ type CreateGitUserOptions struct {
 }
 
 // NewCmdCreateGitUser creates a command
-func NewCmdCreateGitUser(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateGitUser(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateGitUserOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -62,7 +55,6 @@ func NewCmdCreateGitUser(f Factory, in terminal.FileReader, out terminal.FileWri
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	options.ServerFlags.addGitServerFlags(cmd)
 	cmd.Flags().StringVarP(&options.ApiToken, "api-token", "t", "", "The API Token for the user")
 	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "The User password to try automatically create a new API Token")

--- a/pkg/jx/cmd/create_gke_service_account.go
+++ b/pkg/jx/cmd/create_gke_service_account.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type CreateGkeServiceAccountFlags struct {
@@ -36,15 +34,10 @@ var (
 )
 
 // NewCmdCreateGkeServiceAccount creates a command object for the "create" command
-func NewCmdCreateGkeServiceAccount(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateGkeServiceAccount(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateGkeServiceAccountOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -60,7 +53,6 @@ func NewCmdCreateGkeServiceAccount(f Factory, in terminal.FileReader, out termin
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, true)
 
 	return cmd

--- a/pkg/jx/cmd/create_issue.go
+++ b/pkg/jx/cmd/create_issue.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"io"
+	"fmt"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
-	"fmt"
 
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -50,16 +47,10 @@ type CreateIssueOptions struct {
 }
 
 // NewCmdCreateIssue creates a command object for the "create" command
-func NewCmdCreateIssue(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateIssue(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateIssueOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -82,7 +73,6 @@ func NewCmdCreateIssue(f Factory, in terminal.FileReader, out terminal.FileWrite
 	cmd.Flags().StringVarP(&options.Body, "body", "", "", "The body of the issue")
 	cmd.Flags().StringArrayVarP(&options.Labels, "label", "l", []string{}, "The labels to add to the issue")
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_jenkins.go
+++ b/pkg/jx/cmd/create_jenkins.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateJenkinsOptions the options for the create spring command
@@ -13,15 +10,10 @@ type CreateJenkinsOptions struct {
 }
 
 // NewCmdCreateJenkins creates a command object for the "create" command
-func NewCmdCreateJenkins(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateJenkins(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateJenkinsOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -36,7 +28,7 @@ func NewCmdCreateJenkins(f Factory, in terminal.FileReader, out terminal.FileWri
 		},
 	}
 
-	cmd.AddCommand(NewCmdCreateJenkinsUser(f, in, out, errOut))
+	cmd.AddCommand(NewCmdCreateJenkinsUser(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_jenkins_token.go
+++ b/pkg/jx/cmd/create_jenkins_token.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -25,7 +24,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -67,15 +65,10 @@ type CreateJenkinsUserOptions struct {
 }
 
 // NewCmdCreateJenkinsUser creates a command
-func NewCmdCreateJenkinsUser(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateJenkinsUser(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateJenkinsUserOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -92,7 +85,6 @@ func NewCmdCreateJenkinsUser(f Factory, in terminal.FileReader, out terminal.Fil
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	options.ServerFlags.addGitServerFlags(cmd)
 	cmd.Flags().StringVarP(&options.ApiToken, "api-token", "t", "", "The API Token for the user")
 	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "The User password to try automatically create a new API Token")

--- a/pkg/jx/cmd/create_jhipster.go
+++ b/pkg/jx/cmd/create_jhipster.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -40,16 +38,11 @@ type CreateJHipsterOptions struct {
 }
 
 // NewCmdCreateJHipster creates a command object for the "create" command
-func NewCmdCreateJHipster(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateJHipster(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateJHipsterOptions{
 		CreateProjectOptions: CreateProjectOptions{
 			ImportOptions: ImportOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/create_lile.go
+++ b/pkg/jx/cmd/create_lile.go
@@ -3,13 +3,11 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"runtime"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -48,16 +46,11 @@ type CreateLileOptions struct {
 }
 
 // NewCmdCreateLile creates a command object for the "create" command
-func NewCmdCreateLile(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateLile(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateLileOptions{
 		CreateProjectOptions: CreateProjectOptions{
 			ImportOptions: ImportOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/create_micro.go
+++ b/pkg/jx/cmd/create_micro.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -42,16 +40,11 @@ type CreateMicroOptions struct {
 }
 
 // NewCmdCreateMicro creates a command object for the "create" command
-func NewCmdCreateMicro(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateMicro(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateMicroOptions{
 		CreateProjectOptions: CreateProjectOptions{
 			ImportOptions: ImportOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/create_post_preview_job.go
+++ b/pkg/jx/cmd/create_post_preview_job.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -43,16 +40,10 @@ type CreatePostPreviewJobOptions struct {
 }
 
 // NewCmdCreatePostPreviewJob creates a command object for the "create" command
-func NewCmdCreatePostPreviewJob(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreatePostPreviewJob(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreatePostPreviewJobOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -74,7 +65,6 @@ func NewCmdCreatePostPreviewJob(f Factory, in terminal.FileReader, out terminal.
 	cmd.Flags().StringArrayVarP(&options.Commands, "commands", "c", []string{}, "The commands to run in the job")
 	cmd.Flags().Int32VarP(&options.BackoffLimit, "backoff-limit", "l", int32(2), "The backoff limit: how many times to retry the job before considering it failed) to run in the Job")
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_project.go
+++ b/pkg/jx/cmd/create_project.go
@@ -2,12 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
-	"os"
 )
 
 const (
@@ -45,15 +44,10 @@ type CreateProjectWizardOptions struct {
 }
 
 // NewCmdCreateProject creates a command object for the "create" command
-func NewCmdCreateProject(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateProject(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateProjectWizardOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/create_project.go
+++ b/pkg/jx/cmd/create_project.go
@@ -64,7 +64,6 @@ func NewCmdCreateProject(commonOpts *CommonOptions) *cobra.Command {
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_pullrequest.go
+++ b/pkg/jx/cmd/create_pullrequest.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"io"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"fmt"
 
@@ -57,16 +55,10 @@ type CreatePullRequestResults struct {
 }
 
 // NewCmdCreatePullRequest creates a command object for the "create" command
-func NewCmdCreatePullRequest(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreatePullRequest(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreatePullRequestOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -90,7 +82,6 @@ func NewCmdCreatePullRequest(f Factory, in terminal.FileReader, out terminal.Fil
 	cmd.Flags().StringVarP(&options.Base, "base", "", "master", "The base branch to create the pull request into")
 	cmd.Flags().StringArrayVarP(&options.Labels, "label", "l", []string{}, "The labels to add to the pullrequest")
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_quickstart.go
+++ b/pkg/jx/cmd/create_quickstart.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -15,7 +14,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/quickstarts"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -62,16 +60,11 @@ type CreateQuickstartOptions struct {
 }
 
 // NewCmdCreateQuickstart creates a command object for the "create" command
-func NewCmdCreateQuickstart(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateQuickstart(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateQuickstartOptions{
 		CreateProjectOptions: CreateProjectOptions{
 			ImportOptions: ImportOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/create_quickstart_integration_test.go
+++ b/pkg/jx/cmd/create_quickstart_integration_test.go
@@ -22,13 +22,18 @@ func TestCreateQuickstartProjects(t *testing.T) {
 	appName := "myvets"
 
 	o := &cmd.CreateQuickstartOptions{
+		CreateProjectOptions: cmd.CreateProjectOptions{
+			ImportOptions: cmd.ImportOptions{
+				CommonOptions: &cmd.CommonOptions{},
+			},
+		},
 		GitHubOrganisations: []string{"petclinic-gcp"},
 		Filter: quickstarts.QuickstartFilter{
 			Text:        "petclinic-gcp/spring-petclinic-vets-service",
 			ProjectName: appName,
 		},
 	}
-	cmd.ConfigureTestOptions(&o.CommonOptions, gits.NewGitCLI(), helm.NewHelmCLI("helm", helm.V2, testDir, true))
+	cmd.ConfigureTestOptions(o.CommonOptions, gits.NewGitCLI(), helm.NewHelmCLI("helm", helm.V2, testDir, true))
 	o.Dir = testDir
 	o.OutDir = testDir
 	o.DryRun = true

--- a/pkg/jx/cmd/create_quickstart_location.go
+++ b/pkg/jx/cmd/create_quickstart_location.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -53,16 +50,10 @@ type CreateQuickstartLocationOptions struct {
 }
 
 // NewCmdCreateQuickstartLocation creates a command object for the "create" command
-func NewCmdCreateQuickstartLocation(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateQuickstartLocation(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateQuickstartLocationOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -86,7 +77,6 @@ func NewCmdCreateQuickstartLocation(f Factory, in terminal.FileReader, out termi
 	cmd.Flags().StringArrayVarP(&options.Includes, "includes", "i", []string{"*"}, "The patterns to include repositories")
 	cmd.Flags().StringArrayVarP(&options.Excludes, "excludes", "x", []string{"WIP-*"}, "The patterns to exclude repositories")
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_spring.go
+++ b/pkg/jx/cmd/create_spring.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -48,16 +46,11 @@ type CreateSpringOptions struct {
 }
 
 // NewCmdCreateSpring creates a command object for the "create" command
-func NewCmdCreateSpring(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateSpring(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateSpringOptions{
 		CreateProjectOptions: CreateProjectOptions{
 			ImportOptions: ImportOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/create_team.go
+++ b/pkg/jx/cmd/create_team.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
@@ -34,15 +32,10 @@ type CreateTeamOptions struct {
 }
 
 // NewCmdCreateTeam creates a command object for the "create" command
-func NewCmdCreateTeam(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateTeam(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateTeamOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -63,7 +56,6 @@ func NewCmdCreateTeam(f Factory, in terminal.FileReader, out terminal.FileWriter
 	cmd.Flags().StringVarP(&options.Name, optionName, "n", "", "The name of the new Team. Should be all lower case and no special characters other than '-'")
 	cmd.Flags().StringArrayVarP(&options.Members, "member", "m", []string{}, "The usernames of the members to add to the Team")
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_terraform.go
+++ b/pkg/jx/cmd/create_terraform.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"fmt"
@@ -30,7 +29,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // Cluster interface for Clusters
@@ -264,17 +262,12 @@ const (
 )
 
 // NewCmdCreateTerraform creates a command object for the "create" command
-func NewCmdCreateTerraform(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateTerraform(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateTerraformOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
-		InstallOptions: CreateInstallOptions(f, in, out, errOut),
+		InstallOptions: CreateInstallOptions(commonOpts),
 	}
 
 	cmd := &cobra.Command{
@@ -290,7 +283,6 @@ func NewCmdCreateTerraform(f Factory, in terminal.FileReader, out terminal.FileW
 	}
 
 	options.InstallOptions.addInstallFlags(cmd, true)
-	options.addCommonFlags(cmd)
 	options.addFlags(cmd, true)
 
 	cmd.Flags().StringVarP(&options.Flags.OrganisationName, "organisation-name", "o", "", "The organisation name that will be used as the Git repo containing cluster details, the repo will be organisation-<org name>")

--- a/pkg/jx/cmd/create_terraform_integration_test.go
+++ b/pkg/jx/cmd/create_terraform_integration_test.go
@@ -37,7 +37,7 @@ func TestCreateOrganisationFolderStructures(t *testing.T) {
 
 	o := cmd.CreateTerraformOptions{
 		CreateOptions: cmd.CreateOptions{
-			CommonOptions: cmd.CommonOptions{
+			CommonOptions: &cmd.CommonOptions{
 				BatchMode: true,
 				In:        os.Stdin,
 				Out:       os.Stdout,

--- a/pkg/jx/cmd/create_token.go
+++ b/pkg/jx/cmd/create_token.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateTokenOptions the options for the create spring command
@@ -13,15 +10,10 @@ type CreateTokenOptions struct {
 }
 
 // NewCmdCreateToken creates a command object for the "create" command
-func NewCmdCreateToken(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateToken(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateTokenOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -37,7 +29,7 @@ func NewCmdCreateToken(f Factory, in terminal.FileReader, out terminal.FileWrite
 		},
 	}
 
-	cmd.AddCommand(NewCmdCreateTokenAddon(f, in, out, errOut))
+	cmd.AddCommand(NewCmdCreateTokenAddon(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_token_addon.go
+++ b/pkg/jx/cmd/create_token_addon.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/addon"
 	"github.com/jenkins-x/jx/pkg/auth"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -43,15 +41,10 @@ type CreateTokenAddonOptions struct {
 }
 
 // NewCmdCreateTokenAddon creates a command
-func NewCmdCreateTokenAddon(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateTokenAddon(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateTokenAddonOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -68,7 +61,6 @@ func NewCmdCreateTokenAddon(f Factory, in terminal.FileReader, out terminal.File
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	options.ServerFlags.addGitServerFlags(cmd)
 	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "The password for the user")
 	cmd.Flags().StringVarP(&options.ApiToken, "api-token", "t", "", "The API Token for the user")

--- a/pkg/jx/cmd/create_tracker.go
+++ b/pkg/jx/cmd/create_tracker.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateTrackerOptions the options for the create spring command
@@ -13,15 +10,10 @@ type CreateTrackerOptions struct {
 }
 
 // NewCmdCreateTracker creates a command object for the "create" command
-func NewCmdCreateTracker(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateTracker(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateTrackerOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -37,8 +29,8 @@ func NewCmdCreateTracker(f Factory, in terminal.FileReader, out terminal.FileWri
 		},
 	}
 
-	cmd.AddCommand(NewCmdCreateTrackerServer(f, in, out, errOut))
-	cmd.AddCommand(NewCmdCreateTrackerToken(f, in, out, errOut))
+	cmd.AddCommand(NewCmdCreateTrackerServer(commonOpts))
+	cmd.AddCommand(NewCmdCreateTrackerToken(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_tracker_server.go
+++ b/pkg/jx/cmd/create_tracker_server.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -34,15 +32,10 @@ type CreateTrackerServerOptions struct {
 }
 
 // NewCmdCreateTrackerServer creates a command object for the "create" command
-func NewCmdCreateTrackerServer(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateTrackerServer(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateTrackerServerOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/create_tracker_token.go
+++ b/pkg/jx/cmd/create_tracker_token.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/issues"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,15 +40,10 @@ type CreateTrackerTokenOptions struct {
 }
 
 // NewCmdCreateTrackerToken creates a command
-func NewCmdCreateTrackerToken(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateTrackerToken(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateTrackerTokenOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -67,7 +60,6 @@ func NewCmdCreateTrackerToken(f Factory, in terminal.FileReader, out terminal.Fi
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	options.ServerFlags.addGitServerFlags(cmd)
 	cmd.Flags().StringVarP(&options.ApiToken, "api-token", "t", "", "The API Token for the user")
 	cmd.Flags().StringVarP(&options.Timeout, "timeout", "", "", "The timeout if using browser automation to generate the API token (by passing username and password)")

--- a/pkg/jx/cmd/create_user.go
+++ b/pkg/jx/cmd/create_user.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -36,15 +34,10 @@ type CreateUserOptions struct {
 }
 
 // NewCmdCreateUser creates a command object for the "create" command
-func NewCmdCreateUser(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdCreateUser(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateUserOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -66,7 +59,6 @@ func NewCmdCreateUser(f Factory, in terminal.FileReader, out terminal.FileWriter
 	cmd.Flags().StringVarP(&options.UserSpec.Name, "name", "n", "", "The textual full name of the user")
 	cmd.Flags().StringVarP(&options.UserSpec.Email, "email", "e", "", "The users email address")
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/create_vault.go
+++ b/pkg/jx/cmd/create_vault.go
@@ -2,14 +2,15 @@ package cmd
 
 import (
 	"fmt"
-	"io"
+
 	"time"
 
 	"github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
+
 	"github.com/jenkins-x/jx/pkg/kube/services"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	gkevault "github.com/jenkins-x/jx/pkg/cloud/gke/vault"
@@ -53,20 +54,14 @@ type CreateVaultOptions struct {
 }
 
 // NewCmdCreateVault  creates a command object for the "create" command
-func NewCmdCreateVault(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-		Out:     out,
-		Err:     errOut,
-	}
+func NewCmdCreateVault(commonOpts *CommonOptions) *cobra.Command {
 	options := &CreateVaultOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: commonOptions,
+			CommonOptions: commonOpts,
 		},
 		UpgradeIngressOptions: UpgradeIngressOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: commonOptions,
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -89,7 +84,6 @@ func NewCmdCreateVault(f Factory, in terminal.FileReader, out terminal.FileWrite
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "Namespace where the Vault is created")
 	cmd.Flags().StringVarP(&options.SecretsPathPrefix, "secrets-path-prefix", "p", vault.DefaultSecretsPathPrefix, "Path prefix for secrets used for access control config")
 
-	options.addCommonFlags(cmd)
 	options.UpgradeIngressOptions.addFlags(cmd)
 	return cmd
 }

--- a/pkg/jx/cmd/delete.go
+++ b/pkg/jx/cmd/delete.go
@@ -1,17 +1,14 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 // DeleteOptions are the flags for delete commands
 type DeleteOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 var (
@@ -28,14 +25,9 @@ var (
 
 // NewCmdDelete creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdDelete(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDelete(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteOptions{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -52,28 +44,28 @@ func NewCmdDelete(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 		SuggestFor: []string{"remove", "rm", "del"},
 	}
 
-	cmd.AddCommand(NewCmdDeleteAddon(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteApplication(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteBranch(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteChat(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteContext(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteDevPod(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteEks(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteEnv(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteGit(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteJenkins(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteNamespace(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeletePostPreviewJob(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeletePreview(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteQuickstartLocation(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteRepo(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteToken(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteTeam(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteTracker(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteUser(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteAws(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteVault(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteExtension(f, in, out, errOut))
+	cmd.AddCommand(NewCmdDeleteAddon(commonOpts))
+	cmd.AddCommand(NewCmdDeleteApplication(commonOpts))
+	cmd.AddCommand(NewCmdDeleteBranch(commonOpts))
+	cmd.AddCommand(NewCmdDeleteChat(commonOpts))
+	cmd.AddCommand(NewCmdDeleteContext(commonOpts))
+	cmd.AddCommand(NewCmdDeleteDevPod(commonOpts))
+	cmd.AddCommand(NewCmdDeleteEks(commonOpts))
+	cmd.AddCommand(NewCmdDeleteEnv(commonOpts))
+	cmd.AddCommand(NewCmdDeleteGit(commonOpts))
+	cmd.AddCommand(NewCmdDeleteJenkins(commonOpts))
+	cmd.AddCommand(NewCmdDeleteNamespace(commonOpts))
+	cmd.AddCommand(NewCmdDeletePostPreviewJob(commonOpts))
+	cmd.AddCommand(NewCmdDeletePreview(commonOpts))
+	cmd.AddCommand(NewCmdDeleteQuickstartLocation(commonOpts))
+	cmd.AddCommand(NewCmdDeleteRepo(commonOpts))
+	cmd.AddCommand(NewCmdDeleteToken(commonOpts))
+	cmd.AddCommand(NewCmdDeleteTeam(commonOpts))
+	cmd.AddCommand(NewCmdDeleteTracker(commonOpts))
+	cmd.AddCommand(NewCmdDeleteUser(commonOpts))
+	cmd.AddCommand(NewCmdDeleteAws(commonOpts))
+	cmd.AddCommand(NewCmdDeleteVault(commonOpts))
+	cmd.AddCommand(NewCmdDeleteExtension(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_addon.go
+++ b/pkg/jx/cmd/delete_addon.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"github.com/jenkins-x/jx/pkg/kube/services"
-	"io"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"fmt"
@@ -16,21 +14,16 @@ import (
 
 // DeleteAddonOptions are the flags for delete commands
 type DeleteAddonOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Purge bool
 }
 
 // NewCmdDeleteAddon creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdDeleteAddon(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteAddon(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteAddonOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -45,10 +38,10 @@ func NewCmdDeleteAddon(f Factory, in terminal.FileReader, out terminal.FileWrite
 		SuggestFor: []string{"remove", "rm"},
 	}
 
-	cmd.AddCommand(NewCmdDeleteAddonCloudBees(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteAddonGitea(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteAddonSSO(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteAddonKnativeBuild(f, in, out, errOut))
+	cmd.AddCommand(NewCmdDeleteAddonCloudBees(commonOpts))
+	cmd.AddCommand(NewCmdDeleteAddonGitea(commonOpts))
+	cmd.AddCommand(NewCmdDeleteAddonSSO(commonOpts))
+	cmd.AddCommand(NewCmdDeleteAddonKnativeBuild(commonOpts))
 	options.addFlags(cmd)
 	return cmd
 }

--- a/pkg/jx/cmd/delete_addon_cloudbees.go
+++ b/pkg/jx/cmd/delete_addon_cloudbees.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -28,15 +25,10 @@ type DeleteAddoncoreOptions struct {
 }
 
 // NewCmdDeleteAddonCloudBees defines the command
-func NewCmdDeleteAddonCloudBees(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteAddonCloudBees(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteAddoncoreOptions{
 		DeleteAddonOptions: DeleteAddonOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/delete_addon_gitea.go
+++ b/pkg/jx/cmd/delete_addon_gitea.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -28,15 +25,10 @@ type DeleteAddonGiteaOptions struct {
 }
 
 // NewCmdDeleteAddonGitea defines the command
-func NewCmdDeleteAddonGitea(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteAddonGitea(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteAddonGiteaOptions{
 		DeleteAddonOptions: DeleteAddonOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/delete_addon_knative_build.go
+++ b/pkg/jx/cmd/delete_addon_knative_build.go
@@ -4,12 +4,10 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -32,15 +30,10 @@ type DeleteKnativeBuildOptions struct {
 }
 
 // NewCmdDeleteAddonKnativeBuild defines the command
-func NewCmdDeleteAddonKnativeBuild(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteAddonKnativeBuild(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteKnativeBuildOptions{
 		DeleteAddonOptions: DeleteAddonOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/delete_addon_sso.go
+++ b/pkg/jx/cmd/delete_addon_sso.go
@@ -1,15 +1,12 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const optionReleases = "releases"
@@ -35,15 +32,10 @@ type DeleteAddonSSOOptions struct {
 }
 
 // NewCmdDeleteAddonSSO defines the command
-func NewCmdDeleteAddonSSO(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteAddonSSO(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteAddonSSOOptions{
 		DeleteAddonOptions: DeleteAddonOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/delete_app.go
+++ b/pkg/jx/cmd/delete_app.go
@@ -89,7 +89,6 @@ func NewCmdDeleteApplication(commonOpts *CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.PullRequestPollTime, optionPullRequestPollTime, "", "20s", "Poll time when waiting for a Pull Request to merge")
 	// TODO - Create an Application CRD that gets populated with the org when an application is created/imported to store this.
 	cmd.Flags().StringVarP(&options.Org, "org", "o", "", "github organisation/project name that source code resides in. Temporary workaround until the platform can determine this automatically")
-	cmd.Flags().BoolVarP(&options.BatchMode, "batch-mode", "b", false, "Run without being prompted. WARNING! You will not be asked to confirm deletions if you use this flag.")
 
 	return cmd
 }

--- a/pkg/jx/cmd/delete_app.go
+++ b/pkg/jx/cmd/delete_app.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/prow"
-	"github.com/pkg/errors"
-	"io"
 	"os/user"
 	"strings"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/prow"
+	"github.com/pkg/errors"
 
 	"github.com/jenkins-x/jx/pkg/gits"
 
@@ -19,7 +19,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/util"
 )
@@ -45,7 +44,7 @@ var (
 
 // DeleteApplicationOptions are the flags for this delete commands
 type DeleteApplicationOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	SelectAll           bool
 	SelectFilter        string
@@ -64,14 +63,9 @@ type DeleteApplicationOptions struct {
 }
 
 // NewCmdDeleteApplication creates a command object for this command
-func NewCmdDeleteApplication(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteApplication(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteApplicationOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/delete_aws.go
+++ b/pkg/jx/cmd/delete_aws.go
@@ -5,11 +5,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/jenkins-x/jx/pkg/cloud/amazon"
 	"github.com/jenkins-x/jx/pkg/log"
-	logger "github.com/sirupsen/logrus"
-
-	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/spf13/cobra"
 )
 
@@ -35,8 +33,6 @@ func NewCmdDeleteAws(commonOpts *CommonOptions) *cobra.Command {
 			CheckErr(err)
 		},
 	}
-
-	cmd.Flags().StringVarP(&options.LogLevel, "log-level", "", logger.InfoLevel.String(), "Logging level. Possible values - panic, fatal, error, warning, info, debug.")
 
 	cmd.Flags().StringVarP(&options.Profile, "profile", "", "", "AWS profile to use.")
 	cmd.Flags().StringVarP(&options.Region, "region", "", "", "AWS region to use.")

--- a/pkg/jx/cmd/delete_aws.go
+++ b/pkg/jx/cmd/delete_aws.go
@@ -2,34 +2,28 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/jenkins-x/jx/pkg/cloud/amazon"
 	"github.com/jenkins-x/jx/pkg/log"
 	logger "github.com/sirupsen/logrus"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/spf13/cobra"
 )
 
 type DeleteAwsOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Profile string
 	Region  string
 	VpcId   string
 }
 
-func NewCmdDeleteAws(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteAws(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteAwsOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:   "aws",

--- a/pkg/jx/cmd/delete_branch.go
+++ b/pkg/jx/cmd/delete_branch.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -46,15 +44,10 @@ type DeleteBranchOptions struct {
 }
 
 // NewCmdDeleteBranch creates a command object for the "delete repo" command
-func NewCmdDeleteBranch(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteBranch(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteBranchOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -81,7 +74,6 @@ func NewCmdDeleteBranch(f Factory, in terminal.FileReader, out terminal.FileWrit
 	cmd.Flags().StringVarP(&options.SelectFilter, "filter", "f", "", "If selecting branches to remove this filters the list of repositories")
 	cmd.Flags().BoolVarP(&options.SelectAllRepos, "all-repos", "", false, "If selecting projects to remove branches this defaults to selecting them all")
 	cmd.Flags().StringVarP(&options.SelectFilterRepos, "filter-repos", "", "", "If selecting projects to remove brancehs this filters the list of repositories")
-	cmd.Flags().BoolVarP(&options.BatchMode, "batch-mode", "b", false, "Run without being prompted. WARNING! You will not be asked to confirm deletions if you use this flag.")
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_chat.go
+++ b/pkg/jx/cmd/delete_chat.go
@@ -1,27 +1,19 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // DeleteChatOptions are the flags for delete commands
 type DeleteChatOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCmdDeleteChat creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdDeleteChat(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteChat(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteChatOptions{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -36,8 +28,8 @@ func NewCmdDeleteChat(f Factory, in terminal.FileReader, out terminal.FileWriter
 		},
 	}
 
-	cmd.AddCommand(NewCmdDeleteChatServer(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteChatToken(f, in, out, errOut))
+	cmd.AddCommand(NewCmdDeleteChatServer(commonOpts))
+	cmd.AddCommand(NewCmdDeleteChatToken(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_chat_server.go
+++ b/pkg/jx/cmd/delete_chat_server.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -25,20 +23,15 @@ var (
 
 // DeleteChatServerOptions the options for the create spring command
 type DeleteChatServerOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	IgnoreMissingServer bool
 }
 
 // NewCmdDeleteChatServer defines the command
-func NewCmdDeleteChatServer(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteChatServer(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteChatServerOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/delete_chat_token.go
+++ b/pkg/jx/cmd/delete_chat_token.go
@@ -2,15 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -32,15 +29,10 @@ type DeleteChatTokenOptions struct {
 }
 
 // NewCmdDeleteChatToken defines the command
-func NewCmdDeleteChatToken(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteChatToken(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteChatTokenOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/delete_context.go
+++ b/pkg/jx/cmd/delete_context.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -41,15 +39,10 @@ type DeleteContextOptions struct {
 }
 
 // NewCmdDeleteContext creates a command object for the "delete repo" command
-func NewCmdDeleteContext(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteContext(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteContextOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/delete_context.go
+++ b/pkg/jx/cmd/delete_context.go
@@ -65,7 +65,6 @@ func NewCmdDeleteContext(commonOpts *CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.SelectFilter, "filter", "f", "", "Filter the list of contexts to those containing this text")
 	cmd.Flags().BoolVarP(&options.DeleteAuthInfo, "delete-user", "", false, "Also delete the user config associated to the context")
 	cmd.Flags().BoolVarP(&options.DeleteCluster, "delete-cluster", "", false, "Also delete the cluster config associated to the context")
-	cmd.Flags().BoolVarP(&options.Verbose, "verbose", "", false, "Enable verbose logging")
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_devpod.go
+++ b/pkg/jx/cmd/delete_devpod.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os/user"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -35,19 +33,14 @@ var (
 
 // DeleteDevPodOptions are the flags for delete commands
 type DeleteDevPodOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCmdDeleteDevPod creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdDeleteDevPod(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteDevPod(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteDevPodOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/delete_eks.go
+++ b/pkg/jx/cmd/delete_eks.go
@@ -3,15 +3,14 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/cloud/amazon"
-	"io"
 	"os"
 	"os/exec"
+
+	"github.com/jenkins-x/jx/pkg/cloud/amazon"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type DeleteEksOptions struct {
@@ -31,15 +30,10 @@ var (
 	`)
 )
 
-func NewCmdDeleteEks(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteEks(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteEksOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/delete_env.go
+++ b/pkg/jx/cmd/delete_env.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,20 +26,15 @@ var (
 
 // DeleteEnvOptions the options for the create spring command
 type DeleteEnvOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	DeleteNamespace bool
 }
 
 // NewCmdDeleteEnv creates a command object for the "delete repo" command
-func NewCmdDeleteEnv(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteEnv(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteEnvOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/delete_extension.go
+++ b/pkg/jx/cmd/delete_extension.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
@@ -16,7 +15,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -45,20 +43,15 @@ var (
 
 // DeleteExtensionOptions are the flags for delete commands
 type DeleteExtensionOptions struct {
-	CommonOptions
+	*CommonOptions
 	All bool
 }
 
 // NewCmdDeleteExtension creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdDeleteExtension(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteExtension(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteExtensionOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -76,7 +69,6 @@ func NewCmdDeleteExtension(f Factory, in terminal.FileReader, out terminal.FileW
 		SuggestFor: []string{"remove", "rm"},
 	}
 	cmd.Flags().BoolVarP(&options.All, "all", "", false, "Remove all extensions")
-	cmd.Flags().BoolVarP(&options.BatchMode, optionBatchMode, "b", false, "Run in batch mode")
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_git.go
+++ b/pkg/jx/cmd/delete_git.go
@@ -1,27 +1,19 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // DeleteGitOptions are the flags for delete commands
 type DeleteGitOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCmdDeleteGit creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdDeleteGit(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteGit(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteGitOptions{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -36,8 +28,8 @@ func NewCmdDeleteGit(f Factory, in terminal.FileReader, out terminal.FileWriter,
 		SuggestFor: []string{"remove", "rm"},
 	}
 
-	cmd.AddCommand(NewCmdDeleteGitServer(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteGitToken(f, in, out, errOut))
+	cmd.AddCommand(NewCmdDeleteGitServer(commonOpts))
+	cmd.AddCommand(NewCmdDeleteGitToken(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_git_server.go
+++ b/pkg/jx/cmd/delete_git_server.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/auth"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,20 +26,15 @@ var (
 
 // DeleteGitServerOptions the options for the create spring command
 type DeleteGitServerOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	IgnoreMissingServer bool
 }
 
 // NewCmdDeleteGitServer defines the command
-func NewCmdDeleteGitServer(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteGitServer(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteGitServerOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/delete_git_token.go
+++ b/pkg/jx/cmd/delete_git_token.go
@@ -2,15 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -32,15 +29,10 @@ type DeleteGitTokenOptions struct {
 }
 
 // NewCmdDeleteGitToken defines the command
-func NewCmdDeleteGitToken(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteGitToken(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteGitTokenOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/delete_jenkins.go
+++ b/pkg/jx/cmd/delete_jenkins.go
@@ -1,27 +1,19 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // DeleteJenkinsOptions are the flags for delete commands
 type DeleteJenkinsOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCmdDeleteJenkins creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdDeleteJenkins(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteJenkins(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteJenkinsOptions{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -36,7 +28,7 @@ func NewCmdDeleteJenkins(f Factory, in terminal.FileReader, out terminal.FileWri
 		SuggestFor: []string{"remove", "rm"},
 	}
 
-	cmd.AddCommand(NewCmdDeleteJenkinsUser(f, in, out, errOut))
+	cmd.AddCommand(NewCmdDeleteJenkinsUser(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_jenkins_user.go
+++ b/pkg/jx/cmd/delete_jenkins_user.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"strings"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -34,15 +32,10 @@ type DeleteJenkinsUserOptions struct {
 }
 
 // NewCmdDeleteJenkinsUser defines the command
-func NewCmdDeleteJenkinsUser(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteJenkinsUser(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteJenkinsUserOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/delete_namespace.go
+++ b/pkg/jx/cmd/delete_namespace.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 
@@ -11,13 +10,12 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DeleteNamespaceOptions are the flags for delete commands
 type DeleteNamespaceOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	SelectAll    bool
 	SelectFilter string
@@ -40,15 +38,9 @@ var (
 
 // NewCmdDeleteNamespace creates a command object
 // retrieves one or more resources from a server.
-func NewCmdDeleteNamespace(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteNamespace(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteNamespaceOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -65,7 +57,6 @@ func NewCmdDeleteNamespace(f Factory, in terminal.FileReader, out terminal.FileW
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	cmd.Flags().BoolVarP(&options.SelectAll, "all", "a", false, "Should we default to selecting all the matched namespaces for deletion")
 	cmd.Flags().StringVarP(&options.SelectFilter, "filter", "f", "", "Filters the list of namespaces you can pick from")
 	cmd.Flags().BoolVarP(&options.Confirm, "yes", "y", false, "Confirms we should uninstall this installation")
@@ -82,7 +73,7 @@ func (o *DeleteNamespaceOptions) Run() error {
 	namespaceInterface := kubeClient.CoreV1().Namespaces()
 	nsList, err := namespaceInterface.List(metav1.ListOptions{})
 	if err != nil {
-	  return err
+		return err
 	}
 	namespaceNames := []string{}
 	for _, namespace := range nsList.Items {

--- a/pkg/jx/cmd/delete_post_preview_job.go
+++ b/pkg/jx/cmd/delete_post_preview_job.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -32,15 +29,10 @@ type DeletePostPreviewJobOptions struct {
 }
 
 // NewCmdDeletePostPreviewJob creates a command object for the "create" command
-func NewCmdDeletePostPreviewJob(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeletePostPreviewJob(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeletePostPreviewJobOptions{
 		DeleteOptions: DeleteOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -57,7 +49,6 @@ func NewCmdDeletePostPreviewJob(f Factory, in terminal.FileReader, out terminal.
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Name, optionName, "n", "", "The name of the job to be deleted")
 	return cmd

--- a/pkg/jx/cmd/delete_preview.go
+++ b/pkg/jx/cmd/delete_preview.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // DeletePreviewOptions are the flags for delete commands
@@ -18,16 +16,11 @@ type DeletePreviewOptions struct {
 }
 
 // NewCmdDeletePreview creates a command object
-func NewCmdDeletePreview(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeletePreview(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeletePreviewOptions{
 		PreviewOptions: PreviewOptions{
 			PromoteOptions: PromoteOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -43,7 +36,6 @@ func NewCmdDeletePreview(f Factory, in terminal.FileReader, out terminal.FileWri
 		},
 	}
 	options.addPreviewOptions(cmd)
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_quickstart_location.go
+++ b/pkg/jx/cmd/delete_quickstart_location.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -40,21 +38,16 @@ var (
 
 // DeleteQuickstartLocationOptions the options for the create spring command
 type DeleteQuickstartLocationOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	GitUrl string
 	Owner  string
 }
 
 // NewCmdDeleteQuickstartLocation defines the command
-func NewCmdDeleteQuickstartLocation(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteQuickstartLocation(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteQuickstartLocationOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -73,7 +66,6 @@ func NewCmdDeleteQuickstartLocation(f Factory, in terminal.FileReader, out termi
 	cmd.Flags().StringVarP(&options.GitUrl, optionGitUrl, "u", gits.GitHubURL, "The URL of the Git service")
 	cmd.Flags().StringVarP(&options.Owner, optionOwner, "o", "", "The owner is the user or organisation of the Git provider")
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_repo.go
+++ b/pkg/jx/cmd/delete_repo.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/auth"
@@ -12,7 +11,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -47,15 +45,10 @@ type DeleteRepoOptions struct {
 }
 
 // NewCmdDeleteRepo creates a command object for the "delete repo" command
-func NewCmdDeleteRepo(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteRepo(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteRepoOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -80,7 +73,6 @@ func NewCmdDeleteRepo(f Factory, in terminal.FileReader, out terminal.FileWriter
 	cmd.Flags().BoolVarP(&options.GitHub, "github", "", false, "If you wish to pick the repositories from GitHub to import")
 	cmd.Flags().BoolVarP(&options.SelectAll, "all", "a", false, "If selecting projects to delete from a Git provider this defaults to selecting them all")
 	cmd.Flags().StringVarP(&options.SelectFilter, "filter", "f", "", "If selecting projects to delete from a Git provider this filters the list of repositories")
-	cmd.Flags().BoolVarP(&options.BatchMode, "batch-mode", "b", false, "Run without being prompted. WARNING! You will not be asked to confirm deletions if you use this flag.")
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_team.go
+++ b/pkg/jx/cmd/delete_team.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
@@ -12,13 +11,12 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DeleteTeamOptions are the flags for delete commands
 type DeleteTeamOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	SelectAll    bool
 	SelectFilter string
@@ -41,15 +39,9 @@ var (
 
 // NewCmdDeleteTeam creates a command object
 // retrieves one or more resources from a server.
-func NewCmdDeleteTeam(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteTeam(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteTeamOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -66,7 +58,6 @@ func NewCmdDeleteTeam(f Factory, in terminal.FileReader, out terminal.FileWriter
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	cmd.Flags().BoolVarP(&options.SelectAll, "all", "a", false, "Should we default to selecting all the matched teams for deletion")
 	cmd.Flags().StringVarP(&options.SelectFilter, "filter", "f", "", "Filters the list of teams you can pick from")
 	cmd.Flags().BoolVarP(&options.Confirm, "yes", "y", false, "Confirms we should uninstall this installation")

--- a/pkg/jx/cmd/delete_token.go
+++ b/pkg/jx/cmd/delete_token.go
@@ -1,27 +1,19 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // DeleteTokenOptions are the flags for delete commands
 type DeleteTokenOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCmdDeleteToken creates a command object
 // retrieves one or more resources from a server.
-func NewCmdDeleteToken(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteToken(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteTokenOptions{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -36,7 +28,7 @@ func NewCmdDeleteToken(f Factory, in terminal.FileReader, out terminal.FileWrite
 		},
 	}
 
-	cmd.AddCommand(NewCmdDeleteTokenAddon(f, in, out, errOut))
+	cmd.AddCommand(NewCmdDeleteTokenAddon(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_token_addon.go
+++ b/pkg/jx/cmd/delete_token_addon.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -32,15 +30,10 @@ type DeleteTokenAddonOptions struct {
 }
 
 // NewCmdDeleteTokenAddon defines the command
-func NewCmdDeleteTokenAddon(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteTokenAddon(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteTokenAddonOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/delete_tracker.go
+++ b/pkg/jx/cmd/delete_tracker.go
@@ -1,27 +1,19 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // DeleteTrackerOptions are the flags for delete commands
 type DeleteTrackerOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 // NewCmdDeleteTracker creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdDeleteTracker(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteTracker(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteTrackerOptions{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -36,8 +28,8 @@ func NewCmdDeleteTracker(f Factory, in terminal.FileReader, out terminal.FileWri
 		},
 	}
 
-	cmd.AddCommand(NewCmdDeleteTrackerServer(f, in, out, errOut))
-	cmd.AddCommand(NewCmdDeleteTrackerToken(f, in, out, errOut))
+	cmd.AddCommand(NewCmdDeleteTrackerServer(commonOpts))
+	cmd.AddCommand(NewCmdDeleteTrackerToken(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/delete_tracker_server.go
+++ b/pkg/jx/cmd/delete_tracker_server.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -25,20 +23,15 @@ var (
 
 // DeleteTrackerServerOptions the options for the create spring command
 type DeleteTrackerServerOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	IgnoreMissingServer bool
 }
 
 // NewCmdDeleteTrackerServer defines the command
-func NewCmdDeleteTrackerServer(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteTrackerServer(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteTrackerServerOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/delete_tracker_token.go
+++ b/pkg/jx/cmd/delete_tracker_token.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"strings"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -32,16 +30,10 @@ type DeleteTrackerTokenOptions struct {
 }
 
 // NewCmdDeleteTrackerToken defines the command
-func NewCmdDeleteTrackerToken(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteTrackerToken(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteTrackerTokenOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/delete_user.go
+++ b/pkg/jx/cmd/delete_user.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -11,14 +10,13 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DeleteUserOptions are the flags for delete commands
 type DeleteUserOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	SelectAll    bool
 	SelectFilter string
@@ -38,15 +36,9 @@ var (
 
 // NewCmdDeleteUser creates a command object
 // retrieves one or more resources from a server.
-func NewCmdDeleteUser(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteUser(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteUserOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -63,7 +55,6 @@ func NewCmdDeleteUser(f Factory, in terminal.FileReader, out terminal.FileWriter
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	cmd.Flags().BoolVarP(&options.SelectAll, "all", "a", false, "Should we default to selecting all the matched users for deletion")
 	cmd.Flags().StringVarP(&options.SelectFilter, "filter", "f", "", "Fitlers the list of users you can pick from")
 	cmd.Flags().BoolVarP(&options.Confirm, "yes", "y", false, "Confirms we should uninstall this installation")

--- a/pkg/jx/cmd/delete_vault.go
+++ b/pkg/jx/cmd/delete_vault.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	gkevault "github.com/jenkins-x/jx/pkg/cloud/gke/vault"
@@ -14,13 +13,12 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DeleteVaultOptions keeps the options of delete vault command
 type DeleteVaultOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Namespace            string
 	RemoveCloudResources bool
@@ -40,14 +38,9 @@ var (
 )
 
 // NewCmdDeleteVault builds a new delete vault command
-func NewCmdDeleteVault(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDeleteVault(commonOpts *CommonOptions) *cobra.Command {
 	options := &DeleteVaultOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/diagnose.go
+++ b/pkg/jx/cmd/diagnose.go
@@ -2,27 +2,20 @@ package cmd
 
 import (
 	"github.com/jenkins-x/jx/pkg/kube"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type DiagnoseOptions struct {
-	CommonOptions
+	*CommonOptions
 	Namespace string
 }
 
-func NewCmdDiagnose(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDiagnose(commonOpts *CommonOptions) *cobra.Command {
 	options := &DiagnoseOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:   "diagnose",
@@ -35,7 +28,6 @@ func NewCmdDiagnose(f Factory, in terminal.FileReader, out terminal.FileWriter, 
 		},
 	}
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The namespace to display the kube resources from. If left out, defaults to the current namespace")
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/docs.go
+++ b/pkg/jx/cmd/docs.go
@@ -1,12 +1,8 @@
 package cmd
 
 import (
-	"io"
-
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -14,7 +10,7 @@ const (
 )
 
 /* open the docs - Jenkins X docs by default */
-func NewCmdDocs(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdDocs() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "docs",
 		Short: "Open the documentation in a browser",

--- a/pkg/jx/cmd/edit.go
+++ b/pkg/jx/cmd/edit.go
@@ -1,17 +1,13 @@
 package cmd
 
 import (
-	"io"
-
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/spf13/cobra"
 )
 
 // EditOptions contains the CLI options
 type EditOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 var (
@@ -27,14 +23,9 @@ var (
 )
 
 // NewCmdEdit creates the edit command
-func NewCmdEdit(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdEdit(commonOpts *CommonOptions) *cobra.Command {
 	options := &EditOptions{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -51,16 +42,16 @@ func NewCmdEdit(f Factory, in terminal.FileReader, out terminal.FileWriter, errO
 		SuggestFor: []string{"modify"},
 	}
 
-	cmd.AddCommand(NewCmdCreateBranchPattern(f, in, out, errOut))
-	cmd.AddCommand(NewCmdEditAddon(f, in, out, errOut))
-	cmd.AddCommand(NewCmdEditBuildpack(f, in, out, errOut))
-	cmd.AddCommand(NewCmdEditConfig(f, in, out, errOut))
-	cmd.AddCommand(NewCmdEditEnv(f, in, out, errOut))
-	cmd.AddCommand(NewCmdEditHelmBin(f, in, out, errOut))
-	cmd.AddCommand(NewCmdEditStorage(f, in, out, errOut))
-	cmd.AddCommand(NewCmdEditUserRole(f, in, out, errOut))
-	cmd.AddCommand(NewCmdEditExtensionsRepository(f, in, out, errOut))
-	addTeamSettingsCommandsFromTags(cmd, in, out, errOut, options)
+	cmd.AddCommand(NewCmdCreateBranchPattern(commonOpts))
+	cmd.AddCommand(NewCmdEditAddon(commonOpts))
+	cmd.AddCommand(NewCmdEditBuildpack(commonOpts))
+	cmd.AddCommand(NewCmdEditConfig(commonOpts))
+	cmd.AddCommand(NewCmdEditEnv(commonOpts))
+	cmd.AddCommand(NewCmdEditHelmBin(commonOpts))
+	cmd.AddCommand(NewCmdEditStorage(commonOpts))
+	cmd.AddCommand(NewCmdEditUserRole(commonOpts))
+	cmd.AddCommand(NewCmdEditExtensionsRepository(commonOpts))
+	addTeamSettingsCommandsFromTags(cmd, commonOpts.In, commonOpts.Out, commonOpts.Err, options)
 	return cmd
 }
 

--- a/pkg/jx/cmd/edit_addon.go
+++ b/pkg/jx/cmd/edit_addon.go
@@ -2,17 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/addon"
 	"github.com/jenkins-x/jx/pkg/auth"
-	"github.com/jenkins-x/jx/pkg/kube"
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -44,15 +41,10 @@ type EditAddonOptions struct {
 }
 
 // NewCmdEditAddon creates a command object for the "create" command
-func NewCmdEditAddon(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdEditAddon(commonOpts *CommonOptions) *cobra.Command {
 	options := &EditAddonOptions{
 		EditOptions: EditOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/edit_buildpack.go
+++ b/pkg/jx/cmd/edit_buildpack.go
@@ -2,18 +2,16 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/builds"
-	"io"
 	"sort"
 	"strings"
 
+	"github.com/jenkins-x/jx/pkg/builds"
+
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
-	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 var (
@@ -45,15 +43,10 @@ type EditBuildPackOptions struct {
 }
 
 // NewCmdEditBuildpack creates a command object for the "create" command
-func NewCmdEditBuildpack(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdEditBuildpack(commonOpts *CommonOptions) *cobra.Command {
 	options := &EditBuildPackOptions{
 		EditOptions: EditOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/edit_buildpack.go
+++ b/pkg/jx/cmd/edit_buildpack.go
@@ -66,7 +66,6 @@ func NewCmdEditBuildpack(commonOpts *CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.BuildPackURL, "url", "u", "", "The URL for the build pack Git repository")
 	cmd.Flags().StringVarP(&options.BuildPackRef, "ref", "r", "", "The Git reference (branch,tag,sha) in the Git repository to use")
 	cmd.Flags().StringVarP(&options.BuildPackName, "name", "n", "", "The name of the BuildPack resource to use")
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/edit_config.go
+++ b/pkg/jx/cmd/edit_config.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -50,15 +48,10 @@ type EditConfigOptions struct {
 }
 
 // NewCmdEditConfig creates a command object for the "create" command
-func NewCmdEditConfig(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdEditConfig(commonOpts *CommonOptions) *cobra.Command {
 	options := &EditConfigOptions{
 		EditOptions: EditOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/edit_env.go
+++ b/pkg/jx/cmd/edit_env.go
@@ -1,11 +1,6 @@
 package cmd
 
 import (
-	"io"
-
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -14,6 +9,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -48,18 +44,13 @@ type EditEnvOptions struct {
 }
 
 // NewCmdEditEnv creates a command object for the "create" command
-func NewCmdEditEnv(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdEditEnv(commonOpts *CommonOptions) *cobra.Command {
 	options := &EditEnvOptions{
 		HelmValuesConfig: config.HelmValuesConfig{
 			ExposeController: &config.ExposeController{},
 		},
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/edit_extensionsrepository.go
+++ b/pkg/jx/cmd/edit_extensionsrepository.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -17,7 +16,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -56,15 +54,10 @@ type EditExtensionsRepositoryOptions struct {
 	ExtensionsRepositoryHelmPassword string
 }
 
-func NewCmdEditExtensionsRepository(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdEditExtensionsRepository(commonOpts *CommonOptions) *cobra.Command {
 	options := &EditExtensionsRepositoryOptions{
 		EditOptions: EditOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -88,7 +81,6 @@ func NewCmdEditExtensionsRepository(f Factory, in terminal.FileReader, out termi
 	cmd.Flags().StringVarP(&options.ExtensionsRepositoryHelmPassword, optionExtensionsRepositoryHelmPassword, "", "", "The extensions repository Helm Chart Password to use")
 
 	// TODO enable this
-	// options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/edit_helmbin.go
+++ b/pkg/jx/cmd/edit_helmbin.go
@@ -2,16 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -37,15 +34,10 @@ type EditHelmBinOptions struct {
 }
 
 // NewCmdEditHelmBin creates a command object for the "create" command
-func NewCmdEditHelmBin(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdEditHelmBin(commonOpts *CommonOptions) *cobra.Command {
 	options := &EditHelmBinOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -63,7 +55,6 @@ func NewCmdEditHelmBin(f Factory, in terminal.FileReader, out terminal.FileWrite
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/edit_storage.go
+++ b/pkg/jx/cmd/edit_storage.go
@@ -64,8 +64,6 @@ func NewCmdEditStorage(commonOpts *CommonOptions) *cobra.Command {
 		},
 	}
 
-	options.addCommonFlags(cmd)
-
 	cmd.Flags().StringVarP(&options.Classifier, "classifier", "c", "", "A name which classifies this type of file. Example values: "+kube.ClassificationValues)
 	cmd.Flags().StringVarP(&options.HttpURL, "http-url", "", "", "Specify the HTTP endpoint to send each file to")
 	cmd.Flags().StringVarP(&options.GitURL, "git-url", "", "", "Specify the Git URL to populate in a gh-pages branch")

--- a/pkg/jx/cmd/edit_storage.go
+++ b/pkg/jx/cmd/edit_storage.go
@@ -2,13 +2,10 @@ package cmd
 
 import (
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
-	"github.com/jenkins-x/jx/pkg/kube"
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -46,15 +43,10 @@ type EditStorageOptions struct {
 }
 
 // NewCmdEditStorage creates a command object for the "create" command
-func NewCmdEditStorage(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdEditStorage(commonOpts *CommonOptions) *cobra.Command {
 	options := &EditStorageOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -84,7 +76,7 @@ func NewCmdEditStorage(f Factory, in terminal.FileReader, out terminal.FileWrite
 // Run implements the command
 func (o *EditStorageOptions) Run() error {
 	var err error
-	if o.Classifier == "" && ! o.BatchMode {
+	if o.Classifier == "" && !o.BatchMode {
 		o.Classifier, err = util.PickName(kube.Classifications, "Pick the content classification name", "The name is used as a key to store content in different locations", o.In, o.Out, o.Err)
 		if err != nil {
 			return err
@@ -97,11 +89,11 @@ func (o *EditStorageOptions) Run() error {
 	if !o.BatchMode && (o.HttpURL == "" && o.GitURL == "") {
 		o.GitURL, err = util.PickValue("Git repository URL to store content:", o.GitURL, false, "The Git URL will be used to clone and push the storage to", o.In, o.Out, o.Err)
 		if err != nil {
-		  return err
+			return err
 		}
 		o.HttpURL, err = util.PickValue("HTTP URL to POST content to:", o.HttpURL, false, "The Git URL will be used to clone and push the storage to", o.In, o.Out, o.Err)
 		if err != nil {
-		  return err
+			return err
 		}
 	}
 

--- a/pkg/jx/cmd/edit_userrole.go
+++ b/pkg/jx/cmd/edit_userrole.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -39,15 +37,10 @@ type EditUserRoleOptions struct {
 }
 
 // NewCmdEditUserRole creates a command object for the "create" command
-func NewCmdEditUserRole(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdEditUserRole(commonOpts *CommonOptions) *cobra.Command {
 	options := &EditUserRoleOptions{
 		EditOptions: EditOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -68,7 +61,6 @@ func NewCmdEditUserRole(f Factory, in terminal.FileReader, out terminal.FileWrit
 	cmd.Flags().StringVarP(&options.Login, optionLogin, "l", "", "The user login name")
 	cmd.Flags().StringArrayVarP(&options.Roles, "role", "r", []string{}, "The roles to set on a user")
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/environment.go
+++ b/pkg/jx/cmd/environment.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
 
@@ -13,12 +12,11 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/util"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/client-go/kubernetes"
 )
 
 type EnvironmentOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 const ()
@@ -42,14 +40,9 @@ var (
 `)
 )
 
-func NewCmdEnvironment(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdEnvironment(commonOpts *CommonOptions) *cobra.Command {
 	options := &EnvironmentOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "environment",
@@ -64,7 +57,6 @@ func NewCmdEnvironment(f Factory, in terminal.FileReader, out terminal.FileWrite
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/gc.go
+++ b/pkg/jx/cmd/gc.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
@@ -12,7 +9,7 @@ import (
 // GCOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type GCOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Output string
 }
@@ -47,14 +44,9 @@ var (
 
 // NewCmdGC creates a command object for the generic "gc" action, which
 // retrieves one or more resources from a server.
-func NewCmdGC(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGC(commonOpts *CommonOptions) *cobra.Command {
 	options := &GCOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -70,12 +62,12 @@ func NewCmdGC(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut
 		},
 	}
 
-	cmd.AddCommand(NewCmdGCActivities(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGCPreviews(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGCGKE(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGCHelm(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGCPods(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGCReleases(f, in, out, errOut))
+	cmd.AddCommand(NewCmdGCActivities(commonOpts))
+	cmd.AddCommand(NewCmdGCPreviews(commonOpts))
+	cmd.AddCommand(NewCmdGCGKE(commonOpts))
+	cmd.AddCommand(NewCmdGCHelm(commonOpts))
+	cmd.AddCommand(NewCmdGCPods(commonOpts))
+	cmd.AddCommand(NewCmdGCReleases(commonOpts))
 
 	return cmd
 }

--- a/pkg/jx/cmd/gc_activities.go
+++ b/pkg/jx/cmd/gc_activities.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jenkins-x/golang-jenkins"
@@ -20,7 +18,7 @@ import (
 // GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type GCActivitiesOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	RevisionHistoryLimit int
 	jclient              gojenkins.JenkinsClient
@@ -39,14 +37,9 @@ var (
 )
 
 // NewCmd s a command object for the "step" command
-func NewCmdGCActivities(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGCActivities(commonOpts *CommonOptions) *cobra.Command {
 	options := &GCActivitiesOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -62,7 +55,6 @@ func NewCmdGCActivities(f Factory, in terminal.FileReader, out terminal.FileWrit
 		},
 	}
 	cmd.Flags().IntVarP(&options.RevisionHistoryLimit, "revision-history-limit", "l", 5, "Minimum number of Activities per application to keep")
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/gc_gke.go
+++ b/pkg/jx/cmd/gc_gke.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"encoding/json"
 
@@ -24,7 +22,7 @@ import (
 // GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type GCGKEOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	RevisionHistoryLimit int
 	jclient              gojenkins.JenkinsClient
@@ -55,14 +53,9 @@ type Rule struct {
 }
 
 // NewCmd s a command object for the "step" command
-func NewCmdGCGKE(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGCGKE(commonOpts *CommonOptions) *cobra.Command {
 	options := &GCGKEOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/gc_helm.go
+++ b/pkg/jx/cmd/gc_helm.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -12,7 +11,6 @@ import (
 	"strconv"
 
 	"github.com/ghodss/yaml"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
@@ -25,7 +23,7 @@ import (
 // GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type GCHelmOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	RevisionHistoryLimit int
 	OutDir               string
@@ -46,14 +44,9 @@ var (
 )
 
 // NewCmdGCHelm  a command object for the "garbage collect" command
-func NewCmdGCHelm(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGCHelm(commonOpts *CommonOptions) *cobra.Command {
 	options := &GCHelmOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -68,7 +61,6 @@ func NewCmdGCHelm(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	cmd.Flags().IntVarP(&options.RevisionHistoryLimit, "revision-history-limit", "", 10, "Minimum number of versions per release to keep")
 	cmd.Flags().StringVarP(&options.OutDir, optionOutputDir, "o", "configmaps", "Relative directory to output backup to. Defaults to ./configmaps")
 	cmd.Flags().BoolVarP(&options.DryRun, "dry-run", "", false, "Does not perform the delete operation on Kubernetes")

--- a/pkg/jx/cmd/gc_pods.go
+++ b/pkg/jx/cmd/gc_pods.go
@@ -1,21 +1,20 @@
 package cmd
 
 import (
+	"strings"
+	"time"
+
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
-	"time"
 )
 
 // GCPodsOptions containers the CLI options
 type GCPodsOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Selector  string
 	Namespace string
@@ -38,14 +37,9 @@ var (
 )
 
 // NewCmdGCPods creates the command object
-func NewCmdGCPods(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGCPods(commonOpts *CommonOptions) *cobra.Command {
 	options := &GCPodsOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -64,7 +58,6 @@ func NewCmdGCPods(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 	cmd.Flags().StringVarP(&options.Selector, "selector", "s", "", "The selector to use to filter the pods")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The namespace to look for the pods. Defaults to the current namespace")
 	cmd.Flags().DurationVarP(&options.Age, "age", "a", time.Hour, "The minimum age of pods to garbage collect. Any newer pods will be kept")
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/gc_previews.go
+++ b/pkg/jx/cmd/gc_previews.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"strconv"
@@ -21,7 +19,7 @@ import (
 // GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type GCPreviewsOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	DisableImport bool
 	OutDir        string
@@ -41,14 +39,9 @@ var (
 )
 
 // NewCmd s a command object for the "step" command
-func NewCmdGCPreviews(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGCPreviews(commonOpts *CommonOptions) *cobra.Command {
 	options := &GCPreviewsOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -63,7 +56,6 @@ func NewCmdGCPreviews(f Factory, in terminal.FileReader, out terminal.FileWriter
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/gc_releases.go
+++ b/pkg/jx/cmd/gc_releases.go
@@ -2,12 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -16,7 +14,7 @@ import (
 
 // GCReleasesOptions contains the CLI options for this command
 type GCReleasesOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	RevisionHistoryLimit int
 }
@@ -34,15 +32,9 @@ var (
 )
 
 // NewCmd s a command object for the "step" command
-func NewCmdGCReleases(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGCReleases(commonOpts *CommonOptions) *cobra.Command {
 	options := &GCReleasesOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get.go
+++ b/pkg/jx/cmd/get.go
@@ -6,7 +6,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -16,7 +15,7 @@ import (
 // GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type GetOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Output string
 }
@@ -40,14 +39,9 @@ var (
 
 // NewCmdGet creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdGet(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGet(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -64,41 +58,41 @@ func NewCmdGet(f Factory, in terminal.FileReader, out terminal.FileWriter, errOu
 		SuggestFor: []string{"list", "ps"},
 	}
 
-	cmd.AddCommand(NewCmdGetActivity(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetAddon(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetApplications(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetAWSInfo(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetBranchPattern(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetBuild(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetBuildPack(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetChat(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetConfig(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetCVE(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetDevPod(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetEks(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetEnv(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetGit(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetHelmBin(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetIssue(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetIssues(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetLimits(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetPipeline(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetPostPreviewJob(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetPreview(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetQuickstartLocation(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetRelease(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetStorage(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetTeam(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetTeamRole(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetToken(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetTracker(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetURL(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetUser(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetWorkflow(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetVault(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetSecret(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetVaultConfig(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetPlugins(f, in, out, errOut))
+	cmd.AddCommand(NewCmdGetActivity(commonOpts))
+	cmd.AddCommand(NewCmdGetAddon(commonOpts))
+	cmd.AddCommand(NewCmdGetApplications(commonOpts))
+	cmd.AddCommand(NewCmdGetAWSInfo(commonOpts))
+	cmd.AddCommand(NewCmdGetBranchPattern(commonOpts))
+	cmd.AddCommand(NewCmdGetBuild(commonOpts))
+	cmd.AddCommand(NewCmdGetBuildPack(commonOpts))
+	cmd.AddCommand(NewCmdGetChat(commonOpts))
+	cmd.AddCommand(NewCmdGetConfig(commonOpts))
+	cmd.AddCommand(NewCmdGetCVE(commonOpts))
+	cmd.AddCommand(NewCmdGetDevPod(commonOpts))
+	cmd.AddCommand(NewCmdGetEks(commonOpts))
+	cmd.AddCommand(NewCmdGetEnv(commonOpts))
+	cmd.AddCommand(NewCmdGetGit(commonOpts))
+	cmd.AddCommand(NewCmdGetHelmBin(commonOpts))
+	cmd.AddCommand(NewCmdGetIssue(commonOpts))
+	cmd.AddCommand(NewCmdGetIssues(commonOpts))
+	cmd.AddCommand(NewCmdGetLimits(commonOpts))
+	cmd.AddCommand(NewCmdGetPipeline(commonOpts))
+	cmd.AddCommand(NewCmdGetPostPreviewJob(commonOpts))
+	cmd.AddCommand(NewCmdGetPreview(commonOpts))
+	cmd.AddCommand(NewCmdGetQuickstartLocation(commonOpts))
+	cmd.AddCommand(NewCmdGetRelease(commonOpts))
+	cmd.AddCommand(NewCmdGetStorage(commonOpts))
+	cmd.AddCommand(NewCmdGetTeam(commonOpts))
+	cmd.AddCommand(NewCmdGetTeamRole(commonOpts))
+	cmd.AddCommand(NewCmdGetToken(commonOpts))
+	cmd.AddCommand(NewCmdGetTracker(commonOpts))
+	cmd.AddCommand(NewCmdGetURL(commonOpts))
+	cmd.AddCommand(NewCmdGetUser(commonOpts))
+	cmd.AddCommand(NewCmdGetWorkflow(commonOpts))
+	cmd.AddCommand(NewCmdGetVault(commonOpts))
+	cmd.AddCommand(NewCmdGetSecret(commonOpts))
+	cmd.AddCommand(NewCmdGetVaultConfig(commonOpts))
+	cmd.AddCommand(NewCmdGetPlugins(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/get_activity.go
+++ b/pkg/jx/cmd/get_activity.go
@@ -67,7 +67,7 @@ func NewCmdGetActivity(commonOpts *CommonOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&options.Filter, "filter", "f", "", "Text to filter the pipeline names")
-	cmd.Flags().StringVarP(&options.BuildNumber, "build", "b", "", "The build number to filter on")
+	cmd.Flags().StringVarP(&options.BuildNumber, "build", "", "", "The build number to filter on")
 	cmd.Flags().BoolVarP(&options.Watch, "watch", "w", false, "Whether to watch the activities for changes")
 	return cmd
 }

--- a/pkg/jx/cmd/get_activity.go
+++ b/pkg/jx/cmd/get_activity.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	tbl "github.com/jenkins-x/jx/pkg/table"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
@@ -26,7 +24,7 @@ const (
 
 // GetActivityOptions containers the CLI options
 type GetActivityOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Filter      string
 	BuildNumber string
@@ -51,14 +49,9 @@ var (
 )
 
 // NewCmdGetActivity creates the new command for: jx get version
-func NewCmdGetActivity(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetActivity(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetActivityOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "activities",

--- a/pkg/jx/cmd/get_addon.go
+++ b/pkg/jx/cmd/get_addon.go
@@ -1,16 +1,12 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/addon"
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
 )
 
 // GetAddonOptions the command line options
@@ -31,15 +27,10 @@ var (
 )
 
 // NewCmdGetAddon creates the command
-func NewCmdGetAddon(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetAddon(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetAddonOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_applications.go
+++ b/pkg/jx/cmd/get_applications.go
@@ -1,17 +1,17 @@
 package cmd
 
 import (
-	"github.com/jenkins-x/jx/pkg/kube/services"
-	"github.com/jenkins-x/jx/pkg/table"
-	"github.com/pkg/errors"
-	"io"
-	"k8s.io/client-go/kubernetes"
 	"os/user"
 	"sort"
 	"strings"
 
+	"github.com/jenkins-x/jx/pkg/table"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/jenkins-x/jx/pkg/kube/services"
+
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -24,7 +24,7 @@ import (
 
 // GetApplicationsOptions containers the CLI options
 type GetApplicationsOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Namespace   string
 	Environment string
@@ -85,14 +85,9 @@ var (
 )
 
 // NewCmdGetApplications creates the new command for: jx get version
-func NewCmdGetApplications(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetApplications(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetApplicationsOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "applications",

--- a/pkg/jx/cmd/get_aws_info.go
+++ b/pkg/jx/cmd/get_aws_info.go
@@ -1,14 +1,11 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/cloud/amazon"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetAWSInfoOptions containers the CLI options
@@ -28,15 +25,10 @@ var (
 )
 
 // NewCmdGetAWSInfo creates the new command for: jx get env
-func NewCmdGetAWSInfo(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetAWSInfo(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetAWSInfoOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_branchpattern.go
+++ b/pkg/jx/cmd/get_branchpattern.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jenkins"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetBranchPatternOptions containers the CLI options
@@ -39,15 +36,10 @@ var (
 )
 
 // NewCmdGetBranchPattern creates the new command for: jx get env
-func NewCmdGetBranchPattern(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetBranchPattern(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetBranchPatternOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_build.go
+++ b/pkg/jx/cmd/get_build.go
@@ -1,17 +1,14 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 // GetBuildOptions the command line options
 type GetBuildOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Output string
 }
@@ -34,14 +31,9 @@ var (
 )
 
 // NewCmdGetBuild creates the command object
-func NewCmdGetBuild(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetBuild(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetBuildOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -58,8 +50,8 @@ func NewCmdGetBuild(f Factory, in terminal.FileReader, out terminal.FileWriter, 
 		SuggestFor: []string{"list", "ps"},
 	}
 
-	cmd.AddCommand(NewCmdGetBuildLogs(f, in, out, errOut))
-	cmd.AddCommand(NewCmdGetBuildPods(f, in, out, errOut))
+	cmd.AddCommand(NewCmdGetBuildLogs(commonOpts))
+	cmd.AddCommand(NewCmdGetBuildPods(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/get_build_logs.go
+++ b/pkg/jx/cmd/get_build_logs.go
@@ -83,7 +83,7 @@ func NewCmdGetBuildLogs(commonOpts *CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.BuildFilter.Owner, "owner", "o", "", "Filters the owner (person/organisation) of the repository")
 	cmd.Flags().StringVarP(&options.BuildFilter.Repository, "repo", "r", "", "Filters the build repository")
 	cmd.Flags().StringVarP(&options.BuildFilter.Branch, "branch", "", "", "Filters the branch")
-	cmd.Flags().StringVarP(&options.BuildFilter.Build, "build", "b", "", "The build number to view")
+	cmd.Flags().StringVarP(&options.BuildFilter.Build, "build", "", "", "The build number to view")
 
 	return cmd
 }

--- a/pkg/jx/cmd/get_build_logs.go
+++ b/pkg/jx/cmd/get_build_logs.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -58,16 +56,10 @@ var (
 )
 
 // NewCmdGetBuildLogs creates the command
-func NewCmdGetBuildLogs(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetBuildLogs(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetBuildLogsOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_build_pods.go
+++ b/pkg/jx/cmd/get_build_pods.go
@@ -69,7 +69,7 @@ func NewCmdGetBuildPods(commonOpts *CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.BuildFilter.Owner, "owner", "o", "", "Filters the owner (person/organisation) of the repository")
 	cmd.Flags().StringVarP(&options.BuildFilter.Repository, "repo", "r", "", "Filters the build repository")
 	cmd.Flags().StringVarP(&options.BuildFilter.Branch, "branch", "", "", "Filters the branch")
-	cmd.Flags().StringVarP(&options.BuildFilter.Build, "build", "b", "", "Filter a specific build number")
+	cmd.Flags().StringVarP(&options.BuildFilter.Build, "build", "", "", "Filter a specific build number")
 	return cmd
 }
 

--- a/pkg/jx/cmd/get_build_pods.go
+++ b/pkg/jx/cmd/get_build_pods.go
@@ -1,14 +1,13 @@
 package cmd
 
 import (
+	"strings"
+	"time"
+
 	"github.com/jenkins-x/jx/pkg/builds"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
-	"strings"
-	"time"
 )
 
 // GetBuildPodsOptions the command line options
@@ -44,16 +43,10 @@ var (
 )
 
 // NewCmdGetBuildPods creates the command
-func NewCmdGetBuildPods(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetBuildPods(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetBuildPodsOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_buildpack.go
+++ b/pkg/jx/cmd/get_buildpack.go
@@ -2,12 +2,9 @@ package cmd
 
 import (
 	"github.com/jenkins-x/jx/pkg/builds"
-	"github.com/jenkins-x/jx/pkg/util"
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetBuildPackOptions containers the CLI options
@@ -42,16 +39,10 @@ var (
 )
 
 // NewCmdGetBuildPack creates the new command for: jx get env
-func NewCmdGetBuildPack(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetBuildPack(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetBuildPackOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_chat.go
+++ b/pkg/jx/cmd/get_chat.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/chats"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
@@ -34,15 +32,10 @@ var (
 )
 
 // NewCmdGetChat creates the command
-func NewCmdGetChat(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetChat(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetChatOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_config.go
+++ b/pkg/jx/cmd/get_config.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
@@ -32,16 +29,10 @@ var (
 )
 
 // NewCmdGetConfig creates the command
-func NewCmdGetConfig(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetConfig(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetConfigOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_cve.go
+++ b/pkg/jx/cmd/get_cve.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"io"
+	"fmt"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
-	"fmt"
 
 	"github.com/jenkins-x/jx/pkg/cve"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -43,16 +40,10 @@ var (
 )
 
 // NewCmdGetCVE creates the command
-func NewCmdGetCVE(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetCVE(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetCVEOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -70,7 +61,6 @@ func NewCmdGetCVE(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 		},
 	}
 
-	options.addCommonFlags(cmd)
 	options.addGetCVEFlags(cmd)
 
 	return cmd

--- a/pkg/jx/cmd/get_devpod.go
+++ b/pkg/jx/cmd/get_devpod.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"io"
 	"os/user"
 	"time"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
@@ -32,15 +30,10 @@ var (
 )
 
 // NewCmdGetDevPod creates the command
-func NewCmdGetDevPod(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetDevPod(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetDevPodOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_eks.go
+++ b/pkg/jx/cmd/get_eks.go
@@ -2,19 +2,18 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/jenkins-x/jx/pkg/cloud/amazon"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
-	"io"
-	"os"
-	"os/exec"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type GetEksOptions struct {
@@ -40,15 +39,10 @@ var (
 	`)
 )
 
-func NewCmdGetEks(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetEks(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetEksOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_env.go
+++ b/pkg/jx/cmd/get_env.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,15 +36,10 @@ var (
 )
 
 // NewCmdGetEnv creates the new command for: jx get env
-func NewCmdGetEnv(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetEnv(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetEnvOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_git.go
+++ b/pkg/jx/cmd/get_git.go
@@ -1,12 +1,8 @@
 package cmd
 
 import (
-	"io"
-
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/spf13/cobra"
 )
 
 // GetGitOptions the command line options
@@ -27,15 +23,10 @@ var (
 )
 
 // NewCmdGetGit creates the command
-func NewCmdGetGit(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetGit(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetGitOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_helmbin.go
+++ b/pkg/jx/cmd/get_helmbin.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetHelmBinOptions containers the CLI options
@@ -35,15 +32,10 @@ var (
 )
 
 // NewCmdGetHelmBin creates the new command for: jx get env
-func NewCmdGetHelmBin(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetHelmBin(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetHelmBinOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_issue.go
+++ b/pkg/jx/cmd/get_issue.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"io"
 	"os/user"
 	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -40,16 +38,10 @@ var (
 )
 
 // NewCmdGetIssue creates the command
-func NewCmdGetIssue(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetIssue(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetIssueOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_issues.go
+++ b/pkg/jx/cmd/get_issues.go
@@ -1,14 +1,11 @@
 package cmd
 
 import (
-	"io"
 	"strings"
-
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/spf13/cobra"
 )
 
 // GetIssuesOptions contains the command line options
@@ -31,16 +28,10 @@ var (
 )
 
 // NewCmdGetIssues creates the command
-func NewCmdGetIssues(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetIssues(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetIssuesOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_limits.go
+++ b/pkg/jx/cmd/get_limits.go
@@ -1,19 +1,17 @@
 package cmd
 
 import (
-	"io"
-
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"encoding/json"
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"net/http"
 
-	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/spf13/cobra"
+
 	"strconv"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/log"
 )
 
 type RateLimits struct {
@@ -50,15 +48,10 @@ var (
 )
 
 // NewCmdGetLimits creates the command
-func NewCmdGetLimits(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetLimits(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetLimitsOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_pipeline.go
+++ b/pkg/jx/cmd/get_pipeline.go
@@ -2,15 +2,14 @@ package cmd
 
 import (
 	"errors"
-	"github.com/jenkins-x/jx/pkg/prow"
-	"io"
 	"sort"
 
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
+	"github.com/jenkins-x/jx/pkg/prow"
 
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -38,15 +37,10 @@ var (
 )
 
 // NewCmdGetPipeline creates the command
-func NewCmdGetPipeline(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetPipeline(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetPipelineOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_pipeline_test.go
+++ b/pkg/jx/cmd/get_pipeline_test.go
@@ -1,6 +1,11 @@
 package cmd_test
 
 import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/helm/mocks"
@@ -8,14 +13,10 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/prow"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"k8s.io/apimachinery/pkg/runtime"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"github.com/ghodss/yaml"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/test-infra/prow/config"
-	"os"
-	"testing"
 )
 
 func TestGetPipelinesWithProw(t *testing.T) {
@@ -23,9 +24,9 @@ func TestGetPipelinesWithProw(t *testing.T) {
 
 	// fake the output stream to be checked later
 	r, fakeStdout, _ := os.Pipe()
-	o.CommonOptions = cmd.CommonOptions{
-		Out:     fakeStdout,
-		Err:     os.Stderr,
+	o.CommonOptions = &cmd.CommonOptions{
+		Out: fakeStdout,
+		Err: os.Stderr,
 	}
 
 	mockProwConfig(&o, t)
@@ -55,19 +56,19 @@ func mockProwConfig(o *cmd.GetPipelineOptions, t *testing.T) {
 	ps.Name = "release"
 	prowConfig := &config.Config{}
 	prowConfig.Postsubmits = make(map[string][]config.Postsubmit)
-	prowConfig.Postsubmits["test/repo"] = []config.Postsubmit {ps}
+	prowConfig.Postsubmits["test/repo"] = []config.Postsubmit{ps}
 	configYAML, err := yaml.Marshal(&prowConfig)
 	data := make(map[string]string)
 	data[prow.ProwConfigFilename] = string(configYAML)
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: prow.ProwConfigMapName,
+			Name:      prow.ProwConfigMapName,
 			Namespace: "jx",
 		},
 		Data: data,
 	}
 
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{
 			cm,
 		},

--- a/pkg/jx/cmd/get_plugins.go
+++ b/pkg/jx/cmd/get_plugins.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/extensions"
@@ -26,8 +25,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/spf13/cobra"
 )
 
@@ -50,19 +47,14 @@ var (
 )
 
 type GetPluginsOptions struct {
-	CommonOptions
+	*CommonOptions
 	Verifier extensions.PathVerifier
 }
 
 // NewCmdGetPlugins provides a way to list all plugin executables visible to jx
-func NewCmdGetPlugins(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetPlugins(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetPluginsOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_post_preview_job.go
+++ b/pkg/jx/cmd/get_post_preview_job.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"io"
 	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
@@ -29,16 +27,10 @@ type GetPostPreviewJobOptions struct {
 }
 
 // NewCmdGetPostPreviewJob creates a command object for the "create" command
-func NewCmdGetPostPreviewJob(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetPostPreviewJob(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetPostPreviewJobOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -55,7 +47,6 @@ func NewCmdGetPostPreviewJob(f Factory, in terminal.FileReader, out terminal.Fil
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/get_preview.go
+++ b/pkg/jx/cmd/get_preview.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -36,17 +34,11 @@ var (
 )
 
 // NewCmdGetPreview creates the new command for: jx get env
-func NewCmdGetPreview(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetPreview(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetPreviewOptions{
 		GetEnvOptions: GetEnvOptions{
 			GetOptions: GetOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-
-					Out: out,
-					Err: errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/get_quickstart_locations.go
+++ b/pkg/jx/cmd/get_quickstart_locations.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetQuickstartLocationOptions containers the CLI options
@@ -44,16 +42,10 @@ var (
 )
 
 // NewCmdGetQuickstartLocation creates the new command for: jx get env
-func NewCmdGetQuickstartLocation(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetQuickstartLocation(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetQuickstartLocationOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_release.go
+++ b/pkg/jx/cmd/get_release.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetReleaseOptions containers the CLI options
@@ -35,16 +33,10 @@ var (
 )
 
 // NewCmdGetRelease creates the new command for: jx get env
-func NewCmdGetRelease(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetRelease(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetReleaseOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_secret.go
+++ b/pkg/jx/cmd/get_secret.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/vault"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type GetSecretOptions struct {
@@ -37,15 +34,10 @@ var (
 )
 
 // NewCmdGetSecret creates a new command for 'jx get secrets'
-func NewCmdGetSecret(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetSecret(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetSecretOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_storage.go
+++ b/pkg/jx/cmd/get_storage.go
@@ -1,14 +1,13 @@
 package cmd
 
 import (
+	"sort"
+
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/kube"
-	"io"
-	"sort"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetStorageOptions containers the CLI options
@@ -28,15 +27,10 @@ var (
 )
 
 // NewCmdGetStorage creates the new command for: jx get env
-func NewCmdGetStorage(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetStorage(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetStorageOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_team.go
+++ b/pkg/jx/cmd/get_team.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetTeamOptions containers the CLI options
@@ -33,16 +31,10 @@ var (
 )
 
 // NewCmdGetTeam creates the new command for: jx get env
-func NewCmdGetTeam(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetTeam(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetTeamOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_teamrole.go
+++ b/pkg/jx/cmd/get_teamrole.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetTeamRoleOptions containers the CLI options
@@ -28,15 +25,10 @@ var (
 )
 
 // NewCmdGetTeamRole creates the new command for: jx get env
-func NewCmdGetTeamRole(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetTeamRole(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetTeamRoleOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_token.go
+++ b/pkg/jx/cmd/get_token.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetTokenOptions the command line options
@@ -17,15 +14,10 @@ type GetTokenOptions struct {
 }
 
 // NewCmdGetToken creates the command
-func NewCmdGetToken(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetToken(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetTokenOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -40,7 +32,7 @@ func NewCmdGetToken(f Factory, in terminal.FileReader, out terminal.FileWriter, 
 			CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdGetTokenAddon(f, in, out, errOut))
+	cmd.AddCommand(NewCmdGetTokenAddon(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/get_token_addon.go
+++ b/pkg/jx/cmd/get_token_addon.go
@@ -1,14 +1,10 @@
 package cmd
 
 import (
-	"io"
-
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
-	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 // GetTokenAddonOptions the command line options
@@ -29,16 +25,11 @@ var (
 )
 
 // NewCmdGetTokenAddon creates the command
-func NewCmdGetTokenAddon(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetTokenAddon(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetTokenAddonOptions{
 		GetTokenOptions{
 			GetOptions: GetOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/get_tracker.go
+++ b/pkg/jx/cmd/get_tracker.go
@@ -1,16 +1,13 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/issues"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
-	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 // GetTrackerOptions the command line options
@@ -34,15 +31,10 @@ var (
 )
 
 // NewCmdGetTracker creates the command
-func NewCmdGetTracker(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetTracker(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetTrackerOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_url.go
+++ b/pkg/jx/cmd/get_url.go
@@ -1,13 +1,9 @@
 package cmd
 
 import (
-	"github.com/jenkins-x/jx/pkg/kube/services"
-	"io"
-
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/jenkins-x/jx/pkg/kube/services"
+	"github.com/spf13/cobra"
 )
 
 // GetURLOptions the command line options
@@ -31,16 +27,10 @@ var (
 )
 
 // NewCmdGetURL creates the command
-func NewCmdGetURL(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetURL(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetURLOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_user.go
+++ b/pkg/jx/cmd/get_user.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetUserOptions containers the CLI options
@@ -30,15 +28,10 @@ var (
 )
 
 // NewCmdGetUser creates the new command for: jx get env
-func NewCmdGetUser(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetUser(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetUserOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_vault.go
+++ b/pkg/jx/cmd/get_vault.go
@@ -1,14 +1,11 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/kube/vault"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type GetVaultOptions struct {
@@ -29,15 +26,10 @@ var (
 )
 
 // NewCmdGetVault creates a new command for 'jx get vaults'
-func NewCmdGetVault(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetVault(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetVaultOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_vault_config.go
+++ b/pkg/jx/cmd/get_vault_config.go
@@ -2,12 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"runtime"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type GetVaultConfigOptions struct {
@@ -38,15 +36,10 @@ var (
 )
 
 // NewCmdGetVaultConfig creates a new command for 'jx get secrets'
-func NewCmdGetVaultConfig(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetVaultConfig(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetVaultConfigOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/get_workflow.go
+++ b/pkg/jx/cmd/get_workflow.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -9,7 +8,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/workflow"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,15 +33,10 @@ var (
 )
 
 // NewCmdGetWorkflow creates the new command for: jx get env
-func NewCmdGetWorkflow(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdGetWorkflow(commonOpts *CommonOptions) *cobra.Command {
 	options := &GetWorkflowOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/get_workflow_integration_test.go
+++ b/pkg/jx/cmd/get_workflow_integration_test.go
@@ -15,7 +15,11 @@ import (
 )
 
 func TestGetWorkflow(t *testing.T) {
-	o := &cmd.GetWorkflowOptions{}
+	o := &cmd.GetWorkflowOptions{
+		GetOptions: cmd.GetOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
+	}
 
 	staging := kube.NewPermanentEnvironment("staging")
 	production := kube.NewPermanentEnvironment("production")
@@ -23,7 +27,7 @@ func TestGetWorkflow(t *testing.T) {
 	production.Spec.Order = 200
 
 	myFlowName := "myflow"
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{},
 		[]runtime.Object{
 			staging,

--- a/pkg/jx/cmd/import_integration_test.go
+++ b/pkg/jx/cmd/import_integration_test.go
@@ -63,8 +63,10 @@ func testImportProject(t *testing.T, tempDir string, testcase string, srcDir str
 func assertImport(t *testing.T, testDir string, testcase string, withRename bool) error {
 	_, dirName := filepath.Split(testDir)
 	dirName = kube.ToValidName(dirName)
-	o := &cmd.ImportOptions{}
-	cmd.ConfigureTestOptions(&o.CommonOptions, gits.NewGitCLI(), helm.NewHelmCLI("helm", helm.V2, dirName, true))
+	o := &cmd.ImportOptions{
+		CommonOptions: &cmd.CommonOptions{},
+	}
+	cmd.ConfigureTestOptions(o.CommonOptions, gits.NewGitCLI(), helm.NewHelmCLI("helm", helm.V2, dirName, true))
 	o.Dir = testDir
 	o.DryRun = true
 	o.DisableMaven = true

--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"strings"
@@ -20,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -30,7 +28,7 @@ import (
 
 // InitOptions the options for running init
 type InitOptions struct {
-	CommonOptions
+	*CommonOptions
 	Client clientset.Clientset
 	Flags  InitFlags
 }
@@ -88,15 +86,9 @@ var (
 
 // NewCmdInit creates a command object for the generic "init" action, which
 // primes a Kubernetes cluster so it's ready for Jenkins X to be installed
-func NewCmdInit(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdInit(commonOpts *CommonOptions) *cobra.Command {
 	options := &InitOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -112,7 +104,6 @@ func NewCmdInit(f Factory, in terminal.FileReader, out terminal.FileWriter, errO
 		},
 	}
 
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Flags.Provider, "provider", "", "", "Cloud service providing the Kubernetes cluster.  Supported providers: "+KubernetesProviderOptions())
 	cmd.Flags().StringVarP(&options.Flags.Namespace, optionNamespace, "", "jx", "The namespace the Jenkins X platform should be installed into")

--- a/pkg/jx/cmd/install_dependencies.go
+++ b/pkg/jx/cmd/install_dependencies.go
@@ -4,8 +4,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
 )
 
 // InstallDependenciesFlags flags for the install command
@@ -15,7 +13,7 @@ type InstallDependenciesFlags struct {
 
 // InstallDependenciesOptions options for install dependencies
 type InstallDependenciesOptions struct {
-	CommonOptions
+	*CommonOptions
 	Flags InstallDependenciesFlags
 }
 
@@ -60,9 +58,9 @@ var (
 )
 
 // NewCmdInstallDependencies creates a command object to install any required dependencies
-func NewCmdInstallDependencies(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdInstallDependencies(commonOpts *CommonOptions) *cobra.Command {
 
-	options := CreateInstallDependenciesOptions(f, in, out, errOut)
+	options := CreateInstallDependenciesOptions(commonOpts)
 
 	cmd := &cobra.Command{
 		Use:     "dependencies",
@@ -85,15 +83,9 @@ func NewCmdInstallDependencies(f Factory, in terminal.FileReader, out terminal.F
 }
 
 // CreateInstallDependenciesOptions creates the options for jx install dependencies
-func CreateInstallDependenciesOptions(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) InstallDependenciesOptions {
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-		Out:     out,
-		Err:     errOut,
-	}
+func CreateInstallDependenciesOptions(commonOpts *CommonOptions) InstallDependenciesOptions {
 	options := InstallDependenciesOptions{
-		CommonOptions: commonOptions,
+		CommonOptions: commonOpts,
 	}
 	return options
 }

--- a/pkg/jx/cmd/install_dependencies.go
+++ b/pkg/jx/cmd/install_dependencies.go
@@ -76,7 +76,6 @@ func NewCmdInstallDependencies(commonOpts *CommonOptions) *cobra.Command {
 		SuggestFor: []string{"dependency"},
 	}
 
-	options.addCommonFlags(cmd)
 	cmd.Flags().StringArrayVarP(&options.Flags.Dependencies, "dependencies", "d", []string{}, "The dependencies to install")
 
 	return cmd

--- a/pkg/jx/cmd/install_gitops_integration_test.go
+++ b/pkg/jx/cmd/install_gitops_integration_test.go
@@ -46,16 +46,16 @@ func TestInstallGitOps(t *testing.T) {
 		},
 	}
 
-	co := cmd.CommonOptions{
+	co := &cmd.CommonOptions{
 		In:  os.Stdin,
 		Out: os.Stdout,
 		Err: os.Stderr,
 	}
-	o := cmd.CreateInstallOptions(co.Factory, co.In, co.Out, co.Err)
+	o := cmd.CreateInstallOptions(co)
 
 	gitter := gits.NewGitFake()
 	helmer := helm_test.NewFakeHelmer()
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{
 			clusterAdminRole,
 			testkube.CreateFakeGitSecret(),

--- a/pkg/jx/cmd/login.go
+++ b/pkg/jx/cmd/login.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -20,7 +19,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -48,7 +46,7 @@ type UserLoginInfo struct {
 
 // LoginOptions options for login command
 type LoginOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	URL  string
 	Team string
@@ -69,15 +67,9 @@ var (
 		`)
 )
 
-func NewCmdLogin(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdLogin(commonOpts *CommonOptions) *cobra.Command {
 	options := &LoginOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "login",

--- a/pkg/jx/cmd/logs.go
+++ b/pkg/jx/cmd/logs.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -15,7 +14,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 
@@ -24,7 +22,7 @@ import (
 )
 
 type LogsOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Container       string
 	Namespace       string
@@ -53,15 +51,9 @@ var (
 `)
 )
 
-func NewCmdLogs(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdLogs(commonOpts *CommonOptions) *cobra.Command {
 	options := &LogsOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "logs [deployment]",

--- a/pkg/jx/cmd/namespace.go
+++ b/pkg/jx/cmd/namespace.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/jenkins-x/jx/pkg/kube"
-	"io"
 
 	"github.com/spf13/cobra"
 
@@ -15,12 +15,11 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/util"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/client-go/kubernetes"
 )
 
 type NamespaceOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 const (
@@ -41,14 +40,9 @@ var (
 		jx ns cheese`)
 )
 
-func NewCmdNamespace(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdNamespace(commonOpts *CommonOptions) *cobra.Command {
 	options := &NamespaceOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "namespace",
@@ -63,7 +57,6 @@ func NewCmdNamespace(f Factory, in terminal.FileReader, out terminal.FileWriter,
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/open.go
+++ b/pkg/jx/cmd/open.go
@@ -1,12 +1,8 @@
 package cmd
 
 import (
-	"io"
-
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/spf13/cobra"
 )
 
 type OpenOptions struct {
@@ -30,18 +26,12 @@ var (
 		jx open`)
 )
 
-func NewCmdOpen(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdOpen(commonOpts *CommonOptions) *cobra.Command {
 	options := &OpenOptions{
 		ConsoleOptions: ConsoleOptions{
 			GetURLOptions: GetURLOptions{
 				GetOptions: GetOptions{
-					CommonOptions: CommonOptions{
-						Factory: f,
-						In:      in,
-
-						Out: out,
-						Err: errOut,
-					},
+					CommonOptions: commonOpts,
 				},
 			},
 		},

--- a/pkg/jx/cmd/preview.go
+++ b/pkg/jx/cmd/preview.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -20,7 +19,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,18 +82,13 @@ type PreviewOptions struct {
 }
 
 // NewCmdPreview creates a command object for the "create" command
-func NewCmdPreview(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdPreview(commonOpts *CommonOptions) *cobra.Command {
 	options := &PreviewOptions{
 		HelmValuesConfig: config.HelmValuesConfig{
 			ExposeController: &config.ExposeController{},
 		},
 		PromoteOptions: PromoteOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -118,7 +111,6 @@ func NewCmdPreview(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 	//addCreateAppFlags(cmd, &options.CreateOptions)
 
 	options.addPreviewOptions(cmd)
-	options.addCommonFlags(cmd)
 	options.HelmValuesConfig.AddExposeControllerValues(cmd, false)
 	options.PromoteOptions.addPromoteOptions(cmd)
 

--- a/pkg/jx/cmd/preview_test.go
+++ b/pkg/jx/cmd/preview_test.go
@@ -172,7 +172,7 @@ func setupMocks() (*cmd.PreviewOptions, *cs_fake.Clientset) {
 	factory := cmd_mocks.NewMockFactory()
 	previewOpts := &cmd.PreviewOptions{
 		PromoteOptions: cmd.PromoteOptions{
-			CommonOptions: cmd.CommonOptions{
+			CommonOptions: &cmd.CommonOptions{
 				Factory:   factory,
 				Out:       os.Stdout,
 				In:        os.Stdin,

--- a/pkg/jx/cmd/promote.go
+++ b/pkg/jx/cmd/promote.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -22,7 +21,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,7 +39,7 @@ var (
 
 // PromoteOptions containers the CLI options
 type PromoteOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Namespace               string
 	Environment             string
@@ -117,14 +115,9 @@ var (
 )
 
 // NewCmdPromote creates the new command for: jx get prompt
-func NewCmdPromote(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdPromote(commonOpts *CommonOptions) *cobra.Command {
 	options := &PromoteOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "promote [application]",
@@ -139,7 +132,6 @@ func NewCmdPromote(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 		},
 	}
 
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The Namespace to promote to")
 	cmd.Flags().StringVarP(&options.Environment, optionEnvironment, "e", "", "The Environment to promote to")

--- a/pkg/jx/cmd/promote_test.go
+++ b/pkg/jx/cmd/promote_test.go
@@ -1,8 +1,9 @@
 package cmd_test
 
 import (
-	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"testing"
+
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/helm/mocks"
@@ -47,8 +48,8 @@ func TestPromoteToProductionRun(t *testing.T) {
 		// test settings
 		UseFakeHelm: true,
 	}
-	promoteOptions.CommonOptions = *testEnv.CommonOptions // Factory and other mocks initialized by cmd.ConfigureTestOptionsWithResources
-	promoteOptions.BatchMode = true                       // --batch-mode
+	promoteOptions.CommonOptions = testEnv.CommonOptions // Factory and other mocks initialized by cmd.ConfigureTestOptionsWithResources
+	promoteOptions.BatchMode = true                      // --batch-mode
 
 	// Check there is no PR for production env yet
 	jxClient, ns, err := promoteOptions.JXClientAndDevNamespace()
@@ -106,8 +107,8 @@ func TestPromoteToProductionNoMergeRun(t *testing.T) {
 		UseFakeHelm: true,
 	}
 
-	promoteOptions.CommonOptions = *testEnv.CommonOptions // Factory and other mocks initialized by cmd.ConfigureTestOptionsWithResources
-	promoteOptions.BatchMode = true                       // --batch-mode
+	promoteOptions.CommonOptions = testEnv.CommonOptions // Factory and other mocks initialized by cmd.ConfigureTestOptionsWithResources
+	promoteOptions.BatchMode = true                      // --batch-mode
 
 	jxClient, ns, err := promoteOptions.JXClientAndDevNamespace()
 	activities := jxClient.JenkinsV1().PipelineActivities(ns)
@@ -178,8 +179,8 @@ func TestPromoteToProductionPRPollingRun(t *testing.T) {
 		UseFakeHelm: true,
 	}
 
-	promoteOptions.CommonOptions = *testEnv.CommonOptions // Factory and other mocks initialized by cmd.ConfigureTestOptionsWithResources
-	promoteOptions.BatchMode = true                       // --batch-mode
+	promoteOptions.CommonOptions = testEnv.CommonOptions // Factory and other mocks initialized by cmd.ConfigureTestOptionsWithResources
+	promoteOptions.BatchMode = true                      // --batch-mode
 
 	jxClient, ns, err := promoteOptions.JXClientAndDevNamespace()
 	activities := jxClient.JenkinsV1().PipelineActivities(ns)
@@ -244,6 +245,9 @@ func prepareInitialPromotionEnv(t *testing.T, productionManualPromotion bool) (*
 	fakeGitProvider := gits.NewFakeProvider(fakeRepo, stagingRepo, prodRepo)
 
 	o := &cmd.ControllerWorkflowOptions{
+		ControllerOptions: cmd.ControllerOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		NoWatch:          true,
 		FakePullRequests: cmd.NewCreateEnvPullRequestFn(fakeGitProvider),
 		FakeGitProvider:  fakeGitProvider,
@@ -257,7 +261,7 @@ func prepareInitialPromotionEnv(t *testing.T, productionManualPromotion bool) (*
 
 	workflowName := "default"
 
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{},
 		[]runtime.Object{
 			staging,
@@ -317,7 +321,7 @@ func prepareInitialPromotionEnv(t *testing.T, productionManualPromotion bool) (*
 	return &TestEnv{
 		Activity:         a,
 		FakePullRequests: o.FakePullRequests,
-		CommonOptions:    &o.CommonOptions,
+		CommonOptions:    o.CommonOptions,
 		WorkflowOptions:  o,
 		FakeGitProvider:  fakeGitProvider,
 		DevRepo:          fakeRepo,

--- a/pkg/jx/cmd/prompt.go
+++ b/pkg/jx/cmd/prompt.go
@@ -1,13 +1,12 @@
 package cmd
 
 import (
-	"github.com/jenkins-x/jx/pkg/kube"
-	"io"
 	"os"
 	"strings"
 
+	"github.com/jenkins-x/jx/pkg/kube"
+
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/fatih/color"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -23,7 +22,7 @@ const (
 
 // PromptOptions containers the CLI options
 type PromptOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	NoLabel  bool
 	ShowIcon bool
@@ -57,15 +56,9 @@ var (
 )
 
 // NewCmdPrompt creates the new command for: jx get prompt
-func NewCmdPrompt(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdPrompt(commonOpts *CommonOptions) *cobra.Command {
 	options := &PromptOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "prompt",

--- a/pkg/jx/cmd/repository.go
+++ b/pkg/jx/cmd/repository.go
@@ -2,19 +2,17 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 type RepoOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Dir         string
 	OnlyViewURL bool
@@ -35,15 +33,9 @@ var (
 `)
 )
 
-func NewCmdRepo(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdRepo(commonOpts *CommonOptions) *cobra.Command {
 	options := &RepoOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "repository",
@@ -58,7 +50,6 @@ func NewCmdRepo(f Factory, in terminal.FileReader, out terminal.FileWriter, errO
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	cmd.Flags().BoolVarP(&options.OnlyViewURL, "url", "u", false, "Only displays and the URL and does not open the browser")
 	return cmd
 }

--- a/pkg/jx/cmd/rsh.go
+++ b/pkg/jx/cmd/rsh.go
@@ -2,19 +2,16 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"strings"
 
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -25,7 +22,7 @@ const (
 )
 
 type RshOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Container   string
 	Namespace   string
@@ -60,15 +57,9 @@ var (
 `)
 )
 
-func NewCmdRsh(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdRsh(commonOpts *CommonOptions) *cobra.Command {
 	options := &RshOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "rsh [deploymentOrPodName]",

--- a/pkg/jx/cmd/scan.go
+++ b/pkg/jx/cmd/scan.go
@@ -1,16 +1,13 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // Scan Options contains the command line options for scan commands
 type ScanOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 var (
@@ -20,14 +17,9 @@ var (
 )
 
 // NewCmdScan creates a command object for the "scan" command
-func NewCmdScan(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdScan(commonOpts *CommonOptions) *cobra.Command {
 	options := &ScanOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -42,7 +34,7 @@ func NewCmdScan(f Factory, in terminal.FileReader, out terminal.FileWriter, errO
 		},
 	}
 
-	cmd.AddCommand(NewCmdScanCluster(f, in, out, errOut))
+	cmd.AddCommand(NewCmdScanCluster(commonOpts))
 
 	return cmd
 }

--- a/pkg/jx/cmd/scan_cluster.go
+++ b/pkg/jx/cmd/scan_cluster.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"gopkg.in/yaml.v2"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
@@ -61,16 +60,10 @@ type scanResult struct {
 }
 
 // NewCmdScanCluster creates a command object for "scan cluster" command
-func NewCmdScanCluster(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdScanCluster(commonOpts *CommonOptions) *cobra.Command {
 	options := &ScanClusterOptions{
 		ScanOptions: ScanOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/serve_buildnumbers.go
+++ b/pkg/jx/cmd/serve_buildnumbers.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/buildnum"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -18,7 +15,7 @@ const (
 
 // ServeBuildNumbersOptions holds the options for the build number service.
 type ServeBuildNumbersOptions struct {
-	CommonOptions
+	*CommonOptions
 	BindAddress string
 	Port        int
 }
@@ -31,14 +28,9 @@ var (
 )
 
 // NewCmdSControllerBuildNumbers builds a new command to serving build numbers over an HTTP interface.
-func NewCmdSControllerBuildNumbers(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdControllerBuildNumbers(commonOpts *CommonOptions) *cobra.Command {
 	options := ServeBuildNumbersOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     command,

--- a/pkg/jx/cmd/shell.go
+++ b/pkg/jx/cmd/shell.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -19,7 +18,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/util"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -50,7 +48,7 @@ fi
 )
 
 type ShellOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Filter string
 }
@@ -70,14 +68,9 @@ var (
 `)
 )
 
-func NewCmdShell(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdShell(commonOpts *CommonOptions) *cobra.Command {
 	options := &ShellOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "shell",
@@ -93,7 +86,6 @@ func NewCmdShell(f Factory, in terminal.FileReader, out terminal.FileWriter, err
 		},
 	}
 	cmd.Flags().StringVarP(&options.Filter, "filter", "f", "", "Filter the list of contexts to switch between using the given text")
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/start.go
+++ b/pkg/jx/cmd/start.go
@@ -1,17 +1,14 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 // Start contains the command line options
 type Start struct {
-	CommonOptions
+	*CommonOptions
 }
 
 var (
@@ -27,14 +24,9 @@ var (
 
 // NewCmdStart creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdStart(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStart(commonOpts *CommonOptions) *cobra.Command {
 	options := &Start{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -51,8 +43,8 @@ func NewCmdStart(f Factory, in terminal.FileReader, out terminal.FileWriter, err
 		SuggestFor: []string{"begin"},
 	}
 
-	cmd.AddCommand(NewCmdStartPipeline(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStartProtection(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStartPipeline(commonOpts))
+	cmd.AddCommand(NewCmdStartProtection(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/start_pipeline.go
+++ b/pkg/jx/cmd/start_pipeline.go
@@ -3,18 +3,17 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/prow"
-	"io"
-	"k8s.io/api/core/v1"
-	"k8s.io/test-infra/prow/kube"
-	"k8s.io/test-infra/prow/pjutil"
 	"net/url"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/jenkins-x/jx/pkg/prow"
+	"k8s.io/api/core/v1"
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/pjutil"
+
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -62,16 +61,10 @@ var (
 )
 
 // NewCmdStartPipeline creates the command
-func NewCmdStartPipeline(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStartPipeline(commonOpts *CommonOptions) *cobra.Command {
 	options := &StartPipelineOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/start_protection.go
+++ b/pkg/jx/cmd/start_protection.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -10,7 +9,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/prow"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -43,16 +41,10 @@ var (
 )
 
 // NewCmdStartProtection creates the command
-func NewCmdStartProtection(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStartProtection(commonOpts *CommonOptions) *cobra.Command {
 	options := &StartProtectionOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-
-				Out: out,
-				Err: errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/status.go
+++ b/pkg/jx/cmd/status.go
@@ -2,20 +2,19 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/util"
-	"io"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/util"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type StatusOptions struct {
-	CommonOptions
+	*CommonOptions
 	node string
 }
 
@@ -31,15 +30,9 @@ var (
 `)
 )
 
-func NewCmdStatus(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStatus(commonOpts *CommonOptions) *cobra.Command {
 	options := &StatusOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "status [node]",

--- a/pkg/jx/cmd/status_test.go
+++ b/pkg/jx/cmd/status_test.go
@@ -102,7 +102,7 @@ func TestStatusRun(t *testing.T) {
 
 	// Setup options
 	options := &cmd.StatusOptions{
-		CommonOptions: cmd.CommonOptions{
+		CommonOptions: &cmd.CommonOptions{
 			Factory: factory,
 			Out:     os.Stdout,
 			Err:     os.Stderr,

--- a/pkg/jx/cmd/step.go
+++ b/pkg/jx/cmd/step.go
@@ -1,16 +1,13 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type StepOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	DisableImport bool
 	OutDir        string
@@ -19,14 +16,9 @@ type StepOptions struct {
 var ()
 
 // NewCmdStep Steps a command object for the "step" command
-func NewCmdStep(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStep(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -41,30 +33,30 @@ func NewCmdStep(f Factory, in terminal.FileReader, out terminal.FileWriter, errO
 		},
 	}
 
-	cmd.AddCommand(NewCmdStepBuildPack(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepBDD(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepBlog(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepChangelog(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepCreate(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepEnv(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepGit(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepGpgCredentials(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepHelm(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepLinkServices(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepNexus(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepNextVersion(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepNextBuildNumber(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepPre(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepPR(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepPost(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepReport(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepRelease(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepSplitMonorepo(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepTag(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepValidate(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepVerify(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepWaitForArtifact(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepCollect(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStepBuildPack(commonOpts))
+	cmd.AddCommand(NewCmdStepBDD(commonOpts))
+	cmd.AddCommand(NewCmdStepBlog(commonOpts))
+	cmd.AddCommand(NewCmdStepChangelog(commonOpts))
+	cmd.AddCommand(NewCmdStepCreate(commonOpts))
+	cmd.AddCommand(NewCmdStepEnv(commonOpts))
+	cmd.AddCommand(NewCmdStepGit(commonOpts))
+	cmd.AddCommand(NewCmdStepGpgCredentials(commonOpts))
+	cmd.AddCommand(NewCmdStepHelm(commonOpts))
+	cmd.AddCommand(NewCmdStepLinkServices(commonOpts))
+	cmd.AddCommand(NewCmdStepNexus(commonOpts))
+	cmd.AddCommand(NewCmdStepNextVersion(commonOpts))
+	cmd.AddCommand(NewCmdStepNextBuildNumber(commonOpts))
+	cmd.AddCommand(NewCmdStepPre(commonOpts))
+	cmd.AddCommand(NewCmdStepPR(commonOpts))
+	cmd.AddCommand(NewCmdStepPost(commonOpts))
+	cmd.AddCommand(NewCmdStepReport(commonOpts))
+	cmd.AddCommand(NewCmdStepRelease(commonOpts))
+	cmd.AddCommand(NewCmdStepSplitMonorepo(commonOpts))
+	cmd.AddCommand(NewCmdStepTag(commonOpts))
+	cmd.AddCommand(NewCmdStepValidate(commonOpts))
+	cmd.AddCommand(NewCmdStepVerify(commonOpts))
+	cmd.AddCommand(NewCmdStepWaitForArtifact(commonOpts))
+	cmd.AddCommand(NewCmdStepCollect(commonOpts))
 
 	return cmd
 }

--- a/pkg/jx/cmd/step_bdd.go
+++ b/pkg/jx/cmd/step_bdd.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -9,12 +13,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 const (
@@ -58,17 +57,12 @@ var (
 `)
 )
 
-func NewCmdStepBDD(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepBDD(commonOpts *CommonOptions) *cobra.Command {
 	options := StepBDDOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
-		InstallOptions: CreateInstallOptions(f, in, out, errOut),
+		InstallOptions: CreateInstallOptions(commonOpts),
 	}
 	cmd := &cobra.Command{
 		Use:     "bdd",
@@ -85,7 +79,6 @@ func NewCmdStepBDD(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 	installOptions := &options.InstallOptions
 	installOptions.addInstallFlags(cmd, true)
 
-	options.addCommonFlags(cmd)
 	cmd.Flags().StringVarP(&options.Flags.GitProvider, "git-provider", "g", "", "the git provider kind")
 	cmd.Flags().StringVarP(&options.Flags.GitOwner, "git-owner", "", "", "the git owner of new git repositories created by the tests")
 	cmd.Flags().StringVarP(&options.Flags.TestRepoGitCloneUrl, "test-git-repo", "r", "https://github.com/jenkins-x/bdd-jx.git", "the git repository to clone for the BDD tests")
@@ -282,7 +275,7 @@ func (o *StepBDDOptions) deleteTeam(team string) error {
 
 }
 
-func (o *StepBDDOptions) createDefaultCommonOptions() CommonOptions {
+func (o *StepBDDOptions) createDefaultCommonOptions() *CommonOptions {
 	defaultOptions := o.CommonOptions
 	defaultOptions.BatchMode = true
 	defaultOptions.Headless = true

--- a/pkg/jx/cmd/step_blog.go
+++ b/pkg/jx/cmd/step_blog.go
@@ -23,7 +23,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/reports"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -75,15 +74,10 @@ type StepBlogState struct {
 }
 
 // NewCmdStepBlog Creates a new Command object
-func NewCmdStepBlog(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepBlog(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepBlogOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -99,7 +93,6 @@ func NewCmdStepBlog(f Factory, in terminal.FileReader, out terminal.FileWriter, 
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Dir, "dir", "d", "", "The directory to query to find the projects .git directory")
 	cmd.Flags().StringVarP(&options.FromDate, "from-date", "f", "", "The date to create the charts from. Defaults to a week before the to date. Should be a format: "+util.DateFormat)

--- a/pkg/jx/cmd/step_buildpack.go
+++ b/pkg/jx/cmd/step_buildpack.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
 )
 
 // StepBuildPackOptions contains the command line flags
@@ -12,21 +10,16 @@ type StepBuildPackOptions struct {
 }
 
 // NewCmdStepBuildPack Steps a command object for the "step" command
-func NewCmdStepBuildPack(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepBuildPack(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepBuildPackOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
 	cmd := &cobra.Command{
-		Use:   "buildpack",
-		Short: "buildpack [command]",
+		Use:     "buildpack",
+		Short:   "buildpack [command]",
 		Aliases: buildPacksAliases,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Cmd = cmd
@@ -35,7 +28,7 @@ func NewCmdStepBuildPack(f Factory, in terminal.FileReader, out terminal.FileWri
 			CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdStepBuildPackApply(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStepBuildPackApply(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_buildpack_apply.go
+++ b/pkg/jx/cmd/step_buildpack_apply.go
@@ -1,14 +1,17 @@
 package cmd
 
 import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/jenkins-x/jx/pkg/jenkinsfile"
+
+	"os"
+
 	"github.com/jenkins-x/jx/pkg/jenkins"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
-	"os"
-	"path/filepath"
 )
 
 var (
@@ -37,15 +40,10 @@ type StepBuildPackApplyOptions struct {
 }
 
 // NewCmdStepBuildPackApply Creates a new Command object
-func NewCmdStepBuildPackApply(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepBuildPackApply(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepBuildPackApplyOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -61,7 +59,6 @@ func NewCmdStepBuildPackApply(f Factory, in terminal.FileReader, out terminal.Fi
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Dir, "dir", "d", "", "The directory to query to find the projects .git directory")
 	cmd.Flags().StringVarP(&options.Jenkinsfile, "jenkinsfile", "", "", "The name of the Jenkinsfile to use. If not specified then 'Jenkinsfile' will be used")
@@ -77,13 +74,13 @@ func (o *StepBuildPackApplyOptions) Run() error {
 	if dir == "" {
 		dir, err = os.Getwd()
 		if err != nil {
-		  return err
+			return err
 		}
 	}
 
 	settings, err := o.CommonOptions.TeamSettings()
 	if err != nil {
-	  return err
+		return err
 	}
 	log.Infof("build pack is %s\n", settings.BuildPackURL)
 
@@ -112,4 +109,9 @@ func (o *StepBuildPackApplyOptions) Run() error {
 		return err
 	}
 	return nil
+}
+
+// resolveImportFile resolve an import name and file
+func (o *StepBuildPackApplyOptions) resolveImportFile(importFile *jenkinsfile.ImportFile) (string, error) {
+	return importFile.File, fmt.Errorf("not implemented")
 }

--- a/pkg/jx/cmd/step_buildpack_apply_integration_test.go
+++ b/pkg/jx/cmd/step_buildpack_apply_integration_test.go
@@ -1,6 +1,12 @@
 package cmd_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/builds"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -12,12 +18,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"k8s.io/apimachinery/pkg/runtime"
-	"os"
-	"path"
-	"path/filepath"
-	"testing"
 )
 
 func TestStepBuildPackApply(t *testing.T) {
@@ -39,7 +40,7 @@ func TestStepBuildPackApply(t *testing.T) {
 
 	o := &cmd.StepBuildPackApplyOptions{
 		StepOptions: cmd.StepOptions{
-			CommonOptions: cmd.CommonOptions{
+			CommonOptions: &cmd.CommonOptions{
 				In:  os.Stdin,
 				Out: os.Stdout,
 				Err: os.Stderr,
@@ -48,12 +49,11 @@ func TestStepBuildPackApply(t *testing.T) {
 		Dir: tempDir,
 	}
 
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{
 			testkube.CreateFakeGitSecret(),
 		},
-		[]runtime.Object{
-		},
+		[]runtime.Object{},
 		gits.NewGitCLI(),
 		helm.NewHelmCLI("helm", helm.V2, "", true),
 	)

--- a/pkg/jx/cmd/step_changelog.go
+++ b/pkg/jx/cmd/step_changelog.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -23,7 +22,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 
 	chgit "github.com/jenkins-x/chyle/chyle/git"
@@ -136,15 +134,10 @@ e.g. define environment variables GIT_USERNAME and GIT_API_TOKEN
 	JIRAIssueRegex   = regexp.MustCompile(`[A-Z][A-Z]+-(\d+)`)
 )
 
-func NewCmdStepChangelog(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepChangelog(commonOpts *CommonOptions) *cobra.Command {
 	options := StepChangelogOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{
@@ -160,7 +153,6 @@ func NewCmdStepChangelog(f Factory, in terminal.FileReader, out terminal.FileWri
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.PreviousRevision, "previous-rev", "p", "", "the previous tag revision")
 	cmd.Flags().StringVarP(&options.PreviousDate, "previous-date", "", "", "the previous date to find a revision in format 'MonthName dayNumber year'")

--- a/pkg/jx/cmd/step_collect.go
+++ b/pkg/jx/cmd/step_collect.go
@@ -54,6 +54,7 @@ var (
 `)
 )
 
+// NewCmdStepCollect creates a new 'step collect' Command.
 func NewCmdStepCollect(commonOpts *CommonOptions) *cobra.Command {
 	options := StepCollectOptions{
 		StepOptions: StepOptions{

--- a/pkg/jx/cmd/step_collect.go
+++ b/pkg/jx/cmd/step_collect.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/gits"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/jenkins-x/jx/pkg/gits"
 
 	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/kube"
@@ -19,7 +19,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepCollect contains the command line flags
@@ -55,15 +54,10 @@ var (
 `)
 )
 
-func NewCmdStepCollect(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepCollect(commonOpts *CommonOptions) *cobra.Command {
 	options := StepCollectOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/step_create.go
+++ b/pkg/jx/cmd/step_create.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
 )
 
 // StepCreateOptions contains the command line flags
@@ -12,15 +10,10 @@ type StepCreateOptions struct {
 }
 
 // NewCmdStepCreate Steps a command object for the "step" command
-func NewCmdStepCreate(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepCreate(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepCreateOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -34,8 +27,8 @@ func NewCmdStepCreate(f Factory, in terminal.FileReader, out terminal.FileWriter
 			CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdStepCreateBuild(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepCreateBuildTemplate(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStepCreateBuild(commonOpts))
+	cmd.AddCommand(NewCmdStepCreateBuildTemplate(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_create_build.go
+++ b/pkg/jx/cmd/step_create_build.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,15 +10,14 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/pkg/errors"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
+	buildapi "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	buildapi "github.com/knative/build/pkg/apis/build/v1alpha1"
 )
 
 var (
@@ -49,15 +47,10 @@ type StepCreateBuildOptions struct {
 }
 
 // NewCmdStepCreateBuild Creates a new Command object
-func NewCmdStepCreateBuild(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepCreateBuild(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepCreateBuildOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -73,7 +66,6 @@ func NewCmdStepCreateBuild(f Factory, in terminal.FileReader, out terminal.FileW
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Dir, "dir", "d", "", "The directory to query to find the projects .git directory")
 	cmd.Flags().StringVarP(&options.BranchKind, "kind", "k", "", "The kind of build such as 'release' or 'pullRequest' otherwise all of the builds are created")

--- a/pkg/jx/cmd/step_create_build_test.go
+++ b/pkg/jx/cmd/step_create_build_test.go
@@ -142,8 +142,12 @@ func testStepCreateBuild(t *testing.T, tempDir string, testcase string, srcDir s
 	}
 	jxObjects := []runtime.Object{}
 
-	o := &cmd.StepCreateBuildOptions{}
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions, k8sObjects, jxObjects, gits.NewGitCLI(), helm.NewHelmCLI("helm", helm.V2, dirName, true))
+	o := &cmd.StepCreateBuildOptions{
+		StepOptions: cmd.StepOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
+	}
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions, k8sObjects, jxObjects, gits.NewGitCLI(), helm.NewHelmCLI("helm", helm.V2, dirName, true))
 	o.Dir = testDir
 
 	actualFile := filepath.Join(testDir, actualBuildFileName)

--- a/pkg/jx/cmd/step_create_buildtemplate.go
+++ b/pkg/jx/cmd/step_create_buildtemplate.go
@@ -2,6 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/jenkinsfile"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -11,14 +16,8 @@ import (
 	buildapi "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
-	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 const (
@@ -54,15 +53,10 @@ type StepCreateBuildTemplateOptions struct {
 }
 
 // NewCmdStepCreateBuildTemplate Creates a new Command object
-func NewCmdStepCreateBuildTemplate(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepCreateBuildTemplate(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepCreateBuildTemplateOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/step_create_buildtemplate.go
+++ b/pkg/jx/cmd/step_create_buildtemplate.go
@@ -73,7 +73,6 @@ func NewCmdStepCreateBuildTemplate(commonOpts *CommonOptions) *cobra.Command {
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Dir, "dir", "d", "", "The directory to query to find the projects .git directory")
 	cmd.Flags().StringVarP(&options.OutputDir, "output-dir", "o", "jx-build-templates", "The directory where the generated build yaml files will be output to")

--- a/pkg/jx/cmd/step_env.go
+++ b/pkg/jx/cmd/step_env.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
 )
 
 // StepEnvOptions contains the command line flags
@@ -12,15 +10,10 @@ type StepEnvOptions struct {
 }
 
 // NewCmdStepEnv Steps a command object for the "step" command
-func NewCmdStepEnv(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepEnv(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepEnvOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -34,7 +27,7 @@ func NewCmdStepEnv(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 			CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdStepEnvApply(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStepEnvApply(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_env_apply.go
+++ b/pkg/jx/cmd/step_env_apply.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -17,7 +16,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepEnvApplyOptions contains the command line flags
@@ -49,16 +47,11 @@ var (
 )
 
 // NewCmdStepEnvApply registers the command
-func NewCmdStepEnvApply(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepEnvApply(commonOpts *CommonOptions) *cobra.Command {
 	options := StepEnvApplyOptions{
 		StepEnvOptions: StepEnvOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/step_git.go
+++ b/pkg/jx/cmd/step_git.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"fmt"
 	"io/ioutil"
@@ -21,15 +18,10 @@ type StepGitOptions struct {
 }
 
 // NewCmdStepGit Steps a command object for the "step" command
-func NewCmdStepGit(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepGit(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepGitOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -43,8 +35,8 @@ func NewCmdStepGit(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 			CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdStepGitCredentials(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepGitEnvs(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStepGitCredentials(commonOpts))
+	cmd.AddCommand(NewCmdStepGitEnvs(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_git_credentials.go
+++ b/pkg/jx/cmd/step_git_credentials.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -14,7 +13,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -45,15 +43,10 @@ var (
 `)
 )
 
-func NewCmdStepGitCredentials(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepGitCredentials(commonOpts *CommonOptions) *cobra.Command {
 	options := StepGitCredentialsOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/step_git_credentials.go
+++ b/pkg/jx/cmd/step_git_credentials.go
@@ -43,6 +43,7 @@ var (
 `)
 )
 
+// NewCmdStepGitCredentials creates a new 'step git credentials' Command.
 func NewCmdStepGitCredentials(commonOpts *CommonOptions) *cobra.Command {
 	options := StepGitCredentialsOptions{
 		StepOptions: StepOptions{

--- a/pkg/jx/cmd/step_git_envs.go
+++ b/pkg/jx/cmd/step_git_envs.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -37,15 +35,10 @@ var (
 )
 
 // NewCmdStepGitEnvs create the 'step git envs' command
-func NewCmdStepGitEnvs(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepGitEnvs(commonOpts *CommonOptions) *cobra.Command {
 	options := StepGitEnvsOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/step_gpg_credentials.go
+++ b/pkg/jx/cmd/step_gpg_credentials.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -12,7 +11,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -40,15 +38,10 @@ var (
 `)
 )
 
-func NewCmdStepGpgCredentials(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepGpgCredentials(commonOpts *CommonOptions) *cobra.Command {
 	options := StepGpgCredentialsOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/step_gpg_credentials.go
+++ b/pkg/jx/cmd/step_gpg_credentials.go
@@ -38,6 +38,7 @@ var (
 `)
 )
 
+// NewCmdStepGpgCredentials creates a new 'step gpg credentials' Command.
 func NewCmdStepGpgCredentials(commonOpts *CommonOptions) *cobra.Command {
 	options := StepGpgCredentialsOptions{
 		StepOptions: StepOptions{

--- a/pkg/jx/cmd/step_helm.go
+++ b/pkg/jx/cmd/step_helm.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"os"
 
@@ -33,15 +31,10 @@ type StepHelmOptions struct {
 }
 
 // NewCmdStepHelm Steps a command object for the "step" command
-func NewCmdStepHelm(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepHelm(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepHelmOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -55,14 +48,14 @@ func NewCmdStepHelm(f Factory, in terminal.FileReader, out terminal.FileWriter, 
 			CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdStepHelmApply(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepHelmBuild(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepHelmDelete(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepHelmEnv(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepHelmInstall(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepHelmList(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepHelmRelease(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepHelmVersion(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStepHelmApply(commonOpts))
+	cmd.AddCommand(NewCmdStepHelmBuild(commonOpts))
+	cmd.AddCommand(NewCmdStepHelmDelete(commonOpts))
+	cmd.AddCommand(NewCmdStepHelmEnv(commonOpts))
+	cmd.AddCommand(NewCmdStepHelmInstall(commonOpts))
+	cmd.AddCommand(NewCmdStepHelmList(commonOpts))
+	cmd.AddCommand(NewCmdStepHelmRelease(commonOpts))
+	cmd.AddCommand(NewCmdStepHelmVersion(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_helm_apply.go
+++ b/pkg/jx/cmd/step_helm_apply.go
@@ -43,6 +43,7 @@ var (
 	defaultValueFileNames = []string{"values.yaml", "myvalues.yaml", helm.SecretsFileName}
 )
 
+// NewCmdStepHelmApply creates a new 'step helm apply' Command.
 func NewCmdStepHelmApply(commonOpts *CommonOptions) *cobra.Command {
 	options := StepHelmApplyOptions{
 		StepHelmOptions: StepHelmOptions{

--- a/pkg/jx/cmd/step_helm_apply.go
+++ b/pkg/jx/cmd/step_helm_apply.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +14,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/vault"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepHelmApplyOptions contains the command line flags
@@ -45,16 +43,11 @@ var (
 	defaultValueFileNames = []string{"values.yaml", "myvalues.yaml", helm.SecretsFileName}
 )
 
-func NewCmdStepHelmApply(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepHelmApply(commonOpts *CommonOptions) *cobra.Command {
 	options := StepHelmApplyOptions{
 		StepHelmOptions: StepHelmOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/step_helm_build.go
+++ b/pkg/jx/cmd/step_helm_build.go
@@ -28,6 +28,7 @@ var (
 `)
 )
 
+// NewCmdStepHelmBuild creates a new 'step helm build' Command.
 func NewCmdStepHelmBuild(commonOpts *CommonOptions) *cobra.Command {
 	options := StepHelmBuildOptions{
 		StepHelmOptions: StepHelmOptions{

--- a/pkg/jx/cmd/step_helm_build.go
+++ b/pkg/jx/cmd/step_helm_build.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"io"
 	"os"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepHelmBuildOptions contains the command line flags
@@ -30,16 +28,11 @@ var (
 `)
 )
 
-func NewCmdStepHelmBuild(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepHelmBuild(commonOpts *CommonOptions) *cobra.Command {
 	options := StepHelmBuildOptions{
 		StepHelmOptions: StepHelmOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -58,7 +51,6 @@ func NewCmdStepHelmBuild(f Factory, in terminal.FileReader, out terminal.FileWri
 	}
 
 	options.addStepHelmFlags(cmd)
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().BoolVarP(&options.recursive, "recursive", "r", false, "Build recursively the dependent charts")
 

--- a/pkg/jx/cmd/step_helm_delete.go
+++ b/pkg/jx/cmd/step_helm_delete.go
@@ -2,12 +2,11 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
 )
 
 // StepHelmDeleteOptions contains the command line flags
@@ -15,7 +14,7 @@ type StepHelmDeleteOptions struct {
 	StepHelmOptions
 
 	Namespace string
-	Purge bool
+	Purge     bool
 }
 
 var (
@@ -31,16 +30,11 @@ var (
 )
 
 // NewCmdStepHelmDelete creates the command object
-func NewCmdStepHelmDelete(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepHelmDelete(commonOpts *CommonOptions) *cobra.Command {
 	options := StepHelmDeleteOptions{
 		StepHelmOptions: StepHelmOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -80,7 +74,7 @@ func (o *StepHelmDeleteOptions) Run() error {
 	if ns == "" {
 		_, ns, err = o.KubeClient()
 		if err != nil {
-		  return err
+			return err
 		}
 	}
 	err = h.DeleteRelease(ns, releaseName, o.Purge)

--- a/pkg/jx/cmd/step_helm_env.go
+++ b/pkg/jx/cmd/step_helm_env.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepHelmEnvOptions contains the command line flags
@@ -30,16 +28,11 @@ var (
 `)
 )
 
-func NewCmdStepHelmEnv(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepHelmEnv(commonOpts *CommonOptions) *cobra.Command {
 	options := StepHelmEnvOptions{
 		StepHelmOptions: StepHelmOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/step_helm_install.go
+++ b/pkg/jx/cmd/step_helm_install.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepHelmInstallOptions contains the command line flags
@@ -34,16 +32,11 @@ var (
 `)
 )
 
-func NewCmdStepHelmInstall(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepHelmInstall(commonOpts *CommonOptions) *cobra.Command {
 	options := StepHelmInstallOptions{
 		StepHelmOptions: StepHelmOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/step_helm_list.go
+++ b/pkg/jx/cmd/step_helm_list.go
@@ -2,11 +2,10 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
 )
 
 // StepHelmListOptions contains the command line flags
@@ -28,16 +27,11 @@ var (
 `)
 )
 
-func NewCmdStepHelmList(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepHelmList(commonOpts *CommonOptions) *cobra.Command {
 	options := StepHelmListOptions{
 		StepHelmOptions: StepHelmOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/step_helm_release.go
+++ b/pkg/jx/cmd/step_helm_release.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -16,7 +15,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -40,16 +38,11 @@ var (
 `)
 )
 
-func NewCmdStepHelmRelease(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepHelmRelease(commonOpts *CommonOptions) *cobra.Command {
 	options := StepHelmReleaseOptions{
 		StepHelmOptions: StepHelmOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/step_helm_version.go
+++ b/pkg/jx/cmd/step_helm_version.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepHelmVersionOptions contains the command line flags
@@ -33,16 +31,11 @@ var (
 `)
 )
 
-func NewCmdStepHelmVersion(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepHelmVersion(commonOpts *CommonOptions) *cobra.Command {
 	options := StepHelmVersionOptions{
 		StepHelmOptions: StepHelmOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/step_link_services.go
+++ b/pkg/jx/cmd/step_link_services.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,15 +42,10 @@ type StepLinkServicesOptions struct {
 }
 
 // NewCmdStepLinkServices Creates a new Command object
-func NewCmdStepLinkServices(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepLinkServices(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepLinkServicesOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -69,7 +61,6 @@ func NewCmdStepLinkServices(f Factory, in terminal.FileReader, out terminal.File
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.FromNamespace, fromNamespace, "f", "", "The source namespace from which the linking would happen")
 	cmd.Flags().StringVarP(&options.ToNamespace, toNamespace, "t", "", "The destination namespace to which the linking would happen")

--- a/pkg/jx/cmd/step_link_services_test.go
+++ b/pkg/jx/cmd/step_link_services_test.go
@@ -23,6 +23,9 @@ const (
 func TestServiceLinking(t *testing.T) {
 	t.Parallel()
 	o := cmd.StepLinkServicesOptions{
+		StepOptions: cmd.StepOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		FromNamespace: fromNs,
 		Includes:      []string{serviceNameInFromNs},
 		Excludes:      []string{serviceNameDummyInFromNs},
@@ -56,7 +59,7 @@ func TestServiceLinking(t *testing.T) {
 		},
 	}
 
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{fromNspc, toNspc, svcInFromNs, svcInToNs, svcDummyInFromNs},
 		nil,
 		gits.NewGitCLI(),

--- a/pkg/jx/cmd/step_next_buildnumber.go
+++ b/pkg/jx/cmd/step_next_buildnumber.go
@@ -37,6 +37,7 @@ var (
 `)
 )
 
+// NewCmdStepNextBuildNumber creates a new 'step next-buildnumber' Command.
 func NewCmdStepNextBuildNumber(commonOpts *CommonOptions) *cobra.Command {
 	options := StepNextBuildNumberOptions{
 		StepOptions: StepOptions{

--- a/pkg/jx/cmd/step_next_buildnumber.go
+++ b/pkg/jx/cmd/step_next_buildnumber.go
@@ -2,17 +2,15 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/buildnum"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 
-	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -39,15 +37,10 @@ var (
 `)
 )
 
-func NewCmdStepNextBuildNumber(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepNextBuildNumber(commonOpts *CommonOptions) *cobra.Command {
 	options := StepNextBuildNumberOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/step_next_buildnumber.go
+++ b/pkg/jx/cmd/step_next_buildnumber.go
@@ -58,7 +58,7 @@ func NewCmdStepNextBuildNumber(commonOpts *CommonOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&options.Owner, optionOwner, "o", "", "The Git repository owner")
 	cmd.Flags().StringVarP(&options.Repository, optionRepo, "r", "", "The Git repository name")
-	cmd.Flags().StringVarP(&options.Branch, optionBranch, "b", "master", "The Git branch")
+	cmd.Flags().StringVarP(&options.Branch, optionBranch, "", "master", "The Git branch")
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_next_version.go
+++ b/pkg/jx/cmd/step_next_version.go
@@ -57,6 +57,7 @@ var (
 `)
 )
 
+// NewCmdStepNextVersion creates a new 'step next-version' Command.
 func NewCmdStepNextVersion(commonOpts *CommonOptions) *cobra.Command {
 	options := StepNextVersionOptions{
 		StepOptions: StepOptions{

--- a/pkg/jx/cmd/step_next_version.go
+++ b/pkg/jx/cmd/step_next_version.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/xml"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
@@ -14,11 +13,10 @@ import (
 	"encoding/json"
 
 	"github.com/blang/semver"
-	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/go-version"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -59,8 +57,12 @@ var (
 `)
 )
 
-func NewCmdStepNextVersion(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	options := StepNextVersionOptions{}
+func NewCmdStepNextVersion(commonOpts *CommonOptions) *cobra.Command {
+	options := StepNextVersionOptions{
+		StepOptions: StepOptions{
+			CommonOptions: commonOpts,
+		},
+	}
 	cmd := &cobra.Command{
 		Use:     "next-version",
 		Short:   "Writes next semantic version",
@@ -79,7 +81,6 @@ func NewCmdStepNextVersion(f Factory, in terminal.FileReader, out terminal.FileW
 	cmd.Flags().BoolVarP(&options.Tag, "tag", "t", false, "tag and push new version")
 	cmd.Flags().BoolVarP(&options.UseGitTagOnly, "use-git-tag-only", "", false, "only use a git tag so work out new semantic version, else specify filename [pom.xml,package.json,Makefile,Chart.yaml]")
 
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_next_version_integration_test.go
+++ b/pkg/jx/cmd/step_next_version_integration_test.go
@@ -30,7 +30,11 @@ func TestSetVersionJavascript(t *testing.T) {
 	err = git.Init(f)
 	assert.NoError(t, err)
 
-	o := cmd.StepNextVersionOptions{}
+	o := cmd.StepNextVersionOptions{
+		StepOptions: cmd.StepOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
+	}
 	o.Out = tests.Output()
 	o.Dir = f
 	o.Filename = "package.json"
@@ -60,7 +64,11 @@ func TestSetVersionChart(t *testing.T) {
 	err = git.Init(f)
 	assert.NoError(t, err)
 
-	o := cmd.StepNextVersionOptions{}
+	o := cmd.StepNextVersionOptions{
+		StepOptions: cmd.StepOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
+	}
 	o.Out = tests.Output()
 	o.Dir = f
 	o.Filename = "Chart.yaml"

--- a/pkg/jx/cmd/step_next_version_test.go
+++ b/pkg/jx/cmd/step_next_version_test.go
@@ -10,6 +10,9 @@ import (
 func TestMakefile(t *testing.T) {
 	t.Parallel()
 	o := cmd.StepNextVersionOptions{
+		StepOptions: cmd.StepOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		Dir:      "test_data/next_version/make",
 		Filename: "Makefile",
 	}
@@ -24,6 +27,9 @@ func TestMakefile(t *testing.T) {
 func TestPomXML(t *testing.T) {
 	t.Parallel()
 	o := cmd.StepNextVersionOptions{
+		StepOptions: cmd.StepOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		Dir:      "test_data/next_version/java",
 		Filename: "pom.xml",
 	}
@@ -38,6 +44,9 @@ func TestPomXML(t *testing.T) {
 func TestChart(t *testing.T) {
 	t.Parallel()
 	o := cmd.StepNextVersionOptions{
+		StepOptions: cmd.StepOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		Dir:      "test_data/next_version/helm",
 		Filename: "Chart.yaml",
 	}

--- a/pkg/jx/cmd/step_nexus.go
+++ b/pkg/jx/cmd/step_nexus.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"fmt"
 	"io/ioutil"
@@ -27,15 +24,10 @@ type StepNexusOptions struct {
 }
 
 // NewCmdStepNexus Steps a command object for the "step" command
-func NewCmdStepNexus(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepNexus(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepNexusOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -49,8 +41,8 @@ func NewCmdStepNexus(f Factory, in terminal.FileReader, out terminal.FileWriter,
 			CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdStepNexusDrop(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepNexusRelease(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStepNexusDrop(commonOpts))
+	cmd.AddCommand(NewCmdStepNexusRelease(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_nexus_drop.go
+++ b/pkg/jx/cmd/step_nexus_drop.go
@@ -24,6 +24,7 @@ var (
 `)
 )
 
+// NewCmdStepNexusDrop creates a new 'step nexus drop' Command.
 func NewCmdStepNexusDrop(commonOpts *CommonOptions) *cobra.Command {
 	options := StepNexusDropOptions{
 		StepNexusOptions: StepNexusOptions{

--- a/pkg/jx/cmd/step_nexus_drop.go
+++ b/pkg/jx/cmd/step_nexus_drop.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepNexusDropOptions contains the command line flags
@@ -27,17 +24,11 @@ var (
 `)
 )
 
-func NewCmdStepNexusDrop(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepNexusDrop(commonOpts *CommonOptions) *cobra.Command {
 	options := StepNexusDropOptions{
 		StepNexusOptions: StepNexusOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-
-					Out: out,
-					Err: errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/step_nexus_release.go
+++ b/pkg/jx/cmd/step_nexus_release.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepNexusReleaseOptions contains the command line flags
@@ -29,16 +27,11 @@ var (
 `)
 )
 
-func NewCmdStepNexusRelease(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepNexusRelease(commonOpts *CommonOptions) *cobra.Command {
 	options := StepNexusReleaseOptions{
 		StepNexusOptions: StepNexusOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}

--- a/pkg/jx/cmd/step_nexus_release.go
+++ b/pkg/jx/cmd/step_nexus_release.go
@@ -27,6 +27,7 @@ var (
 `)
 )
 
+// NewCmdStepNexusRelease creates a new 'step nexus release' Command.
 func NewCmdStepNexusRelease(commonOpts *CommonOptions) *cobra.Command {
 	options := StepNexusReleaseOptions{
 		StepNexusOptions: StepNexusOptions{

--- a/pkg/jx/cmd/step_post.go
+++ b/pkg/jx/cmd/step_post.go
@@ -1,16 +1,13 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type StepPostOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	DisableImport bool
 	OutDir        string
@@ -19,14 +16,9 @@ type StepPostOptions struct {
 var ()
 
 // NewCmdStep Steps a command object for the "step" command
-func NewCmdStepPost(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepPost(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepPostOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -40,9 +32,9 @@ func NewCmdStepPost(f Factory, in terminal.FileReader, out terminal.FileWriter, 
 		},
 	}
 
-	cmd.AddCommand(NewCmdStepPostBuild(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepPostInstall(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepPostRun(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStepPostBuild(commonOpts))
+	cmd.AddCommand(NewCmdStepPostInstall(commonOpts))
+	cmd.AddCommand(NewCmdStepPostRun(commonOpts))
 
 	return cmd
 }

--- a/pkg/jx/cmd/step_post_build.go
+++ b/pkg/jx/cmd/step_post_build.go
@@ -49,6 +49,7 @@ podAnnotations:
   jenkins-x.io/cve-image-id: %s
 `
 
+// NewCmdStepPostBuild creates a new 'step post build' Command.
 func NewCmdStepPostBuild(commonOpts *CommonOptions) *cobra.Command {
 	options := StepPostBuildOptions{
 		StepOptions: StepOptions{

--- a/pkg/jx/cmd/step_post_build.go
+++ b/pkg/jx/cmd/step_post_build.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/jenkins-x/jx/pkg/kube/services"
-	"io"
 
 	"os"
 
@@ -19,7 +19,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepPostBuildOptions contains the command line flags
@@ -50,15 +49,10 @@ podAnnotations:
   jenkins-x.io/cve-image-id: %s
 `
 
-func NewCmdStepPostBuild(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepPostBuild(commonOpts *CommonOptions) *cobra.Command {
 	options := StepPostBuildOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/step_post_install.go
+++ b/pkg/jx/cmd/step_post_install.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/jenkins"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -16,7 +16,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepPostInstallOptions contains the command line flags
@@ -47,15 +46,10 @@ var (
 )
 
 // NewCmdStepPostInstall creates the command object
-func NewCmdStepPostInstall(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepPostInstall(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepPostInstallOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -72,7 +66,6 @@ func NewCmdStepPostInstall(f Factory, in terminal.FileReader, out terminal.FileW
 		},
 	}
 
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.EnvJobCredentials, "env-job-credentials", "", "", "The Jenkins credentials used by the GitOps Job for this environment")
 	return cmd

--- a/pkg/jx/cmd/step_post_install_integration_test.go
+++ b/pkg/jx/cmd/step_post_install_integration_test.go
@@ -3,6 +3,9 @@
 package cmd_test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/helm"
@@ -15,8 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"os"
-	"testing"
 )
 
 func TestStepPostInstall(t *testing.T) {
@@ -30,14 +31,14 @@ func TestStepPostInstall(t *testing.T) {
 
 	o := cmd.StepPostInstallOptions{
 		StepOptions: cmd.StepOptions{
-			CommonOptions: cmd.CommonOptions{
+			CommonOptions: &cmd.CommonOptions{
 				In:  os.Stdin,
 				Out: os.Stdout,
 				Err: os.Stderr,
 			},
 		},
 	}
-	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+	cmd.ConfigureTestOptionsWithResources(o.CommonOptions,
 		[]runtime.Object{
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/jx/cmd/step_post_run.go
+++ b/pkg/jx/cmd/step_post_run.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -13,7 +12,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
@@ -38,15 +36,10 @@ var (
 )
 
 // NewCmdStep Steps a command object for the "step" command
-func NewCmdStepPostRun(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepPostRun(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepPostRunOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/step_post_run.go
+++ b/pkg/jx/cmd/step_post_run.go
@@ -56,7 +56,6 @@ func NewCmdStepPostRun(commonOpts *CommonOptions) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&options.Verbose, "verbose", "", false, "Enables verbose logging")
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_pr.go
+++ b/pkg/jx/cmd/step_pr.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
@@ -16,15 +13,10 @@ type StepPROptions struct {
 var ()
 
 // NewCmdStep Steps a command object for the "step" command
-func NewCmdStepPR(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepPR(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepPROptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -39,8 +31,7 @@ func NewCmdStepPR(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 		},
 	}
 
-	cmd.AddCommand(NewCmdStepPRComment(f, in, out, errOut))
-	options.addCommonFlags(cmd)
+	cmd.AddCommand(NewCmdStepPRComment(commonOpts))
 
 	return cmd
 }

--- a/pkg/jx/cmd/step_pr_comment.go
+++ b/pkg/jx/cmd/step_pr_comment.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"strconv"
 
@@ -29,16 +26,11 @@ type StepPRCommentFlags struct {
 }
 
 // NewCmdStep Steps a command object for the "step" command
-func NewCmdStepPRComment(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepPRComment(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepPRCommentOptions{
 		StepPROptions: StepPROptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -59,7 +51,6 @@ func NewCmdStepPRComment(f Factory, in terminal.FileReader, out terminal.FileWri
 	cmd.Flags().StringVarP(&options.Flags.Repository, "repository", "r", "", "Git repository")
 	cmd.Flags().StringVarP(&options.Flags.PR, "pull-request", "p", "", "Git Pull Request number")
 
-	options.addCommonFlags(cmd)
 
 	return cmd
 }

--- a/pkg/jx/cmd/step_pre.go
+++ b/pkg/jx/cmd/step_pre.go
@@ -1,15 +1,12 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepPreOptions defines the CLI arguments
 type StepPreOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	DisableImport bool
 	OutDir        string
@@ -18,14 +15,9 @@ type StepPreOptions struct {
 var ()
 
 // NewCmdStep Steps a command object for the "step" command
-func NewCmdStepPre(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepPre(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepPreOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -39,8 +31,8 @@ func NewCmdStepPre(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 		},
 	}
 
-	cmd.AddCommand(NewCmdStepPreBuild(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepPreExtend(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStepPreBuild(commonOpts))
+	cmd.AddCommand(NewCmdStepPreExtend(commonOpts))
 
 	return cmd
 }

--- a/pkg/jx/cmd/step_pre_build.go
+++ b/pkg/jx/cmd/step_pre_build.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/cloud/amazon"
@@ -9,7 +8,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepPreBuildOptions contains the command line flags
@@ -29,15 +27,10 @@ var (
 `)
 )
 
-func NewCmdStepPreBuild(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepPreBuild(commonOpts *CommonOptions) *cobra.Command {
 	options := StepPreBuildOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/step_pre_extend.go
+++ b/pkg/jx/cmd/step_pre_extend.go
@@ -38,6 +38,7 @@ var (
 
 const extensionsConfigDefaultFile = "jenkins-x-extensions.yaml"
 
+// NewCmdStepPreExtend creates a new 'step pre extend' Command.
 func NewCmdStepPreExtend(commonOpts *CommonOptions) *cobra.Command {
 	options := StepPreExtendOptions{
 		StepOptions: StepOptions{

--- a/pkg/jx/cmd/step_pre_extend.go
+++ b/pkg/jx/cmd/step_pre_extend.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	jenkinsv1client "github.com/jenkins-x/jx/pkg/client/clientset/versioned/typed/jenkins.io/v1"
@@ -20,7 +19,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // StepPreBuildOptions contains the command line flags
@@ -40,15 +38,10 @@ var (
 
 const extensionsConfigDefaultFile = "jenkins-x-extensions.yaml"
 
-func NewCmdStepPreExtend(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepPreExtend(commonOpts *CommonOptions) *cobra.Command {
 	options := StepPreExtendOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/step_release.go
+++ b/pkg/jx/cmd/step_release.go
@@ -66,7 +66,7 @@ func NewCmdStepRelease(commonOpts *CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.PullRequestPollTime, optionPullRequestPollTime, "", "20s", "Poll time when waiting for a Pull Request to merge")
 	cmd.Flags().StringVarP(&options.LocalHelmRepoName, "helm-repo-name", "", kube.LocalHelmRepoName, "The name of the helm repository that contains the app")
 	cmd.Flags().StringVarP(&options.HelmRepositoryURL, "helm-repo-url", "", helm.DefaultHelmRepositoryURL, "The Helm Repository URL to use for the App")
-	cmd.Flags().StringVarP(&options.Build, "build", "b", "", "The Build number which is used to update the PipelineActivity. If not specified its defaulted from  the '$BUILD_NUMBER' environment variable")
+	cmd.Flags().StringVarP(&options.Build, "build", "", "", "The Build number which is used to update the PipelineActivity. If not specified its defaulted from  the '$BUILD_NUMBER' environment variable")
 
 	return cmd
 }

--- a/pkg/jx/cmd/step_release.go
+++ b/pkg/jx/cmd/step_release.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -12,7 +11,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -39,15 +37,10 @@ type StepReleaseOptions struct {
 }
 
 // NewCmdStep Steps a command object for the "step" command
-func NewCmdStepRelease(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepRelease(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepReleaseOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/step_report.go
+++ b/pkg/jx/cmd/step_report.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // GetOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
@@ -16,15 +13,10 @@ type StepReportOptions struct {
 var ()
 
 // NewCmdStep Steps a command object for the "step" command
-func NewCmdStepReport(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepReport(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepReportOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -39,8 +31,8 @@ func NewCmdStepReport(f Factory, in terminal.FileReader, out terminal.FileWriter
 		},
 	}
 
-	cmd.AddCommand(NewCmdStepReportActivities(f, in, out, errOut))
-	cmd.AddCommand(NewCmdStepReportReleases(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStepReportActivities(commonOpts))
+	cmd.AddCommand(NewCmdStepReportReleases(commonOpts))
 
 	return cmd
 }

--- a/pkg/jx/cmd/step_report_activities.go
+++ b/pkg/jx/cmd/step_report_activities.go
@@ -34,6 +34,7 @@ var (
 `)
 )
 
+// NewCmdStepReportActivities creates a new 'step report activities' Command.
 func NewCmdStepReportActivities(commonOpts *CommonOptions) *cobra.Command {
 	options := StepReportActivitiesOptions{
 		StepReportOptions: StepReportOptions{

--- a/pkg/jx/cmd/step_report_activities.go
+++ b/pkg/jx/cmd/step_report_activities.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"time"
 
 	"fmt"
@@ -13,7 +12,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	pe "github.com/jenkins-x/jx/pkg/pipeline_events"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
@@ -36,17 +34,11 @@ var (
 `)
 )
 
-func NewCmdStepReportActivities(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepReportActivities(commonOpts *CommonOptions) *cobra.Command {
 	options := StepReportActivitiesOptions{
 		StepReportOptions: StepReportOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-
-					Out: out,
-					Err: errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -64,7 +56,6 @@ func NewCmdStepReportActivities(f Factory, in terminal.FileReader, out terminal.
 	}
 
 	cmd.Flags().BoolVarP(&options.Watch, "watch", "w", false, "Whether to watch activities")
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_report_releases.go
+++ b/pkg/jx/cmd/step_report_releases.go
@@ -34,6 +34,7 @@ var (
 `)
 )
 
+// NewCmdStepReportReleases creates a new 'step report releases' Command.
 func NewCmdStepReportReleases(commonOpts *CommonOptions) *cobra.Command {
 	options := StepReportReleasesOptions{
 		StepReportOptions: StepReportOptions{

--- a/pkg/jx/cmd/step_report_releases.go
+++ b/pkg/jx/cmd/step_report_releases.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"time"
 
 	"fmt"
@@ -13,7 +12,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	pe "github.com/jenkins-x/jx/pkg/pipeline_events"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
@@ -36,16 +34,11 @@ var (
 `)
 )
 
-func NewCmdStepReportReleases(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepReportReleases(commonOpts *CommonOptions) *cobra.Command {
 	options := StepReportReleasesOptions{
 		StepReportOptions: StepReportOptions{
 			StepOptions: StepOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-					Out:     out,
-					Err:     errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -63,7 +56,6 @@ func NewCmdStepReportReleases(f Factory, in terminal.FileReader, out terminal.Fi
 	}
 
 	cmd.Flags().BoolVarP(&options.Watch, "watch", "w", false, "Whether to watch Releases")
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_split_monorepo.go
+++ b/pkg/jx/cmd/step_split_monorepo.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -12,7 +11,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -49,15 +47,10 @@ type StepSplitMonorepoOptions struct {
 }
 
 // NewCmdStepSplitMonorepo Creates a new Command object
-func NewCmdStepSplitMonorepo(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepSplitMonorepo(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepSplitMonorepoOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/step_split_monorepo_test.go
+++ b/pkg/jx/cmd/step_split_monorepo_test.go
@@ -19,6 +19,9 @@ func TestStepSplitMonorepo(t *testing.T) {
 	assert.NoError(t, err)
 
 	options := &cmd.StepSplitMonorepoOptions{
+		StepOptions: cmd.StepOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
 		Organisation: "dummy",
 		Glob:         "*",
 		Dir:          testData,

--- a/pkg/jx/cmd/step_tag.go
+++ b/pkg/jx/cmd/step_tag.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,7 +12,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/helm/pkg/chartutil"
 )
 
@@ -60,15 +58,10 @@ var (
 `)
 )
 
-func NewCmdStepTag(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepTag(commonOpts *CommonOptions) *cobra.Command {
 	options := StepTagOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/step_tag.go
+++ b/pkg/jx/cmd/step_tag.go
@@ -58,6 +58,7 @@ var (
 `)
 )
 
+// NewCmdStepTag creates a new 'step tag' Command.
 func NewCmdStepTag(commonOpts *CommonOptions) *cobra.Command {
 	options := StepTagOptions{
 		StepOptions: StepOptions{

--- a/pkg/jx/cmd/step_tag_test.go
+++ b/pkg/jx/cmd/step_tag_test.go
@@ -35,7 +35,11 @@ func TestStepTagCharts(t *testing.T) {
 	chartFile := filepath.Join(chartsDir, "Chart.yaml")
 	valuesFile := filepath.Join(chartsDir, "values.yaml")
 
-	o := cmd.StepTagOptions{}
+	o := cmd.StepTagOptions{
+		StepOptions: cmd.StepOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
+	}
 	//o.Out = tests.Output()
 	o.Flags.ChartsDir = chartsDir
 	o.Flags.Version = expectedVersion

--- a/pkg/jx/cmd/step_validate.go
+++ b/pkg/jx/cmd/step_validate.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/jenkins-x/jx/pkg/helm"
-	"io"
 
 	"github.com/blang/semver"
 	"github.com/jenkins-x/jx/pkg/config"
@@ -13,7 +13,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/jenkins-x/jx/pkg/version"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -45,15 +44,10 @@ type StepValidateOptions struct {
 }
 
 // NewCmdStepValidate Creates a new Command object
-func NewCmdStepValidate(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepValidate(commonOpts *CommonOptions) *cobra.Command {
 	options := &StepValidateOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/step_validate_test.go
+++ b/pkg/jx/cmd/step_validate_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestStepValidate(t *testing.T) {
 	t.Parallel()
-	AssertValidateWorks(t, &cmd.StepValidateOptions{})
-	AssertValidateWorks(t, &cmd.StepValidateOptions{MinimumJxVersion: "0.0.1"})
+	AssertValidateWorks(t, makeStepValidateOptions("", ""))
+	AssertValidateWorks(t, makeStepValidateOptions("0.0.1", ""))
 
-	AssertValidateFails(t, &cmd.StepValidateOptions{MinimumJxVersion: "100.0.1"})
+	AssertValidateFails(t, makeStepValidateOptions("100.0.1", ""))
 
 	// lets check the test data has a valid addon
 	projectDir := "test_data/project_with_kubeless"
@@ -23,13 +23,13 @@ func TestStepValidate(t *testing.T) {
 	assert.Nil(t, err, "Failed to load project config %s", fileName)
 	assert.NotEmpty(t, cfg.Addons, "Failed to find addons in project config %s", fileName)
 
-	AssertValidateFails(t, &cmd.StepValidateOptions{Dir: projectDir})
+	AssertValidateFails(t, makeStepValidateOptions("", projectDir))
 }
 
 func AssertValidateWorks(t *testing.T, options *cmd.StepValidateOptions) error {
 	//options.Out = tests.Output()
 	//options.Factory = cmd_mocks.NewMockFactory()
-	cmd.ConfigureTestOptions(&options.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
+	cmd.ConfigureTestOptions(options.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
 	err := options.Run()
 	assert.NoError(t, err, "Command failed: %#v", options)
 	return err
@@ -38,8 +38,18 @@ func AssertValidateWorks(t *testing.T, options *cmd.StepValidateOptions) error {
 func AssertValidateFails(t *testing.T, options *cmd.StepValidateOptions) error {
 	//options.Out = tests.Output()
 	//options.Factory = cmd_mocks.NewMockFactory()
-	cmd.ConfigureTestOptions(&options.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
+	cmd.ConfigureTestOptions(options.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
 	err := options.Run()
 	assert.NotNil(t, err, "Command should have failed: %#v", options)
 	return err
+}
+
+func makeStepValidateOptions(minimumJxVersion string, dir string) *cmd.StepValidateOptions {
+	return &cmd.StepValidateOptions{
+		StepOptions: cmd.StepOptions{
+			CommonOptions: &cmd.CommonOptions{},
+		},
+		MinimumJxVersion: minimumJxVersion,
+		Dir:              dir,
+	}
 }

--- a/pkg/jx/cmd/step_verify.go
+++ b/pkg/jx/cmd/step_verify.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
@@ -12,7 +11,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -37,15 +35,10 @@ var (
 	`)
 )
 
-func NewCmdStepVerify(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepVerify(commonOpts *CommonOptions) *cobra.Command {
 	options := StepVerifyOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/step_verify.go
+++ b/pkg/jx/cmd/step_verify.go
@@ -35,6 +35,7 @@ var (
 	`)
 )
 
+// NewCmdStepVerify creates a new 'step verify' Command.
 func NewCmdStepVerify(commonOpts *CommonOptions) *cobra.Command {
 	options := StepVerifyOptions{
 		StepOptions: StepOptions{

--- a/pkg/jx/cmd/step_wait_for_artifact.go
+++ b/pkg/jx/cmd/step_wait_for_artifact.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -57,15 +55,10 @@ var (
 `)
 )
 
-func NewCmdStepWaitForArtifact(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStepWaitForArtifact(commonOpts *CommonOptions) *cobra.Command {
 	options := StepWaitForArtifactOptions{
 		StepOptions: StepOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 	cmd := &cobra.Command{

--- a/pkg/jx/cmd/stop.go
+++ b/pkg/jx/cmd/stop.go
@@ -1,17 +1,14 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
 // Stop contains the command line options
 type Stop struct {
-	CommonOptions
+	*CommonOptions
 }
 
 var (
@@ -26,14 +23,9 @@ var (
 )
 
 // NewCmdStop creates the command object
-func NewCmdStop(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStop(commonOpts *CommonOptions) *cobra.Command {
 	options := &Stop{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -49,7 +41,7 @@ func NewCmdStop(f Factory, in terminal.FileReader, out terminal.FileWriter, errO
 		},
 	}
 
-	cmd.AddCommand(NewCmdStopPipeline(f, in, out, errOut))
+	cmd.AddCommand(NewCmdStopPipeline(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/stop_pipeline.go
+++ b/pkg/jx/cmd/stop_pipeline.go
@@ -57,7 +57,7 @@ func NewCmdStopPipeline(commonOpts *CommonOptions) *cobra.Command {
 			CheckErr(err)
 		},
 	}
-	cmd.Flags().IntVarP(&options.Build, "build", "b", 0, "The build number to stop")
+	cmd.Flags().IntVarP(&options.Build, "build", "", 0, "The build number to stop")
 	cmd.Flags().StringVarP(&options.Filter, "filter", "f", "", "Filters all the available jobs by those that contain the given text")
 
 	return cmd

--- a/pkg/jx/cmd/stop_pipeline.go
+++ b/pkg/jx/cmd/stop_pipeline.go
@@ -2,16 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strings"
-
-	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
 )
 
 // StopPipelineOptions contains the command line options
@@ -40,15 +37,10 @@ var (
 )
 
 // NewCmdStopPipeline creates the command
-func NewCmdStopPipeline(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdStopPipeline(commonOpts *CommonOptions) *cobra.Command {
 	options := &StopPipelineOptions{
 		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/sync.go
+++ b/pkg/jx/cmd/sync.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -11,7 +10,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -22,7 +20,7 @@ import (
 )
 
 type SyncOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Daemon      bool
 	NoKsyncInit bool
@@ -63,14 +61,9 @@ node_modules
 `
 )
 
-func NewCmdSync(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdSync(commonOpts *CommonOptions) *cobra.Command {
 	options := &SyncOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "sync",

--- a/pkg/jx/cmd/team.go
+++ b/pkg/jx/cmd/team.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
@@ -15,7 +13,7 @@ import (
 )
 
 type TeamOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 const ()
@@ -39,14 +37,9 @@ var (
 `)
 )
 
-func NewCmdTeam(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdTeam(commonOpts *CommonOptions) *cobra.Command {
 	options := &TeamOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "team",
@@ -61,7 +54,6 @@ func NewCmdTeam(f Factory, in terminal.FileReader, out terminal.FileWriter, errO
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/templates/templates.go
+++ b/pkg/jx/cmd/templates/templates.go
@@ -83,7 +83,7 @@ func MainUsageTemplate() string {
 
 // OptionsHelpTemplate if the template for 'help' used by the 'options' command.
 func OptionsHelpTemplate() string {
-	return "Dispaly a list of global command-line options\n"
+	return "Display a list of global command-line options\n"
 }
 
 // OptionsUsageTemplate if the template for 'usage' used by the 'options' command.

--- a/pkg/jx/cmd/uninstall.go
+++ b/pkg/jx/cmd/uninstall.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 
@@ -14,12 +13,11 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type UninstallOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Namespace        string
 	Context          string
@@ -35,15 +33,9 @@ var (
 		jx uninstall`)
 )
 
-func NewCmdUninstall(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUninstall(commonOpts *CommonOptions) *cobra.Command {
 	options := &UninstallOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-
-			Out: out,
-			Err: errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
 		Use:     "uninstall",
@@ -57,7 +49,6 @@ func NewCmdUninstall(f Factory, in terminal.FileReader, out terminal.FileWriter,
 			CheckErr(err)
 		},
 	}
-	options.addCommonFlags(cmd)
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The team namespace to uninstall. Defaults to the current namespace.")
 	cmd.Flags().StringVarP(&options.Context, "context", "", "", "The kube context to uninstall JX from. This will be compared with the current context to prevent accidental uninstallation from the wrong cluster")
 	cmd.Flags().BoolVarP(&options.KeepEnvironments, "keep-environments", "", false, "Don't delete environments. Uninstall Jenkins X only.")

--- a/pkg/jx/cmd/uninstall_test.go
+++ b/pkg/jx/cmd/uninstall_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/mocks"
 	kuber_mocks "github.com/jenkins-x/jx/pkg/kube/mocks"
 	"github.com/jenkins-x/jx/pkg/tests"
-	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/stretchr/testify/assert"
 
 	. "github.com/petergtz/pegomock"
 )
@@ -30,13 +31,13 @@ func TestUninstallOptions_Run_ContextSpecifiedAsOption_FailsWhenContextNamesDoNo
 	kubeMock := setupUninstall("current-context")
 
 	o := &cmd.UninstallOptions{
-		CommonOptions: cmd.CommonOptions{
+		CommonOptions: &cmd.CommonOptions{
 			Kuber: kubeMock,
 		},
 		Namespace: "ns",
 		Context:   "target-context",
 	}
-	cmd.ConfigureTestOptions(&o.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
+	cmd.ConfigureTestOptions(o.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
 
 	err := o.Run()
 	assert.EqualError(t, err, "The context 'target-context' must match the current context to uninstall")
@@ -46,13 +47,13 @@ func TestUninstallOptions_Run_ContextSpecifiedAsOption_PassWhenContextNamesMatch
 	kubeMock := setupUninstall("correct-context-to-delete")
 
 	o := &cmd.UninstallOptions{
-		CommonOptions: cmd.CommonOptions{
+		CommonOptions: &cmd.CommonOptions{
 			Kuber: kubeMock,
 		},
 		Namespace: "ns",
 		Context:   "correct-context-to-delete",
 	}
-	cmd.ConfigureTestOptions(&o.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
+	cmd.ConfigureTestOptions(o.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
 
 	// Create fake namespace (that we will uninstall from)
 	err := createNamespace(o, "ns")
@@ -70,13 +71,13 @@ func TestUninstallOptions_Run_ContextSpecifiedAsOption_PassWhenForced(t *testing
 	kubeMock := setupUninstall("correct-context-to-delete")
 
 	o := &cmd.UninstallOptions{
-		CommonOptions: cmd.CommonOptions{
+		CommonOptions: &cmd.CommonOptions{
 			Kuber: kubeMock,
 		},
 		Namespace: "ns",
 		Force:     true,
 	}
-	cmd.ConfigureTestOptions(&o.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
+	cmd.ConfigureTestOptions(o.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
 
 	// Create fake namespace (that we will uninstall from)
 	err := createNamespace(o, "ns")
@@ -107,7 +108,7 @@ func TestUninstallOptions_Run_ContextSpecifiedViaCli_FailsWhenContextNamesDoNotM
 	}()
 
 	o := &cmd.UninstallOptions{
-		CommonOptions: cmd.CommonOptions{
+		CommonOptions: &cmd.CommonOptions{
 			Factory: cmd_test.NewMockFactory(),
 			Kuber:   kubeMock,
 			In:      console.In,
@@ -145,7 +146,7 @@ func TestUninstallOptions_Run_ContextSpecifiedViaCli_PassWhenContextNamesMatch(t
 	}()
 
 	o := &cmd.UninstallOptions{
-		CommonOptions: cmd.CommonOptions{
+		CommonOptions: &cmd.CommonOptions{
 			Factory: cmd_test.NewMockFactory(),
 			Kuber:   kubeMock,
 			In:      console.In,
@@ -155,7 +156,7 @@ func TestUninstallOptions_Run_ContextSpecifiedViaCli_PassWhenContextNamesMatch(t
 		Namespace: "ns",
 	}
 
-	cmd.ConfigureTestOptions(&o.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
+	cmd.ConfigureTestOptions(o.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
 	o.BatchMode = false // The above line sets batch mode to true. Set it back here :-(
 
 	// Create fake namespace (that we will uninstall from)

--- a/pkg/jx/cmd/update.go
+++ b/pkg/jx/cmd/update.go
@@ -1,49 +1,41 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 )
 
-// Update contains the command line options
+// Update contacommonOptss the command lcommonOptse options
 type UpdateOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	DisableImport bool
 	OutDir        string
 }
 
 var (
-	update_resources = `Valid resource types include:
+	update_resources = `Valid resource types commonOptsclude:
 
 	* cluster
 	`
 
 	update_long = templates.LongDesc(`
-		Updates an existing resource.
+		Updates an existcommonOptsg resource.
 
 		` + update_resources + `
 `)
 )
 
 // NewCmdUpdate creates a command object for the "update" command
-func NewCmdUpdate(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUpdate(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpdateOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Updates an existing resource",
+		Short: "Updates an existcommonOptsg resource",
 		Long:  update_long,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Cmd = cmd
@@ -53,8 +45,8 @@ func NewCmdUpdate(f Factory, in terminal.FileReader, out terminal.FileWriter, er
 		},
 	}
 
-	cmd.AddCommand(NewCmdUpdateCluster(f, in, out, errOut))
-	cmd.AddCommand(NewCmdUpdateWebhooks(f, in, out, errOut))
+	cmd.AddCommand(NewCmdUpdateCluster(commonOpts))
+	cmd.AddCommand(NewCmdUpdateWebhooks(commonOpts))
 
 	return cmd
 }

--- a/pkg/jx/cmd/update_cluster.go
+++ b/pkg/jx/cmd/update_cluster.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateClusterOptions the flags for running create cluster
@@ -37,8 +35,8 @@ var (
 
 // NewCmdGet creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
-func NewCmdUpdateCluster(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	options := createUpdateClusterOptions(f, in, out, errOut, "")
+func NewCmdUpdateCluster(commonOpts *CommonOptions) *cobra.Command {
+	options := createUpdateClusterOptions(commonOpts, "")
 
 	cmd := &cobra.Command{
 		Use:     "cluster [kubernetes provider]",
@@ -53,22 +51,15 @@ func NewCmdUpdateCluster(f Factory, in terminal.FileReader, out terminal.FileWri
 		},
 	}
 
-	cmd.AddCommand(NewCmdUpdateClusterGKE(f, in, out, errOut))
+	cmd.AddCommand(NewCmdUpdateClusterGKE(commonOpts))
 
 	return cmd
 }
 
-func createUpdateClusterOptions(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer, cloudProvider string) UpdateClusterOptions {
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-
-		Out: out,
-		Err: errOut,
-	}
+func createUpdateClusterOptions(commonOpts *CommonOptions, cloudProvider string) UpdateClusterOptions {
 	options := UpdateClusterOptions{
 		UpdateOptions: UpdateOptions{
-			CommonOptions: commonOptions,
+			CommonOptions: commonOpts,
 		},
 		Provider: cloudProvider,
 	}

--- a/pkg/jx/cmd/update_cluster_gke.go
+++ b/pkg/jx/cmd/update_cluster_gke.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateClusterOptions the flags for running create cluster
@@ -27,8 +24,8 @@ var (
 `)
 )
 
-func NewCmdUpdateClusterGKE(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	options := createUpdateClusterGKEOptions(f, in, out, errOut, GKE)
+func NewCmdUpdateClusterGKE(commonOpts *CommonOptions) *cobra.Command {
+	options := createUpdateClusterGKEOptions(commonOpts, GKE)
 
 	cmd := &cobra.Command{
 		Use:     "gke",
@@ -43,22 +40,16 @@ func NewCmdUpdateClusterGKE(f Factory, in terminal.FileReader, out terminal.File
 		},
 	}
 
-	cmd.AddCommand(NewCmdUpdateClusterGKETerraform(f, in, out, errOut))
+	cmd.AddCommand(NewCmdUpdateClusterGKETerraform(commonOpts))
 
 	return cmd
 }
 
-func createUpdateClusterGKEOptions(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer, cloudProvider string) UpdateClusterGKEOptions {
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-		Out:     out,
-		Err:     errOut,
-	}
+func createUpdateClusterGKEOptions(commonOpts *CommonOptions, cloudProvider string) UpdateClusterGKEOptions {
 	options := UpdateClusterGKEOptions{
 		UpdateClusterOptions: UpdateClusterOptions{
 			UpdateOptions: UpdateOptions{
-				CommonOptions: commonOptions,
+				CommonOptions: commonOpts,
 			},
 			Provider: cloudProvider,
 		},

--- a/pkg/jx/cmd/update_cluster_gke.go
+++ b/pkg/jx/cmd/update_cluster_gke.go
@@ -24,6 +24,7 @@ var (
 `)
 )
 
+// NewCmdUpdateClusterGKE creates a new 'update cluster gke' Command
 func NewCmdUpdateClusterGKE(commonOpts *CommonOptions) *cobra.Command {
 	options := createUpdateClusterGKEOptions(commonOpts, GKE)
 

--- a/pkg/jx/cmd/update_cluster_gke_terraform.go
+++ b/pkg/jx/cmd/update_cluster_gke_terraform.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-
 	"os"
 	"path/filepath"
 
@@ -13,7 +11,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateClusterOptions the flags for running create cluster
@@ -45,8 +42,8 @@ var (
 
 // NewCmdGet creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
-func NewCmdUpdateClusterGKETerraform(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	options := createUpdateClusterGKETerraformOptions(f, in, out, errOut, GKE)
+func NewCmdUpdateClusterGKETerraform(commonOpts *CommonOptions) *cobra.Command {
+	options := createUpdateClusterGKETerraformOptions(commonOpts, GKE)
 
 	cmd := &cobra.Command{
 		Use:     "terraform",
@@ -61,7 +58,6 @@ func NewCmdUpdateClusterGKETerraform(f Factory, in terminal.FileReader, out term
 		},
 	}
 
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().StringVarP(&options.Flags.ClusterName, optionClusterName, "n", "", "The name of this cluster")
 	cmd.Flags().BoolVarP(&options.Flags.SkipLogin, "skip-login", "", false, "Skip Google auth if already logged in via gcloud auth")
@@ -70,17 +66,11 @@ func NewCmdUpdateClusterGKETerraform(f Factory, in terminal.FileReader, out term
 	return cmd
 }
 
-func createUpdateClusterGKETerraformOptions(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer, cloudProvider string) UpdateClusterGKETerraformOptions {
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-		Out:     out,
-		Err:     errOut,
-	}
+func createUpdateClusterGKETerraformOptions(commonOpts *CommonOptions, cloudProvider string) UpdateClusterGKETerraformOptions {
 	options := UpdateClusterGKETerraformOptions{
 		UpdateClusterOptions: UpdateClusterOptions{
 			UpdateOptions: UpdateOptions{
-				CommonOptions: commonOptions,
+				CommonOptions: commonOpts,
 			},
 			Provider: cloudProvider,
 		},

--- a/pkg/jx/cmd/update_webhooks.go
+++ b/pkg/jx/cmd/update_webhooks.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -12,14 +11,13 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // UpdateWebhooks the flags for running create cluster
 type UpdateWebhooksOptions struct {
-	CommonOptions
+	*CommonOptions
 	Org             string
 	Repo            string
 	ExactHookMatch  bool
@@ -41,8 +39,10 @@ var (
 `)
 )
 
-func NewCmdUpdateWebhooks(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	options := createUpdateWebhooksOptions(f, in, out, errOut)
+func NewCmdUpdateWebhooks(commonOpts *CommonOptions) *cobra.Command {
+	options := UpdateWebhooksOptions{
+		CommonOptions: commonOpts,
+	}
 
 	cmd := &cobra.Command{
 		Use:     "webhooks",
@@ -63,19 +63,6 @@ func NewCmdUpdateWebhooks(f Factory, in terminal.FileReader, out terminal.FileWr
 	cmd.Flags().StringVarP(&options.PreviousHookUrl, "previous-hook-url", "", "", "Whether to match based on an another URL")
 
 	return cmd
-}
-
-func createUpdateWebhooksOptions(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) UpdateWebhooksOptions {
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-		Out:     out,
-		Err:     errOut,
-	}
-	options := UpdateWebhooksOptions{
-		CommonOptions: commonOptions,
-	}
-	return options
 }
 
 func (options *UpdateWebhooksOptions) Run() error {

--- a/pkg/jx/cmd/update_webhooks.go
+++ b/pkg/jx/cmd/update_webhooks.go
@@ -39,6 +39,7 @@ var (
 `)
 )
 
+// NewCmdUpdateWebhooks creates a new 'update webhooks' command.
 func NewCmdUpdateWebhooks(commonOpts *CommonOptions) *cobra.Command {
 	options := UpdateWebhooksOptions{
 		CommonOptions: commonOpts,

--- a/pkg/jx/cmd/upgrade.go
+++ b/pkg/jx/cmd/upgrade.go
@@ -1,16 +1,13 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // UpgradeOptions are the flags for delete commands
 type UpgradeOptions struct {
-	CommonOptions
+	*CommonOptions
 }
 
 var (
@@ -31,16 +28,10 @@ var (
 )
 
 // NewCmdUpgrade creates the command
-func NewCmdUpgrade(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUpgrade(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradeOptions{
-		CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
-
 	cmd := &cobra.Command{
 		Use:     "upgrade [flags]",
 		Short:   "Upgrades a resource",
@@ -55,14 +46,14 @@ func NewCmdUpgrade(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 		SuggestFor: []string{"update"},
 	}
 
-	cmd.AddCommand(NewCmdUpgradeAddons(f, in, out, errOut))
-	cmd.AddCommand(NewCmdUpgradeCLI(f, in, out, errOut))
-	cmd.AddCommand(NewCmdUpgradeBinaries(f, in, out, errOut))
-	cmd.AddCommand(NewCmdUpgradeCluster(f, in, out, errOut))
-	cmd.AddCommand(NewCmdUpgradeIngress(f, in, out, errOut))
-	cmd.AddCommand(NewCmdUpgradePlatform(f, in, out, errOut))
-	cmd.AddCommand(NewCmdUpgradeExtensions(f, in, out, errOut))
-	cmd.AddCommand(NewCmdUpgradeApps(f, in, out, errOut))
+	cmd.AddCommand(NewCmdUpgradeAddons(commonOpts))
+	cmd.AddCommand(NewCmdUpgradeCLI(commonOpts))
+	cmd.AddCommand(NewCmdUpgradeBinaries(commonOpts))
+	cmd.AddCommand(NewCmdUpgradeCluster(commonOpts))
+	cmd.AddCommand(NewCmdUpgradeIngress(commonOpts))
+	cmd.AddCommand(NewCmdUpgradePlatform(commonOpts))
+	cmd.AddCommand(NewCmdUpgradeExtensions(commonOpts))
+	cmd.AddCommand(NewCmdUpgradeApps(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/upgrade_addons.go
+++ b/pkg/jx/cmd/upgrade_addons.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"io"
-
 	"fmt"
 
 	"github.com/ghodss/yaml"
@@ -14,7 +12,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -41,15 +38,10 @@ type UpgradeAddonsOptions struct {
 }
 
 // NewCmdUpgradeAddons defines the command
-func NewCmdUpgradeAddons(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUpgradeAddons(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradeAddonsOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -69,7 +61,6 @@ func NewCmdUpgradeAddons(f Factory, in terminal.FileReader, out terminal.FileWri
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "", "", "The Namespace to promote to")
 	cmd.Flags().StringVarP(&options.Set, "set", "s", "", "The Helm parameters to pass in while upgrading")
 
-	options.addCommonFlags(cmd)
 	options.InstallFlags.addCloudEnvOptions(cmd)
 
 	return cmd

--- a/pkg/jx/cmd/upgrade_apps.go
+++ b/pkg/jx/cmd/upgrade_apps.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"io"
-
 	"fmt"
 
 	"github.com/ghodss/yaml"
@@ -15,7 +13,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -62,15 +59,10 @@ type UpgradeAppsOptions struct {
 }
 
 // NewCmdUpgradeApps defines the command
-func NewCmdUpgradeApps(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUpgradeApps(commonOpts *CommonOptions) *cobra.Command {
 	o := &UpgradeAppsOptions{
 		AddOptions: AddOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/upgrade_apps.go
+++ b/pkg/jx/cmd/upgrade_apps.go
@@ -82,8 +82,6 @@ func NewCmdUpgradeApps(commonOpts *CommonOptions) *cobra.Command {
 
 	o.GitOps, o.DevEnv = o.GetDevEnv()
 
-	cmd.Flags().BoolVarP(&o.BatchMode, optionBatchMode, "b", false, "In batch mode the command never prompts for user input")
-	cmd.Flags().BoolVarP(&o.Verbose, optionVerbose, "", false, "Enable verbose logging")
 	cmd.Flags().StringVarP(&o.Version, "username", "", "",
 		"The username for the repository")
 	cmd.Flags().StringVarP(&o.Version, "password", "", "",

--- a/pkg/jx/cmd/upgrade_apps_test.go
+++ b/pkg/jx/cmd/upgrade_apps_test.go
@@ -20,7 +20,7 @@ func TestUpgradeAppsForGitOps(t *testing.T) {
 
 	o := &cmd.UpgradeAppsOptions{
 		AddOptions: cmd.AddOptions{
-			CommonOptions: *testEnv.CommonOptions,
+			CommonOptions: testEnv.CommonOptions,
 		},
 		FakePullRequests: testEnv.FakePullRequests,
 		Version:          "0.0.1",

--- a/pkg/jx/cmd/upgrade_binaries.go
+++ b/pkg/jx/cmd/upgrade_binaries.go
@@ -23,6 +23,7 @@ type UpgradeBinariesOptions struct {
 	CreateOptions
 }
 
+// NewCmdUpgradeBinaries creates a new 'upgrade binaries' command.
 func NewCmdUpgradeBinaries(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradeBinariesOptions{
 		CreateOptions: CreateOptions{

--- a/pkg/jx/cmd/upgrade_binaries.go
+++ b/pkg/jx/cmd/upgrade_binaries.go
@@ -42,7 +42,6 @@ func NewCmdUpgradeBinaries(commonOpts *CommonOptions) *cobra.Command {
 			CheckErr(err)
 		},
 	}
-	cmd.Flags().BoolVarP(&options.Verbose, "verbose", "", false, "Enable verbose logging")
 	return cmd
 }
 

--- a/pkg/jx/cmd/upgrade_binaries.go
+++ b/pkg/jx/cmd/upgrade_binaries.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"io"
 	"io/ioutil"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -25,15 +23,10 @@ type UpgradeBinariesOptions struct {
 	CreateOptions
 }
 
-func NewCmdUpgradeBinaries(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUpgradeBinaries(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradeBinariesOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/upgrade_cli.go
+++ b/pkg/jx/cmd/upgrade_cli.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io"
 	"runtime"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -10,7 +9,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/version"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -32,15 +30,10 @@ type UpgradeCLIOptions struct {
 }
 
 // NewCmdUpgradeCLI defines the command
-func NewCmdUpgradeCLI(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUpgradeCLI(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradeCLIOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -58,7 +51,6 @@ func NewCmdUpgradeCLI(f Factory, in terminal.FileReader, out terminal.FileWriter
 		},
 	}
 	cmd.Flags().StringVarP(&options.Version, "version", "v", "", "The specific version to upgrade to")
-	options.addCommonFlags(cmd)
 	return cmd
 }
 

--- a/pkg/jx/cmd/upgrade_cluster.go
+++ b/pkg/jx/cmd/upgrade_cluster.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 var (
@@ -34,15 +32,10 @@ type UpgradeClusterOptions struct {
 }
 
 // NewCmdUpgradeCluster defines the command
-func NewCmdUpgradeCluster(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUpgradeCluster(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradeClusterOptions{
 		UpgradeOptions: UpgradeOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 

--- a/pkg/jx/cmd/upgrade_extensions.go
+++ b/pkg/jx/cmd/upgrade_extensions.go
@@ -55,6 +55,7 @@ type UpgradeExtensionsOptions struct {
 	ExtensionsRepositoryFile string
 }
 
+// NewCmdUpgradeExtensions creates a new 'upgrade extensions' Command
 func NewCmdUpgradeExtensions(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradeExtensionsOptions{
 		CreateOptions: CreateOptions{

--- a/pkg/jx/cmd/upgrade_extensions.go
+++ b/pkg/jx/cmd/upgrade_extensions.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -32,7 +31,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 //const upstreamExtensionsRepositoryGitHub = "https://raw.githubusercontent.com/jenkins-x/jenkins-x-extensions/master/jenkins-x-extensions-repository.lock.yaml"
@@ -57,15 +55,10 @@ type UpgradeExtensionsOptions struct {
 	ExtensionsRepositoryFile string
 }
 
-func NewCmdUpgradeExtensions(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUpgradeExtensions(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradeExtensionsOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -81,7 +74,7 @@ func NewCmdUpgradeExtensions(f Factory, in terminal.FileReader, out terminal.Fil
 			CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdUpgradeExtensionsRepository(f, in, out, errOut))
+	cmd.AddCommand(NewCmdUpgradeExtensionsRepository(commonOpts))
 	cmd.Flags().BoolVarP(&options.Verbose, "verbose", "", false, "Enable verbose logging")
 	cmd.Flags().StringVarP(&options.ExtensionsRepositoryFile, "extensions-repository-file", "", "", "Specify the extensions repository yaml file to read from")
 	return cmd

--- a/pkg/jx/cmd/upgrade_extensions.go
+++ b/pkg/jx/cmd/upgrade_extensions.go
@@ -75,7 +75,6 @@ func NewCmdUpgradeExtensions(commonOpts *CommonOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(NewCmdUpgradeExtensionsRepository(commonOpts))
-	cmd.Flags().BoolVarP(&options.Verbose, "verbose", "", false, "Enable verbose logging")
 	cmd.Flags().StringVarP(&options.ExtensionsRepositoryFile, "extensions-repository-file", "", "", "Specify the extensions repository yaml file to read from")
 	return cmd
 }

--- a/pkg/jx/cmd/upgrade_extensions_repository.go
+++ b/pkg/jx/cmd/upgrade_extensions_repository.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/base64"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -27,7 +26,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // CreateExtensionsRepositoryOptions the flags for running create cluster
@@ -70,17 +68,11 @@ var (
 
 // NewCmdGet creates a command object for the generic "init" action, which
 // installs the dependencies required to run the jenkins-x platform on a Kubernetes cluster.
-func NewCmdUpgradeExtensionsRepository(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUpgradeExtensionsRepository(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradeExtensionsRepositoryOptions{
 		UpgradeExtensionsOptions: UpgradeExtensionsOptions{
 			CreateOptions: CreateOptions{
-				CommonOptions: CommonOptions{
-					Factory: f,
-					In:      in,
-
-					Out: out,
-					Err: errOut,
-				},
+				CommonOptions: commonOpts,
 			},
 		},
 	}
@@ -99,8 +91,6 @@ func NewCmdUpgradeExtensionsRepository(f Factory, in terminal.FileReader, out te
 	}
 	cmd.Flags().StringVarP(&options.InputFile, "input-file", "i", "jenkins-x-extensions-repository.yaml", "The input file to read to generate the .lock file")
 	cmd.Flags().StringVarP(&options.OutputFile, "output-file", "o", "jenkins-x-extensions-repository.lock.yaml", "The output .lock file")
-	cmd.Flags().BoolVarP(&options.Verbose, "verbose", "", false, "Enable verbose logging")
-	cmd.Flags().BoolVarP(&options.BatchMode, "batch-mode", "b", false, "Enable batch mode")
 	return cmd
 }
 

--- a/pkg/jx/cmd/upgrade_ingress.go
+++ b/pkg/jx/cmd/upgrade_ingress.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -15,7 +14,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,17 +51,10 @@ type UpgradeIngressOptions struct {
 }
 
 // NewCmdUpgradeIngress defines the command
-func NewCmdUpgradeIngress(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
-	commonOptions := CommonOptions{
-		Factory: f,
-		In:      in,
-		Out:     out,
-		Err:     errOut,
-	}
-
+func NewCmdUpgradeIngress(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradeIngressOptions{
 		CreateOptions: CreateOptions{
-			CommonOptions: commonOptions,
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -81,7 +72,6 @@ func NewCmdUpgradeIngress(f Factory, in terminal.FileReader, out terminal.FileWr
 		},
 	}
 	options.addFlags(cmd)
-	options.addCommonFlags(cmd)
 
 	return cmd
 }

--- a/pkg/jx/cmd/upgrade_ingress_test.go
+++ b/pkg/jx/cmd/upgrade_ingress_test.go
@@ -1,10 +1,11 @@
 package cmd_test
 
 import (
-	"github.com/jenkins-x/jx/pkg/kube/services"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/jenkins-x/jx/pkg/kube/services"
 
 	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/jx/cmd"
@@ -23,7 +24,7 @@ type TestOptions struct {
 func (o *TestOptions) Setup() {
 	o.UpgradeIngressOptions = cmd.UpgradeIngressOptions{
 		CreateOptions: cmd.CreateOptions{
-			CommonOptions: cmd.CommonOptions{
+			CommonOptions: &cmd.CommonOptions{
 				KubeClientCached: testclient.NewSimpleClientset(),
 			},
 		},

--- a/pkg/jx/cmd/upgrade_platform.go
+++ b/pkg/jx/cmd/upgrade_platform.go
@@ -4,7 +4,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	configio "github.com/jenkins-x/jx/pkg/io"
 
-	"io"
 	"io/ioutil"
 	"strings"
 
@@ -22,7 +21,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -52,15 +50,10 @@ type UpgradePlatformOptions struct {
 }
 
 // NewCmdUpgradePlatform defines the command
-func NewCmdUpgradePlatform(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdUpgradePlatform(commonOpts *CommonOptions) *cobra.Command {
 	options := &UpgradePlatformOptions{
 		InstallOptions: InstallOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
-				Out:     out,
-				Err:     errOut,
-			},
+			CommonOptions: commonOpts,
 		},
 	}
 
@@ -85,7 +78,6 @@ func NewCmdUpgradePlatform(f Factory, in terminal.FileReader, out terminal.FileW
 	cmd.Flags().BoolVarP(&options.AlwaysUpgrade, "always-upgrade", "", false, "If set to true, jx will upgrade platform Helm chart even if requested version is already installed.")
 	cmd.Flags().BoolVarP(&options.Flags.CleanupTempFiles, "cleanup-temp-files", "", true, "Cleans up any temporary values.yaml used by helm install [default true]")
 
-	options.addCommonFlags(cmd)
 	options.InstallFlags.addCloudEnvOptions(cmd)
 
 	return cmd

--- a/pkg/jx/cmd/version.go
+++ b/pkg/jx/cmd/version.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"regexp"
 	"strings"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/util/system"
 	"github.com/jenkins-x/jx/pkg/version"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -19,7 +17,7 @@ const (
 )
 
 type VersionOptions struct {
-	CommonOptions
+	*CommonOptions
 
 	Container      string
 	Namespace      string
@@ -27,14 +25,9 @@ type VersionOptions struct {
 	NoVersionCheck bool
 }
 
-func NewCmdVersion(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+func NewCmdVersion(commonOpts *CommonOptions) *cobra.Command {
 	options := &VersionOptions{
-		CommonOptions: CommonOptions{
-			Factory: f,
-			In:      in,
-			Out:     out,
-			Err:     errOut,
-		},
+		CommonOptions: commonOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -51,7 +44,6 @@ func NewCmdVersion(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 		cmd.Flags().BoolP("client", "c", false, "Client version only (no server required).")
 		cmd.Flags().BoolP("short", "", false, "Print just the version number.")
 	*/
-	options.addCommonFlags(cmd)
 
 	cmd.Flags().MarkShorthandDeprecated("client", "please use --client instead.")
 	cmd.Flags().BoolVarP(&options.HelmTLS, "helm-tls", "", false, "Whether to use TLS with helm")

--- a/pkg/jx/cmd/version.go
+++ b/pkg/jx/cmd/version.go
@@ -25,6 +25,7 @@ type VersionOptions struct {
 	NoVersionCheck bool
 }
 
+// NewCmdVersion creates a new 'version' Command.
 func NewCmdVersion(commonOpts *CommonOptions) *cobra.Command {
 	options := &VersionOptions{
 		CommonOptions: commonOpts,

--- a/pkg/jx/cmd/version_test.go
+++ b/pkg/jx/cmd/version_test.go
@@ -55,7 +55,9 @@ func TestVersisonCheckWhenCurrentVersionIsLessThanReleaseVersion(t *testing.T) {
 	jxVersion := semver.Version{Major: 1, Minor: 3, Patch: 153}
 	setup(jxVersion)
 	version.Map["version"] = "1.0.0"
-	opts := &cmd.VersionOptions{}
+	opts := &cmd.VersionOptions{
+		CommonOptions: &cmd.CommonOptions{},
+	}
 	err := opts.VersionCheck()
 	assert.Error(t, err, "VersionCheck should exit with failure")
 }
@@ -66,7 +68,9 @@ func TestVersisonCheckWhenCurrentVersionIsEqualToReleaseVersionWithPatch(t *test
 	jxVersion := semver.Version{Major: 1, Minor: 2, Patch: 3, Pre: prVersions, Build: []string(nil)}
 	setup(jxVersion)
 	version.Map["version"] = "1.2.3"
-	opts := &cmd.VersionOptions{}
+	opts := &cmd.VersionOptions{
+		CommonOptions: &cmd.CommonOptions{},
+	}
 	err := opts.VersionCheck()
 	assert.NoError(t, err, "VersionCheck should exit without failure")
 }
@@ -76,7 +80,9 @@ func TestVersisonCheckWhenCurrentVersionWithPatchIsEqualToReleaseVersion(t *test
 	jxVersion := semver.Version{Major: 1, Minor: 2, Patch: 3}
 	setup(jxVersion)
 	version.Map["version"] = "1.2.3-dev+6a8285f4"
-	opts := &cmd.VersionOptions{}
+	opts := &cmd.VersionOptions{
+		CommonOptions: &cmd.CommonOptions{},
+	}
 	err := opts.VersionCheck()
 	assert.NoError(t, err, "VersionCheck should exit without failure")
 }
@@ -85,7 +91,9 @@ func TestVersisonCheckWhenCurrentVersionWithPatchIsLessThanReleaseVersion(t *tes
 	jxVersion := semver.Version{Major: 1, Minor: 2, Patch: 3}
 	setup(jxVersion)
 	version.Map["version"] = "1.2.2-dev+6a8285f4"
-	opts := &cmd.VersionOptions{}
+	opts := &cmd.VersionOptions{
+		CommonOptions: &cmd.CommonOptions{},
+	}
 	err := opts.VersionCheck()
 	assert.NoError(t, err, "VersionCheck should exit without failure")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Add CommonOptions to the root command so that they are available (inherited) in all sub-commands
that are created. This also means that 'jx options' actually returns something, because it finds the
options inherited from the base command.

#### Special notes for the reviewer(s)

This PR has got pretty big... unavoidable really because the refactoring touches any usage of `CommonOptions`, which is obviously a lot!
Whilst it feels like the right fix, I have some 'fear' about the impact of this change, and this PR is just looking for thoughts & feedback atm.

Don't expect anyone to read all of it - in summary the change is:
 - Each of the specific Options (e.g. `AddOptions`) now contains a _pointer_ to `CommonOptions` rather than its own `CommonOptions`.
 - `cmd.NewJXCommand()` (which creates all the commands) now creates _one_ CommonOptions and passes it into the sub-commands it creates.
 - `cmd.NewJXCommand()` adds the common options once to the root command, so they are inherited by all sub-commands.

There is a conflict on the `-b` short option (batch-mode from common, and build from some specific commands). I have therefore **removed** the batch-mode short option. But concerned about any pipeline steps for e.g. that might break...
(I tried to remove the common batch-mode one when the build one is in use (as discussed on slack), but couldn't find a way to do this.)

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
