### PR TITLE
Added Java11 POM detection

### DIFF
--- a/pkg/jx/cmd/common_buildpacks.go
+++ b/pkg/jx/cmd/common_buildpacks.go
@@ -90,19 +90,7 @@ func (o *CommonOptions) invokeDraftPack(i *InvokeDraftPack) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			if len(pack) > 0 {
-				if pack == util.LIBERTY {
-					lpack = filepath.Join(packsDir, "liberty")
-				} else if pack == util.APPSERVER {
-					lpack = filepath.Join(packsDir, "appserver")
-				} else if pack == util.DROPWIZARD {
-					lpack = filepath.Join(packsDir, "dropwizard")
-				} else {
-					log.Warn("Do not know how to handle pack: " + pack)
-				}
-			} else {
-				lpack = filepath.Join(packsDir, "maven")
-			}
+			lpack = filepath.Join(packsDir, pack)
 
 			exists, _ = util.FileExists(lpack)
 			if !exists {

--- a/pkg/util/pom_flavour.go
+++ b/pkg/util/pom_flavour.go
@@ -6,9 +6,11 @@ import (
 )
 
 const (
-	APPSERVER  = "appserver"
-	LIBERTY    = "liberty"
-	DROPWIZARD = "dropwizard"
+	MAVEN          = "maven"
+	MAVEN_JAVA11   = "maven-java11"
+	APPSERVER      = "appserver"
+	LIBERTY        = "liberty"
+	DROPWIZARD     = "dropwizard"
 )
 
 func PomFlavour(path string) (string, error) {
@@ -29,7 +31,9 @@ func PomFlavour(path string) (string, error) {
 	if strings.Contains(s, "<groupId>org.apache.tomcat") {
 		return APPSERVER, nil
 	}
+	if strings.Contains(s, "<java.version>11</java.version>") {
+		return MAVEN_JAVA11, nil
+	}
 
-	return "", nil
-
+	return MAVEN, nil
 }

--- a/pkg/util/pom_flavour_test.go
+++ b/pkg/util/pom_flavour_test.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMavenIsDefault(t *testing.T) {
+	t.Parallel()
+
+	file, err := ioutil.TempFile("", "jx_test")
+	assert.Nil(t, err)
+	err = ioutil.WriteFile(file.Name(), []byte(""), 0600)
+	assert.Nil(t, err)
+	flavour, err := PomFlavour(file.Name())
+	assert.Nil(t, err)
+	assert.Equal(t, MAVEN, flavour)
+}
+
+func TestMavenJava11Detection(t *testing.T) {
+	t.Parallel()
+
+	file, err := ioutil.TempFile("", "jx_test")
+	assert.Nil(t, err)
+	err = ioutil.WriteFile(file.Name(), []byte("<java.version>11</java.version>"), 0600)
+	assert.Nil(t, err)
+	flavour, err := PomFlavour(file.Name())
+	assert.Nil(t, err)
+	assert.Equal(t, MAVEN_JAVA11, flavour)
+}
+
+func TestLibertyDetection(t *testing.T) {
+	t.Parallel()
+
+	file, err := ioutil.TempFile("", "jx_test")
+	assert.Nil(t, err)
+	err = ioutil.WriteFile(file.Name(), []byte("<groupId>io.dropwizard"), 0600)
+	assert.Nil(t, err)
+	flavour, err := PomFlavour(file.Name())
+	assert.Nil(t, err)
+	assert.Equal(t, DROPWIZARD, flavour)
+}

--- a/pkg/util/pom_flavour_test.go
+++ b/pkg/util/pom_flavour_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,8 @@ func TestMavenIsDefault(t *testing.T) {
 	flavour, err := PomFlavour(file.Name())
 	assert.Nil(t, err)
 	assert.Equal(t, MAVEN, flavour)
+	err = os.Remove(file.Name())
+	assert.Nil(t, err)
 }
 
 func TestMavenJava11Detection(t *testing.T) {
@@ -29,6 +32,8 @@ func TestMavenJava11Detection(t *testing.T) {
 	flavour, err := PomFlavour(file.Name())
 	assert.Nil(t, err)
 	assert.Equal(t, MAVEN_JAVA11, flavour)
+	err = os.Remove(file.Name())
+	assert.Nil(t, err)
 }
 
 func TestLibertyDetection(t *testing.T) {
@@ -41,4 +46,6 @@ func TestLibertyDetection(t *testing.T) {
 	flavour, err := PomFlavour(file.Name())
 	assert.Nil(t, err)
 	assert.Equal(t, DROPWIZARD, flavour)
+	err = os.Remove(file.Name())
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
I've added Java 11 build pack detection for Maven projects.

Also simplified POM flavor detection logic by removing conditional branches that are never executed.