### PR TITLE
feat: add liveness & readiness probe endpoints to build number service.

### DIFF
--- a/pkg/buildnum/build_num_gen.go
+++ b/pkg/buildnum/build_num_gen.go
@@ -2,10 +2,11 @@
 package buildnum
 
 import (
-	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"sync"
 
-	"github.com/jenkins-x/jx/pkg/client/clientset/versioned/typed/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+
+	v1 "github.com/jenkins-x/jx/pkg/client/clientset/versioned/typed/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/kube"
 )
 
@@ -28,6 +29,11 @@ func NewCRDBuildNumGen(jxClient versioned.Interface, ns string) *PipelineActivit
 		pipelineCache:    kube.NewPipelineCache(jxClient, ns),
 		activitiesGetter: jxClient.JenkinsV1().PipelineActivities(ns),
 	}
+}
+
+// Ready returns true if the generator's cache has done its initial load.
+func (g *PipelineActivityBuildNumGen) Ready() bool {
+	return g.pipelineCache.Ready()
 }
 
 // NextBuildNumber returns the next build number for the specified pipeline ID, storing the sequence in K8S.

--- a/pkg/buildnum/http_build_num.go
+++ b/pkg/buildnum/http_build_num.go
@@ -11,6 +11,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	HealthPath = "/health"
+	ReadyPath  = "/ready"
+)
+
 // HTTPBuildNumberServer runs an HTTP server to serve build numbers, similar to Prow's tot
 // (https://github.com/kubernetes/test-infra/tree/master/prow/cmd/tot)
 type HTTPBuildNumberServer struct {
@@ -38,9 +43,25 @@ func NewHTTPBuildNumberServer(bindAddress string, port int, issuer BuildNumberIs
 func (s *HTTPBuildNumberServer) Start() error {
 	mux := http.NewServeMux()
 	mux.Handle(s.path, http.HandlerFunc(s.vend))
+	mux.Handle(HealthPath, http.HandlerFunc(s.health))
+	mux.Handle(ReadyPath, http.HandlerFunc(s.ready))
 
 	logrus.Infof("Serving build numbers at http://%s:%d%s", s.bindAddress, s.port, s.path)
 	return http.ListenAndServe(":"+strconv.Itoa(s.port), mux)
+}
+
+func (s *HTTPBuildNumberServer) health(w http.ResponseWriter, r *http.Request) {
+	logrus.Debug("Health check")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *HTTPBuildNumberServer) ready(w http.ResponseWriter, r *http.Request) {
+	logrus.Debug("Ready check")
+	if s.issuer.Ready() {
+		w.WriteHeader(http.StatusNoContent)
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
 }
 
 // Serve an incoming request to the server's base URL (default: /vend). The generated build number (or other

--- a/pkg/buildnum/http_build_num.go
+++ b/pkg/buildnum/http_build_num.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
+	// The URL path for the HTTP endpoint that returns health status.
 	HealthPath = "/health"
-	ReadyPath  = "/ready"
+	// The URL path for the HTTP endpoint that returns ready status.
+	ReadyPath = "/ready"
 )
 
 // HTTPBuildNumberServer runs an HTTP server to serve build numbers, similar to Prow's tot
@@ -50,11 +52,13 @@ func (s *HTTPBuildNumberServer) Start() error {
 	return http.ListenAndServe(":"+strconv.Itoa(s.port), mux)
 }
 
+// health returns either HTTP 204 if the build number service is healthy, otherwise nothing ('cos it's dead).
 func (s *HTTPBuildNumberServer) health(w http.ResponseWriter, r *http.Request) {
 	logrus.Debug("Health check")
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// ready returns either HTTP 204 if the build number service is ready to serve /vend requests, otherwise HTTP 503.
 func (s *HTTPBuildNumberServer) ready(w http.ResponseWriter, r *http.Request) {
 	logrus.Debug("Ready check")
 	if s.issuer.Ready() {

--- a/pkg/buildnum/http_build_num.go
+++ b/pkg/buildnum/http_build_num.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	// The URL path for the HTTP endpoint that returns health status.
+	// HealthPath is the URL path for the HTTP endpoint that returns health status.
 	HealthPath = "/health"
-	// The URL path for the HTTP endpoint that returns ready status.
+	// ReadyPath URL path for the HTTP endpoint that returns ready status.
 	ReadyPath = "/ready"
 )
 

--- a/pkg/buildnum/interface.go
+++ b/pkg/buildnum/interface.go
@@ -7,7 +7,10 @@ import "github.com/jenkins-x/jx/pkg/kube"
 //go:generate pegomock generate github.com/jenkins-x/jx/pkg/buildnum BuildNumberIssuer -o mocks/build_num.go --generate-matchers
 type BuildNumberIssuer interface {
 
-	//Generate the next build number for the supplied pipeline.
-	//Returns the build number, or the error that occurred.
+	// NextBuildNumber generates the next build number for the supplied pipeline.
+	// Returns the build number, or the error that occurred.
 	NextBuildNumber(pipeline kube.PipelineID) (string, error)
+
+	// Ready returns true if the generator is ready to generate build numbers, otherwise false.
+	Ready() bool
 }

--- a/pkg/buildnum/mocks/build_num.go
+++ b/pkg/buildnum/mocks/build_num.go
@@ -4,10 +4,11 @@
 package buildnum_test
 
 import (
-	kube "github.com/jenkins-x/jx/pkg/kube"
-	pegomock "github.com/petergtz/pegomock"
 	"reflect"
 	"time"
+
+	kube "github.com/jenkins-x/jx/pkg/kube"
+	pegomock "github.com/petergtz/pegomock"
 )
 
 type MockBuildNumberIssuer struct {
@@ -35,6 +36,21 @@ func (mock *MockBuildNumberIssuer) NextBuildNumber(_param0 kube.PipelineID) (str
 		}
 	}
 	return ret0, ret1
+}
+
+func (mock *MockBuildNumberIssuer) Ready() bool {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockBuildNumberIssuer().")
+	}
+	params := []pegomock.Param{}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("Ready", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	var ret0 bool
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(bool)
+		}
+	}
+	return ret0
 }
 
 func (mock *MockBuildNumberIssuer) VerifyWasCalledOnce() *VerifierBuildNumberIssuer {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Add two new HTTP endpoints, `/health` and `/live` to be used as K8S liveness & readiness probes. (Separate PR/repo to make use of these).

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
