### PR TITLE
fix(vault): ensure that the created vault has a service account and a proper role binding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/andygrunwald/go-gerrit v0.0.0-20181026193842-43cfd7a94eb4
 	github.com/andygrunwald/go-jira v1.5.0
 	github.com/aws/aws-sdk-go v1.15.50
-	github.com/banzaicloud/bank-vaults v0.0.0-20181015112421-ca15a6960a3a
+	github.com/banzaicloud/bank-vaults v0.0.0-20181129101211-e31657d7c4fe
 	github.com/beevik/etree v1.0.1
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/banzaicloud/bank-vaults v0.0.0-20181011153359-b267885f420d h1:yDythYf
 github.com/banzaicloud/bank-vaults v0.0.0-20181011153359-b267885f420d/go.mod h1:DCXyt+jITEQ5JUfxOWiYUKUE6ILZ5P4IU0MKgGcnmuc=
 github.com/banzaicloud/bank-vaults v0.0.0-20181015112421-ca15a6960a3a h1:v8iLXUUy8UR3m2fdcZgkPZxIF4IzAI5nXIjNYM0YARo=
 github.com/banzaicloud/bank-vaults v0.0.0-20181015112421-ca15a6960a3a/go.mod h1:DCXyt+jITEQ5JUfxOWiYUKUE6ILZ5P4IU0MKgGcnmuc=
+github.com/banzaicloud/bank-vaults v0.0.0-20181129101211-e31657d7c4fe h1:20rYK7/kelCwMs3lTlKfR/RQ2T99VpaqntPG7Vt3+cg=
+github.com/banzaicloud/bank-vaults v0.0.0-20181129101211-e31657d7c4fe/go.mod h1:DCXyt+jITEQ5JUfxOWiYUKUE6ILZ5P4IU0MKgGcnmuc=
 github.com/beevik/etree v1.0.1 h1:lWzdj5v/Pj1X360EV7bUudox5SRipy4qZLjY0rhb0ck=
 github.com/beevik/etree v1.0.1/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=

--- a/pkg/jx/cmd/create_addon_vault.go
+++ b/pkg/jx/cmd/create_addon_vault.go
@@ -19,7 +19,7 @@ const (
 	jxRepoName                   = "jenkinsxio"
 	jxRepoURL                    = "https://chartmuseum.jx.cd.jenkins-x.io"
 	vaultOperatorImageRepository = "banzaicloud/vault-operator"
-	vaultOperatorImageTag        = "0.3.6"
+	vaultOperatorImageTag        = "0.3.17"
 	defaultVaultOperatorVersion  = ""
 )
 

--- a/pkg/jx/cmd/create_vault.go
+++ b/pkg/jx/cmd/create_vault.go
@@ -220,7 +220,7 @@ func (o *CreateVaultOptions) createVault(vaultOperatorClient versioned.Interface
 		KmsLocation: kmsConfig.Location,
 		GcsBucket:   vaultBucket,
 	}
