### PR TITLE
fix(ingress): Don't use empty strings in possible organisations

### DIFF
--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -270,8 +270,11 @@ func PickOrganisation(orgLister OrganisationLister, userName string, in terminal
 
 // GetOrganizations gets the organisation
 func GetOrganizations(orgLister OrganisationLister, userName string) []string {
+	var orgNames []string
 	// Always include the username as a pseudo organization
-	orgNames := []string{userName}
+	if userName != "" {
+		orgNames = append(orgNames, userName)
+	}
 
 	orgs, _ := orgLister.ListOrganisations()
 	for _, o := range orgs {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [] Change is covered by existing or new tests.

#### Description
When performing `jx upgrade ingress`, an empty selection is presented to the user (because `userName` is passed as `nil`)

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2389
