### PR TITLE
fix: re-add support for `jx start protection`

### DIFF
--- a/pkg/jx/cmd/start_protection.go
+++ b/pkg/jx/cmd/start_protection.go
@@ -18,7 +18,7 @@ import (
 
 // StartProtectionOptions contains the command line options
 type StartProtectionOptions struct {
-	GetOptions
+	CommonOptions
 
 	Tail   bool
 	Filter string
@@ -45,14 +45,12 @@ var (
 // NewCmdStartProtection creates the command
 func NewCmdStartProtection(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
 	options := &StartProtectionOptions{
-		GetOptions: GetOptions{
-			CommonOptions: CommonOptions{
-				Factory: f,
-				In:      in,
+		CommonOptions: CommonOptions{
+			Factory: f,
+			In:      in,
 
-				Out: out,
-				Err: errOut,
-			},
+			Out: out,
+			Err: errOut,
 		},
 	}
 

--- a/pkg/jx/cmd/start_protection_test.go
+++ b/pkg/jx/cmd/start_protection_test.go
@@ -1,0 +1,62 @@
+package cmd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/prow/config"
+
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/helm/mocks"
+	"github.com/jenkins-x/jx/pkg/prow"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd"
+)
+
+const (
+	protectionRepoName = "test-repo"
+	protectionOrgName  = "test-org"
+	protectionContext  = "test-context"
+)
+
+func TestStartProtection(t *testing.T) {
+	o := cmd.StartProtectionOptions{
+		CommonOptions: cmd.CommonOptions{},
+	}
+
+	cmd.ConfigureTestOptionsWithResources(&o.CommonOptions,
+		[]runtime.Object{},
+		[]runtime.Object{},
+		&gits.GitFake{},
+		helm_test.NewMockHelmer(),
+	)
+
+	kubeClient, ns, err := o.KubeClientAndDevNamespace()
+	assert.NoError(t, err)
+	// First configure a repo in prow
+	repo := fmt.Sprintf("%s/%s", protectionOrgName, protectionRepoName)
+	repos := []string{repo}
+	err = prow.AddApplication(kubeClient, repos, ns, "")
+	defer func() {
+		err = prow.DeleteApplication(kubeClient, repos, ns)
+		assert.NoError(t, err)
+	}()
+	assert.NoError(t, err)
+
+	o.Args = []string{protectionContext, repo}
+	err = o.Run()
+	assert.NoError(t, err)
+	prowOptions := prow.Options{
+		Kind:       config.Protection,
+		KubeClient: kubeClient,
+		NS:         ns,
+	}
+	prowConfig, _, err := prowOptions.GetProwConfig()
+	assert.NoError(t, err)
+	contexts, err := config.GetBranchProtectionContexts(protectionOrgName, protectionRepoName, prowConfig)
+	assert.Equal(t, []string{protectionContext}, contexts)
+
+}

--- a/pkg/prow/config/branch_protection.go
+++ b/pkg/prow/config/branch_protection.go
@@ -45,6 +45,10 @@ func AddRepoToBranchProtection(bp *config.BranchProtection, repoSpec string, con
 		if !util.Contains(contexts, PromotionBuild) {
 			contexts = append(contexts, PromotionBuild)
 		}
+	case Protection:
+		if !util.Contains(contexts, context) {
+			contexts = append(contexts, context)
+		}
 	default:
 		return fmt.Errorf("unknown Prow config kind %s", kind)
 	}

--- a/pkg/prow/config/branch_protection.go
+++ b/pkg/prow/config/branch_protection.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
@@ -20,9 +21,12 @@ func AddRepoToBranchProtection(bp *config.BranchProtection, repoSpec string, con
 	}
 	requiredOrg, requiredRepo := url.Organisation, url.Name
 	if _, ok := bp.Orgs[requiredOrg]; !ok {
-		bp.Orgs[requiredOrg] = config.Org{
-			Repos: make(map[string]config.Repo, 0),
-		}
+		bp.Orgs[requiredOrg] = config.Org{}
+	}
+	if bp.Orgs[requiredOrg].Repos == nil {
+		org := bp.Orgs[requiredOrg]
+		org.Repos = make(map[string]config.Repo, 0)
+		bp.Orgs[requiredOrg] = org
 	}
 	if _, ok := bp.Orgs[requiredOrg].Repos[requiredRepo]; !ok {
 		bp.Orgs[requiredOrg].Repos[requiredRepo] = config.Repo{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)
Oops, told @agentgonzo this wasn't needed anymore, when in fact it is :-)

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
