### PR TITLE
feat(vault): Store a flag in the jx-install-config to denote if secrets are to be stored in vault

### DIFF
--- a/pkg/io/secrets/secret_locations.go
+++ b/pkg/io/secrets/secret_locations.go
@@ -9,31 +9,51 @@ import (
 
 const vaultSecretsMarker = "useVaultForSecrets"
 
-var usingVault *bool // use a tri-state boolean. nil means uninitialised (so need to lookup from cluster)
+type SecretLocation interface {
+	// InVault returns whether secrets are stored in Vault
+	InVault() bool
+	// SetInVault sets whether secrets are stored in Vault or not
+	SetInVault(useVault bool)
+}
+
+type secretLocation struct {
+	kubeClient kubernetes.Interface
+	namespace  string
+	usingVault *bool // use a tri-state boolean. nil means uninitialised (so need to lookup from cluster)
+}
+
+// NewSecretLocation creates a SecretLocation
+func NewSecretLocation(kubeClient kubernetes.Interface, namespace string) SecretLocation {
+	return &secretLocation{
+		kubeClient: kubeClient,
+		namespace:  namespace,
+	}
+}
+
+// UsingVaultForSecrets returns true if the cluster has been configured to store secrets in vault
+func (s *secretLocation) InVault() bool {
+	if s.usingVault == nil {
+		configMap := getInstallConfigMap(s.kubeClient, s.namespace)
+		b := configMap[vaultSecretsMarker] != ""
+		s.usingVault = &b
+	}
+	return *s.usingVault
+}
 
 // UseVaultForSecrets configures the cluster's installation config map to denote that secrets should be stored in vault
-func UseVaultForSecrets(kubeClient kubernetes.Interface, namespace string, useVault bool) {
-	_, err := kube.DefaultModifyConfigMap(kubeClient, namespace, kube.ConfigMapNameJXInstallConfig, func(configMap *v1.ConfigMap) error {
+func (s *secretLocation) SetInVault(useVault bool) {
+	_, err := kube.DefaultModifyConfigMap(s.kubeClient, s.namespace, kube.ConfigMapNameJXInstallConfig, func(configMap *v1.ConfigMap) error {
 		if useVault {
 			configMap.Data[vaultSecretsMarker] = "true"
 		} else {
 			delete(configMap.Data, vaultSecretsMarker)
 		}
-		usingVault = newBool(useVault)
+		s.usingVault = &useVault
 		return nil
 	}, nil)
 	if err != nil {
 		logrus.Errorf("Error saving configmap %s: %v", kube.ConfigMapNameJXInstallConfig, err)
 	}
-}
-
-// UsingVaultForSecrets returns true if the cluster has been configured to store secrets in vault
-func UsingVaultForSecrets(kubeClient kubernetes.Interface, namespace string) bool {
-	if usingVault == nil {
-		configMap := getInstallConfigMap(kubeClient, namespace)
-		usingVault = newBool(configMap[vaultSecretsMarker] != "")
-	}
-	return *usingVault
 }
 
 func getInstallConfigMap(kubeClient kubernetes.Interface, namespace string) map[string]string {
@@ -42,9 +62,4 @@ func getInstallConfigMap(kubeClient kubernetes.Interface, namespace string) map[
 		logrus.Errorf("Error getting configmap %s: %v", kube.ConfigMapNameJXInstallConfig, err)
 	}
 	return configMap
-}
-
-// Helper method to create a *bool value
-func newBool(b bool) *bool {
-	return &b
 }

--- a/pkg/io/secrets/secret_locations.go
+++ b/pkg/io/secrets/secret_locations.go
@@ -1,0 +1,39 @@
+package secrets
+
+import (
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const vaultSecretsMarker = "useVaultForSecrets"
+
+// UseVaultForSecrets configures the cluster's installation config map to denote that secrets should be stored in vault
+func UseVaultForSecrets(kubeClient kubernetes.Interface, namespace string, useVault bool) {
+	_, err := kube.DefaultModifyConfigMap(kubeClient, namespace, kube.ConfigMapNameJXInstallConfig, func(configMap *v1.ConfigMap) error {
+		if useVault {
+			configMap.Data[vaultSecretsMarker] = "true"
+		} else {
+			delete(configMap.Data, vaultSecretsMarker)
+		}
+		return nil
+	}, nil)
+	if err != nil {
+		logrus.Errorf("Error saving configmap %s: %v", kube.ConfigMapNameJXInstallConfig, err)
+	}
+}
+
+// UsingVaultForSecrets returns true if the cluster has been configured to store secrets in vault
+func UsingVaultForSecrets(kubeClient kubernetes.Interface, namespace string) bool {
+	configMap := getInstallConfigMap(kubeClient, namespace)
+	return configMap[vaultSecretsMarker] != ""
+}
+
+func getInstallConfigMap(kubeClient kubernetes.Interface, namespace string) map[string]string {
+	configMap, err := kube.GetConfigMapData(kubeClient, kube.ConfigMapNameJXInstallConfig, namespace)
+	if err != nil {
+		logrus.Errorf("Error getting configmap %s: %v", kube.ConfigMapNameJXInstallConfig, err)
+	}
+	return configMap
+}

--- a/pkg/io/secrets/secret_locations.go
+++ b/pkg/io/secrets/secret_locations.go
@@ -9,6 +9,7 @@ import (
 
 const vaultSecretsMarker = "useVaultForSecrets"
 
+// SecretLocation interfaces to identify where is the secrets location
 type SecretLocation interface {
 	// InVault returns whether secrets are stored in Vault
 	InVault() bool

--- a/pkg/io/secrets/secret_locations_test.go
+++ b/pkg/io/secrets/secret_locations_test.go
@@ -1,0 +1,51 @@
+package secrets
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+const ns = "Galaxy"
+
+func TestUseVaultForSecrets(t *testing.T) {
+	kubeClient := createMockCluster()
+
+	UseVaultForSecrets(kubeClient, ns, true)
+
+	// Test we have actually added the item to the configmap
+	configMap, err := kubeClient.Core().ConfigMaps(ns).Get("jx-install-config", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "true", configMap.Data["useVaultForSecrets"])
+	// Test we haven't overwritten the configmap
+	assert.Equal(t, "two", configMap.Data["one"])
+	assert.True(t, UsingVaultForSecrets(kubeClient, ns))
+
+	UseVaultForSecrets(kubeClient, ns, false)
+
+	configMap, err = kubeClient.Core().ConfigMaps(ns).Get("jx-install-config", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "", configMap.Data["useVaultForSecrets"])
+	// Test we haven't overwritten the configmap
+	assert.Equal(t, "two", configMap.Data["one"])
+	assert.False(t, UsingVaultForSecrets(kubeClient, ns))
+}
+
+func createMockCluster() *fake.Clientset {
+	namespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ns,
+		},
+	}
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "jx-install-config",
+			Namespace: ns,
+		},
+		Data: map[string]string{"one": "two"},
+	}
+	kubeClient := fake.NewSimpleClientset(namespace, configMap)
+	return kubeClient
+}

--- a/pkg/io/secrets/secret_locations_test.go
+++ b/pkg/io/secrets/secret_locations_test.go
@@ -36,6 +36,28 @@ func TestUseVaultForSecrets(t *testing.T) {
 	assert.False(t, secretLocation.InVault())
 }
 
+func TestUseVaultForSecrets_NoJxInstallConfigMap(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := fake.NewSimpleClientset()
+	secretLocation := NewSecretLocation(kubeClient, ns)
+
+	secretLocation.SetInVault(true)
+
+	// Test we have actually added the item to the configmap
+	configMap, err := kubeClient.Core().ConfigMaps(ns).Get("jx-install-config", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "true", configMap.Data["useVaultForSecrets"])
+	assert.True(t, secretLocation.InVault())
+
+	secretLocation.SetInVault(false)
+
+	configMap, err = kubeClient.Core().ConfigMaps(ns).Get("jx-install-config", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "", configMap.Data["useVaultForSecrets"])
+	assert.False(t, secretLocation.InVault())
+}
+
 func createMockCluster() *fake.Clientset {
 	namespace := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"io"
 	"strings"
 
@@ -288,12 +289,12 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 		return err
 	}
 
-	ns := o.InstallOptions.Flags.Namespace
-	if ns == "" {
-		_, ns, _ = o.KubeClient()
-		if err != nil {
-			return err
-		}
+	kubeClient, ns, err := o.KubeClient()
+	if err != nil {
+		return err
+	}
+	if o.InstallOptions.Flags.Namespace != "" {
+		ns = o.InstallOptions.Flags.Namespace
 	}
 
 	err = o.RunCommand("kubectl", "config", "set-context", context, "--namespace", ns)
@@ -312,7 +313,7 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 		if err = InstallVaultOperator(&o.CommonOptions, ""); err != nil {
 			return err
 		}
-		o.Factory.UseVault(true)
+		secrets.UseVaultForSecrets(kubeClient, ns, true)
 	}
 
 	return nil

--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -313,7 +313,7 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 		if err = InstallVaultOperator(&o.CommonOptions, ""); err != nil {
 			return err
 		}
-		secrets.UseVaultForSecrets(kubeClient, ns, true)
+		secrets.NewSecretLocation(kubeClient, ns).SetInVault(true)
 	}
 
 	return nil

--- a/pkg/jx/cmd/extraValues.yaml
+++ b/pkg/jx/cmd/extraValues.yaml
@@ -1,0 +1,7 @@
+expose:
+  config:
+    domain: test-domain
+preview:
+  image:
+    repository: MyOrganisation:5000/MyOrganisation/MyApp
+    tag: v0.1.2

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -736,7 +736,7 @@ func (options *InstallOptions) Run() error {
 			log.Infof("System vault created named %s in namespace %s.\n",
 				util.ColorInfo(vault.SystemVaultName), util.ColorInfo(ns))
 		}
-		secrets.UseVaultForSecrets(client, ns, options.Flags.Vault)
+		secrets.NewSecretLocation(client, ns).SetInVault(options.Flags.Vault)
 	}
 
 	// get secrets to use in helm install

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -736,7 +736,6 @@ func (options *InstallOptions) Run() error {
 			log.Infof("System vault created named %s in namespace %s.\n",
 				util.ColorInfo(vault.SystemVaultName), util.ColorInfo(ns))
 		}
-		options.Factory.UseVault(true)
 		secrets.UseVaultForSecrets(client, ns, options.Flags.Vault)
 	}
 

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/base64"
 	"fmt"
