### PR TITLE
It should be possible to specify Git server type when creating new environment

### DIFF
--- a/pkg/gits/git_repo.go
+++ b/pkg/gits/git_repo.go
@@ -21,12 +21,13 @@ type CreateRepoData struct {
 }
 
 type GitRepositoryOptions struct {
-	ServerURL string
-	Username  string
-	ApiToken  string
-	Owner     string
-	RepoName  string
-	Private   bool
+	ServerURL  string
+	ServerKind string
+	Username   string
+	ApiToken   string
+	Owner      string
+	RepoName   string
+	Private    bool
 }
 
 // GetRepository returns the repository if it already exists
@@ -131,6 +132,9 @@ func PickNewOrExistingGitRepository(batchMode bool, authConfigSvc auth.ConfigSer
 	gitUsername := userAuth.Username
 	fmt.Fprintf(out, "\n\nAbout to create repository %s on server %s with user %s\n", util.ColorInfo(defaultRepoName), util.ColorInfo(url), util.ColorInfo(gitUsername))
 
+	if repoOptions.ServerKind != "" {
+		server.Kind = repoOptions.ServerKind
+	}
 	provider, err := CreateProvider(server, userAuth, git)
 	if err != nil {
 		return nil, err

--- a/pkg/jx/cmd/common_git.go
+++ b/pkg/jx/cmd/common_git.go
@@ -250,6 +250,8 @@ func (o *CommonOptions) discoverGitURL(gitConf string) (string, error) {
 
 func addGitRepoOptionsArguments(cmd *cobra.Command, repositoryOptions *gits.GitRepositoryOptions) {
 	cmd.Flags().StringVarP(&repositoryOptions.ServerURL, "git-provider-url", "", "https://github.com", "The Git server URL to create new Git repositories inside")
+	cmd.Flags().StringVarP(&repositoryOptions.ServerKind, "git-provider-kind", "", "",
+		"Kind of Git server. If not specified, kind of server will be autodetected from Git provider URL. Possible values: bitbucketcloud, bitbucketserver, gitea, gitlab, github, fakegit")
 	cmd.Flags().StringVarP(&repositoryOptions.Username, "git-username", "", "", "The Git username to use for creating new Git repositories")
 	cmd.Flags().StringVarP(&repositoryOptions.ApiToken, "git-api-token", "", "", "The Git API token to use for creating new Git repositories")
 	cmd.Flags().BoolVarP(&repositoryOptions.Private, "git-private", "", false, "Create new Git repositories as private")


### PR DESCRIPTION
Right now when executing `jx create env` Git server kind is auto-detected from Git provider server URL. It works OK for cloud solutions like GitHub or BitBucketCloud, but doesn't work well for self-hosted BitBucket or GitLab.

It should be possible to enforce Git provider kind using command line option.