### PR TITLE
Using PATCH instead of PUT to update PipelineActivity

### DIFF
--- a/pkg/kube/activity.go
+++ b/pkg/kube/activity.go
@@ -4,15 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/util"
 
-	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	typev1 "github.com/jenkins-x/jx/pkg/client/clientset/versioned/typed/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -410,14 +407,6 @@ func (k *PromoteStepActivityKey) GetOrCreatePromoteUpdate(activities typev1.Pipe
 	return a, s, p, p.Update, created, err
 }
 
-
-// PatchRow is a json patch structure
-type PatchRow struct {
-	Op    string `json:"op"`
-	Path  string `json:"path"`
-	Value interface{} `json:"value"`
-}
-
 // Almost making a full Update, but using Patch to work around problem with sometimes getting http status 409 back
 func patchSpec(activities typev1.PipelineActivityInterface, activity *v1.PipelineActivity) (err error) {
 	things := make([]PatchRow, 1)
@@ -427,6 +416,7 @@ func patchSpec(activities typev1.PipelineActivityInterface, activity *v1.Pipelin
 
 	patchBytes, err := json.Marshal(things)
 	if err != nil {
+		err = fmt.Errorf("Unable to marshall patch to JSON: %s", err)
 		return
 	}
 	_, err = activities.Patch(activity.Name, types.JSONPatchType, patchBytes)

--- a/pkg/kube/activity_functions.go
+++ b/pkg/kube/activity_functions.go
@@ -48,15 +48,9 @@ func StartPromotionPullRequest(a *v1.PipelineActivity, s *v1.PipelineActivitySte
 			Time: time.Now(),
 		}
 	}
-	if a.Spec.WorkflowStatus != v1.ActivityStatusTypeRunning {
-		a.Spec.WorkflowStatus = v1.ActivityStatusTypeRunning
-	}
-	if a.Spec.Status != v1.ActivityStatusTypeRunning {
-		a.Spec.Status = v1.ActivityStatusTypeRunning
-	}
-	if p.Status != v1.ActivityStatusTypeRunning {
-		p.Status = v1.ActivityStatusTypeRunning
-	}
+	a.Spec.WorkflowStatus = v1.ActivityStatusTypeRunning
+	a.Spec.Status = v1.ActivityStatusTypeRunning
+	p.Status = v1.ActivityStatusTypeRunning
 	return nil
 }
 
@@ -71,15 +65,9 @@ func StartPromotionUpdate(a *v1.PipelineActivity, s *v1.PipelineActivityStep, ps
 			Time: time.Now(),
 		}
 	}
-	if a.Spec.WorkflowStatus != v1.ActivityStatusTypeRunning {
-		a.Spec.WorkflowStatus = v1.ActivityStatusTypeRunning
-	}
-	if a.Spec.Status != v1.ActivityStatusTypeRunning {
-		a.Spec.Status = v1.ActivityStatusTypeRunning
-	}
-	if p.Status != v1.ActivityStatusTypeRunning {
-		p.Status = v1.ActivityStatusTypeRunning
-	}
+	a.Spec.WorkflowStatus = v1.ActivityStatusTypeRunning
+	a.Spec.Status = v1.ActivityStatusTypeRunning
+	p.Status = v1.ActivityStatusTypeRunning
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This is to avoid http status 409 when other process has updated activity.
Also simplifying a bit by updating once in any case and not zero, one or two times depending on. The zero case didn't happen anyway as far as I could see.

#### Special notes for the reviewer(s)

This pull request was first made as #2110. Then James Nord created a new (#2309) one subsuming the first. But that pull request was basically abandoned. So now I try again...

A problem is that FakePipelineActivities.Patch doesn't support other than strategic merge patch which at least is the main reason that some tests fail. See k8s.io/client-go@v8.0.0+incompatible/testing/fixture.go:140
Later versions of k8s.io/client-go supports JSON Patch as well. I tried upgrading but had to give up when I found out that heptio/sonobuoy doesn't support later versions of k8s.io/client-go. It isn't obvious to me how to resolve this.

#### Which issue this PR fixes

fixes #1890

