### PR TITLE
feat(vault): apply the --vault flag to all commands

### DIFF
--- a/pkg/jx/cmd/cmd.go
+++ b/pkg/jx/cmd/cmd.go
@@ -21,14 +21,18 @@ const (
     `
 )
 
+var _factory Factory
+
 // NewJXCommand creates the `jx` command and its nested children.
 func NewJXCommand(f Factory, in terminal.FileReader, out terminal.FileWriter, err io.Writer) *cobra.Command {
+	_factory = f
 	cmds := &cobra.Command{
 		Use:   "jx",
 		Short: "jx is a command line tool for working with Jenkins X",
 		Long: `
  `,
-		Run: runHelp,
+		Run:              runHelp,
+		PersistentPreRun: preRun,
 		/*
 			BashCompletionFunction: bash_completion_func,
 		*/
@@ -203,4 +207,11 @@ func fullPath(command *cobra.Command) string {
 
 func runHelp(cmd *cobra.Command, args []string) {
 	cmd.Help()
+}
+
+func preRun(cmd *cobra.Command, args []string) {
+	useVault, err := cmd.Flags().GetBool("vault")
+	if err != nil {
+		_factory.UseVault(useVault)
+	}
 }

--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -79,6 +79,7 @@ type CommonOptions struct {
 	Username               string
 	ExternalJenkinsBaseURL string
 	PullSecrets            string
+	Vault                  bool
 
 	// common cached clients
 	KubeClientCached       kubernetes.Interface
@@ -148,6 +149,7 @@ func (options *CommonOptions) addCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&options.InstallDependencies, optionInstallDeps, "", false, "Should any required dependencies be installed automatically")
 	cmd.Flags().BoolVarP(&options.SkipAuthSecretsMerge, optionSkipAuthSecMerge, "", false, "Skips merging a local git auth yaml file with any pipeline secrets that are found")
 	cmd.Flags().StringVarP(&options.PullSecrets, optionPullSecrets, "", "", "The pull secrets the service account created should have (useful when deploying to your own private registry): provide multiple pull secrets by providing them in a singular block of quotes e.g. --pull-secrets \"foo, bar, baz\"")
+	cmd.Flags().BoolVarP(&options.Vault, "vault", "", false, "Uses a Hashicorp Vault for storing secrets")
 
 	options.Cmd = cmd
 }

--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -307,8 +307,8 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 	}
 
 	// TODO - Reenable vault for GitOpsMode
-	//o.CreateClusterOptions.InstallOptions.GitOpsMode || o.CreateClusterOptions.InstallOptions.Vault {
-	if o.CreateClusterOptions.InstallOptions.Vault {
+	//o.CreateClusterOptions.InstallOptions.GitOpsMode || o.Vault {
+	if o.Vault {
 		if err = InstallVaultOperator(&o.CommonOptions, ""); err != nil {
 			return err
 		}

--- a/pkg/jx/cmd/create_env.go
+++ b/pkg/jx/cmd/create_env.go
@@ -57,7 +57,6 @@ type CreateEnvOptions struct {
 	GitRepositoryOptions   gits.GitRepositoryOptions
 	Prefix                 string
 	BranchPattern          string
-	Vault                  bool
 }
 
 // NewCmdCreateEnv creates a command object for the "create" command
@@ -108,7 +107,6 @@ func NewCmdCreateEnv(f Factory, in terminal.FileReader, out terminal.FileWriter,
 
 	cmd.Flags().BoolVarP(&options.NoGitOps, "no-gitops", "x", false, "Disables the use of GitOps on the environment so that promotion is implemented by directly modifying the resources via helm instead of using a Git repository")
 	cmd.Flags().BoolVarP(&options.Prow, "prow", "", false, "Install and use Prow for environment promotion")
-	cmd.Flags().BoolVarP(&options.Vault, "vault", "", false, "Sets up a Hashicorp Vault for storing secrets during the cluster creation")
 
 	addGitRepoOptionsArguments(cmd, &options.GitRepositoryOptions)
 	options.HelmValuesConfig.AddExposeControllerValues(cmd, false)

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -87,7 +87,6 @@ type InstallFlags struct {
 	NoGitOpsEnvApply         bool
 	NoGitOpsEnvRepo          bool
 	NoGitOpsVault            bool
-	Vault                    bool
 	BuildPackName            string
 }
 
@@ -343,7 +342,6 @@ func (options *InstallOptions) addInstallFlags(cmd *cobra.Command, includesInit 
 	cmd.Flags().BoolVarP(&flags.NoGitOpsEnvApply, "no-gitops-env-apply", "", false, "When using GitOps to create the source code for the development environment and installation, don't run 'jx step env apply' to perform the install")
 	cmd.Flags().BoolVarP(&flags.NoGitOpsEnvRepo, "no-gitops-env-repo", "", false, "When using GitOps to create the source code for the development environment this flag disables the creation of a git repository for the source code")
 	cmd.Flags().BoolVarP(&flags.NoGitOpsVault, "no-gitops-vault", "", false, "When using GitOps to create the source code for the development environment this flag disables the creation of a vault")
-	cmd.Flags().BoolVarP(&flags.Vault, "vault", "", false, "Sets up a Hashicorp Vault for storing secrets during installation")
 	cmd.Flags().StringVarP(&flags.BuildPackName, "buildpack", "", "", "The name of the build pack to use for the Team")
 
 	addGitRepoOptionsArguments(cmd, &options.GitRepositoryOptions)
@@ -682,8 +680,8 @@ func (options *InstallOptions) Run() error {
 	}
 
 	// TODO - we want to enable storing secrets in Vault for gitops. Reenable this once the feature is finished
-	//if options.Flags.GitOpsMode && !options.Flags.NoGitOpsVault || options.Flags.Vault {
-	if options.Flags.Vault {
+	//if options.Flags.GitOpsMode && !options.Flags.NoGitOpsVault || options.Vault {
+	if options.Vault {
 		// Install Vault Operator into the new env
 		err = InstallVaultOperator(&options.CommonOptions, "")
 		if err != nil {


### PR DESCRIPTION
the `--vault` flag now applies to all commands.
When applied, the factory will use vault to store (some - still a WIP) secrets in vault rather than the local filesystem