### PR TITLE
fix: do not clean certs on cb addon install

### DIFF
--- a/pkg/jx/cmd/create_addon_cloudbees.go
+++ b/pkg/jx/cmd/create_addon_cloudbees.go
@@ -161,18 +161,11 @@ To register to get your username/password to to: %s
 			return errors.Wrap(err, "ensuring cert-manager is installed")
 		}
 
-		ingressConfig.TLS = true
-		ingressConfig.Issuer = kube.CertmanagerIssuerProd
-		err = kube.CleanCertmanagerResources(client, o.Namespace, ingressConfig)
-		if err != nil {
-			return errors.Wrap(err, "creating cert-manager issuer")
-		}
-
 		values := []string{
 			"sso.create=true",
 			"sso.oidcIssuerUrl=" + dexURL,
 			"sso.domain=" + domain,
-			"sso.certIssuerName=" + ingressConfig.Issuer}
+			"sso.certIssuerName=" + kube.CertmanagerIssuerProd}
 
 		if len(o.SetValues) > 0 {
 			o.SetValues = o.SetValues + "," + strings.Join(values, ",")


### PR DESCRIPTION
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Cleaning certificates and issuers is not needed when installing this addon.
it was generating a full round of new certificate requests which sums up for the rate limit of let's encrypt.
So this is reducing the number of requested certificates when installing the addon.

#### Special notes for the reviewer(s)

This is based on a conversation with @ccojocar, he told me there is no need to recreate all certificates because a separate certificate request would be done for the addon automatically. I've tested this locally and it works fine (the certificate is issued correctly).
