### PR TITLE
added ability to use preemptible vms in the node pool

### DIFF
--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -47,6 +47,7 @@ type CreateClusterGKEFlags struct {
 	Namespace       string
 	Labels          string
 	Scopes          []string
+	Preemptible 	bool
 }
 
 const clusterListHeader = "PROJECT_ID"
@@ -112,6 +113,7 @@ func NewCmdCreateClusterGKE(f Factory, in terminal.FileReader, out terminal.File
 	cmd.Flags().BoolVarP(&options.Flags.SkipLogin, "skip-login", "", false, "Skip Google auth if already logged in via gcloud auth")
 	cmd.Flags().StringVarP(&options.Flags.Labels, "labels", "", "", "The labels to add to the cluster being created such as 'foo=bar,whatnot=123'. Label names must begin with a lowercase character ([a-z]), end with a lowercase alphanumeric ([a-z0-9]) with dashes (-), and lowercase alphanumeric ([a-z0-9]) between.")
 	cmd.Flags().StringArrayVarP(&options.Flags.Scopes, "scope", "", []string{}, "The OAuth scopes to be added to the cluster")
+	cmd.Flags().BoolVarP(&options.Flags.Preemptible, "preemptible", "", false, "Use preemptible VMs in the node-pool")
 
 	cmd.AddCommand(NewCmdCreateClusterGKETerraform(f, in, out, errOut))
 
@@ -255,6 +257,10 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 
 	if len(o.Flags.Scopes) > 0 {
 		args = append(args, fmt.Sprintf("--scopes=%s", strings.Join(o.Flags.Scopes, ",")))
+	}
+
+	if o.Flags.Preemptible {
+		args = append(args, "--preemptible")
 	}
 
 	labels := o.Flags.Labels


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.






fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->