### PR TITLE
chore(tests): Windows tests fail

### DIFF
--- a/pkg/gits/provider_test.go
+++ b/pkg/gits/provider_test.go
@@ -144,7 +144,8 @@ func restoreEnviron(t *testing.T, environ map[string]string) {
 
 func TestCreateGitProviderFromURL(t *testing.T) {
 	t.Parallel()
-
+	utiltests.SkipForWindows(t, "go-expect does not work on Windows")	
+	
 	git := mocks.NewMockGitter()
 
 	tests := []struct {


### PR DESCRIPTION
`go-expect` tests don't work on windows. Please remember this

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
