### PR TITLE
feat(teams) store the admin namespace in the team

### DIFF
--- a/pkg/jx/cmd/controller_team.go
+++ b/pkg/jx/cmd/controller_team.go
@@ -306,6 +306,11 @@ func (o *ControllerTeamOptions) onTeamChange(obj interface{}, kubeClient kuberne
 			}
 		}
 
+		err = kube.SetAdminNamespace(kubeClient, teamNs, adminNs)
+		if err != nil {
+			log.Errorf("Unable set admin namespace on team %s to %s - %s", util.ColorInfo(teamNs), util.ColorInfo(adminNs), err)
+			return
+		}
 		err = oc.ModifyTeam(adminNs, team.Name, func(team *v1.Team) error {
 			team.Status.ProvisionStatus = v1.TeamProvisionStatusComplete
 			team.Status.Message = "Installation complete"
@@ -315,7 +320,14 @@ func (o *ControllerTeamOptions) onTeamChange(obj interface{}, kubeClient kuberne
 			log.Errorf("Unable to update team %s to %s - %s", util.ColorInfo(teamNs), v1.TeamProvisionStatusComplete, err)
 			return
 		}
+	} else if v1.TeamProvisionStatusComplete == team.Status.ProvisionStatus {
+		err := kube.SetAdminNamespace(kubeClient, teamNs, adminNs)
+		if err != nil {
+			log.Errorf("Unable set admin namespace on team %s to %s - %s", util.ColorInfo(teamNs), util.ColorInfo(adminNs), err)
+			return
+		}
 	}
+
 }
 
 // LoadProwOAuthConfig returns the OAuth Token for Prow

--- a/pkg/kube/teams.go
+++ b/pkg/kube/teams.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const admin_namespace_annotation = "jenkins-x.io/admin-namespace"
+const adminNamespaceAnnotation = "jenkins-x.io/admin-namespace"
 
 // GetAdminNamespace tries to find the admin namespace that corresponds to this team.
 // in other words this is the namespace where the team CRD was initially created when this team was created,
@@ -21,7 +21,7 @@ func GetAdminNamespace(kubeClient kubernetes.Interface, teamNs string) (string, 
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to obtain the team namespace (%s) when getting the admin namespace", teamNs)
 	}
-	adminNs := namespace.Annotations[admin_namespace_annotation]
+	adminNs := namespace.Annotations[adminNamespaceAnnotation]
 	if adminNs != "" {
 		return adminNs, nil
 	}
