### PR TITLE
feat(cli): add --no-comment flag to `jx preview` cmd

### DIFF
--- a/pkg/jx/cmd/preview.go
+++ b/pkg/jx/cmd/preview.go
@@ -75,6 +75,7 @@ type PreviewOptions struct {
 	GitConfDir      string
 	GitProvider     gits.GitProvider
 	GitInfo         *gits.GitRepository
+	NoComment       bool
 
 	// calculated fields
 	PostPreviewJobTimeoutDuration time.Duration
@@ -138,6 +139,7 @@ func (options *PreviewOptions) addPreviewOptions(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&options.SourceRef, "source-ref", "", "", "The source code git ref (branch/sha)")
 	cmd.Flags().StringVarP(&options.PostPreviewJobTimeout, optionPostPreviewJobTimeout, "", "2h", "The duration before we consider the post preview Jobs failed")
 	cmd.Flags().StringVarP(&options.PostPreviewJobPollTime, optionPostPreviewJobPollTime, "", "10s", "The amount of time between polls for the post preview Job status")
+	cmd.Flags().BoolVarP(&options.NoComment, "no-comment", "", false, "Disables commenting on the Pull Request after preview is created.")
 }
 
 // Run implements the command
@@ -557,7 +559,9 @@ func (o *PreviewOptions) Run() error {
 		},
 	}
 	stepPRCommentOptions.BatchMode = true
-	err = stepPRCommentOptions.Run()
+	if !o.NoComment {
+		err = stepPRCommentOptions.Run()
+	}
 	if err != nil {
 		log.Warnf("Failed to comment on the Pull Request with owner %s repo %s: %s\n", o.GitInfo.Organisation, o.GitInfo.Name, err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Adds a `--no-comment`flag to the `jx preview` command which in turn determines whether 

#### Special notes for the reviewer(s)

Any tests I can write/append here?

#### Which issue this PR fixes

fixes #2664

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
