### PR TITLE
refactor(upgrade ingress): add a flag to skip the update of jx related resources

### DIFF
--- a/pkg/jx/cmd/create_vault.go
+++ b/pkg/jx/cmd/create_vault.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
-	"github.com/jenkins-x/jx/pkg/kube/services"
 	"io"
 	"time"
 
+	"github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
@@ -260,5 +260,6 @@ func (o *CreateVaultOptions) exposeVault(vaultService string) error {
 	options := &o.UpgradeIngressOptions
 	options.Namespaces = []string{o.Namespace}
 	options.Services = []string{vaultService}
+	options.SkipJxResourcesUpdate = true
 	return options.Run()
 }

--- a/pkg/jx/cmd/create_vault.go
+++ b/pkg/jx/cmd/create_vault.go
@@ -260,6 +260,6 @@ func (o *CreateVaultOptions) exposeVault(vaultService string) error {
 	options := &o.UpgradeIngressOptions
 	options.Namespaces = []string{o.Namespace}
 	options.Services = []string{vaultService}
-	options.SkipJxResourcesUpdate = true
+	options.SkipResourcesUpdate = true
 	return options.Run()
 }

--- a/pkg/jx/cmd/upgrade_ingress.go
+++ b/pkg/jx/cmd/upgrade_ingress.go
@@ -41,13 +41,13 @@ const (
 type UpgradeIngressOptions struct {
 	CreateOptions
 
-	SkipCertManager       bool
-	Cluster               bool
-	Namespaces            []string
-	Version               string
-	TargetNamespaces      []string
-	Services              []string
-	SkipJxResourcesUpdate bool
+	SkipCertManager     bool
+	Cluster             bool
+	Namespaces          []string
+	Version             string
+	TargetNamespaces    []string
+	Services            []string
+	SkipResourcesUpdate bool
 
 	IngressConfig kube.IngressConfig
 }
@@ -91,7 +91,7 @@ func (o *UpgradeIngressOptions) addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVarP(&o.Namespaces, "namespaces", "", []string{}, "Namespaces to upgrade")
 	cmd.Flags().BoolVarP(&o.SkipCertManager, "skip-certmanager", "", false, "Skips certmanager installation")
 	cmd.Flags().StringArrayVarP(&o.Services, "services", "", []string{}, "Services to upgrdde")
-	cmd.Flags().BoolVarP(&o.SkipJxResourcesUpdate, "skip-jx-resources-update", "", false, "Skips the update of jx related resources such as webhook or Jenkins URL")
+	cmd.Flags().BoolVarP(&o.SkipResourcesUpdate, "skip-resources-update", "", false, "Skips the update of jx related resources such as webhook or Jenkins URL")
 }
 
 // Run implements the command
@@ -106,7 +106,7 @@ func (o *UpgradeIngressOptions) Run() error {
 		return errors.Wrap(err, "getting the dev namesapce")
 	}
 	previousWebHookEndpoint := ""
-	if !o.SkipJxResourcesUpdate {
+	if !o.SkipResourcesUpdate {
 		previousWebHookEndpoint, err = o.GetWebHookEndpoint()
 		if err != nil {
 			return errors.Wrap(err, "getting the webhook endpoint")
@@ -171,8 +171,8 @@ func (o *UpgradeIngressOptions) Run() error {
 		return errors.Wrap(err, "recreating the ingress rules")
 	}
 
-	if !o.SkipJxResourcesUpdate {
-		o.updateJxResources(previousWebHookEndpoint)
+	if !o.SkipResourcesUpdate {
+		o.updateResources(previousWebHookEndpoint)
 	}
 
 	log.Success("Ingress rules recreated\n")
@@ -189,7 +189,7 @@ func (o *UpgradeIngressOptions) Run() error {
 	return nil
 }
 
-func (o *UpgradeIngressOptions) updateJxResources(previousWebHookEndpoint string) error {
+func (o *UpgradeIngressOptions) updateResources(previousWebHookEndpoint string) error {
 	_, _, err := o.JXClient()
 	if err != nil {
 		return errors.Wrap(err, "failed to get jxclient")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Add a flag to skip the update of jx related resource in the 'upgrade ingress' command. This allows to run the command 
before installing the jx platform. For instance when exposing the Vault used to stored the credentials.


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->