### PR TITLE
bug(create team): Update status on the Team CRD in the admin namespace

### DIFF
--- a/pkg/jx/cmd/common_team_settings.go
+++ b/pkg/jx/cmd/common_team_settings.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/builds"
 	"io"
 	"os/user"
 	"reflect"
 	"strconv"
+
+	"github.com/jenkins-x/jx/pkg/builds"
 
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -25,7 +26,7 @@ type BranchPatterns struct {
 }
 
 const (
-	defaultHelmBin          = "helm"
+	defaultHelmBin = "helm"
 )
 
 // TeamSettings returns the team settings
@@ -232,8 +233,9 @@ func (o *CommonOptions) registerWorkflowCRD() error {
 	return nil
 }
 
-// ModifyTeam lazily creates the team if it does not exist or updates it if it requires a change
-func (o *CommonOptions) ModifyTeam(teamName string, callback func(env *v1.Team) error) error {
+// ModifyTeam lazily creates the Team CRD if it does not exist or updates it if it requires a change.
+// The Team CRD will be modified in the specified admin namespace.
+func (o *CommonOptions) ModifyTeam(adminNs string, teamName string, callback func(env *v1.Team) error) error {
 	err := o.registerTeamCRD()
 	if err != nil {
 		return err
@@ -242,11 +244,12 @@ func (o *CommonOptions) ModifyTeam(teamName string, callback func(env *v1.Team) 
 	if err != nil {
 		return err
 	}
-	jxClient, devNs, err := o.JXClientAndDevNamespace()
+	//Ignore admin NS returned here and use the one provided; JXClientAndAdminNamespace is returning the dev NS atm.
+	jxClient, _, err := o.JXClientAndAdminNamespace()
 	if err != nil {
 		return errors.Wrap(err, "failed to create the jx client")
 	}
-	ns, err := kube.GetAdminNamespace(kubeClient, devNs)
+	ns, err := kube.GetAdminNamespace(kubeClient, adminNs)
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/delete_team.go
+++ b/pkg/jx/cmd/delete_team.go
@@ -161,7 +161,8 @@ func (o *DeleteTeamOptions) deleteTeam(name string) error {
 	}
 	o.changeNamespace(name)
 
-	err = o.ModifyTeam(name, func(team *v1.Team) error {
+	//TODO: will be wrong admin ns here.
+	err = o.ModifyTeam(ns, name, func(team *v1.Team) error {
 		team.Status.ProvisionStatus = v1.TeamProvisionStatusDeleting
 		team.Status.Message = "Deleting resources"
 		return nil
@@ -171,7 +172,8 @@ func (o *DeleteTeamOptions) deleteTeam(name string) error {
 	}
 	err = uninstall.Run()
 	if err != nil {
-		o.ModifyTeam(name, func(team *v1.Team) error {
+		//TODO: will be wrong admin namespace here.
+		o.ModifyTeam(ns, name, func(team *v1.Team) error {
 			team.Status.ProvisionStatus = v1.TeamProvisionStatusError
 			team.Status.Message = fmt.Sprintf("Failed to delete team resources: %s", err)
 			return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The code tries to use the admin namespace as returned by kube.GetAdminNamespace(), but this appears to just return
the current namespace rather than finding the admin namespace - i.e. it can change!
Fixed by being explicit at all times about the admin NS to use. But I think there is another todo to sort out the current
'TODO' in kube.GetAdminNamespace():
`// TODO find the admin namespace via a label on the current dev namespace - or use current?`

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
