### PR TITLE
fix(previews): add helm/tiller/kubectl in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM centos:7
 
+ENV HELM_VERSION 2.12.2
+RUN curl -f https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz  | tar xzv && \
+  mv linux-amd64/helm /usr/bin/ && \
+  mv linux-amd64/tiller /usr/bin/ && \
+  rm -rf linux-amd64
+
+RUN curl -f -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+  chmod +x kubectl && \
+  mv kubectl /usr/bin/
+
 ENTRYPOINT ["jx", "version"]
 
 COPY ./build/linux/jx /usr/bin/jx


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

adding the `helm`, `tiller` and `kubectl` binaries in the docker image, so that we can run "helm delete" from inside the gcpreviews jobs

#### Special notes for the reviewer(s)

This is a proposed fix for https://github.com/jenkins-x/jx/issues/2723 - another option would be to use the `jenkinsxio/builder-base` docker image in the gcpreviews jobs, but then we'll need to add the version in the values.yaml file, and find a way to setup updatebot to update it automatically...

#### Which issue this PR fixes

fixes #2723
