### PR TITLE
feat(vault): Store a flag in the jx-install-config to denote if secrets are to be stored in vault

### DIFF
--- a/pkg/io/secrets/secret_locations.go
+++ b/pkg/io/secrets/secret_locations.go
@@ -1,0 +1,39 @@
+package secrets
+
+import (
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const vaultSecretsMarker = "useVaultForSecrets"
+
+// UseVaultForSecrets configures the cluster's installation config map to denote that secrets should be stored in vault
+func UseVaultForSecrets(kubeClient kubernetes.Interface, namespace string, useVault bool) {
+	_, err := kube.DefaultModifyConfigMap(kubeClient, namespace, kube.ConfigMapNameJXInstallConfig, func(configMap *v1.ConfigMap) error {
+		if useVault {
+			configMap.Data[vaultSecretsMarker] = "true"
+		} else {
+			delete(configMap.Data, vaultSecretsMarker)
+		}
+		return nil
+	}, nil)
+	if err != nil {
+		logrus.Errorf("Error saving configmap %s: %v", kube.ConfigMapNameJXInstallConfig, err)
+	}
+}
+
+// UsingVaultForSecrets returns true if the cluster has been configured to store secrets in vault
+func UsingVaultForSecrets(kubeClient kubernetes.Interface, namespace string) bool {
+	configMap := getInstallConfigMap(kubeClient, namespace)
+	return configMap[vaultSecretsMarker] != ""
+}
+
+func getInstallConfigMap(kubeClient kubernetes.Interface, namespace string) map[string]string {
+	configMap, err := kube.GetConfigMapData(kubeClient, kube.ConfigMapNameJXInstallConfig, namespace)
+	if err != nil {
+		logrus.Errorf("Error getting configmap %s: %v", kube.ConfigMapNameJXInstallConfig, err)
+	}
+	return configMap
+}

--- a/pkg/io/secrets/secret_locations_test.go
+++ b/pkg/io/secrets/secret_locations_test.go
@@ -1,0 +1,51 @@
+package secrets
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+const ns = "Galaxy"
+
+func TestUseVaultForSecrets(t *testing.T) {
+	kubeClient := createMockCluster()
+
+	UseVaultForSecrets(kubeClient, ns, true)
+
+	// Test we have actually added the item to the configmap
+	configMap, err := kubeClient.Core().ConfigMaps(ns).Get("jx-install-config", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "true", configMap.Data["useVaultForSecrets"])
+	// Test we haven't overwritten the configmap
+	assert.Equal(t, "two", configMap.Data["one"])
+	assert.True(t, UsingVaultForSecrets(kubeClient, ns))
+
+	UseVaultForSecrets(kubeClient, ns, false)
+
+	configMap, err = kubeClient.Core().ConfigMaps(ns).Get("jx-install-config", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "", configMap.Data["useVaultForSecrets"])
+	// Test we haven't overwritten the configmap
+	assert.Equal(t, "two", configMap.Data["one"])
+	assert.False(t, UsingVaultForSecrets(kubeClient, ns))
+}
+
+func createMockCluster() *fake.Clientset {
+	namespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ns,
+		},
+	}
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "jx-install-config",
+			Namespace: ns,
+		},
+		Data: map[string]string{"one": "two"},
+	}
+	kubeClient := fake.NewSimpleClientset(namespace, configMap)
+	return kubeClient
+}

--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"io"
 	"strings"
 
@@ -288,12 +289,12 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 		return err
 	}
 
-	ns := o.InstallOptions.Flags.Namespace
-	if ns == "" {
-		_, ns, _ = o.KubeClient()
-		if err != nil {
-			return err
-		}
+	kubeClient, ns, _ := o.KubeClient()
+	if err != nil {
+		return err
+	}
+	if o.InstallOptions.Flags.Namespace != "" {
+		ns = o.InstallOptions.Flags.Namespace
 	}
 
 	err = o.RunCommand("kubectl", "config", "set-context", context, "--namespace", ns)
@@ -312,7 +313,7 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 		if err = InstallVaultOperator(&o.CommonOptions, ""); err != nil {
 			return err
 		}
-		o.Factory.UseVault(true)
+		secrets.UseVaultForSecrets(kubeClient, ns, true)
 	}
 
 	return nil

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -720,7 +720,6 @@ func (options *InstallOptions) Run() error {
 			log.Infof("System vault created named %s in namespace %s.\n",
 				util.ColorInfo(vault.SystemVaultName), util.ColorInfo(ns))
 		}
-		options.Factory.UseVault(true)
 		secrets.UseVaultForSecrets(client, ns, options.Flags.Vault)
 	}
 

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/base64"
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"github.com/jenkins-x/jx/pkg/vault"
 	"io"
 	"io/ioutil"
