### PR TITLE
Added Git provider kind option to `jx install`

### DIFF
--- a/pkg/gits/git_repo.go
+++ b/pkg/gits/git_repo.go
@@ -21,12 +21,13 @@ type CreateRepoData struct {
 }
 
 type GitRepositoryOptions struct {
-	ServerURL string
-	Username  string
-	ApiToken  string
-	Owner     string
-	RepoName  string
-	Private   bool
+	ServerURL  string
+	ServerKind string
+	Username   string
+	ApiToken   string
+	Owner      string
+	RepoName   string
+	Private    bool
 }
 
 // GetRepository returns the repository if it already exists

--- a/pkg/jx/cmd/common_git.go
+++ b/pkg/jx/cmd/common_git.go
@@ -250,6 +250,8 @@ func (o *CommonOptions) discoverGitURL(gitConf string) (string, error) {
 
 func addGitRepoOptionsArguments(cmd *cobra.Command, repositoryOptions *gits.GitRepositoryOptions) {
 	cmd.Flags().StringVarP(&repositoryOptions.ServerURL, "git-provider-url", "", "https://github.com", "The Git server URL to create new Git repositories inside")
+	cmd.Flags().StringVarP(&repositoryOptions.ServerKind, "git-provider-kind", "", "",
+		"Kind of Git server. If not specified, kind of server will be autodetected from Git provider URL. Possible values: bitbucketcloud, bitbucketserver, gitea, gitlab, github, fakegit")
 	cmd.Flags().StringVarP(&repositoryOptions.Username, "git-username", "", "", "The Git username to use for creating new Git repositories")
 	cmd.Flags().StringVarP(&repositoryOptions.ApiToken, "git-api-token", "", "", "The Git API token to use for creating new Git repositories")
 	cmd.Flags().BoolVarP(&repositoryOptions.Private, "git-private", "", false, "Create new Git repositories as private")

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1049,7 +1049,12 @@ func (options *InstallOptions) configureGitAuth() error {
 
 	var authServer *auth.AuthServer
 	if gitServer != "" {
-		kind := gits.SaasGitKind(gitServer)
+		kind := ""
+		if options.GitRepositoryOptions.ServerKind == "" {
+			kind = gits.SaasGitKind(gitServer)
+		} else {
+			kind = options.GitRepositoryOptions.ServerKind
+		}
 		authServer = authConfig.GetOrCreateServerName(gitServer, "", kind)
 	} else {
 		authServer, err = authConfig.PickServer("Which Git provider:", options.BatchMode, options.In, options.Out, options.Err)


### PR DESCRIPTION
Hi @jstrachan . Here is the missing Git provider kind option we've been discussing earlier today.