### PR TITLE
Fixed Helm installation error handling

### DIFF
--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -798,7 +798,7 @@ func (o *CommonOptions) installHelm3() error {
 func (o *CommonOptions) installHelmSecretsPlugin(helmBinary string, clientOnly bool) error {
 	err := o.Helm().Init(clientOnly, "", "", false)
 	if err != nil {
-		errors.Wrap(err, "failed to initialize helm")
+		return errors.Wrap(err, "failed to initialize helm")
 	}
 	// remove the plugin just in case is already installed
 	cmd := util.Command{
@@ -807,7 +807,7 @@ func (o *CommonOptions) installHelmSecretsPlugin(helmBinary string, clientOnly b
 	}
 	_, err = cmd.RunWithoutRetry()
 	if err != nil {
-		errors.Wrap(err, "failed to remove helm secrets")
+		return errors.Wrap(err, "failed to remove helm secrets")
 	}
 	cmd = util.Command{
 		Name: helmBinary,


### PR DESCRIPTION
There are two `return` statements missing in Helm installation code. It leads to weird behavior if Helm initialization fails.  