### PR TITLE
Removing nonsensical alias `helm` for `jx get storage`

### DIFF
--- a/pkg/jx/cmd/get_storage.go
+++ b/pkg/jx/cmd/get_storage.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
-// GetStorageOptions containers the CLI options
+// GetStorageOptions contains the CLI options
 type GetStorageOptions struct {
 	GetOptions
 }
@@ -43,7 +43,6 @@ func NewCmdGetStorage(f Factory, in terminal.FileReader, out terminal.FileWriter
 	cmd := &cobra.Command{
 		Use:     "storage",
 		Short:   "Display the storage configuration for different classifications",
-		Aliases: []string{"helm"},
 		Long:    getStorageLong,
 		Example: getStorageExample,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
I presume this was copied from `get_helmbin.go`.