### PR TITLE
fix(install): use http redirects to get latest github releases

### DIFF
--- a/pkg/util/downloads_test.go
+++ b/pkg/util/downloads_test.go
@@ -1,0 +1,102 @@
+package util
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_getLatestReleaseFromGithubUsingHttpRedirect(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		githubOwner string
+		githubRepo  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			"Happy Path",
+			args{
+				githubOwner: "org",
+				githubRepo:  "repo",
+			},
+			"v1.2.3",
+			false,
+		},
+		{
+			"Redirection from one repo to another (redirects to happy path)",
+			args{
+				githubOwner: "redirect",
+				githubRepo:  "repo",
+			},
+			"v1.2.3",
+			false,
+		},
+		{
+			"Not a redirect",
+			args{
+				githubOwner: "foo",
+				githubRepo:  "bar",
+			},
+			"",
+			true,
+		},
+		{
+			"Redirect but no location header",
+			args{
+				githubOwner: "no",
+				githubRepo:  "location",
+			},
+			"",
+			true,
+		},
+		{
+			"Bad Redirect - redirect to a page of an unknown format",
+			args{
+				githubOwner: "bad",
+				githubRepo:  "location",
+			},
+			"",
+			true,
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Send response to be tested
+		if req.URL.Path == "/org/repo/releases/latest" {
+			rw.Header().Add("Location", "https://github.com/org/repo/releases/tag/v1.2.3")
+			rw.WriteHeader(302)
+		} else if req.URL.Path == "/redirect/repo/releases/latest" {
+			// permanent Redirect to the happy path
+			rw.Header().Add("Location", "/org/repo/releases/latest")
+			rw.WriteHeader(301)
+		} else if req.URL.Path == "/no/location/releases/latest" {
+			// No location header in the response
+			rw.WriteHeader(302)
+		} else if req.URL.Path == "/bad/location/releases/latest" {
+			rw.Header().Add("Location", "https://foo.bar")
+			rw.WriteHeader(302)
+		} else {
+			_, _ = rw.Write([]byte(`This is not the redirect you are looking for`))
+		}
+	}))
+	// Close the server when test finishes
+	defer server.Close()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getLatestReleaseFromHostUsingHttpRedirect(server.URL, tt.args.githubOwner, tt.args.githubRepo)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getLatestReleaseFromGithubUsingHttpRedirect() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getLatestReleaseFromGithubUsingHttpRedirect() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
using the Github API unauthenticated will impact the low (60/hour) API limits. This can affect teams working behind a common IP address.

We can find the latest release by getting the redirect issues by github when trying to GET https://github.com/org/repo/releases/latest and use this instead.

This still tries to use the API as a fallback if it does not succeed.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2062

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
