### PR TITLE
fix: add test case and fix for failure in BDD create cluster tests

### DIFF
--- a/pkg/kube/git_services.go
+++ b/pkg/kube/git_services.go
@@ -108,8 +108,12 @@ func GetServiceKindFromSecrets(kubeClient kubernetes.Interface, ns string, gitSe
 		return "", errors.Wrap(err, "failed to list the secrets")
 	}
 
+	// note sometimes the Git secret is just called 'jx-pipeline-git' if its created as part of
+	// 'jx create cluster --git-provider-url' - so lets handle the missing - on the name
+	secretNamePrefix := strings.TrimSuffix(SecretJenkinsPipelineGitCredentials, "-")
+
 	for _, secret := range secretList.Items {
-		if strings.HasPrefix(secret.GetName(), SecretJenkinsPipelineGitCredentials) {
+		if strings.HasPrefix(secret.GetName(), secretNamePrefix) {
 			annotations := secret.GetAnnotations()
 			url, ok := annotations[AnnotationURL]
 			if !ok {


### PR DESCRIPTION
we don't find the git service kind due to the secret name not having a `-github-ghe` prefix when we create clusters via `jx create cluster gke ... --git-provider-url`