### PR TITLE
fix(buildnum): Services fails on repos with underscores

### DIFF
--- a/pkg/kube/activity.go
+++ b/pkg/kube/activity.go
@@ -63,12 +63,14 @@ type PipelineID struct {
 // The string identifier is expected to follow the format `<owner>/>repository>/<branch>`, though this isn't actually
 // validated/mandated here.
 func NewPipelineIDFromString(id string) PipelineID {
+	sanitisedName := strings.Replace(strings.ToLower(id), "/", "-", -1)
+	sanitisedName = strings.Replace(sanitisedName, "_", "-", -1)
 	pID := PipelineID{
 		ID: id,
 		//TODO: disabling the encoding of the name, as it doesn't work for some upper case values. Upshot is conflicts on org/repo/branch that differ only in case.
 		//See https://github.com/jenkins-x/jx/issues/2551
 		//Name: util.EncodeKubernetesName(strings.Replace(id, "/", "-", -1)),
-		Name: strings.Replace(strings.ToLower(id), "/", "-", -1),
+		Name: sanitisedName,
 	}
 	return pID
 }


### PR DESCRIPTION
Trying to build https://github.com/jenkins-x/oauth2_proxy, it fails

eg:
```
time="2019-01-14T14:38:19Z" level=error msg="Unable to get next build number for pipeline jenkins-x/oauth2_proxy/master" error="PipelineActivity.jenkins.io \"jenkins-x-oauth2_proxy-master-1\" is invalid: metadata.name: Invalid value: \"jenkins-x-oauth2_proxy-master-1\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"
```