### PR TITLE
chore(jx) fix file leak in helm template code

### DIFF
--- a/pkg/helm/helm_template.go
+++ b/pkg/helm/helm_template.go
@@ -595,6 +595,7 @@ func splitObjectsInFiles(file string) ([]string, error) {
 	if err != nil {
 		return result, errors.Wrapf(err, "opening file %q", file)
 	}
+	defer f.Close()
 	scanner := bufio.NewScanner(f)
 	var buf bytes.Buffer
 	dir := filepath.Dir(file)
@@ -644,6 +645,7 @@ func writeObjectInFile(buf *bytes.Buffer, dir string, fileName string, count int
 	if err != nil {
 		return "", errors.Wrapf(err, "creating file %q", absFile)
 	}
+	defer file.Close()
 	_, err = buf.WriteTo(file)
 	if err != nil {
 		return "", errors.Wrapf(err, "writing object to file %q", absFile)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

the helm template code had a file leak that caused the tests to fail
when run on a filesystem with strong locking symantics.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2674

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
