### PR TITLE
fix:  Provides a more reliable way to get the previous git tag sha

### DIFF
--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -482,9 +482,16 @@ func (g *GitCLI) RemoteBranchNames(dir string, prefix string) ([]string, error) 
 
 // GetPreviousGitTagSHA returns the previous git tag from the repository at the given directory
 func (g *GitCLI) GetPreviousGitTagSHA(dir string) (string, error) {
-	// when in a release branch we need to skip 2 rather that 1 to find the revision of the previous tag
-	// no idea why! :)
-	return g.gitCmdWithOutput(dir, "rev-list", "--tags", "--skip=2", "--max-count=1")
+	latestTag, err := g.gitCmdWithOutput(dir, "describe","--abbrev=0", "--tags")
+	if err != nil {
+		return "", fmt.Errorf("failed to find latest tag for project in %s : %s", dir, err)
+	}
+
+	previousTag, err := g.gitCmdWithOutput(dir, "describe", "--abbrev=0", "--tags", "--always",  latestTag + "^")
+	if err != nil {
+		return "", fmt.Errorf("failed to find previous tag for project in %s : %s", dir, err)
+	}
+	return previousTag, err
 }
 
 // GetRevisionBeforeDate returns the revision before the given date


### PR DESCRIPTION
Provides a more reliable way to get the previous git tag sha, even if there is only one tag defined on the branch.  Previously this would cause the first build of a spring boot quickstart to fail on its first build

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
This fix uses `git describe` to retrieve the sha of the previous git tag in  the current branch.
ex of the:
`newest=git describe --abbrev=0 --tags`
`git describe --always --abbrev=0 --tags $newest^`

`--always` is used to handle the case when there is only a single tag defined

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2288 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
