### PR TITLE
fix: removed additional 'Needs more' in jx status output

### DIFF
--- a/pkg/jx/cmd/status.go
+++ b/pkg/jx/cmd/status.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/util"
 	"io"
 	"time"
 
@@ -111,7 +112,7 @@ func (o *StatusOptions) Run() error {
 		return err
 	}
 	if resourceStr != "" {
-		log.Warnf("Jenkins X installed for %s. Jenkins is running at %s. Need more %s\n", clusterStatus.Info(), jenkinsURL, resourceStr)
+		log.Warnf("Jenkins X installed for %s. Jenkins is running at %s. %s\n", clusterStatus.Info(), jenkinsURL, util.ColorWarning(resourceStr))
 	} else {
 		log.Successf("Jenkins X checks passed for %s. Jenkins is running at %s\n", clusterStatus.Info(), jenkinsURL)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.






fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->