### PR TITLE
bug(delete team): Clear cached clients & namespaces when switching namespaces

### DIFF
--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -850,6 +850,8 @@ func (o *CommonOptions) GetWebHookEndpoint() (string, error) {
 	return webHookUrl, nil
 }
 
+//ChangeNamespace switches the current jx/K8S namespace to the one specified.
+//This is analogous to running `jx namespace cheese`.
 func (o *CommonOptions) ChangeNamespace(ns string) {
 	nsOptions := &NamespaceOptions{
 		CommonOptions: *o,

--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -850,6 +850,25 @@ func (o *CommonOptions) GetWebHookEndpoint() (string, error) {
 	return webHookUrl, nil
 }
 
+func (o *CommonOptions) ChangeNamespace(ns string) {
+	nsOptions := &NamespaceOptions{
+		CommonOptions: *o,
+	}
+	nsOptions.BatchMode = true
+	nsOptions.Args = []string{ns}
+	err := nsOptions.Run()
+	if err != nil {
+		log.Warnf("Failed to set context to namespace %s: %s", ns, err)
+	}
+
+	//Reset all the cached clients & namespace values when switching so that they can be properly recalculated for
+	//the new namespace.
+	o.KubeClientCached = nil
+	o.jxClient = nil
+	o.currentNamespace = ""
+	o.devNamespace = ""
+}
+
 func (o *CommonOptions) GetIn() terminal.FileReader {
 	return o.In
 }

--- a/pkg/jx/cmd/delete_team.go
+++ b/pkg/jx/cmd/delete_team.go
@@ -153,7 +153,7 @@ func (o *DeleteTeamOptions) deleteTeam(name string) error {
 		return kube.DeleteTeam(jxClient, ns, name)
 	}
 	origNamespace := o.currentNamespace
-	o.changeNamespace(name)
+	o.ChangeNamespace(name)
 
 	uninstall := &UninstallOptions{
 		CommonOptions: o.CommonOptions,
@@ -180,25 +180,6 @@ func (o *DeleteTeamOptions) deleteTeam(name string) error {
 	} else {
 		err = kube.DeleteTeam(jxClient, ns, name)
 	}
-	o.changeNamespace(origNamespace)
+	o.ChangeNamespace(origNamespace)
 	return err
-}
-
-func (o *DeleteTeamOptions) changeNamespace(ns string) {
-	nsOptions := &NamespaceOptions{
-		CommonOptions: o.CommonOptions,
-	}
-	nsOptions.BatchMode = true
-	nsOptions.Args = []string{ns}
-	err := nsOptions.Run()
-	if err != nil {
-		log.Warnf("Failed to set context to namespace %s: %s", ns, err)
-	}
-
-	//Reset all the cached clients & namespace values when switching so that they can be properly recalculated for
-	//the new namespace.
-	o.CommonOptions.KubeClientCached = nil
-	o.CommonOptions.jxClient = nil
-	o.CommonOptions.currentNamespace = ""
-	o.CommonOptions.devNamespace = ""
 }

--- a/pkg/jx/cmd/delete_team.go
+++ b/pkg/jx/cmd/delete_team.go
@@ -147,6 +147,14 @@ func (o *DeleteTeamOptions) deleteTeam(name string) error {
 		return err
 	}
 
+	_, err = kubeClient.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
+	if err != nil {
+		// we don't have the namespace so the team cannot have been provisioned yet
+		return kube.DeleteTeam(jxClient, ns, name)
+	}
+	origNamespace := o.currentNamespace
+	o.changeNamespace(name)
+
 	uninstall := &UninstallOptions{
 		CommonOptions: o.CommonOptions,
 		Namespace:     name,
@@ -154,14 +162,6 @@ func (o *DeleteTeamOptions) deleteTeam(name string) error {
 	}
 	uninstall.BatchMode = true
 
-	_, err = kubeClient.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
-	if err != nil {
-		// we don't have the namespace so the team cannot have been provisioned yet
-		return kube.DeleteTeam(jxClient, ns, name)
-	}
-	o.changeNamespace(name)
-
-	//TODO: will be wrong admin ns here.
 	err = o.ModifyTeam(ns, name, func(team *v1.Team) error {
 		team.Status.ProvisionStatus = v1.TeamProvisionStatusDeleting
 		team.Status.Message = "Deleting resources"
@@ -172,7 +172,6 @@ func (o *DeleteTeamOptions) deleteTeam(name string) error {
 	}
 	err = uninstall.Run()
 	if err != nil {
-		//TODO: will be wrong admin namespace here.
 		o.ModifyTeam(ns, name, func(team *v1.Team) error {
 			team.Status.ProvisionStatus = v1.TeamProvisionStatusError
 			team.Status.Message = fmt.Sprintf("Failed to delete team resources: %s", err)
@@ -181,7 +180,7 @@ func (o *DeleteTeamOptions) deleteTeam(name string) error {
 	} else {
 		err = kube.DeleteTeam(jxClient, ns, name)
 	}
-	o.changeNamespace("default")
+	o.changeNamespace(origNamespace)
 	return err
 }
 
@@ -195,4 +194,11 @@ func (o *DeleteTeamOptions) changeNamespace(ns string) {
 	if err != nil {
 		log.Warnf("Failed to set context to namespace %s: %s", ns, err)
 	}
+
+	//Reset all the cached clients & namespace values when switching so that they can be properly recalculated for
+	//the new namespace.
+	o.CommonOptions.KubeClientCached = nil
+	o.CommonOptions.jxClient = nil
+	o.CommonOptions.currentNamespace = ""
+	o.CommonOptions.devNamespace = ""
 }


### PR DESCRIPTION
JXClient, KubeClient, and namespaces are all cached for efficiency, but after switching namespaces these values might
be wrong. Clear them all out when changing namespaces, which will force the various setup methods in CommonOptions
(e.g. JXClient()) to create new ones, and recalculate dev namespaces etc.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2451 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
