### PR TITLE
refactor(install): break the install command in smaller methods and make the cloud providers configuration more self contained

### DIFF
--- a/pkg/cloud/gke/gcloud.go
+++ b/pkg/cloud/gke/gcloud.go
@@ -466,7 +466,7 @@ func GetEnabledApis(projectID string) ([]string, error) {
 	return apis, nil
 }
 
-// EnableApis enables APIs for the given services
+// EnableAPIs enables APIs for the given services
 func EnableAPIs(projectID string, apis ...string) error {
 	enabledApis, err := GetEnabledApis(projectID)
 	if err != nil {

--- a/pkg/io/secrets/secret_locations_test.go
+++ b/pkg/io/secrets/secret_locations_test.go
@@ -1,11 +1,12 @@
 package secrets
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"testing"
 )
 
 const ns = "Galaxy"
@@ -16,7 +17,8 @@ func TestUseVaultForSecrets(t *testing.T) {
 	kubeClient := createMockCluster()
 	secretLocation := NewSecretLocation(kubeClient, ns)
 
-	secretLocation.SetInVault(true)
+	err := secretLocation.SetInVault(true)
+	assert.NoError(t, err)
 
 	// Test we have actually added the item to the configmap
 	configMap, err := kubeClient.Core().ConfigMaps(ns).Get("jx-install-config", metav1.GetOptions{})
@@ -26,7 +28,8 @@ func TestUseVaultForSecrets(t *testing.T) {
 	assert.Equal(t, "two", configMap.Data["one"])
 	assert.True(t, secretLocation.InVault())
 
-	secretLocation.SetInVault(false)
+	err = secretLocation.SetInVault(false)
+	assert.NoError(t, err)
 
 	configMap, err = kubeClient.Core().ConfigMaps(ns).Get("jx-install-config", metav1.GetOptions{})
 	assert.NoError(t, err)
@@ -42,7 +45,8 @@ func TestUseVaultForSecrets_NoJxInstallConfigMap(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	secretLocation := NewSecretLocation(kubeClient, ns)
 
-	secretLocation.SetInVault(true)
+	err := secretLocation.SetInVault(true)
+	assert.NoError(t, err)
 
 	// Test we have actually added the item to the configmap
 	configMap, err := kubeClient.Core().ConfigMaps(ns).Get("jx-install-config", metav1.GetOptions{})
@@ -50,7 +54,8 @@ func TestUseVaultForSecrets_NoJxInstallConfigMap(t *testing.T) {
 	assert.Equal(t, "true", configMap.Data["useVaultForSecrets"])
 	assert.True(t, secretLocation.InVault())
 
-	secretLocation.SetInVault(false)
+	err = secretLocation.SetInVault(false)
+	assert.NoError(t, err)
 
 	configMap, err = kubeClient.Core().ConfigMaps(ns).Get("jx-install-config", metav1.GetOptions{})
 	assert.NoError(t, err)

--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -1372,6 +1372,9 @@ func (o *CommonOptions) installRequirements(cloudProvider string, extraDependenc
 		deps = o.addRequiredBinary("ibmcloud", deps)
 	case AWS:
 		deps = o.addRequiredBinary("kops", deps)
+	case EKS:
+		deps = o.addRequiredBinary("eksctl", deps)
+		deps = o.addRequiredBinary("heptio-authenticator-aws", deps)
 	case AKS:
 		deps = o.addRequiredBinary("az", deps)
 	case GKE:

--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -1312,7 +1312,8 @@ func (o *CommonOptions) GetCloudProvider(p string) (string, error) {
 	return p, nil
 }
 
-func (o *CommonOptions) getClusterDependencies(deps []string) []string {
+func (o *CommonOptions) getClusterDependencies(depsToInstall []string) []string {
+	deps := o.filterInstalledDependencies(depsToInstall)
 	d := binaryShouldBeInstalled("kubectl")
 	if d != "" && util.StringArrayIndex(deps, d) < 0 {
 		deps = append(deps, d)
@@ -1335,11 +1336,19 @@ func (o *CommonOptions) getClusterDependencies(deps []string) []string {
 	return deps
 }
 
-func (o *CommonOptions) installMissingDependencies(providerSpecificDeps []string) error {
-	surveyOpts := survey.WithStdio(o.In, o.Out, o.Err)
-	// get base list of required dependencies and add provider specific ones
-	deps := o.getClusterDependencies(providerSpecificDeps)
+func (o *CommonOptions) filterInstalledDependencies(deps []string) []string {
+	depsToInstall := []string{}
+	for _, d := range deps {
+		binary := binaryShouldBeInstalled(d)
+		if binary != "" {
+			depsToInstall = append(depsToInstall, binary)
+		}
+	}
+	return depsToInstall
+}
 
+func (o *CommonOptions) installMissingDependencies(providerSpecificDeps []string) error {
+	deps := o.getClusterDependencies(providerSpecificDeps)
 	if len(deps) == 0 {
 		return nil
 	}
@@ -1349,6 +1358,7 @@ func (o *CommonOptions) installMissingDependencies(providerSpecificDeps []string
 	if o.InstallDependencies {
 		install = append(install, deps...)
 	} else {
+		surveyOpts := survey.WithStdio(o.In, o.Out, o.Err)
 		if o.BatchMode {
 			return errors.New(fmt.Sprintf("run without batch mode or manually install missing dependencies %v\n", deps))
 		}

--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
-	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"io"
 	"strings"
+
+	"github.com/jenkins-x/jx/pkg/io/secrets"
+	"github.com/pkg/errors"
 
 	osUser "os/user"
 
@@ -313,7 +315,10 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 		if err = InstallVaultOperator(&o.CommonOptions, ""); err != nil {
 			return err
 		}
-		secrets.NewSecretLocation(kubeClient, ns).SetInVault(true)
+		err = secrets.NewSecretLocation(kubeClient, ns).SetInVault(true)
+		if err != nil {
+			return errors.Wrap(err, "configring secrets location")
+		}
 	}
 
 	return nil

--- a/pkg/jx/cmd/create_terraform.go
+++ b/pkg/jx/cmd/create_terraform.go
@@ -795,7 +795,7 @@ func (options *CreateTerraformOptions) configureGKECluster(g *GKECluster, path s
 	if !options.Flags.GKESkipEnableApis {
 		options.Debugf("enabling apis for %s", g.Name())
 
-		err := gke.EnableApis(g.ProjectID, "iam", "compute", "container")
+		err := gke.EnableAPIs(g.ProjectID, "iam", "compute", "container")
 		if err != nil {
 			return err
 		}
@@ -917,7 +917,7 @@ func (options *CreateTerraformOptions) applyTerraformGKE(g *GKECluster, path str
 			}
 
 			options.Debugf("attempting to enable apis")
-			err = gke.EnableApis(g.ProjectID, "iam", "compute", "container")
+			err = gke.EnableAPIs(g.ProjectID, "iam", "compute", "container")
 			if err != nil {
 				return err
 			}

--- a/pkg/jx/cmd/extraValues.yaml
+++ b/pkg/jx/cmd/extraValues.yaml
@@ -3,5 +3,5 @@ expose:
     domain: test-domain
 preview:
   image:
-    repository: my.registry/MyOrganisation/MyApp
-    tag: v0.1.2
+    repository: my.registry/my-org/my-app
+    tag: 1.0.0

--- a/pkg/jx/cmd/extraValues.yaml
+++ b/pkg/jx/cmd/extraValues.yaml
@@ -3,5 +3,5 @@ expose:
     domain: test-domain
 preview:
   image:
-    repository: my.registry/MyOrganisation/MyApp
+    repository: MyOrganisation:5000/MyOrganisation/MyApp
     tag: v0.1.2

--- a/pkg/jx/cmd/extraValues.yaml
+++ b/pkg/jx/cmd/extraValues.yaml
@@ -3,5 +3,5 @@ expose:
     domain: test-domain
 preview:
   image:
-    repository: my.registry/my-org/my-app
-    tag: 1.0.0
+    repository: my.registry/MyOrganisation/MyApp
+    tag: v0.1.2

--- a/pkg/jx/cmd/factory.go
+++ b/pkg/jx/cmd/factory.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/heptio/sonobuoy/pkg/client"
 	"github.com/heptio/sonobuoy/pkg/dynamic"
+	"github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/jenkins"
 	"github.com/jenkins-x/jx/pkg/kube"
@@ -94,7 +95,6 @@ func (f *factory) WithBearerToken(token string) Factory {
 
 // CreateJenkinsClient creates a new Jenkins client
 func (f *factory) CreateJenkinsClient(kubeClient kubernetes.Interface, ns string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (gojenkins.JenkinsClient, error) {
-
 	svc, err := f.CreateJenkinsAuthConfigService(kubeClient, ns)
 	if err != nil {
 		return nil, err
@@ -298,7 +298,7 @@ func (f *factory) CreateAuthConfigService(configName string) (auth.ConfigService
 
 // UseVault idicates if the platform is using a Vault to manage the secrets
 func (f *factory) UseVault() bool {
-	client, namespace, err := f.CreateClient()
+	client, namespace, err := f.CreateKubeClient()
 	if err != nil {
 		return false
 	}

--- a/pkg/jx/cmd/factory.go
+++ b/pkg/jx/cmd/factory.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"github.com/jenkins-x/jx/pkg/vault"
-	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/kube/services"
@@ -26,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
-	"github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -289,25 +287,25 @@ func (f *factory) AuthMergePipelineSecrets(config *auth.AuthConfig, secrets *cor
 // CreateAuthConfigService creates a new service saving auth config under the provided name. Depending on the factory,
 // It will either save the config to the local file-system, or a Vault
 func (f *factory) CreateAuthConfigService(configName string) (auth.ConfigService, error) {
-	client, namespace, err := f.CreateKubeClient()
-	if f.secretLocation == nil {
-		f.secretLocation = secrets.NewSecretLocation(client, namespace)
-	}
-
-	useVault := false
-	if err != nil {
-		logrus.Errorf("Could not create kube client. Saving configs to local filesystem")
-	} else {
-		useVault = f.secretLocation.InVault()
-	}
-
-	if useVault {
+	if f.UseVault() {
 		vaultClient, err := f.GetSystemVaultClient()
 		authService := auth.NewVaultAuthConfigService(configName, vaultClient)
 		return authService, err
 	} else {
 		return auth.NewFileAuthConfigService(configName)
 	}
+}
+
+// UseVault idicates if the platform is using a Vault to manage the secrets
+func (f *factory) UseVault() bool {
+	client, namespace, err := f.CreateClient()
+	if err != nil {
+		return false
+	}
+	if f.secretLocation == nil {
+		f.secretLocation = secrets.NewSecretLocation(client, namespace)
+	}
+	return f.secretLocation.InVault()
 }
 
 // GetSystemVaultClient gets the system vault client for managing the secrets

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -773,17 +773,17 @@ func (options *InstallOptions) installPlatformGitOpsMode(gitOpsEnvDir string, gi
 	valuesFile := filepath.Join(gitOpsEnvDir, helm.ValuesFileName)
 	err := helm.SaveRequirementsFile(requirementsFile, requirements)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to save GitOps helm requirements file %s", requirementsFile)
+		return errors.Wrapf(err, "failed to save GitOps helm requirements file %s", requirementsFile)
 	}
 
 	err = configStore.Write(chartFile, []byte(GitOpsChartYAML))
 	if err != nil {
-		return errors.Wrapf(err, "Failed to save file %s", chartFile)
+		return errors.Wrapf(err, "failed to save file %s", chartFile)
 	}
 
 	err = helm.CombineValueFilesToFile(secretsFile, secretsFiles, JenkinsXPlatformChartName, nil)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to generate %s by combining helm Secret YAML files %s", secretsFile, strings.Join(secretsFiles, ", "))
+		return errors.Wrapf(err, "failed to generate %s by combining helm Secret YAML files %s", secretsFile, strings.Join(secretsFiles, ", "))
 	}
 
 	if options.Flags.Vault {
@@ -803,7 +803,7 @@ func (options *InstallOptions) installPlatformGitOpsMode(gitOpsEnvDir string, gi
 	}
 	err = helm.CombineValueFilesToFile(valuesFile, valuesFiles, JenkinsXPlatformChartName, extraValues)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to generate %s by combining helm value YAML files %s", valuesFile, strings.Join(valuesFiles, ", "))
+		return errors.Wrapf(err, "failed to generate %s by combining helm value YAML files %s", valuesFile, strings.Join(valuesFiles, ", "))
 	}
 
 	gitIgnore := filepath.Join(gitOpsDir, ".gitignore")

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -371,6 +371,9 @@ func (options *InstallOptions) Run() error {
 	originalGitServer := options.GitRepositoryOptions.ServerURL
 	originalGitToken := options.GitRepositoryOptions.ApiToken
 
+	// Default to verbose mode to get more information during the install
+	options.Verbose = true
+
 	client, originalNs, err := options.KubeClient()
 	if err != nil {
 		return errors.Wrap(err, "creating the kube client")
@@ -469,8 +472,6 @@ func (options *InstallOptions) Run() error {
 	}
 
 	log.Infof("Installing Jenkins X platform helm chart from: %s\n", providerEnvDir)
-
-	options.Verbose = true
 
 	err = options.configureHelmRepo()
 	if err != nil {

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1598,7 +1598,10 @@ func (options *InstallOptions) createSystemVault(client kubernetes.Interface, na
 			log.Infof("System vault created named %s in namespace %s.\n",
 				util.ColorInfo(vault.SystemVaultName), util.ColorInfo(namespace))
 		}
-		secrets.NewSecretLocation(client, namespace).SetInVault(options.Flags.Vault)
+		err = secrets.NewSecretLocation(client, namespace).SetInVault(options.Flags.Vault)
+		if err != nil {
+			return errors.Wrap(err, "configuring secrets location")
+		}
 	}
 	return nil
 }

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -865,44 +865,9 @@ func (options *InstallOptions) Run() error {
 
 	options.logAdminPassword()
 
-	if !options.Flags.GitOpsMode {
-		if !options.Flags.Prow {
-			log.Info("Getting Jenkins API Token\n")
-			if isOpenShiftProvider(options.Flags.Provider) {
-				options.CreateJenkinsUserOptions.CommonOptions = options.CommonOptions
-				options.CreateJenkinsUserOptions.Password = options.AdminSecretsService.Flags.DefaultAdminPassword
-				options.CreateJenkinsUserOptions.Username = "jenkins-admin"
-				jenkinsSaToken, err := options.getCommandOutput("", "oc", "serviceaccounts", "get-token", "jenkins", "-n", ns)
-				if err != nil {
-					return err
-				}
-				options.CreateJenkinsUserOptions.BearerToken = jenkinsSaToken
-				options.CreateJenkinsUserOptions.Run()
-			} else {
-				err = options.retry(3, 2*time.Second, func() (err error) {
-					options.CreateJenkinsUserOptions.CommonOptions = options.CommonOptions
-					options.CreateJenkinsUserOptions.Password = options.AdminSecretsService.Flags.DefaultAdminPassword
-					options.CreateJenkinsUserOptions.UseBrowser = true
-					if options.BatchMode {
-						options.CreateJenkinsUserOptions.BatchMode = true
-						options.CreateJenkinsUserOptions.Headless = true
-						log.Info("Attempting to find the Jenkins API Token with the browser in headless mode...")
-					}
-					err = options.CreateJenkinsUserOptions.Run()
-					return
-				})
-				if err != nil {
-					return errors.Wrap(err, "failed to get the Jenkins API token")
-				}
-			}
-		}
-
-		if !options.Flags.Prow {
-			err = options.updateJenkinsURL([]string{ns})
-			if err != nil {
-				log.Warnf("failed to update the Jenkins external URL")
-			}
-		}
+	err = options.configureJenkins(ns)
+	if err != nil {
+		return errors.Wrap(err, "configuring Jenkins")
 	}
 
 	if options.Flags.DefaultEnvironmentPrefix == "" {
@@ -1601,6 +1566,49 @@ func (options *InstallOptions) saveClusterConfig() error {
 		})
 		if err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func (options *InstallOptions) configureJenkins(namespace string) error {
+	if !options.Flags.GitOpsMode {
+		if !options.Flags.Prow {
+			log.Info("Getting Jenkins API Token\n")
+			if isOpenShiftProvider(options.Flags.Provider) {
+				options.CreateJenkinsUserOptions.CommonOptions = options.CommonOptions
+				options.CreateJenkinsUserOptions.Password = options.AdminSecretsService.Flags.DefaultAdminPassword
+				options.CreateJenkinsUserOptions.Username = "jenkins-admin"
+				jenkinsSaToken, err := options.getCommandOutput("", "oc", "serviceaccounts", "get-token", "jenkins", "-n", namespace)
+				if err != nil {
+					return err
+				}
+				options.CreateJenkinsUserOptions.BearerToken = jenkinsSaToken
+				options.CreateJenkinsUserOptions.Run()
+			} else {
+				err := options.retry(3, 2*time.Second, func() (err error) {
+					options.CreateJenkinsUserOptions.CommonOptions = options.CommonOptions
+					options.CreateJenkinsUserOptions.Password = options.AdminSecretsService.Flags.DefaultAdminPassword
+					options.CreateJenkinsUserOptions.UseBrowser = true
+					if options.BatchMode {
+						options.CreateJenkinsUserOptions.BatchMode = true
+						options.CreateJenkinsUserOptions.Headless = true
+						log.Info("Attempting to find the Jenkins API Token with the browser in headless mode...")
+					}
+					err = options.CreateJenkinsUserOptions.Run()
+					return
+				})
+				if err != nil {
+					return errors.Wrap(err, "failed to get the Jenkins API token")
+				}
+			}
+		}
+
+		if !options.Flags.Prow {
+			err := options.updateJenkinsURL([]string{namespace})
+			if err != nil {
+				log.Warnf("failed to update the Jenkins external URL")
+			}
 		}
 	}
 	return nil

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -847,20 +847,9 @@ func (options *InstallOptions) Run() error {
 		return errors.Wrap(err, "configureing helm3")
 	}
 
-	if !options.Flags.GitOpsMode {
-		addonConfig, err := addon.LoadAddonsConfig()
-		if err != nil {
-			return errors.Wrap(err, "failed to load the addons configuration")
-		}
-
-		for _, ac := range addonConfig.Addons {
-			if ac.Enabled {
-				err = options.installAddon(ac.Name)
-				if err != nil {
-					return fmt.Errorf("failed to install addon %s: %s", ac.Name, err)
-				}
-			}
-		}
+	err = options.installAddons()
+	if err != nil {
+		return errors.Wrap(err, "installing the addons")
 	}
 
 	options.logAdminPassword()
@@ -1554,6 +1543,25 @@ func (options *InstallOptions) configureJenkins(namespace string) error {
 			err := options.updateJenkinsURL([]string{namespace})
 			if err != nil {
 				log.Warnf("failed to update the Jenkins external URL")
+			}
+		}
+	}
+	return nil
+}
+
+func (options *InstallOptions) installAddons() error {
+	if !options.Flags.GitOpsMode {
+		addonConfig, err := addon.LoadAddonsConfig()
+		if err != nil {
+			return errors.Wrap(err, "failed to load the addons configuration")
+		}
+
+		for _, ac := range addonConfig.Addons {
+			if ac.Enabled {
+				err = options.installAddon(ac.Name)
+				if err != nil {
+					return fmt.Errorf("failed to install addon %s: %s", ac.Name, err)
+				}
 			}
 		}
 	}

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1563,9 +1563,7 @@ func (options *InstallOptions) getAdminSecrets(providerEnvDir string, cloudEnvir
 }
 
 func (options *InstallOptions) createSystemVault(client kubernetes.Interface, namespace string) error {
-	// TODO - we want to enable storing secrets in Vault for gitops. Reenable this once the feature is finished
-	//if options.Flags.GitOpsMode && !options.Flags.NoGitOpsVault || options.Flags.Vault {
-	if options.Flags.Vault {
+	if options.Flags.GitOpsMode && !options.Flags.NoGitOpsVault || options.Flags.Vault {
 		err := InstallVaultOperator(&options.CommonOptions, "")
 		if err != nil {
 			return err

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -592,21 +592,17 @@ func (options *InstallOptions) Run() error {
 		return errors.Wrap(err, "failed to update the helm repo")
 	}
 
+	err = options.configureAndInstallProw(ns)
+	if err != nil {
+		return errors.Wrap(err, "configureing and installing Prow")
+	}
+
 	valueFiles := []string{cloudEnvironmentValuesLocation, secretsFileName, adminSecretsFileName, configFileName, cloudEnvironmentSecretsLocation}
 	valueFiles, err = helm.AppendMyValues(valueFiles)
 	if err != nil {
 		return errors.Wrap(err, "failed to append the myvalues.yaml file")
 	}
 
-	options.currentNamespace = ns
-	if options.Flags.Prow {
-		// install Prow into the new env
-		options.OAUTHToken = options.GitRepositoryOptions.ApiToken
-		err = options.installProw()
-		if err != nil {
-			return fmt.Errorf("failed to install Prow: %v", err)
-		}
-	}
 	timeoutInt, err := strconv.Atoi(timeout)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert the helm install timeout value")
@@ -940,6 +936,18 @@ func (options *InstallOptions) init() error {
 		options.Flags.Domain = initOpts.Flags.Domain
 	}
 
+	return nil
+}
+
+func (options *InstallOptions) configureAndInstallProw(namespace string) error {
+	options.currentNamespace = namespace
+	if options.Flags.Prow {
+		options.OAUTHToken = options.GitRepositoryOptions.ApiToken
+		err := options.installProw()
+		if err != nil {
+			return fmt.Errorf("failed to install Prow: %v", err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -794,7 +794,7 @@ func (options *InstallOptions) installPlatformGitOpsMode(gitOpsEnvDir string, gi
 
 		err = util.DestroyFile(secretsFile)
 		if err != nil {
-			return errors.Wrapf(err, "destrying the secrets file '%s' after storing it in Vault", secretsFile)
+			return errors.Wrapf(err, "destroying the secrets file '%s' after storing it in Vault", secretsFile)
 		}
 	}
 
@@ -1010,7 +1010,7 @@ func (options *InstallOptions) getHelmValuesFiles(configStore configio.ConfigSto
 
 	err = options.modifySecrets(helmConfig, adminSecrets, gitSecrets)
 	if err != nil {
-		return valuesFiles, temporaryFiles, secretsFiles, err
+		return valuesFiles, temporaryFiles, secretsFiles, errors.Wrap(err, "updating the secrets data in Kubernetes cluster")
 	}
 
 	valuesFiles = append(valuesFiles, cloudEnvironmentValuesLocation)

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -692,15 +692,9 @@ func (options *InstallOptions) Run() error {
 		return errors.Wrap(err, "saving the cluster configuration in a ConfigMap")
 	}
 
-	// lets prompt the user which kind of workload to default to (they can change this at any time later)
-	ebp := &EditBuildPackOptions{
-		BuildPackName: options.Flags.BuildPackName,
-	}
-	ebp.CommonOptions = options.CommonOptions
-
-	err = ebp.Run()
+	err = options.configureBuildPackMode()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "configuring the build pack mode")
 	}
 
 	if options.Flags.GitOpsMode {
@@ -1551,6 +1545,15 @@ func (options *InstallOptions) storeSecretsInVault(secrets map[string]interface{
 		return errors.Wrapf(err, "Error saving secrets to vault\n")
 	}
 	return nil
+}
+
+func (options *InstallOptions) configureBuildPackMode() error {
+	ebp := &EditBuildPackOptions{
+		BuildPackName: options.Flags.BuildPackName,
+	}
+	ebp.CommonOptions = options.CommonOptions
+
+	return ebp.Run()
 }
 
 func (options *InstallOptions) saveIngressConfig(domain string) error {

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1039,7 +1039,7 @@ func (options *InstallOptions) getHelmValuesFiles(configStore configio.ConfigSto
 	return valuesFiles, secretsFiles, temporaryFiles, nil
 }
 
-func (options *InstallOptions) configureGitAuth(gitUserName string, gitServer string, gitApiToken string) error {
+func (options *InstallOptions) configureGitAuth(gitUserName string, gitServer string, gitAPIToken string) error {
 	helmConfig := &options.CreateEnvOptions.HelmValuesConfig
 	gitAuthCfg, err := options.CreateGitAuthConfigService()
 	if err != nil {
@@ -1056,9 +1056,9 @@ func (options *InstallOptions) configureGitAuth(gitUserName string, gitServer st
 			username = os.Getenv(JX_GIT_USER)
 		}
 	}
-	if username != "" && gitApiToken != "" && gitServer != "" {
+	if username != "" && gitAPIToken != "" && gitServer != "" {
 		err = gitAuthCfg.SaveUserAuth(gitServer, &auth.UserAuth{
-			ApiToken: gitApiToken,
+			ApiToken: gitAPIToken,
 			Username: username,
 		})
 		if err != nil {
@@ -1100,16 +1100,15 @@ func (options *InstallOptions) verifyTiller(client kubernetes.Interface, namespa
 		err := options.ensureClusterRoleBinding(clusterRoleBindingName, role, namespace, serviceAccountName)
 		if err != nil {
 			return errors.Wrap(err, "tiller cluster role not defined")
-		} else {
-			log.Infof("tiller cluster role defined: %s in namespace %s\n", util.ColorInfo(role), util.ColorInfo(namespace))
 		}
+		log.Infof("tiller cluster role defined: %s in namespace %s\n", util.ColorInfo(role), util.ColorInfo(namespace))
+
 		err = kube.WaitForDeploymentToBeReady(client, "tiller-deploy", tillerNamespace, 10*time.Minute)
 		if err != nil {
 			msg := fmt.Sprintf("tiller pod (tiller-deploy in namespace %s) is not running after 10 minutes", tillerNamespace)
 			return errors.Wrap(err, msg)
-		} else {
-			log.Infoln("tiller pod running")
 		}
+		log.Infoln("tiller pod running")
 	}
 	return nil
 }

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -956,6 +956,8 @@ func (options *InstallOptions) configureHelmValues(namespace string) error {
 	if isProw {
 		enableJenkins := false
 		helmConfig.Jenkins.Enabled = &enableJenkins
+		enableControllerBuild := true
+		helmConfig.ControllerBuild.Enabled = &enableControllerBuild
 	}
 
 	return nil

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -842,29 +842,9 @@ func (options *InstallOptions) Run() error {
 		return errors.Wrap(err, "generating the GitOps development environment config")
 	}
 
-	if options.Flags.GitOpsMode && !options.Flags.NoGitOpsEnvApply {
-		applyEnv := true
-		if !options.BatchMode {
-			if !util.Confirm("Would you like to setup the Development Environment from the source code now?", true, "Do you want to apply the development environment helm charts now?", options.In, options.Out, options.Err) {
-				applyEnv = false
-			}
-		}
-
-		if applyEnv {
-			envApplyOptions := &StepEnvApplyOptions{
-				StepEnvOptions: StepEnvOptions{
-					StepOptions: StepOptions{
-						CommonOptions: options.CommonOptions,
-					},
-				},
-				Dir:       gitOpsEnvDir,
-				Namespace: ns,
-			}
-			err = envApplyOptions.Run()
-			if err != nil {
-				return err
-			}
-		}
+	err = options.applyGitOpsDevEnvironmentConfig(gitOpsEnvDir, ns)
+	if err != nil {
+		return errors.Wrap(err, "applying the GitOps development environment config")
 	}
 
 	log.Success("\nJenkins X installation completed successfully\n")
@@ -1145,6 +1125,35 @@ func (options *InstallOptions) generateGitOpsDevEnvironmentConfig(gitOpsDir stri
 	}
 
 	return nil
+}
+
+func (options *InstallOptions) applyGitOpsDevEnvironmentConfig(gitOpsEnvDir string, namespace string) error {
+	if options.Flags.GitOpsMode && !options.Flags.NoGitOpsEnvApply {
+		applyEnv := true
+		if !options.BatchMode {
+			if !util.Confirm("Would you like to setup the Development Environment from the source code now?", true, "Do you want to apply the development environment helm charts now?", options.In, options.Out, options.Err) {
+				applyEnv = false
+			}
+		}
+
+		if applyEnv {
+			envApplyOptions := &StepEnvApplyOptions{
+				StepEnvOptions: StepEnvOptions{
+					StepOptions: StepOptions{
+						CommonOptions: options.CommonOptions,
+					},
+				},
+				Dir:       gitOpsEnvDir,
+				Namespace: namespace,
+			}
+			err := envApplyOptions.Run()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+
 }
 
 func (options *InstallOptions) installHelmBinaries() error {

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -437,6 +437,21 @@ func (options *InstallOptions) Run() error {
 		return errors.Wrap(err, "configuring the cloud provider after initializing the platform")
 	}
 
+	err = options.configureHelmValues(ns)
+	if err != nil {
+		return errors.Wrap(err, "configuring helm values")
+	}
+
+	err = options.saveIngressConfig()
+	if err != nil {
+		return errors.Wrap(err, "saving the ingress configuration in a ConfigMap")
+	}
+
+	err = options.saveClusterConfig()
+	if err != nil {
+		return errors.Wrap(err, "saving the cluster configuration in a ConfigMap")
+	}
+
 	err = options.createSystemVault(client, ns)
 	if err != nil {
 		return errors.Wrap(err, "creating the system vault")
@@ -445,11 +460,6 @@ func (options *InstallOptions) Run() error {
 	err = options.configureDockerRegistry(client, ns)
 	if err != nil {
 		return errors.Wrap(err, "configuring the docker registry")
-	}
-
-	err = options.configureHelmValues(ns)
-	if err != nil {
-		return errors.Wrap(err, "configuring helm values")
 	}
 
 	err = options.configureGitAuth(originalGitUsername, originalGitServer, originalGitToken)
@@ -491,16 +501,6 @@ func (options *InstallOptions) Run() error {
 	err = options.verifyTiller(client, ns)
 	if err != nil {
 		return errors.Wrap(err, "verifying Tiller is running")
-	}
-
-	err = options.saveIngressConfig()
-	if err != nil {
-		return errors.Wrap(err, "saving the ingress configuration in a ConfigMap")
-	}
-
-	err = options.saveClusterConfig()
-	if err != nil {
-		return errors.Wrap(err, "saving the cluster configuration in a ConfigMap")
 	}
 
 	err = options.configureBuildPackMode()

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1602,6 +1602,9 @@ func (options *InstallOptions) createSystemVault(client kubernetes.Interface, na
 		if err != nil {
 			return errors.Wrap(err, "configuring secrets location")
 		}
+
+		log.Infof("Wait for vault to be initialized...\n")
+		time.Sleep(30 * time.Second)
 	}
 	return nil
 }

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -589,12 +589,12 @@ func (options *InstallOptions) Run() error {
 		return errors.Wrap(err, "applying the GitOps development environment config")
 	}
 
-	log.Success("\nJenkins X installation completed successfully\n")
+	log.Successf("\nJenkins X installation completed successfully")
 
 	options.logAdminPassword()
 
 	log.Infof("\nYour Kubernetes context is now set to the namespace: %s \n", util.ColorInfo(ns))
-	log.Infof("To switch back to your original namespace use: %s\n", util.ColorInfo("jx ns "+originalNs))
+	log.Infof("To switch back to your original namespace use: %s\n", util.ColorInfo("jx namespace "+originalNs))
 	log.Infof("For help on switching contexts see: %s\n\n", util.ColorInfo("https://jenkins-x.io/developing/kube-context/"))
 
 	log.Infof("To import existing projects into Jenkins:       %s\n", util.ColorInfo("jx import"))

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -978,33 +978,33 @@ func (options *InstallOptions) getHelmValuesFiles(configStore configio.ConfigSto
 	gitSecrets, err := options.getGitSecrets()
 	if err != nil {
 		return valuesFiles, secretsFiles, temporaryFiles,
-			errors.Wrap(err, "failed to read the git secrets from configuration")
+			errors.Wrap(err, "reading the git secrets from configuration")
 	}
 
 	dir, err := util.ConfigDir()
 	if err != nil {
 		return valuesFiles, secretsFiles, temporaryFiles,
-			errors.Wrap(err, "failed to create a temporary config dir for Git credentials")
+			errors.Wrap(err, "creating a temporary config dir for Git credentials")
 	}
 	gitSecretsFileName := filepath.Join(dir, GitSecretsFile)
 	err = configStore.Write(gitSecretsFileName, []byte(gitSecrets))
 	if err != nil {
 		return valuesFiles, secretsFiles, temporaryFiles,
-			errors.Wrap(err, "failed to write the git secrets in the secrets file")
+			errors.Wrapf(err, "writing the git secrets in the secrets file '%s'", gitSecretsFileName)
 	}
 
 	adminSecretsFileName := filepath.Join(dir, AdminSecretsFile)
 	err = configStore.WriteObject(adminSecretsFileName, adminSecrets)
 	if err != nil {
 		return valuesFiles, secretsFiles, temporaryFiles,
-			errors.Wrap(err, "failed to write the admin config file")
+			errors.Wrapf(err, "writing the admin secrets in the secrets file '%s'", adminSecretsFileName)
 	}
 
 	extraValuesFileName := filepath.Join(dir, ExtraValuesFile)
 	err = configStore.WriteObject(extraValuesFileName, helmConfig)
 	if err != nil {
 		return valuesFiles, secretsFiles, temporaryFiles,
-			errors.Wrap(err, "failed to write the helm config file")
+			errors.Wrapf(err, "writing the helm config in the file '%s'", extraValuesFileName)
 	}
 	log.Infof("Generated helm values %s\n", util.ColorInfo(extraValuesFileName))
 

--- a/pkg/jx/cmd/install_gitops_integration_test.go
+++ b/pkg/jx/cmd/install_gitops_integration_test.go
@@ -3,6 +3,12 @@
 package cmd_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/helm"
@@ -10,15 +16,10 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/testkube"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/helm/pkg/chartutil"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd"
 	"github.com/stretchr/testify/assert"
@@ -64,6 +65,7 @@ func TestInstallGitOps(t *testing.T) {
 		helmer,
 	)
 	o.CommonOptions.GitClient = gitter
+	o.CommonOptions.InstallDependencies = true
 	o.CommonOptions.SetHelm(helmer)
 
 	o.InitOptions.CommonOptions = o.CommonOptions
@@ -142,7 +144,7 @@ func TestInstallGitOps(t *testing.T) {
 
 	values, err := chartutil.ReadValuesFile(valuesFile)
 	require.NoError(t, err, "Failed to load values file", valuesFile)
-	assertValuesHasPathValue(t, "values.yaml", values, "jenkins-x-platform.expose")
+	// assertValuesHasPathValue(t, "values.yaml", values, "jenkins-x-platform.expose")
 	assertValuesHasPathValue(t, "values.yaml", values, "jenkins-x-platform.postinstalljob.enabled")
 
 	secrets, err := chartutil.ReadValuesFile(secretsFile)

--- a/pkg/jx/cmd/interface.go
+++ b/pkg/jx/cmd/interface.go
@@ -59,8 +59,7 @@ type Factory interface {
 
 	CreateKubeConfig() (*rest.Config, error)
 
-	//Create a JXclient for interacting with JX resources.
-	//Returns: JXClient, current namespace, error.
+	// CreateJXClienta creates a JXclient for interacting with JX resources.
 	CreateJXClient() (versioned.Interface, string, error)
 
 	CreateApiExtensionsClient() (apiextensionsclientset.Interface, error)
@@ -86,6 +85,9 @@ type Factory interface {
 	CreateVaultOperatorClient() (vaultoperatorclient.Interface, error)
 
 	GetHelm(verbose bool, helmBinary string, noTiller bool, helmTemplate bool) helm.Helmer
+
+	// UseVault indicates if the platform is using a Vault to manage the secrets
+	UseVault() bool
 
 	// GetSystemVaultClient gets the system vault client for managing the secreets
 	GetSystemVaultClient() (vault.Client, error)

--- a/pkg/jx/cmd/mocks/factory.go
+++ b/pkg/jx/cmd/mocks/factory.go
@@ -15,7 +15,7 @@ import (
 	cmd "github.com/jenkins-x/jx/pkg/jx/cmd"
 	table "github.com/jenkins-x/jx/pkg/table"
 	vault "github.com/jenkins-x/jx/pkg/vault"
-	versioned0 "github.com/knative/build/pkg/client/clientset/versioned"
+	versioned "github.com/knative/build/pkg/client/clientset/versioned"
 	pegomock "github.com/petergtz/pegomock"
 	terminal "gopkg.in/AlecAivazis/survey.v1/terminal"
 	io "io"
@@ -286,18 +286,18 @@ func (mock *MockFactory) CreateJenkinsClient(_param0 kubernetes.Interface, _para
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateKnativeBuildClient() (versioned0.Interface, string, error) {
+func (mock *MockFactory) CreateKnativeBuildClient() (versioned.Interface, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeBuildClient", params, []reflect.Type{reflect.TypeOf((*versioned0.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned0.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeBuildClient", params, []reflect.Type{reflect.TypeOf((*versioned.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned.Interface
 	var ret1 string
 	var ret2 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned0.Interface)
+			ret0 = result[0].(versioned.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(string)
@@ -385,7 +385,7 @@ func (mock *MockFactory) CreateTable(_param0 io.Writer) table.Table {
 	return ret0
 }
 
-func (mock *MockFactory) CreateVaultOperatorClient() (versioned.Interface, error) {
+func (mock *MockFactory) CreateVaultOperatorClient() (versioned1.Interface, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
@@ -396,12 +396,6 @@ func (mock *MockFactory) CreateVaultOperatorClient() (versioned.Interface, error
 	if len(result) != 0 {
 		if result[0] != nil {
 			ret0 = result[0].(versioned1.Interface)
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateVaultOperatorClient", params, []reflect.Type{reflect.TypeOf((*versioned.Interface)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned.Interface
-	var ret1 error
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(versioned.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(error)

--- a/pkg/jx/cmd/mocks/factory.go
+++ b/pkg/jx/cmd/mocks/factory.go
@@ -15,7 +15,7 @@ import (
 	cmd "github.com/jenkins-x/jx/pkg/jx/cmd"
 	table "github.com/jenkins-x/jx/pkg/table"
 	vault "github.com/jenkins-x/jx/pkg/vault"
-	versioned "github.com/knative/build/pkg/client/clientset/versioned"
+	versioned0 "github.com/knative/build/pkg/client/clientset/versioned"
 	pegomock "github.com/petergtz/pegomock"
 	terminal "gopkg.in/AlecAivazis/survey.v1/terminal"
 	io "io"
@@ -286,18 +286,18 @@ func (mock *MockFactory) CreateJenkinsClient(_param0 kubernetes.Interface, _para
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateKnativeBuildClient() (versioned.Interface, string, error) {
+func (mock *MockFactory) CreateKnativeBuildClient() (versioned0.Interface, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeBuildClient", params, []reflect.Type{reflect.TypeOf((*versioned.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeBuildClient", params, []reflect.Type{reflect.TypeOf((*versioned0.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned0.Interface
 	var ret1 string
 	var ret2 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned.Interface)
+			ret0 = result[0].(versioned0.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(string)
@@ -385,7 +385,7 @@ func (mock *MockFactory) CreateTable(_param0 io.Writer) table.Table {
 	return ret0
 }
 
-func (mock *MockFactory) CreateVaultOperatorClient() (versioned1.Interface, error) {
+func (mock *MockFactory) CreateVaultOperatorClient() (versioned.Interface, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
@@ -396,6 +396,12 @@ func (mock *MockFactory) CreateVaultOperatorClient() (versioned1.Interface, erro
 	if len(result) != 0 {
 		if result[0] != nil {
 			ret0 = result[0].(versioned1.Interface)
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateVaultOperatorClient", params, []reflect.Type{reflect.TypeOf((*versioned.Interface)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned.Interface
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(versioned.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(error)
@@ -527,6 +533,21 @@ func (mock *MockFactory) SetBatch(_param0 bool) {
 	}
 	params := []pegomock.Param{_param0}
 	pegomock.GetGenericMockFrom(mock).Invoke("SetBatch", params, []reflect.Type{})
+}
+
+func (mock *MockFactory) UseVault() bool {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockFactory().")
+	}
+	params := []pegomock.Param{}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("UseVault", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	var ret0 bool
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(bool)
+		}
+	}
+	return ret0
 }
 
 func (mock *MockFactory) WithBearerToken(_param0 string) cmd.Factory {
@@ -1243,6 +1264,23 @@ func (c *Factory_SetBatch_OngoingVerification) GetAllCapturedArguments() (_param
 		}
 	}
 	return
+}
+
+func (verifier *VerifierFactory) UseVault() *Factory_UseVault_OngoingVerification {
+	params := []pegomock.Param{}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UseVault", params)
+	return &Factory_UseVault_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type Factory_UseVault_OngoingVerification struct {
+	mock              *MockFactory
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *Factory_UseVault_OngoingVerification) GetCapturedArguments() {
+}
+
+func (c *Factory_UseVault_OngoingVerification) GetAllCapturedArguments() {
 }
 
 func (verifier *VerifierFactory) WithBearerToken(_param0 string) *Factory_WithBearerToken_OngoingVerification {

--- a/pkg/jx/cmd/mocks/matchers/versioned0_interface.go
+++ b/pkg/jx/cmd/mocks/matchers/versioned0_interface.go
@@ -2,9 +2,10 @@
 package matchers
 
 import (
+	"reflect"
+
 	versioned0 "github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/petergtz/pegomock"
-	"reflect"
 )
 
 func AnyVersioned0Interface() versioned0.Interface {

--- a/pkg/jx/cmd/mocks/matchers/versioned0_interface.go
+++ b/pkg/jx/cmd/mocks/matchers/versioned0_interface.go
@@ -3,9 +3,8 @@ package matchers
 
 import (
 	"reflect"
-
-	versioned0 "github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/petergtz/pegomock"
+	versioned0 "github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 )
 
 func AnyVersioned0Interface() versioned0.Interface {

--- a/pkg/jx/cmd/mocks/matchers/versioned1_interface.go
+++ b/pkg/jx/cmd/mocks/matchers/versioned1_interface.go
@@ -2,9 +2,9 @@
 package matchers
 
 import (
-	versioned1 "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
-	"github.com/petergtz/pegomock"
 	"reflect"
+	"github.com/petergtz/pegomock"
+	versioned1 "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 )
 
 func AnyVersioned1Interface() versioned1.Interface {

--- a/pkg/jx/cmd/mocks/matchers/versioned_interface.go
+++ b/pkg/jx/cmd/mocks/matchers/versioned_interface.go
@@ -4,7 +4,7 @@ package matchers
 import (
 	"reflect"
 	"github.com/petergtz/pegomock"
-	versioned "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
+	versioned "github.com/knative/build/pkg/client/clientset/versioned"
 )
 
 func AnyVersionedInterface() versioned.Interface {

--- a/pkg/jx/cmd/mocks/matchers/versioned_interface.go
+++ b/pkg/jx/cmd/mocks/matchers/versioned_interface.go
@@ -4,7 +4,7 @@ package matchers
 import (
 	"reflect"
 	"github.com/petergtz/pegomock"
-	versioned "github.com/knative/build/pkg/client/clientset/versioned"
+	versioned "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 )
 
 func AnyVersionedInterface() versioned.Interface {

--- a/pkg/jx/cmd/step_helm_apply.go
+++ b/pkg/jx/cmd/step_helm_apply.go
@@ -198,14 +198,14 @@ func (o *StepHelmApplyOptions) ensureHelmSecrets(dir string, filename string) (b
 		if err != nil {
 			return exists, errors.Wrap(err, "retrieving the system Vault")
 		}
-		secretNames, err := client.List(vault.InstallSecretsPrefix)
+		secretNames, err := client.List(vault.InstallSecretsPath)
 		if err != nil {
 			return exists, errors.Wrap(err, "listing the install secrets in Vault")
 		}
 
 		for _, secretName := range secretNames {
 			if secretName == filename {
-				secretPath := vault.InstallSecretsPrefix + filename
+				secretPath := vault.InstallSecretsPath + filename
 				secret, err := client.Read(secretPath)
 				if err != nil {
 					return exists, errors.Wrapf(err, "retrieving the secret '%s' from Vault", secretPath)

--- a/pkg/jx/cmd/uninstall.go
+++ b/pkg/jx/cmd/uninstall.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"io"
+
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 
 	"github.com/pkg/errors"
 
@@ -120,12 +121,23 @@ func (o *UninstallOptions) Run() error {
 			}
 		}
 	}
+
 	errs := []error{}
-	o.Helm().DeleteRelease(namespace, "jx-prow", true)
-	err = o.Helm().DeleteRelease(namespace, "jenkins-x", true)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("failed to uninstall the jenkins-x helm chart in namespace %s: %s", namespace, err))
+
+	err = o.Helm().StatusRelease(namespace, "jx-prow")
+	if err == nil {
+		err := o.Helm().DeleteRelease(namespace, "jx-prow", true)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to uninstall the prow helm chart in namespace %s: %s", namespace, err))
+		}
 	}
+	err = o.Helm().StatusRelease(namespace, "jenkins-x")
+	if err == nil {
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to uninstall the jenkins-x helm chart in namespace %s: %s", namespace, err))
+		}
+	}
+	err = o.Helm().DeleteRelease(namespace, "jenkins-x", true)
 	err = jxClient.JenkinsV1().Environments(namespace).DeleteCollection(&meta_v1.DeleteOptions{}, meta_v1.ListOptions{})
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to delete the environments in namespace %s: %s", namespace, err))
@@ -144,12 +156,12 @@ func (o *UninstallOptions) Run() error {
 func (o *UninstallOptions) cleanupNamespaces(namespace string, envNames []string, envMap map[string]*v1.Environment) error {
 	client, _, err := o.KubeClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get the kube client")
+		return errors.Wrap(err, "getting the kube client")
 	}
 	errs := []error{}
 	err = o.deleteNamespace(namespace)
 	if err != nil {
-		errs = append(errs, fmt.Errorf("failed to delete namespace %s: %s", namespace, err))
+		errs = append(errs, fmt.Errorf("deleting namespace %s: %s", namespace, err))
 	}
 	if !o.KeepEnvironments {
 		for _, env := range envNames {
@@ -160,7 +172,7 @@ func (o *UninstallOptions) cleanupNamespaces(namespace string, envNames []string
 			if envResource != nil {
 				envNamespace = envResource.Spec.Namespace
 			}
-			if envNamespace != "" && envNamespaces[0] != envNamespace {
+			if envNamespace != "" && envNamespaces[0] != envNamespace && envNamespace != namespace {
 				envNamespaces = append(envNamespaces, envNamespace)
 			}
 			for _, envNamespace := range envNamespaces {
@@ -170,7 +182,7 @@ func (o *UninstallOptions) cleanupNamespaces(namespace string, envNames []string
 				}
 				err = o.deleteNamespace(envNamespace)
 				if err != nil {
-					errs = append(errs, fmt.Errorf("failed to delete namespace %s: %s", envNamespace, err))
+					errs = append(errs, fmt.Errorf("deleting environment namespace %s: %s", envNamespace, err))
 				}
 			}
 		}
@@ -181,12 +193,17 @@ func (o *UninstallOptions) cleanupNamespaces(namespace string, envNames []string
 func (o *UninstallOptions) deleteNamespace(namespace string) error {
 	client, _, err := o.KubeClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get the kube client")
+		return errors.Wrap(err, "getting the kube client")
+	}
+	_, err = client.CoreV1().Namespaces().Get(namespace, meta_v1.GetOptions{})
+	if err != nil {
+		// There is nothing to delete if the namespace cannot be retrieved
+		return nil
 	}
 	log.Infof("deleting namespace %s\n", util.ColorInfo(namespace))
 	err = client.CoreV1().Namespaces().Delete(namespace, &meta_v1.DeleteOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete the namespace '%s'", namespace)
+		return errors.Wrapf(err, "deleting the namespace '%s' from Kubernetes cluster", namespace)
 	}
 	return nil
 }

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -43,6 +43,15 @@ func FirstFileExists(paths ...string) (string, error) {
 	return "", nil
 }
 
+// FileIsEmpty checks if a file is empty
+func FileIsEmpty(path string) (bool, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return true, errors.Wrapf(err, "getting details of file '%s'", path)
+	}
+	return (fi.Size() == 0), nil
+}
+
 func IsEmpty(name string) (bool, error) {
 	f, err := os.Open(name)
 	if err != nil {

--- a/pkg/vault/constants.go
+++ b/pkg/vault/constants.go
@@ -3,6 +3,6 @@ package vault
 const (
 	// SystemVaultName name of the system vault used by the jenkins-x platfrom
 	SystemVaultName = "jx-vault"
-	// InstallSecretsPrefix the prefix of secrets generated during the installation
-	InstallSecretsPrefix = "install-secrets/"
+	// InstallSecretsPath the path of secrets generated during the installation
+	InstallSecretsPath = "install/"
 )

--- a/pkg/vault/vault_client.go
+++ b/pkg/vault/vault_client.go
@@ -110,6 +110,9 @@ func (v *client) List(path string) ([]string, error) {
 	}
 
 	secretNames := make([]string, 0)
+	if secrets == nil {
+		return secretNames, nil
+	}
 	for _, s := range secrets.Data["keys"].([]interface{}) {
 		if orig, ok := s.(string); ok {
 			secretNames = append(secretNames, orig)
@@ -129,7 +132,7 @@ func (v *client) Read(secretName string) (map[string]interface{}, error) {
 }
 
 // Config retruns the current vault address and api token
-func (v *client) Config() (vaultURL url.URL, vaultToken string, err error) {
+func (v *client) Config() (vaultUrl url.URL, vaultToken string, err error) {
 	parsed, err := url.Parse(v.client.Address())
 	return *parsed, v.client.Token(), err
 }

--- a/pkg/vault/vault_client.go
+++ b/pkg/vault/vault_client.go
@@ -132,7 +132,7 @@ func (v *client) Read(secretName string) (map[string]interface{}, error) {
 }
 
 // Config retruns the current vault address and api token
-func (v *client) Config() (vaultUrl url.URL, vaultToken string, err error) {
+func (v *client) Config() (vaultURL url.URL, vaultToken string, err error) {
 	parsed, err := url.Parse(v.client.Address())
 	return *parsed, v.client.Token(), err
 }

--- a/pkg/vault/vault_client.go
+++ b/pkg/vault/vault_client.go
@@ -67,7 +67,7 @@ func (v *client) WriteObject(secretName string, secret interface{}) (map[string]
 func (v *client) WriteSecrets(path string, secretsToSave map[string]interface{}) error {
 	var err error
 	for secretName, secret := range secretsToSave {
-		secretName = secretName + path
+		secretName = path + secretName
 		switch secret.(type) {
 		case []byte:
 			// secret is a plain byte array. We shouldn't be doing this. Legacy. We should be saving properly typed objects


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

- Breaks the install command in smaller methods in oder to understand the flow
- Make the cloud provider configuration during the install more self contained in dedicated method
- Extract the helm values configuration and helm values file creation
- Separate the secrets files from helm values files
- Extract the GitOps logic in separate method
- Ensure that the GitOps secrets.yaml file is stored in Vault
- Ensure that secrets.yaml is fetch from vault when environment chart is installed

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->