### PR TITLE
chore() prevent external use of `KubeClientCached`

### DIFF
--- a/pkg/jx/cmd/common_cert_manager.go
+++ b/pkg/jx/cmd/common_cert_manager.go
@@ -12,7 +12,7 @@ import (
 
 func (o *CommonOptions) ensureCertmanager() error {
 	log.Infof("Looking for %s deployment in namespace %s...\n", CertManagerDeployment, CertManagerNamespace)
-	_, err := kube.GetDeploymentPods(o.KubeClientCached, CertManagerDeployment, CertManagerNamespace)
+	_, err := kube.GetDeploymentPods(o.kubeClientCached, CertManagerDeployment, CertManagerNamespace)
 	if err != nil {
 		ok := util.Confirm("CertManager deployment not found, shall we install it now?", true, "CertManager automatically configures Ingress rules with TLS using signed certificates from LetsEncrypt", o.In, o.Out, o.Err)
 		if ok {
@@ -32,7 +32,7 @@ func (o *CommonOptions) ensureCertmanager() error {
 
 			log.Info("waiting for CertManager deployment to be ready, this can take a few minutes\n")
 
-			err = kube.WaitForDeploymentToBeReady(o.KubeClientCached, CertManagerDeployment, CertManagerNamespace, 10*time.Minute)
+			err = kube.WaitForDeploymentToBeReady(o.kubeClientCached, CertManagerDeployment, CertManagerNamespace, 10*time.Minute)
 			if err != nil {
 				return err
 			}

--- a/pkg/jx/cmd/common_helm.go
+++ b/pkg/jx/cmd/common_helm.go
@@ -109,7 +109,7 @@ func (o *CommonOptions) installChartAt(dir string, releaseName string, chart str
 }
 
 func (o *CommonOptions) installChartOptions(options helm.InstallChartOptions) error {
-	return helm.InstallFromChartOptions(options, o.Helm(), o.KubeClientCached, defaultInstallTimeout)
+	return helm.InstallFromChartOptions(options, o.Helm(), o.kubeClientCached, defaultInstallTimeout)
 }
 
 // deleteChart deletes the given chart

--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -1460,7 +1460,7 @@ func (o *CommonOptions) updateJenkinsURL(namespaces []string) error {
 
 	// loop over each namespace and update the Jenkins URL if a Jenkins service is found
 	for _, n := range namespaces {
-		externalURL, err := services.GetServiceURLFromName(o.KubeClientCached, "jenkins", n)
+		externalURL, err := services.GetServiceURLFromName(o.kubeClientCached, "jenkins", n)
 		if err != nil {
 			// skip namespace if no Jenkins service found
 			continue
@@ -1468,7 +1468,7 @@ func (o *CommonOptions) updateJenkinsURL(namespaces []string) error {
 
 		log.Infof("Updating Jenkins with new external URL details %s\n", externalURL)
 
-		jenkins, err := o.Factory.CreateJenkinsClient(o.KubeClientCached, n, o.In, o.Out, o.Err)
+		jenkins, err := o.Factory.CreateJenkinsClient(o.kubeClientCached, n, o.In, o.Out, o.Err)
 
 		if err != nil {
 			return err
@@ -1561,13 +1561,13 @@ func (o *CommonOptions) installProw() error {
 		}
 	}
 
-	if o.KubeClientCached == nil {
+	if o.kubeClientCached == nil {
 		_, _, err = o.KubeClient()
 		if err != nil {
 			return err
 		}
 	}
-	devNamespace, _, err := kube.GetDevNamespace(o.KubeClientCached, o.currentNamespace)
+	devNamespace, _, err := kube.GetDevNamespace(o.kubeClientCached, o.currentNamespace)
 	if err != nil {
 		return fmt.Errorf("cannot find a dev team namespace to get existing exposecontroller config from. %v", err)
 	}
@@ -1577,9 +1577,9 @@ func (o *CommonOptions) installProw() error {
 	values = append(values, setValues...)
 
 	// create initial configmaps if they don't already exist, use a dummy repo so tide doesn't start scanning all github
-	_, err = o.KubeClientCached.CoreV1().ConfigMaps(devNamespace).Get("config", metav1.GetOptions{})
+	_, err = o.kubeClientCached.CoreV1().ConfigMaps(devNamespace).Get("config", metav1.GetOptions{})
 	if err != nil {
-		err = prow.AddApplication(o.KubeClientCached, []string{"jenkins-x/dummy"}, devNamespace, "base")
+		err = prow.AddApplication(o.kubeClientCached, []string{"jenkins-x/dummy"}, devNamespace, "base")
 		if err != nil {
 			return err
 		}
@@ -1626,7 +1626,7 @@ func (o *CommonOptions) installProw() error {
 }
 
 func (o *CommonOptions) createWebhookProw(gitURL string, gitProvider gits.GitProvider) error {
-	ns, _, err := kube.GetDevNamespace(o.KubeClientCached, o.currentNamespace)
+	ns, _, err := kube.GetDevNamespace(o.kubeClientCached, o.currentNamespace)
 	if err != nil {
 		return err
 	}
@@ -1634,13 +1634,13 @@ func (o *CommonOptions) createWebhookProw(gitURL string, gitProvider gits.GitPro
 	if err != nil {
 		return err
 	}
-	baseURL, err := services.GetServiceURLFromName(o.KubeClientCached, "hook", ns)
+	baseURL, err := services.GetServiceURLFromName(o.kubeClientCached, "hook", ns)
 	if err != nil {
 		return err
 	}
 	webhookUrl := util.UrlJoin(baseURL, "hook")
 
-	hmacToken, err := o.KubeClientCached.CoreV1().Secrets(ns).Get("hmac-token", metav1.GetOptions{})
+	hmacToken, err := o.kubeClientCached.CoreV1().Secrets(ns).Get("hmac-token", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/create_addon.go
+++ b/pkg/jx/cmd/create_addon.go
@@ -117,7 +117,7 @@ func (o *CreateAddonOptions) ExposeAddon(addon string) error {
 	if !ok {
 		return nil
 	}
-	svc, err := o.KubeClientCached.CoreV1().Services(o.Namespace).Get(service, meta_v1.GetOptions{})
+	svc, err := o.kubeClientCached.CoreV1().Services(o.Namespace).Get(service, meta_v1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "getting the addon service: %s", service)
 	}
@@ -127,12 +127,12 @@ func (o *CreateAddonOptions) ExposeAddon(addon string) error {
 	}
 	if svc.Annotations[kube.AnnotationExpose] == "" {
 		svc.Annotations[kube.AnnotationExpose] = "true"
-		svc, err = o.KubeClientCached.CoreV1().Services(o.Namespace).Update(svc)
+		svc, err = o.kubeClientCached.CoreV1().Services(o.Namespace).Update(svc)
 		if err != nil {
 			return errors.Wrap(err, "updating the service annotations")
 		}
 	}
-	devNamespace, _, err := kube.GetDevNamespace(o.KubeClientCached, o.currentNamespace)
+	devNamespace, _, err := kube.GetDevNamespace(o.kubeClientCached, o.currentNamespace)
 	if err != nil {
 		return errors.Wrap(err, "retrieving the dev namespace")
 	}

--- a/pkg/jx/cmd/create_addon_anchore.go
+++ b/pkg/jx/cmd/create_addon_anchore.go
@@ -110,7 +110,7 @@ func (o *CreateAddonAnchoreOptions) Run() error {
 		return err
 	}
 
-	devNamespace, _, err := kube.GetDevNamespace(o.KubeClientCached, o.currentNamespace)
+	devNamespace, _, err := kube.GetDevNamespace(o.kubeClientCached, o.currentNamespace)
 	if err != nil {
 		return fmt.Errorf("cannot find a dev team namespace to get existing exposecontroller config from. %v", err)
 	}
@@ -127,7 +127,7 @@ func (o *CreateAddonAnchoreOptions) Run() error {
 
 	log.Info("waiting for anchore deployment to be ready, this can take a few minutes\n")
 
-	err = kube.WaitForDeploymentToBeReady(o.KubeClientCached, anchoreDeploymentName, o.Namespace, 10*time.Minute)
+	err = kube.WaitForDeploymentToBeReady(o.kubeClientCached, anchoreDeploymentName, o.Namespace, 10*time.Minute)
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func (o *CreateAddonAnchoreOptions) Run() error {
 	}
 
 	// get the external anchore services URL
-	ing, err := services.GetServiceURLFromName(o.KubeClientCached, anchoreServiceName, o.Namespace)
+	ing, err := services.GetServiceURLFromName(o.kubeClientCached, anchoreServiceName, o.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get external URL for service %s: %v", anchoreServiceName, err)
 	}
@@ -166,10 +166,10 @@ func (o *CreateAddonAnchoreOptions) Run() error {
 		return fmt.Errorf("failed to create addonAuth.yaml error: %v", err)
 	}
 
-	_, err = o.KubeClientCached.CoreV1().Services(o.currentNamespace).Get(anchoreServiceName, meta_v1.GetOptions{})
+	_, err = o.kubeClientCached.CoreV1().Services(o.currentNamespace).Get(anchoreServiceName, meta_v1.GetOptions{})
 	if err != nil {
 		// create a service link
-		err = services.CreateServiceLink(o.KubeClientCached, o.currentNamespace, o.Namespace, anchoreServiceName, ing)
+		err = services.CreateServiceLink(o.kubeClientCached, o.currentNamespace, o.Namespace, anchoreServiceName, ing)
 		if err != nil {
 			return fmt.Errorf("failed creating a service link for %s in target namespace %s", anchoreServiceName, o.Namespace)
 		}

--- a/pkg/jx/cmd/create_addon_cloudbees.go
+++ b/pkg/jx/cmd/create_addon_cloudbees.go
@@ -135,11 +135,11 @@ To register to get your username/password to to: %s
 
 	if o.Sso {
 		log.Infof("Configuring %s...\n", util.ColorInfo("single sign-on"))
-		o.devNamespace, _, err = kube.GetDevNamespace(o.KubeClientCached, o.currentNamespace)
+		o.devNamespace, _, err = kube.GetDevNamespace(o.kubeClientCached, o.currentNamespace)
 		if err != nil {
 			return errors.Wrap(err, "retrieving the development namespace")
 		}
-		ingressConfig, err := kube.GetIngressConfig(o.KubeClientCached, o.devNamespace)
+		ingressConfig, err := kube.GetIngressConfig(o.kubeClientCached, o.devNamespace)
 		if err != nil {
 			return errors.Wrap(err, "retrieving existing ingress configuration")
 		}
@@ -163,7 +163,7 @@ To register to get your username/password to to: %s
 
 		ingressConfig.TLS = true
 		ingressConfig.Issuer = kube.CertmanagerIssuerProd
-		err = kube.CleanCertmanagerResources(o.KubeClientCached, o.Namespace, ingressConfig)
+		err = kube.CleanCertmanagerResources(o.kubeClientCached, o.Namespace, ingressConfig)
 		if err != nil {
 			return errors.Wrap(err, "creating cert-manager issuer")
 		}
@@ -190,7 +190,7 @@ To register to get your username/password to to: %s
 	}
 
 	if o.Basic {
-		devNamespace, _, err := kube.GetDevNamespace(o.KubeClientCached, o.currentNamespace)
+		devNamespace, _, err := kube.GetDevNamespace(o.kubeClientCached, o.currentNamespace)
 		if err != nil {
 			return fmt.Errorf("cannot find a dev team namespace to get existing exposecontroller config from. %v", err)
 		}
@@ -216,7 +216,7 @@ To register to get your username/password to to: %s
 			annotationsUpdated = true
 		}
 		if annotationsUpdated {
-			svc, err = o.KubeClientCached.CoreV1().Services(o.Namespace).Update(svc)
+			svc, err = o.kubeClientCached.CoreV1().Services(o.Namespace).Update(svc)
 			if err != nil {
 				return fmt.Errorf("failed to update service %s/%s", o.Namespace, cbServiceName)
 			}

--- a/pkg/jx/cmd/create_addon_istio.go
+++ b/pkg/jx/cmd/create_addon_istio.go
@@ -127,7 +127,7 @@ func (o *CreateAddonIstioOptions) Run() error {
 		return err
 	}
 
-	devNamespace, _, err := kube.GetDevNamespace(o.KubeClientCached, o.currentNamespace)
+	devNamespace, _, err := kube.GetDevNamespace(o.kubeClientCached, o.currentNamespace)
 	if err != nil {
 		return fmt.Errorf("cannot find a dev team namespace to get existing exposecontroller config from. %v", err)
 	}

--- a/pkg/jx/cmd/create_addon_pipeline_events.go
+++ b/pkg/jx/cmd/create_addon_pipeline_events.go
@@ -103,7 +103,7 @@ func (o *CreateAddonPipelineEventsOptions) Run() error {
 		return err
 	}
 
-	devNamespace, _, err := kube.GetDevNamespace(o.KubeClientCached, o.currentNamespace)
+	devNamespace, _, err := kube.GetDevNamespace(o.kubeClientCached, o.currentNamespace)
 	if err != nil {
 		return fmt.Errorf("cannot find a dev team namespace to get existing exposecontroller config from. %v", err)
 	}
@@ -118,13 +118,13 @@ func (o *CreateAddonPipelineEventsOptions) Run() error {
 
 	log.Info("waiting for elasticsearch deployment to be ready, this can take a few minutes\n")
 
-	err = kube.WaitForDeploymentToBeReady(o.KubeClientCached, esDeploymentName, o.Namespace, 10*time.Minute)
+	err = kube.WaitForDeploymentToBeReady(o.kubeClientCached, esDeploymentName, o.Namespace, 10*time.Minute)
 	if err != nil {
 		return err
 	}
 	log.Info("waiting for kibana deployment to be ready, this can take a few minutes\n")
 
-	err = kube.WaitForDeploymentToBeReady(o.KubeClientCached, kibanaDeploymentName, o.Namespace, 10*time.Minute)
+	err = kube.WaitForDeploymentToBeReady(o.kubeClientCached, kibanaDeploymentName, o.Namespace, 10*time.Minute)
 	if err != nil {
 		return err
 	}
@@ -154,13 +154,13 @@ func (o *CreateAddonPipelineEventsOptions) Run() error {
 	}
 
 	// get the external services URL
-	kIng, err := services.GetServiceURLFromName(o.KubeClientCached, kibanaServiceName, o.Namespace)
+	kIng, err := services.GetServiceURLFromName(o.kubeClientCached, kibanaServiceName, o.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get external URL for service %s: %v", kibanaServiceName, err)
 	}
 
 	// get the external services URL
-	esIng, err := services.GetServiceURLFromName(o.KubeClientCached, esServiceName, o.Namespace)
+	esIng, err := services.GetServiceURLFromName(o.kubeClientCached, esServiceName, o.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get external URL for service %s: %v", kibanaServiceName, err)
 	}
@@ -183,10 +183,10 @@ func (o *CreateAddonPipelineEventsOptions) Run() error {
 		return fmt.Errorf("failed to create addonAuth.yaml error: %v", err)
 	}
 
-	_, err = o.KubeClientCached.CoreV1().Services(o.currentNamespace).Get(esServiceName, meta_v1.GetOptions{})
+	_, err = o.kubeClientCached.CoreV1().Services(o.currentNamespace).Get(esServiceName, meta_v1.GetOptions{})
 	if err != nil {
 		// create a services link
-		err = services.CreateServiceLink(o.KubeClientCached, o.currentNamespace, o.Namespace, esServiceName, esIng)
+		err = services.CreateServiceLink(o.kubeClientCached, o.currentNamespace, o.Namespace, esServiceName, esIng)
 		if err != nil {
 			return fmt.Errorf("failed creating a service link for %s in target namespace %s", esServiceName, o.Namespace)
 		}
@@ -197,7 +197,7 @@ func (o *CreateAddonPipelineEventsOptions) Run() error {
 }
 func (o *CreateAddonPipelineEventsOptions) addExposecontrollerAnnotations(serviceName string) error {
 
-	svc, err := o.KubeClientCached.CoreV1().Services(o.Namespace).Get(serviceName, meta_v1.GetOptions{})
+	svc, err := o.kubeClientCached.CoreV1().Services(o.Namespace).Get(serviceName, meta_v1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get Service %s: %v", serviceName, err)
 	}
@@ -215,7 +215,7 @@ func (o *CreateAddonPipelineEventsOptions) addExposecontrollerAnnotations(servic
 		annotationsUpdated = true
 	}
 	if annotationsUpdated {
-		svc, err = o.KubeClientCached.CoreV1().Services(o.Namespace).Update(svc)
+		svc, err = o.kubeClientCached.CoreV1().Services(o.Namespace).Update(svc)
 		if err != nil {
 			return fmt.Errorf("failed to update service %s/%s", o.Namespace, serviceName)
 		}

--- a/pkg/jx/cmd/create_addon_pipeline_events.go
+++ b/pkg/jx/cmd/create_addon_pipeline_events.go
@@ -154,7 +154,7 @@ func (o *CreateAddonPipelineEventsOptions) Run() error {
 	}
 
 	// get the external services URL
-	kIng, err := services.GetServiceURLFromName(o.kubeClientCached, kibanaServiceName, o.Namespace)
+	kibanaIng, err := services.GetServiceURLFromName(o.kubeClientCached, kibanaServiceName, o.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get external URL for service %s: %v", kibanaServiceName, err)
 	}
@@ -192,7 +192,7 @@ func (o *CreateAddonPipelineEventsOptions) Run() error {
 		}
 	}
 
-	log.Successf("kibana is available and running %s\n", kIng)
+	log.Successf("kibana is available and running %s\n", kibanaIng)
 	return nil
 }
 func (o *CreateAddonPipelineEventsOptions) addExposecontrollerAnnotations(serviceName string) error {

--- a/pkg/jx/cmd/create_addon_prometheus.go
+++ b/pkg/jx/cmd/create_addon_prometheus.go
@@ -87,12 +87,12 @@ func (o *CreateAddonPrometheusOptions) Run() error {
 			Name: "prometheus-ingress",
 		},
 	}
-	_, err = o.KubeClientCached.CoreV1().Secrets(o.Namespace).Create(sec)
+	_, err = o.kubeClientCached.CoreV1().Secrets(o.Namespace).Create(sec)
 	if err != nil {
 		return fmt.Errorf("cannot create secret %s in target namespace %s: %v", "prometheus-ingress", o.Namespace, err)
 	}
 
-	ingressConfig, err := o.KubeClientCached.CoreV1().ConfigMaps(o.Namespace).Get("ingress-config", meta_v1.GetOptions{})
+	ingressConfig, err := o.kubeClientCached.CoreV1().ConfigMaps(o.Namespace).Get("ingress-config", meta_v1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Cannot get ingress config map.")
 	}

--- a/pkg/jx/cmd/create_addon_prow.go
+++ b/pkg/jx/cmd/create_addon_prow.go
@@ -99,7 +99,7 @@ func (o *CreateAddonProwOptions) Run() error {
 		return fmt.Errorf("failed to install Prow: %v", err)
 	}
 
-	devNamespace, _, err := kube.GetDevNamespace(o.KubeClientCached, o.currentNamespace)
+	devNamespace, _, err := kube.GetDevNamespace(o.kubeClientCached, o.currentNamespace)
 	if err != nil {
 		return fmt.Errorf("cannot find a dev team namespace to get existing exposecontroller config from. %v", err)
 	}

--- a/pkg/jx/cmd/create_addon_sso.go
+++ b/pkg/jx/cmd/create_addon_sso.go
@@ -97,7 +97,7 @@ func (o *CreateAddonSSOOptions) Run() error {
 	if err != nil {
 		return fmt.Errorf("cannot connect to Kubernetes cluster: %v", err)
 	}
-	o.devNamespace, _, err = kube.GetDevNamespace(o.KubeClientCached, o.currentNamespace)
+	o.devNamespace, _, err = kube.GetDevNamespace(o.kubeClientCached, o.currentNamespace)
 	if err != nil {
 		return errors.Wrap(err, "retrieving the development namespace")
 	}
@@ -109,7 +109,7 @@ func (o *CreateAddonSSOOptions) Run() error {
 
 	log.Infof("Installing %s...\n", util.ColorInfo("dex identity provider"))
 
-	ingressConfig, err := kube.GetIngressConfig(o.KubeClientCached, o.devNamespace)
+	ingressConfig, err := kube.GetIngressConfig(o.kubeClientCached, o.devNamespace)
 	if err != nil {
 		return errors.Wrap(err, "retrieving existing ingress configuration")
 	}

--- a/pkg/jx/cmd/create_env.go
+++ b/pkg/jx/cmd/create_env.go
@@ -221,7 +221,7 @@ func (o *CreateEnvOptions) Run() error {
 	}
 	if o.Prow {
 		repo := fmt.Sprintf("%s/environment-%s-%s", gitInfo.Organisation, o.Prefix, o.Options.Name)
-		err = prow.AddEnvironment(o.KubeClientCached, []string{repo}, devEnv.Spec.Namespace, env.Spec.Namespace)
+		err = prow.AddEnvironment(o.kubeClientCached, []string{repo}, devEnv.Spec.Namespace, env.Spec.Namespace)
 		if err != nil {
 			return fmt.Errorf("failed to add repo %s to Prow config in namespace %s: %v", repo, env.Spec.Namespace, err)
 		}

--- a/pkg/jx/cmd/create_jenkins_token.go
+++ b/pkg/jx/cmd/create_jenkins_token.go
@@ -202,14 +202,14 @@ func (o *CreateJenkinsUserOptions) Run() error {
 	}
 
 	// now lets create a secret for it so we can perform incluster interactions with Jenkins
-	s, err := o.KubeClientCached.CoreV1().Secrets(o.currentNamespace).Get(kube.SecretJenkins, metav1.GetOptions{})
+	s, err := o.kubeClientCached.CoreV1().Secrets(o.currentNamespace).Get(kube.SecretJenkins, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 	s.Data[kube.JenkinsAdminApiToken] = []byte(userAuth.ApiToken)
 	s.Data[kube.JenkinsBearTokenField] = []byte(userAuth.BearerToken)
 	s.Data[kube.JenkinsAdminUserField] = []byte(userAuth.Username)
-	_, err = o.KubeClientCached.CoreV1().Secrets(o.currentNamespace).Update(s)
+	_, err = o.kubeClientCached.CoreV1().Secrets(o.currentNamespace).Update(s)
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/create_vault.go
+++ b/pkg/jx/cmd/create_vault.go
@@ -239,11 +239,11 @@ func (o *CreateVaultOptions) createVault(vaultOperatorClient versioned.Interface
 }
 
 func (o *CreateVaultOptions) exposeVault(vaultService string) error {
-	err := services.WaitForService(o.KubeClientCached, vaultService, o.Namespace, 1*time.Minute)
+	err := services.WaitForService(o.kubeClientCached, vaultService, o.Namespace, 1*time.Minute)
 	if err != nil {
 		return errors.Wrap(err, "waiting for vault service")
 	}
-	svc, err := o.KubeClientCached.CoreV1().Services(o.Namespace).Get(vaultService, metav1.GetOptions{})
+	svc, err := o.kubeClientCached.CoreV1().Services(o.Namespace).Get(vaultService, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "getting the vault service: %s", vaultService)
 	}
@@ -253,7 +253,7 @@ func (o *CreateVaultOptions) exposeVault(vaultService string) error {
 	if svc.Annotations[kube.AnnotationExpose] == "" {
 		svc.Annotations[kube.AnnotationExpose] = "true"
 		svc.Annotations[kube.AnnotationExposePort] = exposedVaultPort
-		svc, err = o.KubeClientCached.CoreV1().Services(o.Namespace).Update(svc)
+		svc, err = o.kubeClientCached.CoreV1().Services(o.Namespace).Update(svc)
 		if err != nil {
 			return errors.Wrapf(err, "updating %s service annotations", vaultService)
 		}

--- a/pkg/jx/cmd/delete_env.go
+++ b/pkg/jx/cmd/delete_env.go
@@ -129,7 +129,7 @@ func (o *DeleteEnvOptions) deleteEnviroment(jxClient versioned.Interface, ns str
 	}
 	kind := env.Spec.Kind
 	if o.DeleteNamespace || !kind.IsPermanent() {
-		return o.KubeClientCached.CoreV1().Namespaces().Delete(envNs, &metav1.DeleteOptions{})
+		return o.kubeClientCached.CoreV1().Namespaces().Delete(envNs, &metav1.DeleteOptions{})
 	}
 	log.Infof("To delete the associated namespace %s for environment %s then please run this command\n", name, envNs)
 	log.Infof(util.ColorInfo("  kubectl delete namespace %s\n"), envNs)

--- a/pkg/jx/cmd/get_cve.go
+++ b/pkg/jx/cmd/get_cve.go
@@ -134,7 +134,7 @@ func (o *GetCVEOptions) Run() error {
 		query.TargetNamespace = targetNamespace
 	}
 
-	err = p.GetImageVulnerabilityTable(jxClient, o.KubeClientCached, &table, query)
+	err = p.GetImageVulnerabilityTable(jxClient, o.kubeClientCached, &table, query)
 	if err != nil {
 		return fmt.Errorf("error getting vulnerability table for image %s: %v", query.ImageID, err)
 	}

--- a/pkg/jx/cmd/get_pipeline.go
+++ b/pkg/jx/cmd/get_pipeline.go
@@ -88,7 +88,7 @@ func (o *GetPipelineOptions) Run() error {
 
 	if isProw {
 		o.ProwOptions = prow.Options{
-			KubeClient: o.KubeClientCached,
+			KubeClient: o.kubeClientCached,
 			NS:         o.currentNamespace,
 		}
 		names, err := o.ProwOptions.GetReleaseJobs()

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -893,7 +893,7 @@ func (options *ImportOptions) addProwConfig(gitURL string) error {
 		return err
 	}
 	repo := gitInfo.Organisation + "/" + gitInfo.Name
-	err = prow.AddApplication(options.KubeClientCached, []string{repo}, options.currentNamespace, options.DraftPack)
+	err = prow.AddApplication(options.kubeClientCached, []string{repo}, options.currentNamespace, options.DraftPack)
 	if err != nil {
 		return err
 	}
@@ -902,7 +902,7 @@ func (options *ImportOptions) addProwConfig(gitURL string) error {
 		GetOptions: GetOptions{
 			CommonOptions: CommonOptions{
 				Factory:          options.Factory,
-				KubeClientCached: options.KubeClientCached,
+				kubeClientCached: options.kubeClientCached,
 			},
 		},
 	}
@@ -1084,7 +1084,7 @@ func (options *ImportOptions) addAppNameToGeneratedFile(filename, field, value s
 
 func (options *ImportOptions) checkChartmuseumCredentialExists() error {
 	name := jenkins.DefaultJenkinsCredentialsPrefix + jenkins.Chartmuseum
-	secret, err := options.KubeClientCached.CoreV1().Secrets(options.devNamespace).Get(name, metav1.GetOptions{})
+	secret, err := options.kubeClientCached.CoreV1().Secrets(options.devNamespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting %s secret %v", name, err)
 	}

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -373,7 +373,7 @@ func (options *InstallOptions) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create the kube client")
 	}
-	options.KubeClientCached = client
+	options.kubeClientCached = client
 
 	ns := options.Flags.Namespace
 	if ns == "" {

--- a/pkg/jx/cmd/start_pipeline.go
+++ b/pkg/jx/cmd/start_pipeline.go
@@ -110,7 +110,7 @@ func (o *StartPipelineOptions) Run() error {
 	args := o.Args
 	names := []string{}
 	o.ProwOptions = prow.Options{
-		KubeClient: o.KubeClientCached,
+		KubeClient: o.kubeClientCached,
 		NS:         o.currentNamespace,
 	}
 	if len(args) == 0 {

--- a/pkg/jx/cmd/step_link_services_test.go
+++ b/pkg/jx/cmd/step_link_services_test.go
@@ -61,17 +61,17 @@ func TestServiceLinking(t *testing.T) {
 		nil,
 		gits.NewGitCLI(),
 		helm.NewHelmCLI("helm", helm.V2, "", true))
-	serviceListFromNsBeforeStepLink, _ := o.KubeClientCached.CoreV1().Services(fromNs).List(metav1.ListOptions{})
+	serviceListFromNsBeforeStepLink, _ := o.kubeClientCached.CoreV1().Services(fromNs).List(metav1.ListOptions{})
 	assert.EqualValues(t, len(serviceListFromNsBeforeStepLink.Items), 2)
-	serviceListToNsBeforeStepLink, _ := o.KubeClientCached.CoreV1().Services(toNs).List(metav1.ListOptions{})
+	serviceListToNsBeforeStepLink, _ := o.kubeClientCached.CoreV1().Services(toNs).List(metav1.ListOptions{})
 	assert.EqualValues(t, len(serviceListToNsBeforeStepLink.Items), 1)
 	err := o.Run()
-	serviceList, _ := o.KubeClientCached.CoreV1().Services(toNs).List(metav1.ListOptions{})
+	serviceList, _ := o.kubeClientCached.CoreV1().Services(toNs).List(metav1.ListOptions{})
 	serviceNames := []string{""}
 	for _, service := range serviceList.Items {
 		serviceNames = append(serviceNames, service.Name)
 	}
-	serviceListToNsAfterStepLink, _ := o.KubeClientCached.CoreV1().Services(toNs).List(metav1.ListOptions{})
+	serviceListToNsAfterStepLink, _ := o.kubeClientCached.CoreV1().Services(toNs).List(metav1.ListOptions{})
 	assert.EqualValues(t, len(serviceListToNsAfterStepLink.Items), 2)
 
 	assert.Contains(t, serviceNames, serviceNameInFromNs) //Check if service that was in include list got added

--- a/pkg/jx/cmd/step_link_services_test.go
+++ b/pkg/jx/cmd/step_link_services_test.go
@@ -61,17 +61,19 @@ func TestServiceLinking(t *testing.T) {
 		nil,
 		gits.NewGitCLI(),
 		helm.NewHelmCLI("helm", helm.V2, "", true))
-	serviceListFromNsBeforeStepLink, _ := o.kubeClientCached.CoreV1().Services(fromNs).List(metav1.ListOptions{})
+	client, _, err := o.KubeClient()
+	assert.NoError(t, err)
+	serviceListFromNsBeforeStepLink, _ := client.CoreV1().Services(fromNs).List(metav1.ListOptions{})
 	assert.EqualValues(t, len(serviceListFromNsBeforeStepLink.Items), 2)
-	serviceListToNsBeforeStepLink, _ := o.kubeClientCached.CoreV1().Services(toNs).List(metav1.ListOptions{})
+	serviceListToNsBeforeStepLink, _ := client.CoreV1().Services(toNs).List(metav1.ListOptions{})
 	assert.EqualValues(t, len(serviceListToNsBeforeStepLink.Items), 1)
-	err := o.Run()
-	serviceList, _ := o.kubeClientCached.CoreV1().Services(toNs).List(metav1.ListOptions{})
+	err = o.Run()
+	serviceList, _ := client.CoreV1().Services(toNs).List(metav1.ListOptions{})
 	serviceNames := []string{""}
 	for _, service := range serviceList.Items {
 		serviceNames = append(serviceNames, service.Name)
 	}
-	serviceListToNsAfterStepLink, _ := o.kubeClientCached.CoreV1().Services(toNs).List(metav1.ListOptions{})
+	serviceListToNsAfterStepLink, _ := client.CoreV1().Services(toNs).List(metav1.ListOptions{})
 	assert.EqualValues(t, len(serviceListToNsAfterStepLink.Items), 2)
 
 	assert.Contains(t, serviceNames, serviceNameInFromNs) //Check if service that was in include list got added

--- a/pkg/jx/cmd/step_post_build.go
+++ b/pkg/jx/cmd/step_post_build.go
@@ -98,7 +98,7 @@ func (o *StepPostBuildOptions) addImageCVEProvider() error {
 		return util.MissingOption("image")
 	}
 
-	present, err := services.IsServicePresent(o.KubeClientCached, kube.AddonServices[defaultAnchoreName], o.currentNamespace)
+	present, err := services.IsServicePresent(o.kubeClientCached, kube.AddonServices[defaultAnchoreName], o.currentNamespace)
 	if err != nil || !present {
 		log.Infof("no CVE provider running in the current %s namespace so skip adding image to be analysed", o.currentNamespace)
 		return nil

--- a/pkg/jx/cmd/test_helpers.go
+++ b/pkg/jx/cmd/test_helpers.go
@@ -90,7 +90,7 @@ func ConfigureTestOptionsWithResources(o *CommonOptions, k8sObjects []runtime.Ob
 		}
 	}
 
-	o.KubeClientCached = fake.NewSimpleClientset(k8sObjects...)
+	o.kubeClientCached = fake.NewSimpleClientset(k8sObjects...)
 	o.jxClient = v1fake.NewSimpleClientset(jxObjects...)
 	o.apiExtensionsClient = apifake.NewSimpleClientset()
 	o.GitClient = git

--- a/pkg/jx/cmd/uninstall_test.go
+++ b/pkg/jx/cmd/uninstall_test.go
@@ -60,8 +60,11 @@ func TestUninstallOptions_Run_ContextSpecifiedAsOption_PassWhenContextNamesMatch
 	err = o.Run()
 	assert.NoError(t, err)
 
+	client, _, err := o.KubeClient()
+	assert.NoError(t, err)
+
 	// Assert that the namespace has been deleted
-	_, err = o.kubeClientCached.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
+	_, err = client.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
 	assert.Error(t, err)
 }
 
@@ -84,8 +87,11 @@ func TestUninstallOptions_Run_ContextSpecifiedAsOption_PassWhenForced(t *testing
 	err = o.Run()
 	assert.NoError(t, err)
 
+	client, _, err := o.KubeClient()
+	assert.NoError(t, err)
+
 	// Assert that the namespace has been deleted
-	_, err = o.kubeClientCached.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
+	_, err = client.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
 	assert.Error(t, err)
 }
 
@@ -163,8 +169,11 @@ func TestUninstallOptions_Run_ContextSpecifiedViaCli_PassWhenContextNamesMatch(t
 	err = o.Run()
 	assert.NoError(t, err)
 
+	client, _, err := o.KubeClient()
+	assert.NoError(t, err)
+
 	// Assert that the namespace has been deleted
-	_, err = o.kubeClientCached.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
+	_, err = client.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
 	assert.Error(t, err)
 
 	assert.NoError(t, console.Close())
@@ -175,7 +184,11 @@ func TestUninstallOptions_Run_ContextSpecifiedViaCli_PassWhenContextNamesMatch(t
 }
 
 func createNamespace(o *cmd.UninstallOptions, ns string) error {
-	_, err := o.kubeClientCached.CoreV1().Namespaces().Create(&v1.Namespace{
+	client, _, err := o.KubeClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.CoreV1().Namespaces().Create(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
 		},

--- a/pkg/jx/cmd/uninstall_test.go
+++ b/pkg/jx/cmd/uninstall_test.go
@@ -61,7 +61,7 @@ func TestUninstallOptions_Run_ContextSpecifiedAsOption_PassWhenContextNamesMatch
 	assert.NoError(t, err)
 
 	// Assert that the namespace has been deleted
-	_, err = o.KubeClientCached.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
+	_, err = o.kubeClientCached.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
 	assert.Error(t, err)
 }
 
@@ -85,7 +85,7 @@ func TestUninstallOptions_Run_ContextSpecifiedAsOption_PassWhenForced(t *testing
 	assert.NoError(t, err)
 
 	// Assert that the namespace has been deleted
-	_, err = o.KubeClientCached.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
+	_, err = o.kubeClientCached.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
 	assert.Error(t, err)
 }
 
@@ -164,7 +164,7 @@ func TestUninstallOptions_Run_ContextSpecifiedViaCli_PassWhenContextNamesMatch(t
 	assert.NoError(t, err)
 
 	// Assert that the namespace has been deleted
-	_, err = o.KubeClientCached.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
+	_, err = o.kubeClientCached.CoreV1().Namespaces().Get("ns", metav1.GetOptions{})
 	assert.Error(t, err)
 
 	assert.NoError(t, console.Close())
@@ -175,7 +175,7 @@ func TestUninstallOptions_Run_ContextSpecifiedViaCli_PassWhenContextNamesMatch(t
 }
 
 func createNamespace(o *cmd.UninstallOptions, ns string) error {
-	_, err := o.KubeClientCached.CoreV1().Namespaces().Create(&v1.Namespace{
+	_, err := o.kubeClientCached.CoreV1().Namespaces().Create(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
 		},

--- a/pkg/jx/cmd/update_webhooks.go
+++ b/pkg/jx/cmd/update_webhooks.go
@@ -89,7 +89,7 @@ func (options *UpdateWebhooksOptions) Run() error {
 		return errors.Wrap(err, "failed to get kube client")
 	}
 
-	ns, _, err := kube.GetDevNamespace(options.KubeClientCached, options.currentNamespace)
+	ns, _, err := kube.GetDevNamespace(options.kubeClientCached, options.currentNamespace)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (options *UpdateWebhooksOptions) Run() error {
 		return err
 	}
 
-	hmacToken, err := options.KubeClientCached.CoreV1().Secrets(ns).Get("hmac-token", metav1.GetOptions{})
+	hmacToken, err := options.kubeClientCached.CoreV1().Secrets(ns).Get("hmac-token", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/upgrade_addons.go
+++ b/pkg/jx/cmd/upgrade_addons.go
@@ -89,7 +89,7 @@ func (o *UpgradeAddonsOptions) Run() error {
 		}
 	}
 
-	o.devNamespace, _, err = kube.GetDevNamespace(o.KubeClientCached, ns)
+	o.devNamespace, _, err = kube.GetDevNamespace(o.kubeClientCached, ns)
 	if err != nil {
 		return err
 	}
@@ -172,9 +172,9 @@ func (o *UpgradeAddonsOptions) restoreConfigs(config *v1.ConfigMap, plugins *v1.
 	var err error
 	var err1 error
 	if config != nil {
-		_, err = o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("config", metav1.GetOptions{})
+		_, err = o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("config", metav1.GetOptions{})
 		if err != nil {
-			_, err = o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Create(config)
+			_, err = o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Create(config)
 			if err != nil {
 				b, _ := yaml.Marshal(config)
 				err1 = fmt.Errorf("error restoring config %s\n", string(b))
@@ -182,9 +182,9 @@ func (o *UpgradeAddonsOptions) restoreConfigs(config *v1.ConfigMap, plugins *v1.
 		}
 	}
 	if plugins != nil {
-		_, err = o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("plugins", metav1.GetOptions{})
+		_, err = o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("plugins", metav1.GetOptions{})
 		if err != nil {
-			_, err = o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Create(plugins)
+			_, err = o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Create(plugins)
 			if err != nil {
 				b, _ := yaml.Marshal(plugins)
 				err = fmt.Errorf("%v/nerror restoring plugins %s\n", err1, string(b))
@@ -195,8 +195,8 @@ func (o *UpgradeAddonsOptions) restoreConfigs(config *v1.ConfigMap, plugins *v1.
 }
 
 func (o *UpgradeAddonsOptions) backupConfigs() (*v1.ConfigMap, *v1.ConfigMap) {
-	config, _ := o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("config", metav1.GetOptions{})
-	plugins, _ := o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("plugins", metav1.GetOptions{})
+	config, _ := o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("config", metav1.GetOptions{})
+	plugins, _ := o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("plugins", metav1.GetOptions{})
 	config = config.DeepCopy()
 	config.ResourceVersion = ""
 	plugins = plugins.DeepCopy()

--- a/pkg/jx/cmd/upgrade_apps.go
+++ b/pkg/jx/cmd/upgrade_apps.go
@@ -213,7 +213,7 @@ func (o *UpgradeAppsOptions) upgradeApps() error {
 		}
 	}
 
-	o.devNamespace, _, err = kube.GetDevNamespace(o.KubeClientCached, ns)
+	o.devNamespace, _, err = kube.GetDevNamespace(o.kubeClientCached, ns)
 	if err != nil {
 		return err
 	}
@@ -296,9 +296,9 @@ func (o *UpgradeAppsOptions) restoreConfigs(config *v1.ConfigMap, plugins *v1.Co
 	var err error
 	var err1 error
 	if config != nil {
-		_, err = o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("config", metav1.GetOptions{})
+		_, err = o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("config", metav1.GetOptions{})
 		if err != nil {
-			_, err = o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Create(config)
+			_, err = o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Create(config)
 			if err != nil {
 				b, _ := yaml.Marshal(config)
 				err1 = fmt.Errorf("error restoring config %s\n", string(b))
@@ -306,9 +306,9 @@ func (o *UpgradeAppsOptions) restoreConfigs(config *v1.ConfigMap, plugins *v1.Co
 		}
 	}
 	if plugins != nil {
-		_, err = o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("plugins", metav1.GetOptions{})
+		_, err = o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("plugins", metav1.GetOptions{})
 		if err != nil {
-			_, err = o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Create(plugins)
+			_, err = o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Create(plugins)
 			if err != nil {
 				b, _ := yaml.Marshal(plugins)
 				err = fmt.Errorf("%v/nerror restoring plugins %s\n", err1, string(b))
@@ -319,8 +319,8 @@ func (o *UpgradeAppsOptions) restoreConfigs(config *v1.ConfigMap, plugins *v1.Co
 }
 
 func (o *UpgradeAppsOptions) backupConfigs() (*v1.ConfigMap, *v1.ConfigMap) {
-	config, _ := o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("config", metav1.GetOptions{})
-	plugins, _ := o.KubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("plugins", metav1.GetOptions{})
+	config, _ := o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("config", metav1.GetOptions{})
+	plugins, _ := o.kubeClientCached.CoreV1().ConfigMaps(o.devNamespace).Get("plugins", metav1.GetOptions{})
 	config = config.DeepCopy()
 	config.ResourceVersion = ""
 	plugins = plugins.DeepCopy()

--- a/pkg/jx/cmd/upgrade_ingress.go
+++ b/pkg/jx/cmd/upgrade_ingress.go
@@ -490,3 +490,8 @@ func (o *UpgradeIngressOptions) updateWebHooks(oldHookEndpoint string, newHookEn
 
 	return updateWebHook.Run()
 }
+
+// InitForTests should not be used, it is here for testing only as opposed to a bigger refactoring of upgrade ingress tests
+func (o *UpgradeIngressOptions) InitForTests() {
+	o.kubeClientCached, _, _ = o.KubeClient()
+}

--- a/pkg/jx/cmd/upgrade_ingress_test.go
+++ b/pkg/jx/cmd/upgrade_ingress_test.go
@@ -19,10 +19,16 @@ import (
 type TestOptions struct {
 	cmd.UpgradeIngressOptions
 	Service *v1.Service
+	// for testing so we can return the same client
+	cacheKubeClient kubernetes.Interface
+
 }
 
 func (o *TestOptions) KubeClient() (kubernetes.Interface, string, error) {
-	return testclient.NewSimpleClientset(), "test", nil
+	if o.cacheKubeClient == nil {
+		o.cacheKubeClient = testclient.NewSimpleClientset()
+	}
+	return o.cacheKubeClient, "test", nil
 }
 
 func (o *TestOptions) Setup() {
@@ -44,6 +50,7 @@ func (o *TestOptions) Setup() {
 
 	o.Service.Annotations = map[string]string{}
 	o.Service.Annotations[services.ExposeAnnotation] = "true"
+	o.InitForTests()
 }
 
 func TestAnnotateNoExisting(t *testing.T) {

--- a/pkg/jx/cmd/upgrade_ingress_test.go
+++ b/pkg/jx/cmd/upgrade_ingress_test.go
@@ -24,7 +24,7 @@ func (o *TestOptions) Setup() {
 	o.UpgradeIngressOptions = cmd.UpgradeIngressOptions{
 		CreateOptions: cmd.CreateOptions{
 			CommonOptions: cmd.CommonOptions{
-				KubeClientCached: testclient.NewSimpleClientset(),
+				kubeClientCached: testclient.NewSimpleClientset(),
 			},
 		},
 		IngressConfig: kube.IngressConfig{
@@ -49,7 +49,7 @@ func TestAnnotateNoExisting(t *testing.T) {
 	o := TestOptions{}
 	o.Setup()
 
-	_, err := o.KubeClientCached.CoreV1().Services("test").Create(o.Service)
+	_, err := o.kubeClientCached.CoreV1().Services("test").Create(o.Service)
 	assert.NoError(t, err)
 
 	err = o.CleanServiceAnnotations()
@@ -58,7 +58,7 @@ func TestAnnotateNoExisting(t *testing.T) {
 	err = o.AnnotateExposedServicesWithCertManager()
 	assert.NoError(t, err)
 
-	rs, err := o.KubeClientCached.CoreV1().Services("test").Get("foo", metav1.GetOptions{})
+	rs, err := o.kubeClientCached.CoreV1().Services("test").Get("foo", metav1.GetOptions{})
 	ingressAnnotations := rs.Annotations[services.ExposeIngressAnnotation]
 
 	assert.Equal(t, "certmanager.k8s.io/issuer: letsencrypt-prod", ingressAnnotations)
@@ -72,7 +72,7 @@ func TestAnnotateWithExistingAnnotations(t *testing.T) {
 
 	o.Service.Annotations[services.ExposeIngressAnnotation] = "foo: bar\nkubernetes.io/ingress.class: nginx\nnginx.ingress.kubernetes.io/proxy-body-size: 500m"
 
-	_, err := o.KubeClientCached.CoreV1().Services("test").Create(o.Service)
+	_, err := o.kubeClientCached.CoreV1().Services("test").Create(o.Service)
 	assert.NoError(t, err)
 
 	err = o.CleanServiceAnnotations()
@@ -81,7 +81,7 @@ func TestAnnotateWithExistingAnnotations(t *testing.T) {
 	err = o.AnnotateExposedServicesWithCertManager()
 	assert.NoError(t, err)
 
-	rs, err := o.KubeClientCached.CoreV1().Services("test").Get("foo", metav1.GetOptions{})
+	rs, err := o.kubeClientCached.CoreV1().Services("test").Get("foo", metav1.GetOptions{})
 	ingressAnnotations := rs.Annotations[services.ExposeIngressAnnotation]
 
 	assert.Equal(t, "foo: bar\nkubernetes.io/ingress.class: nginx\nnginx.ingress.kubernetes.io/proxy-body-size: 500m\ncertmanager.k8s.io/issuer: letsencrypt-prod", ingressAnnotations)
@@ -95,7 +95,7 @@ func TestAnnotateWithExistingCertManagerAnnotation(t *testing.T) {
 
 	o.Service.Annotations[services.ExposeIngressAnnotation] = services.CertManagerAnnotation + ": letsencrypt-staging"
 
-	_, err := o.KubeClientCached.CoreV1().Services("test").Create(o.Service)
+	_, err := o.kubeClientCached.CoreV1().Services("test").Create(o.Service)
 	assert.NoError(t, err)
 
 	err = o.CleanServiceAnnotations()
@@ -104,7 +104,7 @@ func TestAnnotateWithExistingCertManagerAnnotation(t *testing.T) {
 	err = o.AnnotateExposedServicesWithCertManager()
 	assert.NoError(t, err)
 
-	rs, err := o.KubeClientCached.CoreV1().Services("test").Get("foo", metav1.GetOptions{})
+	rs, err := o.kubeClientCached.CoreV1().Services("test").Get("foo", metav1.GetOptions{})
 	ingressAnnotations := rs.Annotations[services.ExposeIngressAnnotation]
 
 	assert.Equal(t, "certmanager.k8s.io/issuer: letsencrypt-prod", ingressAnnotations)
@@ -121,11 +121,11 @@ func TestCleanExistingExposecontrollerReources(t *testing.T) {
 			Name: "exposecontroller",
 		},
 	}
-	_, err := o.KubeClientCached.CoreV1().ConfigMaps("test").Create(&cm)
+	_, err := o.kubeClientCached.CoreV1().ConfigMaps("test").Create(&cm)
 	assert.NoError(t, err)
 	o.CleanExposecontrollerReources("test")
 
-	_, err = o.KubeClientCached.CoreV1().ConfigMaps("test").Get("exposecontroller", metav1.GetOptions{})
+	_, err = o.kubeClientCached.CoreV1().ConfigMaps("test").Get("exposecontroller", metav1.GetOptions{})
 	assert.Error(t, err)
 }
 
@@ -136,13 +136,13 @@ func TestCleanServiceAnnotations(t *testing.T) {
 
 	o.Service.Annotations[services.ExposeURLAnnotation] = "http://foo.bar"
 
-	_, err := o.KubeClientCached.CoreV1().Services("test").Create(o.Service)
+	_, err := o.kubeClientCached.CoreV1().Services("test").Create(o.Service)
 	assert.NoError(t, err)
 
 	err = o.CleanServiceAnnotations()
 	assert.NoError(t, err)
 
-	rs, err := o.KubeClientCached.CoreV1().Services("test").Get("foo", metav1.GetOptions{})
+	rs, err := o.kubeClientCached.CoreV1().Services("test").Get("foo", metav1.GetOptions{})
 
 	assert.Empty(t, rs.Annotations[services.ExposeURLAnnotation])
 	assert.NoError(t, err)
@@ -163,7 +163,7 @@ func TestRealJenkinsService(t *testing.T) {
 
 	o.Service = svc
 
-	_, err = o.KubeClientCached.CoreV1().Services("test").Create(o.Service)
+	_, err = o.kubeClientCached.CoreV1().Services("test").Create(o.Service)
 	assert.NoError(t, err)
 
 	err = o.CleanServiceAnnotations()
@@ -172,7 +172,7 @@ func TestRealJenkinsService(t *testing.T) {
 	err = o.AnnotateExposedServicesWithCertManager()
 	assert.NoError(t, err)
 
-	rs, err := o.KubeClientCached.CoreV1().Services("test").Get("jenkins", metav1.GetOptions{})
+	rs, err := o.kubeClientCached.CoreV1().Services("test").Get("jenkins", metav1.GetOptions{})
 	ingressAnnotations := rs.Annotations[services.ExposeIngressAnnotation]
 
 	assert.Equal(t, "kubernetes.io/ingress.class: nginx\nnginx.ingress.kubernetes.io/proxy-body-size: 500m\ncertmanager.k8s.io/issuer: letsencrypt-prod", ingressAnnotations)

--- a/pkg/jx/cmd/upgrade_platform.go
+++ b/pkg/jx/cmd/upgrade_platform.go
@@ -216,7 +216,7 @@ func (o *UpgradePlatformOptions) Run() error {
 	adminSecretsFileName := filepath.Join(dir, AdminSecretsFile)
 	configFileName := filepath.Join(dir, ExtraValuesFile)
 
-	secretResources := o.KubeClientCached.CoreV1().Secrets(ns)
+	secretResources := o.kubeClientCached.CoreV1().Secrets(ns)
 	oldSecret, err := secretResources.Get(JXInstallConfig, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to get the jx secret resource")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

`KubeClientCached` can be changed by the running code so it should not be relied upon externally.  Ideally it would not be relied upon internally either but that is a bigger change, so at least prevent external misuse of this.
The replacement is to use `KubeClient()` and check for any error.

#### Special notes for the reviewer(s)

Please check the changes to the test code is ok.

#### Which issue this PR fixes

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
