### PR TITLE
fix: hide the error about missing apt-get/yum

### DIFF
--- a/pkg/jx/cmd/create_devpod.go
+++ b/pkg/jx/cmd/create_devpod.go
@@ -676,8 +676,8 @@ func (o *CreateDevPodOptions) Run() error {
 		log.Infof("Attempting to install Bash Completion into DevPod\n")
 
 		rshExec = append(rshExec,
-			"if which yum 1> /dev/null; then yum install -q -y bash-completion bash-completion-extra; fi",
-			"if which apt-get 1> /dev/null; then apt-get install -qq bash-completion; fi",
+			"if which yum &> /dev/null; then yum install -q -y bash-completion bash-completion-extra; fi",
+			"if which apt-get &> /dev/null; then apt-get install -qq bash-completion; fi",
 			"mkdir -p ~/.jx", "jx completion bash > ~/.jx/bash", "echo \"source ~/.jx/bash\" >> ~/.bashrc",
 		)
 


### PR DESCRIPTION
We need to redirect both stdout and stderr to /dev/null so that we don’t see an error when one of them doesn’t exist

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
