### PR TITLE
fix(teamcontroller): Do not panic when creating teams

### DIFF
--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -723,7 +723,11 @@ func (o *CommonOptions) CleanExposecontrollerReources(ns string) {
 }
 
 func (o *CommonOptions) getDefaultAdminPassword(devNamespace string) (string, error) {
-	basicAuth, err := o.KubeClientCached.CoreV1().Secrets(devNamespace).Get(JXInstallConfig, v1.GetOptions{})
+	client, _, err := o.KubeClient() // cache may not have been created yet...
+	if err != nil {
+		return "", fmt.Errorf("cannot obtain k8s client %v", err)
+	}
+	basicAuth, err := client.CoreV1().Secrets(devNamespace).Get(JXInstallConfig, v1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("cannot find secret %s in namespace %s: %v", kube.SecretBasicAuth, devNamespace, err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

`getDefaultAdminPassword(string)` was expecting (incorrectly) that the
CahcedKubeClient has already been created wich was not correct.

change this to use `KubeClient()` which will create the cache if not
already done and return it if it has.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2381

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
