### PR TITLE
Correct aligment in jx get applications

### DIFF
--- a/pkg/jx/cmd/get_applications.go
+++ b/pkg/jx/cmd/get_applications.go
@@ -153,52 +153,64 @@ func (o *GetApplicationsOptions) generateTable(apps []string, envApps []EnvApps,
 		for _, ea := range envApps {
 			version := ""
 			d, ok := ea.Apps[appName]
-			if ok {
-				appMap := appEnvMap[appName]
-				if appMap == nil {
-					appMap = map[string]*ApplicationEnvironmentInfo{}
-					appEnvMap[appName] = appMap
-				}
-				version = kube.GetVersion(&d.ObjectMeta)
-				appEnvInfo := &ApplicationEnvironmentInfo{
-					Deployment:  &d,
-					Environment: &ea.Environment,
-					Version:     version,
-				}
-				appMap[ea.Environment.Name] = appEnvInfo
-				if ea.Environment.Spec.Kind != v1.EnvironmentKindTypePreview {
-					row = append(row, version)
-				}
-				if !o.HidePod {
-					pods := ""
-					replicas := ""
-					ready := d.Status.ReadyReplicas
-					if d.Spec.Replicas != nil && ready > 0 {
-						replicas = formatInt32(*d.Spec.Replicas)
-						pods = formatInt32(ready) + "/" + replicas
+			if len(ea.Apps) > 0 {
+				if ok {
+					appMap := appEnvMap[appName]
+					if appMap == nil {
+						appMap = map[string]*ApplicationEnvironmentInfo{}
+						appEnvMap[appName] = appMap
 					}
-					row = append(row, pods)
-				}
-				if !o.HideUrl {
-					url, _ := services.FindServiceURL(kubeClient, d.Namespace, appName)
-					if url == "" {
-						url, _ = services.FindServiceURL(kubeClient, d.Namespace, d.Name)
+					version = kube.GetVersion(&d.ObjectMeta)
+					appEnvInfo := &ApplicationEnvironmentInfo{
+						Deployment:  &d,
+						Environment: &ea.Environment,
+						Version:     version,
 					}
-					if url == "" {
-						// handle helm3
-						chart, ok := d.Labels["chart"]
-						if ok {
-							idx := strings.LastIndex(chart, "-")
-							if idx > 0 {
-								svcName := chart[0:idx]
-								if svcName != appName && svcName != d.Name {
-									url, _ = services.FindServiceURL(kubeClient, d.Namespace, svcName)
+					appMap[ea.Environment.Name] = appEnvInfo
+					if ea.Environment.Spec.Kind != v1.EnvironmentKindTypePreview {
+						row = append(row, version)
+					}
+					if !o.HidePod {
+						pods := ""
+						replicas := ""
+						ready := d.Status.ReadyReplicas
+						if d.Spec.Replicas != nil && ready > 0 {
+							replicas = formatInt32(*d.Spec.Replicas)
+							pods = formatInt32(ready) + "/" + replicas
+						}
+						row = append(row, pods)
+					}
+					if !o.HideUrl {
+						url, _ := services.FindServiceURL(kubeClient, d.Namespace, appName)
+						if url == "" {
+							url, _ = services.FindServiceURL(kubeClient, d.Namespace, d.Name)
+						}
+						if url == "" {
+							// handle helm3
+							chart, ok := d.Labels["chart"]
+							if ok {
+								idx := strings.LastIndex(chart, "-")
+								if idx > 0 {
+									svcName := chart[0:idx]
+									if svcName != appName && svcName != d.Name {
+										url, _ = services.FindServiceURL(kubeClient, d.Namespace, svcName)
+									}
 								}
 							}
 						}
+						row = append(row, url)
+						appEnvInfo.URL = url
 					}
-					row = append(row, url)
-					appEnvInfo.URL = url
+				} else {
+					if ea.Environment.Spec.Kind != v1.EnvironmentKindTypePreview {
+						row = append(row, "")
+					}
+					if !o.HidePod {
+						row = append(row, "")
+					}
+					if !o.HideUrl {
+						row = append(row, "")
+					}
 				}
 			}
 		}
@@ -280,17 +292,19 @@ func (o *GetApplicationsOptions) generateTableHeaders(envApps []EnvApps) table.T
 	titles := []string{title}
 	for _, ea := range envApps {
 		envName := ea.Environment.Name
-		if ea.Environment.Spec.Kind == v1.EnvironmentKindTypeEdit {
-			envName = "Edit"
-		}
-		if ea.Environment.Spec.Kind != v1.EnvironmentKindTypePreview {
-			titles = append(titles, strings.ToUpper(envName))
-		}
-		if !o.HidePod {
-			titles = append(titles, "PODS")
-		}
-		if !o.HideUrl {
-			titles = append(titles, "URL")
+		if len(ea.Apps) > 0 {
+			if ea.Environment.Spec.Kind == v1.EnvironmentKindTypeEdit {
+				envName = "Edit"
+			}
+			if ea.Environment.Spec.Kind != v1.EnvironmentKindTypePreview {
+				titles = append(titles, strings.ToUpper(envName))
+			}
+			if !o.HidePod {
+				titles = append(titles, "PODS")
+			}
+			if !o.HideUrl {
+				titles = append(titles, "URL")
+			}
 		}
 	}
 	t.AddRow(titles...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is covered by existing or new tests.

#### Description

This fixes that the details about each application from `jx get applications` doesn't align to the headers of the correct environment unless all application are running in all environment.

Also environments without any running apps (typically edit environments) are now skipped.

So instead of `jx get apps -pu` giving:
```
APPLICATION               EDIT   PRODUCTION STAGING TEST
jx-aws-cluster-autoscaler 0.9.0
jx-charter-trailer        1.0.39 1.0.40     1.0.40
jx-meta-airhotel-control  0.0.15
jx-sms                    1.0.20 1.0.20
selenium-grid-exporter    7
```

The output becomes:
```
APPLICATION               PRODUCTION STAGING TEST
jx-aws-cluster-autoscaler 0.9.0
jx-charter-trailer        1.0.39     1.0.40  1.0.40
jx-meta-airhotel-control             0.0.15
jx-sms                    1.0.20     1.0.20
selenium-grid-exporter                       7
```
