### PR TITLE
fix(import): Use the gitAuth specified by the user when doing `jx import`

### DIFF
--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -327,7 +327,11 @@ func (options *ImportOptions) Run() error {
 
 	if options.RepoURL != "" {
 		if shouldClone {
-			// lets make sure there's a .git at the end for GitHub URLs
+			// Use the git user auth to clone the repo (needed for private repos etc)
+			options.RepoURL, err = options.Git().CreatePushURL(options.RepoURL, userAuth)
+			if err != nil {
+				return err
+			}
 			err = options.CloneRepository()
 			if err != nil {
 				return err
@@ -410,7 +414,6 @@ func (options *ImportOptions) Run() error {
 			return err
 		}
 	}
-
 
 	err = kube.NewSourceRepositoryService(jxClient, ns).CreateOrUpdateSourceRepository(
 		options.AppName, options.Organisation, options.GitProvider.ServerURL())
@@ -1363,7 +1366,7 @@ func (o *ImportOptions) allDraftPacks() ([]string, error) {
 }
 
 // ConfigureImportOptions updates the import options struct based on values from the create repo struct
-func (options *ImportOptions)ConfigureImportOptions(repoData *gits.CreateRepoData) {
+func (options *ImportOptions) ConfigureImportOptions(repoData *gits.CreateRepoData) {
 	// configure the import options based on previous answers
 	options.AppName = repoData.RepoName
 	options.GitProvider = repoData.GitProvider


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
The user/pass/token specified by the user (or fetched from the `gitAuth.yaml` file was not being used when cloning a repo during a `jx import`.
On linux/mac, the CLI took over when doing a push and prompted (again - which is bad) for the user to enter their user/pass
On windows, the push failed (because the `git push` is done via a separate `command` and it didn't like attaching the stdin/out to the new spawned process.

This had two consequences:
1) the push failed on a `jx import`
2) you couldn't clone a private repo (because it didn't have any credentials to do so)

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2514

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
