### PR TITLE
fix: allow `jx get build logs jobName` to be used with prow

### DIFF
--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -589,7 +589,7 @@ func (o *CommonOptions) retryQuiet(attempts int, sleep time.Duration, call func(
 				dot = false
 				log.Blank()
 			}
-			log.Infof("%s\n", lastMessage)
+			log.Warnf("%s\n\n", lastMessage)
 		}
 	}
 	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)

--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -555,7 +555,7 @@ func (o *CommonOptions) retry(attempts int, sleep time.Duration, call func() err
 
 		time.Sleep(sleep)
 
-		log.Infof("\nretrying after error:%s\n", err)
+		log.Warnf("\nretrying after error:%s\n\n", err)
 	}
 	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
 }
@@ -626,7 +626,7 @@ func (o *CommonOptions) retryQuietlyUntilTimeout(timeout time.Duration, sleep ti
 				dot = false
 				log.Blank()
 			}
-			log.Infof("%s\n", lastMessage)
+			log.Warnf("%s\n\n", lastMessage)
 		}
 	}
 }

--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -1625,6 +1625,15 @@ func (o *CommonOptions) installProw() error {
 	kvalues := []string{"build.auth.git.username=" + o.Username, "build.auth.git.password=" + o.OAUTHToken}
 	kvalues = append(kvalues, setValues...)
 
+	settings, err := o.TeamSettings()
+	if err != nil {
+	  return err
+	}
+	if settings.HelmTemplate || settings.NoTiller || settings.HelmBinary != "helm" {
+		// lets disable tiller
+		kvalues = append(kvalues, "tillerNamespace=")
+	}
+
 	err = o.retry(2, time.Second, func() (err error) {
 		return o.installChart(kube.DefaultKnativeBuildReleaseName, kube.ChartKnativeBuild, "", devNamespace, true,
 			kvalues, nil, "")

--- a/pkg/jx/cmd/get_build_logs.go
+++ b/pkg/jx/cmd/get_build_logs.go
@@ -285,7 +285,7 @@ func (o *GetBuildLogsOptions) getProwBuildLog(kubeClient kubernetes.Interface, j
 		}
 	}
 	if build == nil {
-		return fmt.Errorf("No Pipeline found for name %s in values: %", name, strings.Join(names, ", "))
+		return fmt.Errorf("No Pipeline found for name %s in values: %s", name, strings.Join(names, ", "))
 	}
 
 	pod := build.Pod

--- a/pkg/jx/cmd/promote.go
+++ b/pkg/jx/cmd/promote.go
@@ -787,7 +787,7 @@ func (o *PromoteOptions) verifyHelmConfigured() error {
 func (o *PromoteOptions) createPromoteKey(env *v1.Environment) *kube.PromoteStepActivityKey {
 	pipeline := o.Pipeline
 	if o.Build == "" {
-		o.Build = o.Version
+		o.Build = o.getBuildNumber()
 	}
 	build := o.Build
 	buildURL := os.Getenv("BUILD_URL")


### PR DESCRIPTION
which does not need the build number to be included