### PR TITLE
bug(install): use client-only mode to install the Helm secrets plugin.

### DIFF
--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -694,7 +694,7 @@ func (o *CommonOptions) installHelm() error {
 		if err != nil {
 			return err
 		}
-		return o.installHelmSecretsPlugin(binary, false)
+		return o.installHelmSecretsPlugin(binary, true)
 	}
 
 	binDir, err := util.JXBinLocation()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

On a clean system with no previous jx install, there will be no existing K8S context. During the auto-installation of helm, `helm init` is run, which tries to install the tiller server
into the cluster and will fail because it hasn't been created yet. Since the actual requirement at this stage of the process is _only_ to install the helm client, and the (client-side)
secrets plugin, Run configure the helmer for client only mode to avoid trying to install tiller. Later, when the cluster has been created tiller will still get installed via a later
`Helmer.init()` call.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2507 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
