### PR TITLE
Fix jx upgrade extensions repository

### DIFF
--- a/pkg/jx/cmd/common_git.go
+++ b/pkg/jx/cmd/common_git.go
@@ -314,3 +314,20 @@ func (o *CommonOptions) gitProviderForGitServerURL(gitServiceUrl string, gitKind
 	}
 	return gits.CreateProviderForURL(o.Factory.IsInCluster(), authConfigSvc, gitKind, gitServiceUrl, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
 }
+
+func (o *CommonOptions) createGitProviderForURLWithoutKind(gitURL string) (gits.GitProvider, *gits.GitRepositoryInfo, error) {
+	gitInfo, err := gits.ParseGitURL(gitURL)
+	if err != nil {
+		return nil, gitInfo, err
+	}
+	gitKind, err := o.GitServerKind(gitInfo)
+	if err != nil {
+		return nil, gitInfo, err
+	}
+	authConfigSvc, err := o.CreateGitAuthConfigService()
+	if err != nil {
+		return nil, gitInfo, err
+	}
+	gitProvider, err := gits.CreateProviderForURL(o.Factory.IsInCluster(), authConfigSvc, gitKind, gitInfo.HostURL(), o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+	return gitProvider, gitInfo, err
+}

--- a/pkg/jx/cmd/step_split_monorepo.go
+++ b/pkg/jx/cmd/step_split_monorepo.go
@@ -114,7 +114,7 @@ func (o *StepSplitMonorepoOptions) Run() error {
 	}
 	var gitProvider gits.GitProvider
 	if !o.NoGit {
-		gitProvider, err = o.createGitProviderForURL(gits.KindGitHub, gits.GitHubURL)
+		gitProvider, err = o.gitProviderForGitServerURL(gits.GitHubURL, gits.KindGitHub)
 		if err != nil {
 			return err
 		}
@@ -310,31 +310,6 @@ version: 0.0.1-SNAPSHOT
 		}
 	}
 	return nil
-}
-
-func (o *CommonOptions) createGitProviderForURL(gitKind string, gitUrl string) (gits.GitProvider, error) {
-	authConfigSvc, err := o.CreateGitAuthConfigService()
-	if err != nil {
-		return nil, err
-	}
-	return gits.CreateProviderForURL(o.Factory.IsInCluster(), authConfigSvc, gitKind, gitUrl, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
-}
-
-func (o *CommonOptions) createGitProviderForURLWithoutKind(gitUrl string) (gits.GitProvider, *gits.GitRepositoryInfo, error) {
-	gitInfo, err := gits.ParseGitURL(gitUrl)
-	if err != nil {
-		return nil, gitInfo, err
-	}
-	gitKind, err := o.GitServerKind(gitInfo)
-	if err != nil {
-		return nil, gitInfo, err
-	}
-	authConfigSvc, err := o.CreateGitAuthConfigService()
-	if err != nil {
-		return nil, gitInfo, err
-	}
-	gitProvider, err := gits.CreateProviderForURL(o.Factory.IsInCluster(), authConfigSvc, gitKind, gitInfo.HostURL(), o.Git(), o.BatchMode, o.In, o.Out, o.Err)
-	return gitProvider, gitInfo, err
 }
 
 // generateFileIfMissing generates the given file from the source code if the file does not already exist

--- a/pkg/jx/cmd/upgrade_extensions.go
+++ b/pkg/jx/cmd/upgrade_extensions.go
@@ -182,7 +182,7 @@ func (o *UpgradeExtensionsOptions) Run() error {
 				log.Infof("Extensions Repository Lock located at %s\n", util.ColorInfo(path))
 			}
 			if err != nil {
-				return errors.New(fmt.Sprintf("Unable to fetch Extensions Repository Helm Chart %s/%s becasue %v", current.Chart.RepoName, current.Chart.Name, err))
+				return fmt.Errorf("Unable to fetch Extensions Repository Helm Chart %s/%s because %v", current.Chart.RepoName, current.Chart.Name, err)
 			}
 		} else {
 			extensionsRepositoryUrl := current.Url
@@ -190,7 +190,7 @@ func (o *UpgradeExtensionsOptions) Run() error {
 				extensionsRepositoryUrl = upstreamExtensionsRepositoryGitHub
 			}
 			if current.GitHub != "" {
-				_, repoInfo, err := o.createGitProviderForURLWithoutKind(fmt.Sprintf("github.com/%s", current.GitHub))
+				_, repoInfo, err := o.createGitProviderForURLWithoutKind(current.GitHub)
 				if err != nil {
 					return err
 				}

--- a/pkg/jx/cmd/upgrade_extensions_repository.go
+++ b/pkg/jx/cmd/upgrade_extensions_repository.go
@@ -207,7 +207,7 @@ func (o *UpgradeExtensionsRepositoryOptions) Run() error {
 func (o *UpgradeExtensionsRepositoryOptions) walkRemote(remote string, tag string, oldLockNameMap map[string]jenkinsv1.ExtensionSpec, oldLookupByUUID map[string]jenkinsv1.ExtensionSpec) (result []jenkinsv1.ExtensionSpec, err error) {
 	result = make([]jenkinsv1.ExtensionSpec, 0)
 	if strings.HasPrefix(remote, "github.com") {
-		gitProvider, repoInfo, err := o.createGitProviderForURLWithoutKind(remote)
+		gitProvider, repoInfo, err := o.createGitProviderForURLWithoutKind(strings.TrimPrefix(remote, "github.com/"))
 		if err != nil {
 			return result, err
 		}
@@ -224,7 +224,6 @@ func (o *UpgradeExtensionsRepositoryOptions) walkRemote(remote string, tag strin
 			}
 			resolvedTag = fmt.Sprintf("v%s", resolvedTag)
 		}
-
 		content, err := gitProvider.GetContent(org, repo, extensions.ExtensionsDefinitionFile, resolvedTag)
 		if err != nil {
 			return result, err


### PR DESCRIPTION
- Move some functions from `step_split_monorepo` to `common_git`. They were misplaced.
- gits.ParseGitURL doesn't recognize `github.com/org/repo`, pass `org/repo` instead.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This should fix build issues seen at https://github.com/jenkins-x/jenkins-x-extensions/pull/30

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
