### PR TITLE
Why would the help for `jx update webhooks` claim it is not implemented?

### DIFF
--- a/pkg/jx/cmd/update_webhooks.go
+++ b/pkg/jx/cmd/update_webhooks.go
@@ -30,13 +30,13 @@ type UpdateWebhooksOptions struct {
 var (
 	updateWebhooksLong = templates.LongDesc(`
 		
-		Not currently implemented.
+		Updates the webhook for one repository, or all repositories in an organization.
 
 `)
 
 	updateWebhooksExample = templates.Examples(`
 
-		jx update webhooks
+		jx update webhooks --org=mycorp
 
 `)
 )


### PR DESCRIPTION
#2113 introduced a command but this bit of help text seems to have been forgotten.

As an aside, I find the behavior when `--repo` is missing to be odd. It is enumerating all repositories in the org, then updating the per-repo webhook. Why would you not simply update the _organization_ webhook (once)? Is it because some orgs in the repo might have unrelated endpoints?