### PR TITLE
Fix: Create API token on promote if needed

### DIFF
--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -336,6 +336,9 @@ func (i *GitRepositoryInfo) PickOrCreateProvider(authConfigSvc auth.AuthConfigSe
 	if err != nil {
 		return nil, err
 	}
+	if userAuth.IsInvalid() {
+		userAuth, err = createUserForServer(batchMode, userAuth, authConfigSvc, server, git, in, out, errOut)
+	}
 	return i.CreateProviderForUser(server, userAuth, gitKind, git)
 }
 
@@ -369,27 +372,23 @@ func CreateProviderForURL(inCluster bool, authConfigSvc auth.AuthConfigService, 
 	}
 
 	kind := server.Kind
-	if kind != "" {
-		userAuth := auth.CreateAuthUserFromEnvironment(strings.ToUpper(kind))
-		if !userAuth.IsInvalid() {
-			return CreateProvider(server, &userAuth, git)
-		}
-	} else {
-		userAuth := auth.CreateAuthUserFromEnvironment("GIT")
-		if !userAuth.IsInvalid() {
-			return CreateProvider(server, &userAuth, git)
-		}
+	if kind == "" {
+		kind = "GIT"
 	}
-	userAuth, err := createUserForServer(batchMode, authConfigSvc, server, git, in, out, errOut)
+	userAuthVar := auth.CreateAuthUserFromEnvironment(strings.ToUpper(kind))
+	if !userAuthVar.IsInvalid() {
+		return CreateProvider(server, &userAuthVar, git)
+	}
+	userAuth, err := createUserForServer(batchMode, &userAuthVar, authConfigSvc, server, git, in, out, errOut)
 	if err != nil {
 		return nil, err
 	}
 	return CreateProvider(server, userAuth, git)
 }
 
-func createUserForServer(batchMode bool, authConfigSvc auth.AuthConfigService, server *auth.AuthServer,
+func createUserForServer(batchMode bool, userAuth *auth.UserAuth, authConfigSvc auth.AuthConfigService, server *auth.AuthServer,
 	git Gitter, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (*auth.UserAuth, error) {
-	userAuth := &auth.UserAuth{}
+
 
 	f := func(username string) error {
 		git.PrintCreateRepositoryGenerateAccessToken(server, username, out)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is covered by existing or new tests.

#### Description
This fixes error on promote without configured api tokens: POST https://api.github.com/repos/org/environment/pulls: 401 Bad credentials []

There is a bit of cleanup in related code.
Will also solve other cases of missing api tokens.

#### Special notes for the reviewer(s)

I think any additional tests would need to be integration tests. But I haven't written any since it's difficult for me to do without access to the test environment.