### PR TITLE
Make bdd reports optional

### DIFF
--- a/pkg/jx/cmd/step_bdd.go
+++ b/pkg/jx/cmd/step_bdd.go
@@ -401,6 +401,9 @@ func (o *StepBDDOptions) runTests(gopath string) error {
 
 func (o *StepBDDOptions) copyReports(testDir string, err error) error {
 	reportsDir := filepath.Join(testDir, "reports")
+	if _, err := os.Stat(reportsDir); os.IsNotExist(err) {
+		return nil
+	}
 	reportsOutputDir := o.Flags.ReportsOutputDir
 	if reportsOutputDir == "" {
 		reportsOutputDir = "reports"


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Not all BDD tests that use `jx step bdd` may be creating a `reports` directory and the command currently fails if it does not exist.
