### PR TITLE
Fix: `jx sync` now runs first time

### DIFF
--- a/pkg/jx/cmd/sync.go
+++ b/pkg/jx/cmd/sync.go
@@ -110,7 +110,7 @@ func (o *SyncOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	_, err = o.installKSync()
+	version, err := o.installKSync()
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,9 @@ func (o *SyncOptions) Run() error {
 		flag, err := kube.IsDaemonSetExists(client, "ksync", "kube-system")
 		if !flag || err != nil {
 			log.Infof("Initialising ksync\n")
-			err = o.runCommandInteractive(true, "ksync", "init", "--upgrade")
+			// Deal with https://github.com/vapor-ware/ksync/issues/218
+			err = o.runCommandInteractive(true, "ksync", "init", "--upgrade", "--image",
+				fmt.Sprintf("vaporio/ksync:%s", version))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Implements workaround for https://github.com/vapor-ware/ksync/issues/218

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
