### PR TITLE
fix: Apparently missing newline in log message

### DIFF
--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1740,7 +1740,7 @@ func (options *InstallOptions) configureJenkins(namespace string) error {
 					if options.BatchMode {
 						options.CreateJenkinsUserOptions.BatchMode = true
 						options.CreateJenkinsUserOptions.Headless = true
-						log.Info("Attempting to find the Jenkins API Token with the browser in headless mode...")
+						log.Info("Attempting to find the Jenkins API Token with the browser in headless mode...\n")
 					}
 					err = options.CreateJenkinsUserOptions.Run()
 					return


### PR DESCRIPTION
Noticed an apparent display buglet in the build log from something using `jx step bdd`:

```
Getting Jenkins API Token
Attempting to find the Jenkins API Token with the browser in headless mode...Using url http://jenkins.bdd-….nip.io/me/configure
Unable to automatically find API token with chromedp using URL http://jenkins.bdd-….nip.io/me/configure
Error: creating the chrome client: timeout waiting for initial target
retrying after error:Running in batch mode and no default API token found
Attempting to find the Jenkins API Token with the browser in headless mode...Using url http://jenkins.bdd-….nip.io/me/configure
Unable to automatically find API token with chromedp using URL http://jenkins.bdd-….nip.io/me/configure
Error: serching the login form: context deadline exceeded
retrying after error:Running in batch mode and no default API token found
Attempting to find the Jenkins API Token with the browser in headless mode...Using url http://jenkins.bdd-….nip.io/me/configure
Generating the API token...
Created user **** API Token for Jenkins server jenkins.bdd-….nip.io at http://jenkins.bdd-….nip.io
Updating Jenkins with new external URL details http://jenkins.bdd-….nip.io
```

By the way, I find it bizarre that `CreateJenkinsUserOptions.Run` is using a simulated browser and what appears to be screenscraping just to get an API token out of a Jenkins service for which we know the initial admin password (in this case, a dummy nonsecret). You can get an API token using REST calls:

```sh
curl -XPOST -s -u admin:$PASS -H `curl -s -u admin:$PASS $URL'crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'` $URL'me/descriptorByName/jenkins.security.ApiTokenProperty/generateNewToken' | jq -r .data.tokenValue
```

(A little awkwardly since Jenkins requires an anti-CSRF defense token whenever authenticating via password rather than API token, which of course we need to do here.)