### PR TITLE
fix(preview): when deleting the preview, also purge the helm release

### DIFF
--- a/charts/jx/templates/clusterrolebinding.yaml
+++ b/charts/jx/templates/clusterrolebinding.yaml
@@ -11,7 +11,11 @@ roleRef:
   name: {{ template "jx.name" . }}-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
+{{- if .Values.serviceaccount.customName }}
+  name: {{ .Values.serviceaccount.customName }}
+{{- else }}
   name: {{ template "jx.fullname" . }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/charts/jx/templates/cronjob.yaml
+++ b/charts/jx/templates/cronjob.yaml
@@ -24,7 +24,9 @@ spec:
     {{- if .Values.restartPolicy }}
           restartPolicy: {{ .Values.restartPolicy }}
     {{- end }}
-    {{- if .Values.serviceaccount.enabled }}
+    {{- if .Values.serviceaccount.customName }}
+          serviceAccountName: {{ .Values.serviceaccount.customName }}
+    {{- else if .Values.serviceaccount.enabled }}
           serviceAccountName: {{ template "jx.fullname" . }}
     {{- end }}
           containers:

--- a/charts/jx/templates/deployment.yaml
+++ b/charts/jx/templates/deployment.yaml
@@ -24,7 +24,9 @@ spec:
 {{- if .Values.restartPolicy }}
       restartPolicy: {{ .Values.restartPolicy }}
 {{- end }}
-{{- if .Values.serviceaccount.enabled }}
+{{- if .Values.serviceaccount.customName }}
+      serviceAccountName: {{ .Values.serviceaccount.customName }}
+{{- else if .Values.serviceaccount.enabled }}
       serviceAccountName: {{ template "jx.fullname" . }}
 {{- end }}
       containers:

--- a/charts/jx/templates/rolebinding.yaml
+++ b/charts/jx/templates/rolebinding.yaml
@@ -11,7 +11,11 @@ roleRef:
   name: {{ template "jx.name" . }}
 subjects:
 - kind: ServiceAccount
+{{- if .Values.serviceaccount.customName }}
+  name: {{ .Values.serviceaccount.customName }}
+{{- else }}
   name: {{ template "jx.fullname" . }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/charts/jx/templates/serviceaccount.yaml
+++ b/charts/jx/templates/serviceaccount.yaml
@@ -2,7 +2,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- if .Values.serviceaccount.customName }}
+  name: {{ .Values.serviceaccount.customName }}
+{{- else }}
   name: {{ template "jx.fullname" . }}
+{{- end }}
   labels:
     app: {{ template "jx.name" . }}
     chart: {{ template "jx.chart" . }}

--- a/charts/jx/values.yaml
+++ b/charts/jx/values.yaml
@@ -26,6 +26,7 @@ cronjob:
 
 serviceaccount:
   enabled: false
+  customName: ""
 
 role:
   enabled: false

