### PR TITLE
fix(ingress): github webhooks weren't being updated on `jx upgrade ingress`

### DIFF
--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -398,8 +398,8 @@ func (p *GitHubProvider) UpdateWebHook(data *GitWebHookArguments) error {
 		for _, hook := range hooks {
 			c := hook.Config["url"]
 			s, ok := c.(string)
-			if ok && s == webhookUrl {
-				log.Warnf("Found existing webhook for url %s\n", webhookUrl)
+			if ok && s == data.ExistingURL {
+				log.Warnf("Found existing webhook for url %s\n", data.ExistingURL)
 				dataId = hook.GetID()
 			}
 		}
@@ -423,6 +423,8 @@ func (p *GitHubProvider) UpdateWebHook(data *GitWebHookArguments) error {
 
 		log.Infof("Updating GitHub webhook for %s/%s for url %s\n", util.ColorInfo(owner), util.ColorInfo(repo), util.ColorInfo(webhookUrl))
 		_, _, err = p.Client.Repositories.EditHook(p.Context, owner, repo, dataId, hook)
+	} else {
+		log.Warn("No webhooks found to update")
 	}
 	return err
 }

--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -155,11 +155,12 @@ type GitPullRequestArguments struct {
 }
 
 type GitWebHookArguments struct {
-	ID     int64
-	Owner  string
-	Repo   *GitRepository
-	URL    string
-	Secret string
+	ID          int64
+	Owner       string
+	Repo        *GitRepository
+	URL         string
+	ExistingURL string
+	Secret      string
 }
 
 type GitFileContent struct {

--- a/pkg/jx/cmd/update_webhooks.go
+++ b/pkg/jx/cmd/update_webhooks.go
@@ -154,14 +154,13 @@ func (options *UpdateWebhooksOptions) updateRepoHook(git gits.GitProvider, repoN
 					Repo: &gits.GitRepository{
 						Name: repoName,
 					},
-					URL: webhookURL,
+					URL:         webhookURL,
+					ExistingURL: options.PreviousHookUrl,
 				}
 
 				if isProwEnabled {
 					webHookArgs.Secret = string(hmacToken.Data["hmac"])
 				}
-
-				log.Infof("Updating WebHook with new args\n")
 
 				if !options.DryRun {
 					git.UpdateWebHook(webHookArgs)

--- a/pkg/jx/cmd/upgrade_ingress.go
+++ b/pkg/jx/cmd/upgrade_ingress.go
@@ -43,6 +43,7 @@ type UpgradeIngressOptions struct {
 
 	SkipCertManager     bool
 	Cluster             bool
+	Force               bool
 	Namespaces          []string
 	Version             string
 	TargetNamespaces    []string
@@ -92,6 +93,7 @@ func (o *UpgradeIngressOptions) addFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&o.SkipCertManager, "skip-certmanager", "", false, "Skips certmanager installation")
 	cmd.Flags().StringArrayVarP(&o.Services, "services", "", []string{}, "Services to upgrdde")
 	cmd.Flags().BoolVarP(&o.SkipResourcesUpdate, "skip-resources-update", "", false, "Skips the update of jx related resources such as webhook or Jenkins URL")
+	cmd.Flags().BoolVarP(&o.Force, "force", "", false, "Forces upgrades of all webooks even if ingress URL has not changed")
 }
 
 // Run implements the command
@@ -461,6 +463,11 @@ func (o *UpgradeIngressOptions) cleanTLSSecrets(ns string) error {
 }
 
 func (o *UpgradeIngressOptions) updateWebHooks(oldHookEndpoint string, newHookEndpoint string) error {
+	if oldHookEndpoint == newHookEndpoint && !o.Force {
+		log.Infof("Webhook URL unchanged. Use %s to force updating", util.ColorInfo("--force"))
+		return nil
+	}
+
 	log.Infof("Updating all webHooks from %s to %s\n", util.ColorInfo(oldHookEndpoint), util.ColorInfo(newHookEndpoint))
 
 	updateWebHook := UpdateWebhooksOptions{


### PR DESCRIPTION
`jx upgrade ingress` wasn't correctly setting the webhooks in github.
It was incorrectly checking whether the webhook matched the _new_ URL (that you were trying to set it _to_)

fixes #2018