@@ -720,6 +721,7 @@ func (options *InstallOptions) Run() error {
 				util.ColorInfo(vault.SystemVaultName), util.ColorInfo(ns))
 		}
 		options.Factory.UseVault(true)
+		secrets.UseVaultForSecrets(client, ns, options.Flags.Vault)
 	}
 
 	// get secrets to use in helm install

--- a/pkg/jx/cmd/interface.go
+++ b/pkg/jx/cmd/interface.go
@@ -84,7 +84,4 @@ type Factory interface {
 	CreateVaultOperatorClient() (vaultoperatorclient.Interface, error)
 
 	GetHelm(verbose bool, helmBinary string, noTiller bool, helmTemplate bool) helm.Helmer
-
-	// UseVault tells the factory to use Vault to store secrets rather than the filesystem
-	UseVault(use bool)
 }

--- a/pkg/kube/configmap.go
+++ b/pkg/kube/configmap.go
@@ -12,9 +12,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// GetConfigmapData gets config map data
-func GetConfigmapData(client kubernetes.Interface, name, ns string) (map[string]string, error) {
-	cm, err := client.CoreV1().ConfigMaps(ns).Get(name, metav1.GetOptions{})
+// GetConfigMapData gets config map data
+func GetConfigMapData(client kubernetes.Interface, name, ns string) (map[string]string, error) {
+	cm, err := GetConfigMap(client, ns, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get configmap %s in namespace %s, %v", name, ns, err)
 	}
@@ -22,11 +22,16 @@ func GetConfigmapData(client kubernetes.Interface, name, ns string) (map[string]
 	return cm.Data, nil
 }
 
+// GetConfigMap gets a named configmap
+func GetConfigMap(client kubernetes.Interface, ns string, name string) (*v1.ConfigMap, error) {
+	return client.CoreV1().ConfigMaps(ns).Get(name, metav1.GetOptions{})
+}
+
 // GetCurrentDomain gets the current domain
 func GetCurrentDomain(client kubernetes.Interface, ns string) (string, error) {
-	data, err := GetConfigmapData(client, ConfigMapIngressConfig, ns)
+	data, err := GetConfigMapData(client, ConfigMapIngressConfig, ns)
 	if err != nil {
-		data, err = GetConfigmapData(client, ConfigMapExposecontroller, ns)
+		data, err = GetConfigMapData(client, ConfigMapExposecontroller, ns)
 		if err != nil {
 			return "", errors.Wrapf(err, "Failed to find ConfigMap in namespace %s for names %s and %s", ns, ConfigMapExposecontroller, ConfigMapIngressConfig)
 		}
@@ -55,7 +60,7 @@ func ExtractDomainValue(data map[string]string) (string, error) {
 func SaveAsConfigMap(c kubernetes.Interface, configMapName string, ns string, obj interface{}) (*v1.ConfigMap, error) {
 	config := util.ToStringMapStringFromStruct(obj)
 
-	cm, err := c.CoreV1().ConfigMaps(ns).Get(configMapName, metav1.GetOptions{})
+	cm, err := GetConfigMap(c, configMapName, ns)
 
 	if err != nil {
 		cm := &v1.ConfigMap{
@@ -103,10 +108,8 @@ func GetConfigMaps(kubeClient kubernetes.Interface, ns string) (map[string]*v1.C
 
 // DefaultModifyConfigMap default implementation of a function to modify
 func DefaultModifyConfigMap(kubeClient kubernetes.Interface, ns string, name string, fn func(env *v1.ConfigMap) error, defaultConfigMap *v1.ConfigMap) (*v1.ConfigMap, error) {
-	configMapInterface := kubeClient.CoreV1().ConfigMaps(ns)
-
 	create := false
-	configMap, err := configMapInterface.Get(name, metav1.GetOptions{})
+	configMap, err := GetConfigMap(kubeClient, ns, name)
 	if err != nil {
 		create = true
 		initialConfigMap := v1.ConfigMap{
@@ -126,6 +129,7 @@ func DefaultModifyConfigMap(kubeClient kubernetes.Interface, ns string, name str
 	if err != nil {
 		return configMap, err
 	}
+	configMapInterface := kubeClient.CoreV1().ConfigMaps(ns)
 	if create {
 		_, err = configMapInterface.Create(configMap)
 		if err != nil {


### PR DESCRIPTION
If `jx install --vault` is run, secrets get stored in vault. With this PR, it will now update the `jx-install-config` configmap with a new entry: `useVaultForSecrets: "true"` that tells the client that secrets are stored in vault (as opposed to on the file systme).

This can (and is) queried by the client to determine whether to load the secrets from vault.