### PR TITLE
jx should control kubectl version it is using

### DIFF
--- a/pkg/binaries/binaries.go
+++ b/pkg/binaries/binaries.go
@@ -13,6 +13,7 @@ import (
 const EksctlVersion = "0.1.19"
 const IBMCloudVersion = "0.10.1"
 const HeptioAuthenticatorAwsVersion = "1.10.3"
+const KubectlVersion = "1.13.2"
 
 func BinaryWithExtension(binary string) string {
 	if runtime.GOOS == "windows" {

--- a/pkg/jx/cmd/upgrade_binaries.go
+++ b/pkg/jx/cmd/upgrade_binaries.go
@@ -74,6 +74,11 @@ func (o *UpgradeBinariesOptions) Run() error {
 			if err != nil {
 				return err
 			}
+		} else if binary.Name() == "kubectl" {
+			err = o.installKubectl(true)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
IMHO jx should control the `kubectl` version it is using the same way it controls `eksctl` and `heptio-authenticator-aws` versions. We should try to avoid pulling random latest version of binaries dependencies. Instead jx should download version which is "jx-certified" and tested against given version of jx.

This PR locks `kubectl` version and manages it using the same way as `eksctl` and `heptio-authenticator-aws` are managed. It means that you can execute `jx upgrade binaries` command to upgrade your kubectl version to the version that your current jx cli is expecting.