### PR TITLE
fix(git): Handier error message if you get errors pushing to https

### DIFF
--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -3,6 +3,7 @@ package gits
 import (
 	"bytes"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"net/url"
@@ -198,24 +199,30 @@ func (g *GitCLI) Branch(dir string) (string, error) {
 	return g.gitCmdWithOutput(dir, "rev-parse", "--abbrev-ref", "HEAD")
 }
 
+// WriteOperation performs a generic write operation, with nicer error handling
+func (g *GitCLI) WriteOperation(dir string, args ...string) error {
+	return errors.Wrap(g.gitCmd(dir, args...),
+		"Have you set up a git credential helper? See https://help.github.com/articles/caching-your-github-password-in-git/\n")
+}
+
 // Push pushes the changes from the repository at the given directory
 func (g *GitCLI) Push(dir string) error {
-	return g.gitCmd(dir, "push", "origin", "HEAD")
+	return g.WriteOperation(dir, "push", "origin", "HEAD")
 }
 
 // ForcePushBranch does a force push of the local branch into the remote branch of the repository at the given directory
 func (g *GitCLI) ForcePushBranch(dir string, localBranch string, remoteBranch string) error {
-	return g.gitCmd(dir, "push", "-f", "origin", localBranch+":"+remoteBranch)
+	return g.WriteOperation(dir, "push", "-f", "origin", localBranch+":"+remoteBranch)
 }
 
 // PushMaster pushes the master branch into the origin
 func (g *GitCLI) PushMaster(dir string) error {
-	return g.gitCmd(dir, "push", "-u", "origin", "master")
+	return g.WriteOperation(dir, "push", "-u", "origin", "master")
 }
 
 // Pushtag pushes the given tag into the origin
 func (g *GitCLI) PushTag(dir string, tag string) error {
-	return g.gitCmd(dir, "push", "origin", tag)
+	return g.WriteOperation(dir, "push", "origin", tag)
 }
 
 // Add does a git add for all the given arguments


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
If you try to do a jx import, or jx delete app (new PR) it tries to do a pull request to the environment repos. The URLs for these repos are HTTPS, meaning that if you haven't set up a git credential helper, you will get an error: `fatal could not read Username for `https://github.com`: No error: exit status 128
This is because the git cli will go "you're not authenticated" and prompt you for a username password, but because we don't attach stdin/out to the git process, it fails.
This error prompts you to do the better thing - check that you have the git credential helper set up so it will automatically pass your creds over to your git repo when doing a write operation.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
