### PR TITLE
feat(certs): wait for certificate issuer on create addon cb

### DIFF
--- a/pkg/jx/cmd/create_addon_cloudbees.go
+++ b/pkg/jx/cmd/create_addon_cloudbees.go
@@ -254,7 +254,7 @@ To register to get your username/password to to: %s
 		}
 	}
 
-	log.Infof("Addon installed successfully.\n Run `jx cloudbees` to open the app in a browser\n")
+	log.Infof("Addon installed successfully.\n\n  %s Open the app in a browser\n\n", util.ColorInfo("jx cloudbees"))
 
 	return nil
 }

--- a/pkg/jx/cmd/create_addon_cloudbees.go
+++ b/pkg/jx/cmd/create_addon_cloudbees.go
@@ -204,7 +204,7 @@ To register to get your username/password to to: %s
 		if err != nil {
 			return errors.Wrap(err, "creating the cert-manager client")
 		}
-		err = pki.WaitCertificateExists(certMngrClient, certName, o.Namespace, 3*time.Minute)
+		err = pki.WaitCertificateIssuedReady(certMngrClient, certName, o.Namespace, 3*time.Minute)
 		if err != nil {
 			return err // this is already wrapped by the previous call
 		}

--- a/pkg/jx/cmd/delete_addon_cloudbees.go
+++ b/pkg/jx/cmd/delete_addon_cloudbees.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/jenkins-x/jx/pkg/log"
 	"io"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -67,6 +68,7 @@ func (o *DeleteAddoncoreOptions) Run() error {
 	if err != nil {
 		return err
 	}
+	log.Infof("Addon %s deleted successfully\n", util.ColorInfo(o.ReleaseName))
 
 	return nil
 }

--- a/pkg/kube/pki/certificate.go
+++ b/pkg/kube/pki/certificate.go
@@ -35,7 +35,6 @@ func WaitCertificateIssuedReady(client certclient.Interface, name string, ns str
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		cert, err := client.CertmanagerV1alpha1().Certificates(ns).Get(name, metav1.GetOptions{})
 		if err != nil {
-			logrus.Warnf("Failed getting certificate %q: %v", name, err)
 			return false, nil
 		}
 		isReady := cert.HasCondition(certmng.CertificateCondition{

--- a/pkg/kube/pki/certificate.go
+++ b/pkg/kube/pki/certificate.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// CertSecretPrefix used as prefix for all certificate object names
 const CertSecretPrefix = "tls-"
 
 // Certificate keeps some information related to a certificate issued by cert-manager
@@ -53,6 +54,7 @@ func WaitCertificateIssuedReady(client certclient.Interface, name string, ns str
 	return nil
 }
 
+// WaitCertificateExists waits until the timeout for the certificate with the provided name to be available in the certificates list
 func WaitCertificateExists(client certclient.Interface, name string, ns string, timeout time.Duration) error {
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		_, err := client.CertmanagerV1alpha1().Certificates(ns).Get(name, metav1.GetOptions{})

--- a/pkg/kube/pki/certificate.go
+++ b/pkg/kube/pki/certificate.go
@@ -3,6 +3,7 @@ package pki
 import (
 	"context"
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/util"
 	"strings"
 	"time"
 
@@ -11,14 +12,14 @@ import (
 	certclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 )
 
-const certSecretPrefix = "tls-"
+const CertSecretPrefix = "tls-"
 
 // Certificate keeps some information related to a certificate issued by cert-manager
 type Certificate struct {
@@ -31,7 +32,7 @@ type Certificate struct {
 // WaitCertificateIssuedReady wait for a certificate issued by cert-manager until is ready or the timeout is reached
 func WaitCertificateIssuedReady(client certclient.Interface, name string, ns string, timeout time.Duration) error {
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-		cert, err := client.Certmanager().Certificates(ns).Get(name, metav1.GetOptions{})
+		cert, err := client.CertmanagerV1alpha1().Certificates(ns).Get(name, metav1.GetOptions{})
 		if err != nil {
 			logrus.Warnf("Failed getting certificate %q: %v", name, err)
 			return false, nil
@@ -43,10 +44,25 @@ func WaitCertificateIssuedReady(client certclient.Interface, name string, ns str
 		if !isReady {
 			return false, nil
 		}
+		logrus.Infof("Ready Cert: %s\n", util.ColorInfo(name))
 		return true, nil
 	})
 	if err != nil {
-		return errors.Wrapf(err, "waiting for certificate %q to be ready in namespace %q", name, ns)
+		return errors.Wrapf(err, "waiting for certificate %q to be ready in namespace %q.", name, ns)
+	}
+	return nil
+}
+
+func WaitCertificateExists(client certclient.Interface, name string, ns string, timeout time.Duration) error {
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		_, err := client.CertmanagerV1alpha1().Certificates(ns).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "waiting for certificate %q to be created in namespace %q.", name, ns)
 	}
 	return nil
 }
@@ -54,7 +70,7 @@ func WaitCertificateIssuedReady(client certclient.Interface, name string, ns str
 // CleanAllCerts removes all certs and their associated secrets which hold a TLS certificated issued by cert-manager
 func CleanAllCerts(client kubernetes.Interface, certclient certclient.Interface, ns string) error {
 	return cleanCerts(client, certclient, ns, func(cert string) bool {
-		return strings.HasPrefix(cert, certSecretPrefix)
+		return strings.HasPrefix(cert, CertSecretPrefix)
 	})
 }
 
@@ -171,7 +187,7 @@ func ToCertificates(services []*v1.Service) []Certificate {
 	result := make([]Certificate, 0)
 	for _, svc := range services {
 		app := kubeservices.ServiceAppName(svc)
-		cert := certSecretPrefix + app
+		cert := CertSecretPrefix + app
 		ns := svc.GetNamespace()
 		result = append(result, Certificate{
 			Name:      cert,


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

`jx create addon cloudbees --sso` now waits for the TLS configuration to be ready (certificate issued for the service).

Output:
```
$ jx create addon cloudbees --sso
Configuring single sign-on...
? Domain: my-domain.com
? Dex URL: https://dex.sso.my-domain.com
Looking for cert-manager deployment in namespace cert-manager...
Updating Helm repository...
Helm repository update done.
Waiting for cert: tls-core...
Ready Cert: tls-core
Addon installed successfully.

  jx cloudbees Open the app in a browser

``` 

#### Which issue this PR fixes

fixes #2876 