@@ -35,12 +35,12 @@ func SetAdminNamespace(kubeClient kubernetes.Interface, teamNs string , adminNs 
 	if err != nil {
 		return errors.Wrapf(err, "Failed to update the obtain the namespace (%s) when updating the admin namespace", teamNs)
 	}
-	oldAdminNs := namespace.Annotations[admin_namespace_annotation]
+	oldAdminNs := namespace.Annotations[adminNamespaceAnnotation]
 	if oldAdminNs == adminNs {
 		// nothing to do
 		return nil
 	}
-	namespace.Annotations[admin_namespace_annotation] = adminNs
+	namespace.Annotations[adminNamespaceAnnotation] = adminNs
 	// TODO use patch
 	_, err = kubeClient.CoreV1().Namespaces().Update(namespace)
 	return err

--- a/pkg/kube/teams.go
+++ b/pkg/kube/teams.go
@@ -19,7 +19,7 @@ const adminNamespaceAnnotation = "jenkins-x.io/admin-namespace"
 func GetAdminNamespace(kubeClient kubernetes.Interface, teamNs string) (string, error) {
 	namespace, err := kubeClient.CoreV1().Namespaces().Get(teamNs, metav1.GetOptions{})
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to obtain the team namespace (%s) when getting the admin namespace", teamNs)
+		return "", errors.Wrapf(err, "obtaining the team namespace (%s) when getting the admin namespace", teamNs)
 	}
 	adminNs := namespace.Annotations[adminNamespaceAnnotation]
 	if adminNs != "" {
@@ -33,7 +33,7 @@ func GetAdminNamespace(kubeClient kubernetes.Interface, teamNs string) (string, 
 func SetAdminNamespace(kubeClient kubernetes.Interface, teamNs string , adminNs string) error {
 	namespace, err := kubeClient.CoreV1().Namespaces().Get(teamNs, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "Failed to update the obtain the namespace (%s) when updating the admin namespace", teamNs)
+		return errors.Wrapf(err, "obtaining the namespace (%s) when updating the admin namespace", teamNs)
 	}
 	oldAdminNs := namespace.Annotations[adminNamespaceAnnotation]
 	if oldAdminNs == adminNs {

--- a/pkg/kube/teams.go
+++ b/pkg/kube/teams.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const ADMIN_NAMESPACE_ANNOTATION = "jenkins-x.io/admin-namespace"
+const admin_namespace_annotation = "jenkins-x.io/admin-namespace"
 
 // GetAdminNamespace tries to find the admin namespace that corresponds to this team.
 // in other words this is the namespace where the team CRD was initially created when this team was created,
@@ -21,7 +21,7 @@ func GetAdminNamespace(kubeClient kubernetes.Interface, teamNs string) (string, 
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to obtain the team namespace (%s) when getting the admin namespace", teamNs)
 	}
-	adminNs := namespace.Annotations[ADMIN_NAMESPACE_ANNOTATION]
+	adminNs := namespace.Annotations[admin_namespace_annotation]
 	if adminNs != "" {
 		return adminNs, nil
 	}
@@ -35,12 +35,12 @@ func SetAdminNamespace(kubeClient kubernetes.Interface, teamNs string , adminNs 
 	if err != nil {
 		return errors.Wrapf(err, "Failed to update the obtain the namespace (%s) when updating the admin namespace", teamNs)
 	}
-	oldAdminNs := namespace.Annotations[ADMIN_NAMESPACE_ANNOTATION]
+	oldAdminNs := namespace.Annotations[admin_namespace_annotation]
 	if oldAdminNs == adminNs {
 		// nothing to do
 		return nil
 	}
-	namespace.Annotations[ADMIN_NAMESPACE_ANNOTATION] = adminNs
+	namespace.Annotations[admin_namespace_annotation] = adminNs
 	// TODO use patch
 	_, err = kubeClient.CoreV1().Namespaces().Update(namespace)
 	return err

--- a/pkg/kube/teams_test.go
+++ b/pkg/kube/teams_test.go
@@ -1,0 +1,108 @@
+package kube
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"testing"
+
+	kube_mocks "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetAdminNamespace(t *testing.T) {
+	t.Parallel()
+	namespace := `apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    jenkins-x.io/created-by: Jenkins X
+    jenkins-x.io/admin-namespace: admin-namespace
+  labels:
+    env: dev
+    team: myteam
+  name: myteam
+status:
+  phase: Active`
+
+	client, err := createMockClient(namespace)
+	require.NoError(t, err, "failed to create mock client")
+	adminNamespace, err := GetAdminNamespace(client, "myteam")
+	assert.NoError(t, err, "GetAdminNamespace should not error")
+	assert.Equal(t, "admin-namespace", adminNamespace)
+}
+
+func TestGetAdminNamespaceDefaulted(t *testing.T) {
+	t.Parallel()
+	namespace := `apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    jenkins-x.io/created-by: Jenkins X
+  labels:
+    env: dev
+    team: myteam
+  name: myteam
+status:
+  phase: Active`
+
+	client, err := createMockClient(namespace)
+	require.NoError(t, err, "failed to create mock client")
+	adminNamespace, err := GetAdminNamespace(client, "myteam")
+	assert.NoError(t, err, "error occurred calling GetAdminNamespace")
+	assert.Equal(t, "myteam", adminNamespace)
+}
+
+// TestGetAdminNamespaceOnNonTeam tests that when there are no annotations the code does not blow up.
+// there should always be one annotation "jenkins-x.io/created-by: Jenkins X" for a team but better to not blow up
+func TestGetAdminNamespaceOnNonTeam(t *testing.T) {
+
+	t.Parallel()
+	namespace := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: myteam
+status:
+  phase: Active`
+
+	client, err := createMockClient(namespace)
+	require.NoError(t, err, "failed to create mock client")
+	adminNamespace, err := GetAdminNamespace(client, "myteam")
+	assert.NoError(t, err, "error occurred calling GetAdminNamespace")
+	assert.Equal(t, "myteam", adminNamespace)
+}
+
+func TestSetAdminNamespace(t *testing.T) {
+	t.Parallel()
+	namespace := `apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    jenkins-x.io/created-by: Jenkins X
+  labels:
+    env: dev
+    team: myteam
+  name: myteam
+status:
+  phase: Active`
+	client, err := createMockClient(namespace)
+	require.NoError(t, err, "failed to create mock client")
+	err = SetAdminNamespace(client, "myteam", "my-admin-namespace")
+	assert.NoError(t, err, "error occurred calling SetAdminNamespace")
+	adminNs, err := GetAdminNamespace(client, "myteam")
+	assert.NoError(t, err, "error occurred calling GetAdminNamespace")
+	assert.Equal(t, "my-admin-namespace" ,adminNs)
+}
+
+func createMockClient(nsJson string) (kubernetes.Interface, error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, _, err := decode([]byte(nsJson), nil, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not decode data")
+	}
+
+	mockKubeClient := kube_mocks.NewSimpleClientset(obj)
+	//ki, bool := mockKubeClient.(kubernetes.Interface)
+	return mockKubeClient, nil
+}

--- a/pkg/kube/teams_test.go
+++ b/pkg/kube/teams_test.go
@@ -95,9 +95,9 @@ status:
 	assert.Equal(t, "my-admin-namespace" ,adminNs)
 }
 
-func createMockClient(nsJson string) (kubernetes.Interface, error) {
+func createMockClient(objDef string) (kubernetes.Interface, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
-	obj, _, err := decode([]byte(nsJson), nil, nil)
+	obj, _, err := decode([]byte(objDef), nil, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not decode data")
 	}

--- a/pkg/kube/teams_test.go
+++ b/pkg/kube/teams_test.go
@@ -103,6 +103,5 @@ func createMockClient(objDef string) (kubernetes.Interface, error) {
 	}
 
 	mockKubeClient := kube_mocks.NewSimpleClientset(obj)
-	//ki, bool := mockKubeClient.(kubernetes.Interface)
 	return mockKubeClient, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Various commands need to know where the admin namespace is, this change
now records the admin namespace for a team as an annotation on the team

It will also update any existing teams with the annotation when the team
controller is run.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2662

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
