### PR TITLE
fix: add caching into the build number generator

### DIFF
--- a/pkg/buildnum/build_num_gen.go
+++ b/pkg/buildnum/build_num_gen.go
@@ -16,7 +16,7 @@ type PipelineActivityBuildNumGen struct {
 	//pipelineID->Mutex to serialise build number generation for a given pipeline ID.
 	pipelineMutexes  map[string]*sync.Mutex
 	activitiesGetter v1.PipelineActivityInterface
-	pipelineCache  *kube.PipelineNamespaceCache
+	pipelineCache    *kube.PipelineNamespaceCache
 }
 
 // NewCRDBuildNumGen initialises a new PipelineActivityBuildNumGen that will use the supplied
@@ -25,7 +25,7 @@ func NewCRDBuildNumGen(jxClient versioned.Interface, ns string) *PipelineActivit
 	return &PipelineActivityBuildNumGen{
 		mutex:            &sync.Mutex{},
 		pipelineMutexes:  make(map[string]*sync.Mutex),
-		pipelineCache: kube.NewPipelineCache(jxClient, ns),
+		pipelineCache:    kube.NewPipelineCache(jxClient, ns),
 		activitiesGetter: jxClient.JenkinsV1().PipelineActivities(ns),
 	}
 }

--- a/pkg/jx/cmd/serve_buildnumbers.go
+++ b/pkg/jx/cmd/serve_buildnumbers.go
@@ -64,8 +64,7 @@ func (o *ServeBuildNumbersOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	activities := jxClient.JenkinsV1().PipelineActivities(ns)
-	buildNumGen := buildnum.NewCRDBuildNumGen(activities)
+	buildNumGen := buildnum.NewCRDBuildNumGen(jxClient, ns)
 
 	httpBuildNumServer := buildnum.NewHTTPBuildNumberServer(o.BindAddress, o.Port, buildNumGen)
 	return httpBuildNumServer.Start()

--- a/pkg/jx/cmd/start_pipeline.go
+++ b/pkg/jx/cmd/start_pipeline.go
@@ -122,6 +122,7 @@ func (o *StartPipelineOptions) Run() error {
 			if err != nil {
 				return err
 			}
+			names = util.StringsContaining(names, o.Filter)
 		} else {
 			jobMap, err := o.getJobMap(o.Filter)
 			if err != nil {

--- a/pkg/jx/cmd/step_next_buildnumber.go
+++ b/pkg/jx/cmd/step_next_buildnumber.go
@@ -81,8 +81,7 @@ func (o *StepNextBuildNumberOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	activities := jxClient.JenkinsV1().PipelineActivities(ns)
-	buildNumGen := buildnum.NewCRDBuildNumGen(activities)
+	buildNumGen := buildnum.NewCRDBuildNumGen(jxClient, ns)
 
 	pID := kube.NewPipelineID(o.Owner, o.Repository, o.Branch)
 

--- a/pkg/kube/activity.go
+++ b/pkg/kube/activity.go
@@ -119,15 +119,9 @@ func CreatePipelineDetails(activity *v1.PipelineActivity) *PipelineDetails {
 }
 
 // GenerateBuildNumber generates a new build number for the given pipeline
-func GenerateBuildNumber(activities typev1.PipelineActivityInterface, pn PipelineID) (string, *v1.PipelineActivity, error) {
+func GenerateBuildNumber(activities typev1.PipelineActivityInterface, pipelines []*v1.PipelineActivity, pn PipelineID) (string, *v1.PipelineActivity, error) {
 	buildCounter := 0
-	pipelines, err := activities.List(metav1.ListOptions{})
-
-	if err != nil {
-		return "", nil, err
-	}
-
-	for _, pipeline := range pipelines.Items {
+	for _, pipeline := range pipelines {
 		if strings.EqualFold(pipeline.Spec.Pipeline, pn.ID) {
 			b := pipeline.Spec.Build
 			if b != "" {

--- a/pkg/kube/pipeline_cache.go
+++ b/pkg/kube/pipeline_cache.go
@@ -1,0 +1,87 @@
+package kube
+
+import (
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/log"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+	"sort"
+	"time"
+)
+
+// PipelineNamespaceCache caches the pipelines for a single namespace
+type PipelineNamespaceCache struct {
+	pipelines map[string]*v1.PipelineActivity
+}
+
+// NewPipelineCache creates a cache of pipelines for a namespace
+func NewPipelineCache(jxClient versioned.Interface, ns string) *PipelineNamespaceCache {
+	pipeline := &v1.PipelineActivity{}
+	stop := make(chan struct{})
+	pipelineListWatch := cache.NewListWatchFromClient(jxClient.JenkinsV1().RESTClient(), "pipelineactivities", ns, fields.Everything())
+
+	namespaceCache := &PipelineNamespaceCache{
+		pipelines: map[string]*v1.PipelineActivity{},
+	}
+
+	_, pipelineController := cache.NewInformer(
+		pipelineListWatch,
+		pipeline,
+		time.Minute*10,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				namespaceCache.onPipelineObj(obj, jxClient, ns)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				namespaceCache.onPipelineObj(newObj, jxClient, ns)
+			},
+			DeleteFunc: func(obj interface{}) {
+				namespaceCache.onPipelineDelete(obj, jxClient, ns)
+			},
+		},
+	)
+
+	go pipelineController.Run(stop)
+
+	return namespaceCache
+}
+
+// Pipelines returns the pipelines in this namespace sorted in name order
+func (c *PipelineNamespaceCache) Pipelines() []*v1.PipelineActivity {
+	answer := []*v1.PipelineActivity{}
+	names := []string{}
+	for k := range c.pipelines {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		pipeline := c.pipelines[name]
+		if pipeline != nil {
+			answer = append(answer, pipeline)
+		}
+	}
+	return answer
+}
+
+func (c *PipelineNamespaceCache) onPipelineObj(obj interface{}, jxClient versioned.Interface, ns string) {
+	pipeline, ok := obj.(*v1.PipelineActivity)
+	if !ok {
+		log.Warnf("Object is not a PipelineActivity %#v\n", obj)
+		return
+	}
+	if pipeline != nil {
+		c.pipelines[pipeline.Name] = pipeline
+	}
+}
+
+func (c *PipelineNamespaceCache) onPipelineDelete(obj interface{}, jxClient versioned.Interface, ns string) {
+	pipeline, ok := obj.(*v1.PipelineActivity)
+	if !ok {
+		log.Warnf("Object is not a PipelineActivity %#v\n", obj)
+		return
+	}
+	if pipeline != nil {
+		delete(c.pipelines, pipeline.Name)
+	}
+}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -131,6 +131,21 @@ func StringMatchesPattern(text string, pattern string) bool {
 	return text == pattern
 }
 
+
+// StringsContaining if the filter is not empty return all the strings which contain the text
+func StringsContaining(slice []string, filter string) []string {
+	if filter == "" {
+		return slice
+	}
+	answer := []string{}
+	for _, text := range slice {
+		if strings.Contains(text, filter) {
+			answer = append(answer, text)
+		}
+	}
+	return answer
+}
+
 // RandStringBytesMaskImprSrc returns a random hexadecimal string of length n.
 func RandStringBytesMaskImprSrc(n int) (string, error) {
 	src := rand.New(rand.NewSource(time.Now().UnixNano()))


### PR DESCRIPTION
so we don't have to wait to List all PipelineActivity resources every time we need a build number; instead we only do it on startup of the build number generator

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