-	err = vault.CreateVault(vaultOperatorClient, vaultName, o.Namespace, gcpServiceAccountSecretName,
+	err = vault.CreateVault(kubeClient, vaultOperatorClient, vaultName, o.Namespace, gcpServiceAccountSecretName,
 		gcpConfig, vaultAuthServiceAccount, o.Namespace, o.SecretsPathPrefix)
 	if err != nil {
 		return errors.Wrap(err, "creating vault")

--- a/pkg/jx/cmd/create_vault.go
+++ b/pkg/jx/cmd/create_vault.go
@@ -138,12 +138,12 @@ func (o *CreateVaultOptions) createVaultGKE(vaultName string) error {
 		return errors.Wrap(err, "creating vault operator client")
 	}
 
-	return o.DoCreateVault(vaultOperatorClient, vaultName)
+	return o.createVault(vaultOperatorClient, vaultName)
 }
 
 // DoCreateVault creates a vault in the existing namespace.
 // If the vault already exists, it will error
-func (o *CreateVaultOptions) DoCreateVault(vaultOperatorClient versioned.Interface, vaultName string) error {
+func (o *CreateVaultOptions) createVault(vaultOperatorClient versioned.Interface, vaultName string) error {
 	kubeClient, _, err := o.KubeClient()
 	if err != nil {
 		return err

--- a/pkg/jx/cmd/delete_vault.go
+++ b/pkg/jx/cmd/delete_vault.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	gkevault "github.com/jenkins-x/jx/pkg/cloud/gke/vault"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -13,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"io"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -116,6 +117,11 @@ func (o *DeleteVaultOptions) Run() error {
 	err = client.CoreV1().Secrets(o.Namespace).Delete(gcpServiceAccountSecretName, &metav1.DeleteOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "deleting secret '%s' where GCP service account is stored", gcpServiceAccountSecretName)
+	}
+
+	err = kube.DeleteClusterRoleBinding(client, vaultName)
+	if err != nil {
+		return errors.Wrapf(err, "deleteing the cluster role binding '%s' for vault", vaultName)
 	}
 
 	log.Infof("Vault %s deleted\n", util.ColorInfo(vaultName))

--- a/pkg/jx/cmd/delete_vault.go
+++ b/pkg/jx/cmd/delete_vault.go
@@ -121,7 +121,7 @@ func (o *DeleteVaultOptions) Run() error {
 
 	err = kube.DeleteClusterRoleBinding(client, vaultName)
 	if err != nil {
-		return errors.Wrapf(err, "deleteing the cluster role binding '%s' for vault", vaultName)
+		return errors.Wrapf(err, "deleting the cluster role binding '%s' for vault", vaultName)
 	}
 
 	log.Infof("Vault %s deleted\n", util.ColorInfo(vaultName))

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/vault"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/vault"
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io"
@@ -712,7 +713,7 @@ func (options *InstallOptions) Run() error {
 				util.ColorInfo(vault.SystemVaultName), util.ColorInfo(ns))
 		} else {
 			log.Info("Creating new system vault\n")
-			err = cvo.DoCreateVault(vaultOperatorClient, vault.SystemVaultName)
+			err = cvo.createVault(vaultOperatorClient, vault.SystemVaultName)
 			if err != nil {
 				return err
 			}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -215,14 +215,24 @@ func ensureVaultRoleBinding(client kubernetes.Interface, namespace string, roleN
 	apiGroups := []string{"authentication.k8s.io"}
 	resources := []string{"tokenreviews"}
 	verbs := []string{"*"}
+	found := kube.IsClusterRole(client, roleName)
+	if found {
+		err := kube.DeleteClusterRole(client, roleName)
+		if err != nil {
+			return errors.Wrapf(err, "deleting the existing cluster role '%s'", roleName)
+		}
+	}
 	err := kube.CreateClusterRole(client, namespace, roleName, apiGroups, resources, verbs)
 	if err != nil {
 		return errors.Wrapf(err, "creating the cluster role '%s' for vault", roleName)
 	}
 
-	found := kube.IsClusterRoleBinding(client, roleBindingName)
+	found = kube.IsClusterRoleBinding(client, roleBindingName)
 	if found {
-		kube.DeleteClusterRoleBinding(client, roleBindingName)
+		err := kube.DeleteClusterRoleBinding(client, roleBindingName)
+		if err != nil {
+			return errors.Wrapf(err, "deleting the existing cluster role binding '%s'", roleBindingName)
+		}
 	}
 
 	err = kube.CreateClusterRoleBinding(client, namespace, roleBindingName, serviceAccount, roleName)

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -220,6 +220,11 @@ func ensureVaultRoleBinding(client kubernetes.Interface, namespace string, roleN
 		return errors.Wrapf(err, "creating the cluster role '%s' for vault", roleName)
 	}
 
+	found := kube.IsClusterRoleBinding(client, roleBindingName)
+	if found {
+		kube.DeleteClusterRoleBinding(client, roleBindingName)
+	}
+
 	err = kube.CreateClusterRoleBinding(client, namespace, roleBindingName, serviceAccount, roleName)
 	if err != nil {
 		return errors.Wrapf(err, "creating the cluster role binding '%s' for vault", roleBindingName)

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -101,7 +101,7 @@ func CreateVault(kubeClient kubernetes.Interface, vaultOperatorClient versioned.
 
 	err := createVaultServiceAccount(kubeClient, ns, name)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "creating the vault service account '%s'", name)
 	}
 
 	err = ensureVaultRoleBinding(kubeClient, ns, vaultRoleName, name, name)

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -53,11 +53,17 @@ func TestCreateVault(t *testing.T) {
 			}
 
 			vault, err := vaultclient.Vault().Vaults(tc.namespace).Get(tc.name, metav1.GetOptions{})
-			assert.NoError(t, err, "should retrive created vault without an error")
+			assert.NoError(t, err, "should retrieve created vault without an error")
 			assert.NotNil(t, vault, "created vault should not be nil")
 			sa, err := client.CoreV1().ServiceAccounts(tc.namespace).Get(tc.name, metav1.GetOptions{})
-			assert.NoError(t, err, "should retrive vault service account without error")
+			assert.NoError(t, err, "should retrieve vault service account without error")
 			assert.NotNil(t, sa, "created vault service account should not be nil")
+			role, err := client.RbacV1().ClusterRoles().Get("vault-auth", metav1.GetOptions{})
+			assert.NoError(t, err, "should retrieve vault cluster role without error")
+			assert.NotNil(t, role, "created vault cluster role should not be nil")
+			rb, err := client.RbacV1().ClusterRoleBindings().Get(tc.name, metav1.GetOptions{})
+			assert.NoError(t, err, "should retrieve vault cluster role binding without error")
+			assert.NotNil(t, rb, "created vault cluster role binding should not be nil")
 		})
 	}
 }

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -55,6 +55,9 @@ func TestCreateVault(t *testing.T) {
 			vault, err := vaultclient.Vault().Vaults(tc.namespace).Get(tc.name, metav1.GetOptions{})
 			assert.NoError(t, err, "should retrive created vault without an error")
 			assert.NotNil(t, vault, "created vault should not be nil")
+			sa, err := client.CoreV1().ServiceAccounts(tc.namespace).Get(tc.name, metav1.GetOptions{})
+			assert.NoError(t, err, "should retrive vault service account without error")
+			assert.NotNil(t, sa, "created vault service account should not be nil")
 		})
 	}
 }

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -1,16 +1,20 @@
-package kube_test
+package vault_test
 
 import (
-	"github.com/jenkins-x/jx/pkg/vault"
 	"testing"
+
+	"github.com/jenkins-x/jx/pkg/vault"
 
 	fakevaultclient "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestCreateVault(t *testing.T) {
-	client := fakevaultclient.NewSimpleClientset()
+
+	client := k8sfake.NewSimpleClientset()
+	vaultclient := fakevaultclient.NewSimpleClientset()
 
 	tests := map[string]struct {
 		name               string
@@ -40,7 +44,7 @@ func TestCreateVault(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := vault.CreateVault(client, tc.name, tc.namespace, tc.gcpSecretName,
+			err := vault.CreateVault(client, vaultclient, tc.name, tc.namespace, tc.gcpSecretName,
 				tc.gcpConfig, tc.authServiceAccount, tc.namespace, tc.secretsPathPrefix)
 			if tc.err {
 				assert.Error(t, err, "should create vault with an error")
@@ -48,7 +52,7 @@ func TestCreateVault(t *testing.T) {
 				assert.NoError(t, err, "should create vault without an error")
 			}
 
-			vault, err := client.Vault().Vaults(tc.namespace).Get(tc.name, metav1.GetOptions{})
+			vault, err := vaultclient.Vault().Vaults(tc.namespace).Get(tc.name, metav1.GetOptions{})
 			assert.NoError(t, err, "should retrive created vault without an error")
 			assert.NotNil(t, vault, "created vault should not be nil")
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Ensure that the created vault has a service account and a proper role binding

Starting with kubernetes 1.10, a cluster role binding is required for service account token review. Vault
uses this feature to authenticate with a Kubernetes service account.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->