### PR TITLE
Better error message

### DIFF
--- a/pkg/jx/cmd/promote.go
+++ b/pkg/jx/cmd/promote.go
@@ -984,7 +984,7 @@ func (o *PromoteOptions) getJenkinsURL() string {
 	}
 	url, err := o.GetJenkinsURL()
 	if err != nil {
-		log.Warnf("Could not find Jenkins URL %s", err)
+		log.Warnf("Could not find Jenkins URL: %s", err)
 	} else {
 		o.jenkinsURL = url
 	}


### PR DESCRIPTION
#### Description

`Could not find Jenkins URL: services "jenkins" not found in namespace jx`

instead of 

`Could not find Jenkins URL services "jenkins" not found in namespace jx`

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

