### PR TITLE
fix(helm): Passwords for helm repos were logged in plaintext to the command line

### DIFF
--- a/pkg/helm/helm_cli.go
+++ b/pkg/helm/helm_cli.go
@@ -121,8 +121,15 @@ func (h *HelmCLI) Init(clientOnly bool, serviceAccount string, tillerNamespace s
 }
 
 // AddRepo adds a new helm repo with the given name and URL
-func (h *HelmCLI) AddRepo(repo string, URL string) error {
-	return h.runHelm("repo", "add", repo, URL)
+func (h *HelmCLI) AddRepo(repo, URL, username, password string) error {
+	args := []string{"repo", "add", repo, URL}
+	if username != "" {
+		args = append(args, "--username", username)
+	}
+	if password != "" {
+		args = append(args, "--password", password)
+	}
+	return h.runHelm(args...)
 }
 
 // RemoveRepo removes the given repo from helm

--- a/pkg/helm/helm_cli_test.go
+++ b/pkg/helm/helm_cli_test.go
@@ -86,7 +86,7 @@ func TestAddRepo(t *testing.T) {
 	expectedArgs := []string{"repo", "add", repo, repoURL}
 	helm, runner := createHelm(t, nil, "")
 
-	err := helm.AddRepo(repo, repoURL)
+	err := helm.AddRepo(repo, repoURL, "", "")
 
 	assert.NoError(t, err, "should add helm repo without any error")
 	verifyArgs(t, helm, runner, expectedArgs...)

--- a/pkg/helm/helm_template.go
+++ b/pkg/helm/helm_template.go
@@ -115,8 +115,8 @@ func (h *HelmTemplate) Init(clientOnly bool, serviceAccount string, tillerNamesp
 }
 
 // AddRepo adds a new helm repo with the given name and URL
-func (h *HelmTemplate) AddRepo(repo string, URL string) error {
-	return h.Client.AddRepo(repo, URL)
+func (h *HelmTemplate) AddRepo(repo, URL, username, password string) error {
+	return h.Client.AddRepo(repo, URL, username, password)
 }
 
 // RemoveRepo removes the given repo from helm
@@ -472,7 +472,7 @@ func (h *HelmTemplate) StatusReleases(ns string) (map[string]Release, error) {
 			releaseName := labels[LabelReleaseName]
 			release := Release{
 				Release: releaseName,
-				Status: "DEPLOYED",
+				Status:  "DEPLOYED",
 				Version: "",
 			}
 

--- a/pkg/helm/interface.go
+++ b/pkg/helm/interface.go
@@ -7,7 +7,7 @@ type Helmer interface {
 	HelmBinary() string
 	SetHelmBinary(binary string)
 	Init(clientOnly bool, serviceAccount string, tillerNamespace string, upgrade bool) error
-	AddRepo(repo string, URL string) error
+	AddRepo(repo, URL, username, password string) error
 	RemoveRepo(repo string) error
 	ListRepos() (map[string]string, error)
 	UpdateRepo() error

--- a/pkg/helm/mocks/helmer.go
+++ b/pkg/helm/mocks/helmer.go
@@ -17,11 +17,11 @@ func NewMockHelmer() *MockHelmer {
 	return &MockHelmer{fail: pegomock.GlobalFailHandler}
 }
 
-func (mock *MockHelmer) AddRepo(_param0 string, _param1 string) error {
+func (mock *MockHelmer) AddRepo(_param0 string, _param1 string, _param2 string, _param3 string) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockHelmer().")
 	}
-	params := []pegomock.Param{_param0, _param1}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("AddRepo", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
@@ -455,8 +455,8 @@ type VerifierHelmer struct {
 	inOrderContext         *pegomock.InOrderContext
 }
 
-func (verifier *VerifierHelmer) AddRepo(_param0 string, _param1 string) *Helmer_AddRepo_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1}
+func (verifier *VerifierHelmer) AddRepo(_param0 string, _param1 string, _param2 string, _param3 string) *Helmer_AddRepo_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "AddRepo", params)
 	return &Helmer_AddRepo_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -466,12 +466,12 @@ type Helmer_AddRepo_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *Helmer_AddRepo_OngoingVerification) GetCapturedArguments() (string, string) {
-	_param0, _param1 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+func (c *Helmer_AddRepo_OngoingVerification) GetCapturedArguments() (string, string, string, string) {
+	_param0, _param1, _param2, _param3 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1]
 }
 
-func (c *Helmer_AddRepo_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
+func (c *Helmer_AddRepo_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string, _param3 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(params[0]))
@@ -481,6 +481,14 @@ func (c *Helmer_AddRepo_OngoingVerification) GetAllCapturedArguments() (_param0 
 		_param1 = make([]string, len(params[1]))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
+		}
+		_param2 = make([]string, len(params[2]))
+		for u, param := range params[2] {
+			_param2[u] = param.(string)
+		}
+		_param3 = make([]string, len(params[3]))
+		for u, param := range params[3] {
+			_param3[u] = param.(string)
 		}
 	}
 	return

--- a/pkg/helm/mocks/helmer_fake.go
+++ b/pkg/helm/mocks/helmer_fake.go
@@ -16,7 +16,7 @@ func NewFakeHelmer() helm.Helmer {
 }
 
 // AddRepo add repo
-func (FakeHelmer) AddRepo(repo string, URL string) error {
+func (FakeHelmer) AddRepo(repo, URL, username, password string) error {
 	return nil
 }
 

--- a/pkg/jx/cmd/common_helm.go
+++ b/pkg/jx/cmd/common_helm.go
@@ -2,19 +2,17 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/helm"
+	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/kube/services"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
-
-	"github.com/jenkins-x/jx/pkg/helm"
-	"github.com/jenkins-x/jx/pkg/kube"
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/jenkins-x/jx/pkg/util"
-	"github.com/pkg/errors"
 )
 
 func (o *CommonOptions) registerLocalHelmRepo(repoName, ns string) error {
@@ -79,16 +77,11 @@ func (o *CommonOptions) addHelmBinaryRepoIfMissing(helmUrl, repoName, username, 
 	}
 	if missing {
 		log.Infof("Adding missing Helm repo: %s %s\n", util.ColorInfo(repoName), util.ColorInfo(helmUrl))
-		err = o.retry(6, 10*time.Second, func() (err error) {
-			err = o.Helm().AddRepo(repoName, helmUrl, username, password)
-			if err == nil {
-				log.Infof("Successfully added Helm repository %s.\n", repoName)
-			}
-			return errors.Wrapf(err, "failed to add the repository '%s' with URL '%s'", repoName, helmUrl)
-		})
-		if err != nil {
-			return err
+		err = o.Helm().AddRepo(repoName, helmUrl, username, password)
+		if err == nil {
+			log.Infof("Successfully added Helm repository %s.\n", repoName)
 		}
+		return errors.Wrapf(err, "failed to add the repository '%s' with URL '%s'", repoName, helmUrl)
 	}
 	return nil
 }

--- a/pkg/jx/cmd/create_addon_ambassador.go
+++ b/pkg/jx/cmd/create_addon_ambassador.go
@@ -85,7 +85,7 @@ func (o *CreateAddonAmbassadorOptions) Run() error {
 	if o.Chart == "" {
 		return util.MissingOption(optionChart)
 	}
-	err := o.addHelmRepoIfMissing(ambassadorRepoUrl, ambassadorRepoName)
+	err := o.addHelmRepoIfMissing(ambassadorRepoUrl, ambassadorRepoName, "", "")
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/create_addon_cloudbees.go
+++ b/pkg/jx/cmd/create_addon_cloudbees.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"gopkg.in/AlecAivazis/survey.v1"
 	"io"
 	"strings"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
-	"gopkg.in/AlecAivazis/survey.v1"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,7 +22,7 @@ const (
 	defaultCloudBeesNamespace   = "jx"
 	coreRepoName                = "cb"
 	cbServiceName               = "cb-core"
-	coreRepoUrl                 = "https://%s:%s@chartmuseum.jx.charts-demo.cloudbees.com"
+	coreRepoUrl                 = "https://chartmuseum.jx.charts-demo.cloudbees.com"
 	defaultCloudBeesVersion     = ""
 )
 
@@ -101,7 +101,7 @@ func (o *CreateAddonCloudBeesOptions) Run() error {
 
 	// check if Helm repo is missing, the repo is authenticated and includes username/password so check with dummy values
 	// first as we wont need to prompt for username password if the host part of the URL matches an existing repo
-	missing, err := o.isHelmRepoMissing(fmt.Sprintf(coreRepoUrl, "dummy", "dummy"))
+	missing, err := o.isHelmRepoMissing(coreRepoUrl)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ To register to get your username/password to to: %s
 		}
 		survey.AskOne(passPrompt, &password, nil, surveyOpts)
 
-		err := o.addHelmRepoIfMissing(fmt.Sprintf(coreRepoUrl, username, password), coreRepoName)
+		err := o.addHelmRepoIfMissing(coreRepoUrl, coreRepoName, username, password)
 		if err != nil {
 			return err
 		}

--- a/pkg/jx/cmd/create_addon_sso.go
+++ b/pkg/jx/cmd/create_addon_sso.go
@@ -143,7 +143,7 @@ func (o *CreateAddonSSOOptions) Run() error {
 		return errors.Wrap(err, "checking if helm is installed")
 	}
 
-	err = o.addHelmRepoIfMissing(repoURL, repoName)
+	err = o.addHelmRepoIfMissing(repoURL, repoName, "", "")
 	if err != nil {
 		return errors.Wrap(err, "adding dex chart helm repository")
 	}

--- a/pkg/jx/cmd/create_addon_vault.go
+++ b/pkg/jx/cmd/create_addon_vault.go
@@ -87,7 +87,7 @@ func InstallVaultOperator(o *CommonOptions, namespace string) error {
 		return errors.Wrap(err, "checking if helm is installed")
 	}
 
-	err = o.addHelmRepoIfMissing(jxRepoURL, jxRepoName)
+	err = o.addHelmRepoIfMissing(jxRepoURL, jxRepoName, "", "")
 	if err != nil {
 		return errors.Wrapf(err, "adding '%s' helm charts repository", jxRepoURL)
 	}

--- a/pkg/jx/cmd/edit_extensionsrepository.go
+++ b/pkg/jx/cmd/edit_extensionsrepository.go
@@ -214,7 +214,7 @@ func (o *EditExtensionsRepositoryOptions) Run() error {
 						return err
 					}
 				} else {
-					err := o.addHelmRepoIfMissing(current.Chart.Repo, current.Chart.RepoName)
+					err := o.addHelmRepoIfMissing(current.Chart.Repo, current.Chart.RepoName, "", "")
 					if err != nil {
 						return err
 					}
@@ -268,7 +268,7 @@ func (o *EditExtensionsRepositoryOptions) Run() error {
 		} else {
 			repoUrl = fmt.Sprintf("https://%s", current.Chart.Repo)
 		}
-		err := o.addHelmRepoIfMissing(repoUrl, current.Chart.RepoName)
+		err := o.addHelmRepoIfMissing(repoUrl, current.Chart.RepoName, "", "")
 		if err != nil {
 			return err
 		}

--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -418,7 +418,7 @@ func (o *InitOptions) initHelm() error {
 		}
 	}
 
-	err = o.Helm().AddRepo("jenkins-x", DEFAULT_CHARTMUSEUM_URL)
+	err = o.Helm().AddRepo("jenkins-x", DEFAULT_CHARTMUSEUM_URL, "", "")
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -882,7 +882,7 @@ func (options *InstallOptions) configureHelm(client kubernetes.Interface, namesp
 }
 
 func (options *InstallOptions) configureHelmRepo() error {
-	err := options.addHelmBinaryRepoIfMissing(DEFAULT_CHARTMUSEUM_URL, "jenkins-x")
+	err := options.addHelmBinaryRepoIfMissing(DEFAULT_CHARTMUSEUM_URL, "jenkins-x", "", "")
 	if err != nil {
 		return errors.Wrap(err, "failed to add the jenkinx-x helm repo")
 	}
@@ -1563,7 +1563,7 @@ func (options *InstallOptions) configureCloudProivderPostInit(client kubernetes.
 			return errors.Wrap(err, "failed to enable the OpenShiftSCC")
 		}
 	case IKS:
-		err := options.addHelmBinaryRepoIfMissing(DEFAULT_IBMREPO_URL, "ibm")
+		err := options.addHelmBinaryRepoIfMissing(DEFAULT_IBMREPO_URL, "ibm", "", "")
 		if err != nil {
 			return errors.Wrap(err, "failed to add the IBM helm repo")
 		}


### PR DESCRIPTION
If you were using a password protected helm repo (`jx create addon cloudbees`) and enterred the username/password incorrectly (or some other error occurred), then the password was printed out to the command line in plaintext.:

```
? CloudBees Preview password [? for help] **
Adding missing Helm repo: cb https://chartmuseum.jx.charts-demo.cloudbees.com
error: failed to add the repository 'cb' with URL 'https://chartmuseum.jx.charts-demo.cloudbees.com': failed to run 'helm repo add cb https://chartmuseum.jx.chart
s-demo.cloudbees.com --username myusername --password mypassword' command in directory '' <snip>
```

This fix will replace it with asterisks
```
? CloudBees Preview password [? for help] **
Adding missing Helm repo: cb https://chartmuseum.jx.charts-demo.cloudbees.com
error: failed to add the repository 'cb' with URL 'https://chartmuseum.jx.charts-demo.cloudbees.com': failed to run 'helm repo add cb https://chartmuseum.jx.chart
s-demo.cloudbees.com --username myusername --password *****' command in directory '' <snip>
```
