### PR TITLE
fix(secrets): clean up the old jenkins-git-credentials secret

### DIFF
--- a/pkg/jx/cmd/upgrade_platform.go
+++ b/pkg/jx/cmd/upgrade_platform.go
@@ -212,7 +212,6 @@ func (o *UpgradePlatformOptions) Run() error {
 		return errors.Wrap(err, "failed to create a temporary config dir for Git credentials")
 	}
 
-	secretsFileName := filepath.Join(dir, GitSecretsFile)
 	adminSecretsFileName := filepath.Join(dir, AdminSecretsFile)
 	configFileName := filepath.Join(dir, ExtraValuesFile)
 
@@ -238,18 +237,6 @@ func (o *UpgradePlatformOptions) Run() error {
 	cloudEnvironmentValuesLocation := filepath.Join(makefileDir, CloudEnvValuesFile)
 	cloudEnvironmentSecretsLocation := filepath.Join(makefileDir, CloudEnvSecretsFile)
 	cloudEnvironmentSopsLocation := filepath.Join(makefileDir, CloudEnvSopsConfigFile)
-
-	secretsFileNameExists, err := util.FileExists(secretsFileName)
-	if err != nil {
-		return errors.Wrapf(err, "unable to determine if %s exist", secretsFileName)
-	}
-	if !secretsFileNameExists {
-		log.Infof("Creating %s from %s\n", util.ColorInfo(secretsFileName), util.ColorInfo(JXInstallConfig))
-		err = ioutil.WriteFile(secretsFileName, oldSecret.Data[GitSecretsFile], 0644)
-		if err != nil {
-			return errors.Wrapf(err, "failed to write the config file %s", secretsFileName)
-		}
-	}
 
 	adminSecretsFileNameExists, err := util.FileExists(adminSecretsFileName)
 	if err != nil {
@@ -300,7 +287,7 @@ func (o *UpgradePlatformOptions) Run() error {
 		}
 	}
 
-	valueFiles := []string{cloudEnvironmentValuesLocation, secretsFileName, adminSecretsFileName, configFileName, cloudEnvironmentSecretsLocation}
+	valueFiles := []string{cloudEnvironmentValuesLocation, adminSecretsFileName, configFileName, cloudEnvironmentSecretsLocation}
 	valueFiles, err = helm.AppendMyValues(valueFiles)
 	if err != nil {
 		return errors.Wrap(err, "failed to append the myvalues.yaml file")
@@ -322,11 +309,6 @@ func (o *UpgradePlatformOptions) Run() error {
 	}
 
 	if o.Flags.CleanupTempFiles {
-		err = util.DestroyFile(secretsFileName)
-		if err != nil {
-			return errors.Wrap(err, "failed to cleanup the secrets file")
-		}
-
 		if !configFileNameExists {
 			err = os.Remove(configFileName)
 			if err != nil {

--- a/pkg/kube/constants.go
+++ b/pkg/kube/constants.go
@@ -61,9 +61,6 @@ const (
 	// ServiceKubernetesDashboard the Kubernetes dashboard
 	ServiceKubernetesDashboard = "jenkins-x-kubernetes-dashboard"
 
-	// SecretJenkinsGitCredentials the git credentials secret
-	SecretJenkinsGitCredentials = "jenkins-git-credentials"
-
 	// SecretJenkinsChartMuseum the chart museum secret
 	SecretJenkinsChartMuseum = "jenkins-x-chartmuseum"
 


### PR DESCRIPTION
This secret does not seems to be used anymore by the pipeline.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Remove the old and unused jenkins-git-credentials secret from code. This is also the cleanup from the platform https://github.com/jenkins-x/jenkins-x-platform/pull/4502

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->