### PR TITLE
fixes(#2496) add support for bash completion on debian devpod images

### DIFF
--- a/pkg/jx/cmd/create_devpod.go
+++ b/pkg/jx/cmd/create_devpod.go
@@ -675,11 +675,11 @@ func (o *CreateDevPodOptions) Run() error {
 		//  Let install bash-completion to make life better
 		log.Infof("Attempting to install Bash Completion into DevPod\n")
 
-    rshExec = append(rshExec,
-      "if which yum 1> /dev/null; then yum install -q -y bash-completion bash-completion-extra; fi",
-      "if which apt-get 1> /dev/null; then apt-get install -qq bash-completion; fi",
-      "mkdir -p ~/.jx", "jx completion bash > ~/.jx/bash", "echo \"source ~/.jx/bash\" >> ~/.bashrc",
-    )
+		rshExec = append(rshExec,
+			"if which yum 1> /dev/null; then yum install -q -y bash-completion bash-completion-extra; fi",
+			"if which apt-get 1> /dev/null; then apt-get install -qq bash-completion; fi",
+			"mkdir -p ~/.jx", "jx completion bash > ~/.jx/bash", "echo \"source ~/.jx/bash\" >> ~/.bashrc",
+		)
 
 		// Only add git secrets to the Theia container when sync flag is missing (otherwise Theia container won't exist)
 		if !o.Sync {

--- a/pkg/jx/cmd/create_devpod.go
+++ b/pkg/jx/cmd/create_devpod.go
@@ -674,7 +674,6 @@ func (o *CreateDevPodOptions) Run() error {
 	if create {
 		//  Let install bash-completion to make life better
 		log.Infof("Attempting to install Bash Completion into DevPod\n")
-		// rshExec = append(rshExec, "yum install -q -y bash-completion bash-completion-extra", "mkdir -p ~/.jx", "jx completion bash > ~/.jx/bash", "echo \"source ~/.jx/bash\" >> ~/.bashrc")
 
     rshExec = append(rshExec,
       "if which yum 1> /dev/null; then yum install -q -y bash-completion bash-completion-extra; fi",

--- a/pkg/jx/cmd/create_devpod.go
+++ b/pkg/jx/cmd/create_devpod.go
@@ -673,8 +673,14 @@ func (o *CreateDevPodOptions) Run() error {
 	var rshExec []string
 	if create {
 		//  Let install bash-completion to make life better
-		log.Infof("Installing Bash Completion into DevPod\n")
-		rshExec = append(rshExec, "yum install -q -y bash-completion bash-completion-extra", "mkdir -p ~/.jx", "jx completion bash > ~/.jx/bash", "echo \"source ~/.jx/bash\" >> ~/.bashrc")
+		log.Infof("Attempting to install Bash Completion into DevPod\n")
+		// rshExec = append(rshExec, "yum install -q -y bash-completion bash-completion-extra", "mkdir -p ~/.jx", "jx completion bash > ~/.jx/bash", "echo \"source ~/.jx/bash\" >> ~/.bashrc")
+
+    rshExec = append(rshExec,
+      "if which yum 1> /dev/null; then yum install -q -y bash-completion bash-completion-extra; fi",
+      "if which apt-get 1> /dev/null; then apt-get install -qq bash-completion; fi",
+      "mkdir -p ~/.jx", "jx completion bash > ~/.jx/bash", "echo \"source ~/.jx/bash\" >> ~/.bashrc",
+    )
 
 		// Only add git secrets to the Theia container when sync flag is missing (otherwise Theia container won't exist)
 		if !o.Sync {

--- a/pkg/jx/cmd/status.go
+++ b/pkg/jx/cmd/status.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/util"
 	"io"
 	"time"
 
@@ -111,7 +112,7 @@ func (o *StatusOptions) Run() error {
 		return err
 	}
 	if resourceStr != "" {
-		log.Warnf("Jenkins X installed for %s. Jenkins is running at %s. Need more %s\n", clusterStatus.Info(), jenkinsURL, resourceStr)
+		log.Warnf("Jenkins X installed for %s. Jenkins is running at %s. %s\n", clusterStatus.Info(), jenkinsURL, util.ColorWarning(resourceStr))
 	} else {
 		log.Successf("Jenkins X checks passed for %s. Jenkins is running at %s\n", clusterStatus.Info(), jenkinsURL)
 	}


### PR DESCRIPTION
#### Description
1) Prevent `jx create devpod` from exiting with `127` when `yum` or `apt-get` is not available to install bash completion packages.  
2) If `yum` is not available, attempt to use `apt-get` to support debian based images

#### Which issue this PR fixes

fixes #2496