+
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"github.com/jenkins-x/jx/pkg/vault"
 
 	"github.com/Pallinder/go-randomdata"
@@ -20,8 +22,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/addon"
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/auth"
-	"github.com/jenkins-x/jx/pkg/cloud/amazon"
 	"github.com/jenkins-x/jx/pkg/cloud/aks"
+	"github.com/jenkins-x/jx/pkg/cloud/amazon"
 	"github.com/jenkins-x/jx/pkg/cloud/iks"
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -735,6 +737,7 @@ func (options *InstallOptions) Run() error {
 				util.ColorInfo(vault.SystemVaultName), util.ColorInfo(ns))
 		}
 		options.Factory.UseVault(true)
+		secrets.UseVaultForSecrets(client, ns, options.Flags.Vault)
 	}
 
 	// get secrets to use in helm install
@@ -767,8 +770,8 @@ func (options *InstallOptions) Run() error {
 		server := kube.CurrentServer(kubeConfig)
 		azureCLI := aks.NewAzureRunner()
 		resourceGroup, name, cluster, err := azureCLI.GetClusterClient(server)
-		 if err != nil {
-		  	return errors.Wrap(err, "failed to get cluster from Azure")
+		if err != nil {
+			return errors.Wrap(err, "failed to get cluster from Azure")
 		}
 		registryID := ""
 		helmConfig.PipelineSecrets.DockerConfig, dockerRegistry, registryID, err = azureCLI.GetRegistry(resourceGroup, name, dockerRegistry)

--- a/pkg/jx/cmd/interface.go
+++ b/pkg/jx/cmd/interface.go
@@ -84,7 +84,4 @@ type Factory interface {
 	CreateVaultOperatorClient() (vaultoperatorclient.Interface, error)
 
 	GetHelm(verbose bool, helmBinary string, noTiller bool, helmTemplate bool) helm.Helmer
-
-	// UseVault tells the factory to use Vault to store secrets rather than the filesystem
-	UseVault(use bool)
 }


### PR DESCRIPTION
If `jx install --vault` is run, secrets get stored in vault. With this PR, it will now update the `jx-install-config` configmap with a new entry: `useVaultForSecrets: "true"` that tells the client that secrets are stored in vault (as opposed to on the file systme).

This can (and is) queried by the client to determine whether to load the secrets from vault.