### PR TITLE
`jx create env` should not ask for name in batch mode

### DIFF
--- a/pkg/kube/env.go
+++ b/pkg/kube/env.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -47,6 +48,10 @@ func CreateEnvironmentSurvey(batchMode bool, authConfigSvc auth.ConfigService, d
 			}
 			data.Name = config.Name
 		} else {
+			if batchMode {
+				return nil, errors.New("Environment name cannot be empty. Use --name option.")
+			}
+
 			validator := func(val interface{}) error {
 				err := ValidateName(val)
 				if err != nil {


### PR DESCRIPTION
`jx create env` command executed in batch mode (`-b`) should not prompt for name of the environment. It return information about missing option instead.