--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -313,7 +313,10 @@ func (o *CommonOptions) SetGit(git gits.Gitter) {
 
 func (o *CommonOptions) Helm() helm.Helmer {
 	if o.helm == nil {
-		helmBinary, noTiller, helmTemplate, _ := o.TeamHelmBin()
+		helmBinary, noTiller, helmTemplate, err := o.TeamHelmBin()
+		if err != nil {
+			log.Warnf("Failed to retrieve team settings: %v - falling back to default settings...\n", err)
+		}
 		o.helm = o.CreateHelm(o.Verbose, helmBinary, noTiller, helmTemplate)
 	}
 	return o.helm

--- a/pkg/jx/cmd/delete_preview.go
+++ b/pkg/jx/cmd/delete_preview.go
@@ -98,6 +98,24 @@ func (o *DeletePreviewOptions) Run() error {
 }
 
 func (o *DeletePreviewOptions) deletePreview(name string) error {
+	jxClient, ns, err := o.JXClient()
+	if err != nil {
+		return err
+	}
+
+	environment, err := kube.GetEnvironment(jxClient, ns, name)
+	if err != nil {
+		return err
+	}
+	releaseName := kube.GetPreviewEnvironmentReleaseName(environment)
+	if len(releaseName) > 0 {
+		log.Infof("Deleting helm release: %s\n", util.ColorInfo(releaseName))
+		err = o.Helm().DeleteRelease(ns, releaseName, true)
+		if err != nil {
+			return err
+		}
+	}
+
 	log.Infof("Deleting preview environment: %s\n", util.ColorInfo(name))
 	deleteOptions := &DeleteEnvOptions{
 		CommonOptions:   o.CommonOptions,

--- a/pkg/jx/cmd/gc_previews.go
+++ b/pkg/jx/cmd/gc_previews.go
@@ -12,7 +12,7 @@ import (
 
 	"strings"
 
-	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -124,12 +124,14 @@ func (o *GCPreviewsOptions) Run() error {
 
 			if strings.HasPrefix(lowerState, "clos") || strings.HasPrefix(lowerState, "merged") || strings.HasPrefix(lowerState, "superseded") || strings.HasPrefix(lowerState, "declined") {
 				// lets delete the preview environment
-				deleteOpts := DeleteEnvOptions{
-					DeleteNamespace: true,
-					CommonOptions:   o.CommonOptions,
+				deleteOpts := DeletePreviewOptions{
+					PreviewOptions: PreviewOptions{
+						PromoteOptions: PromoteOptions{
+							CommonOptions: o.CommonOptions,
+						},
+					},
 				}
-				deleteOpts.CommonOptions.Args = []string{e.Name}
-				err = deleteOpts.Run()
+				err = deleteOpts.deletePreview(e.Name)
 				if err != nil {
 					return fmt.Errorf("failed to delete preview environment %s: %v\n", e.Name, err)
 				}

--- a/pkg/jx/cmd/preview_test.go
+++ b/pkg/jx/cmd/preview_test.go
@@ -40,6 +40,7 @@ import (
 // Constants for some test data to be used.
 const (
 	application    = "test-app"
+	releaseName    = "test-app-release-name"
 	name           = "test-app-name"
 	namespace      = "jx"
 	gitHubLink     = "https://github.com/an-org/a-repo"
@@ -179,6 +180,7 @@ func setupMocks() (*cmd.PreviewOptions, *cs_fake.Clientset) {
 				BatchMode: true,
 			},
 			Application: application,
+			ReleaseName: releaseName,
 		},
 		Namespace:    namespace,
 		DevNamespace: "jx",
@@ -282,6 +284,7 @@ func validatePreviewEnvironment(t *testing.T, cs *cs_fake.Clientset) {
 	assert.NotNil(t, previewEnv)
 	assert.Equal(t, namespace, previewEnv.Namespace)
 	assert.Equal(t, name, previewEnv.Name)
+	assert.Equal(t, releaseName, previewEnv.Annotations[kube.AnnotationReleaseName])
 	//Validate preview environment spec:
 	assert.NotNil(t, previewEnv.Spec)
 	assert.Equal(t, v1.EnvironmentKindTypePreview, previewEnv.Spec.Kind)

--- a/pkg/kube/constants.go
+++ b/pkg/kube/constants.go
@@ -224,6 +224,9 @@ const (
 	// AnnotationIsDefaultStorageClass used to indicate a storageclass is default
 	AnnotationIsDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"
 
+	// AnnotationReleaseName is the name of the annotation that stores the release name in the preview environment
+	AnnotationReleaseName = "jenkins.io/chart-release"
+
 	// SecretDataUsername the username in a Secret/Credentials
 	SecretDataUsername = "username"
 

--- a/pkg/kube/env.go
+++ b/pkg/kube/env.go
@@ -949,3 +949,12 @@ func GetDevEnvironment(jxClient versioned.Interface, ns string) (*v1.Environment
 	return nil, fmt.Errorf("Error fetching dev environment resource definition in namespace %s, No Environment called: %s or with selector: %s found %d entries: %v",
 		ns, name, selector, len(envList.Items), envList.Items)
 }
+
+// GetPreviewEnvironmentReleaseName returns the (helm) release name for the given (preview) environment
+// or the empty string is the environment is not a preview environment, or has no release name associated with it
+func GetPreviewEnvironmentReleaseName(env *v1.Environment) string {
+	if !IsPreviewEnvironment(env) {
+		return ""
+	}
+	return env.Annotations[AnnotationReleaseName]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Instead of just deleting the Environment resource and the associated namespace,
deleting a preview should also delete (purge) the helm release:
- allows to run pre/post-delete helm hooks
- if using std helm - without the template or no-tiller flag - it avoids leaving broken releases behind

Our use-case is that we have charts using hooks to register and cleanup cloud resources. the registration part works well when the chart is deployed in a preview environment, but the delete hooks are never called, because right now the helm release is never deleted.

#### Special notes for the reviewer(s)

Calling helm in the gcpreviews jobs also has impacts on the RBAC setup, because if the team setting is to use a local tiller, then the job will need to have sufficient rights to create/delete resources.
To handle this, I added a new feature in the jx chart: setting a custom service account name. This allows to run a pod with an existing service account, without creating a new one.
I opened another PR in jenkins-x-platform to run the gcpreviews with the jenkins service account (which is cluster-admin): https://github.com/jenkins-x/jenkins-x-platform/pull/4652