### PR TITLE
fix: Import from non dev team namespace

### DIFF
--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -1616,7 +1616,11 @@ func (o *CommonOptions) createWebhookProw(gitURL string, gitProvider gits.GitPro
 }
 
 func (o *CommonOptions) isProw() (bool, error) {
-	env, err := kube.GetEnvironment(o.jxClient, o.currentNamespace, "dev")
+	ns := o.devNamespace
+	if ns == "" {
+		ns = o.currentNamespace
+	}
+	env, err := kube.GetEnvironment(o.jxClient, ns, "dev")
 	if err != nil {
 		return false, err
 	}

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -220,8 +220,7 @@ func (options *ImportOptions) Run() error {
 		if err != nil {
 			return err
 		}
-
-		_, _, err = options.JXClient()
+		_, _, err = options.JXClientAndDevNamespace()
 		if err != nil {
 			return err
 		}
@@ -1085,7 +1084,7 @@ func (options *ImportOptions) addAppNameToGeneratedFile(filename, field, value s
 
 func (options *ImportOptions) checkChartmuseumCredentialExists() error {
 	name := jenkins.DefaultJenkinsCredentialsPrefix + jenkins.Chartmuseum
-	secret, err := options.KubeClientCached.CoreV1().Secrets(options.currentNamespace).Get(name, metav1.GetOptions{})
+	secret, err := options.KubeClientCached.CoreV1().Secrets(options.devNamespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting %s secret %v", name, err)
 	}


### PR DESCRIPTION
This fixes a regression appearing with the introduction of prow that made
import and other commands calling ImportOptions.Run with another team
namespace than dev as the current namespace fail with:

`error: no environment with name 'dev' found`

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is covered by existing or new tests.
