### PR TITLE
Refactor/simplify build number controller to reduce chance of deadlocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ test-slow-integration-report: get-test-deps test-slow-integration
 test-slow-integration-report-html: get-test-deps test-slow-integration
 	@gocov convert cover.out | gocov-html > cover.html && open cover.html
 
+test-soak:
+	@CGO_ENABLED=$(CGO_ENABLED) $(GO) test -p 2 -count=1 -tags soak -coverprofile=cover.out ./...
+
 docker-test:
 	docker run --rm -v $(shell pwd):/go/src/github.com/jenkins-x/jx golang:1.11 sh -c "rm /usr/bin/git && cd /go/src/github.com/jenkins-x/jx && make test"
 

--- a/pkg/buildnum/http_build_num_soak_test.go
+++ b/pkg/buildnum/http_build_num_soak_test.go
@@ -1,0 +1,74 @@
+// +build soak
+
+package buildnum
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/petergtz/pegomock"
+
+	build_num_test "github.com/jenkins-x/jx/pkg/buildnum/mocks"
+	"github.com/jenkins-x/jx/pkg/buildnum/mocks/matchers"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	numRequests = 5000
+	numThreads  = 25
+)
+
+func TestSoakTest(t *testing.T) {
+	mockIssuer := build_num_test.NewMockBuildNumberIssuer()
+	When(mockIssuer.NextBuildNumber(matchers.AnyKubePipelineID())).Then(generateBuildNumber)
+	server := NewHTTPBuildNumberServer("", 1234, mockIssuer)
+
+	fmt.Printf("Using %d clients to make %d requests each.\n", numThreads, numRequests)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < numThreads; i++ {
+		go func() {
+			wg.Add(1)
+			for i := 0; i < numRequests; i++ {
+				runVendClient(t, server)
+			}
+			wg.Done()
+		}()
+	}
+
+	fmt.Printf("Waiting for %d clients to complete.\n", numThreads)
+	wg.Wait()
+	fmt.Print("Done\n")
+}
+
+// To be called by pegomock as NextBuildNumber() implementation - add a small sleep to simulate the real processing &
+// increase concurrency in the build number service.
+func generateBuildNumber(params []Param) ReturnValues {
+	time.Sleep(time.Millisecond * 25)
+	return ReturnValues{strconv.Itoa(rand.Intn(numThreads)), nil}
+}
+
+// Act as a client making a /vend request to the specified server.
+func runVendClient(t *testing.T, server *HTTPBuildNumberServer) {
+	//pID := kube.NewPipelineIDFromString(fmt.Sprintf("owner1/repo1/branch-%d", rand.Intn(100)))
+	//pegomock.When(mockIssuer.NextBuildNumber(matchers.EqKubePipelineID(pID))).ThenReturn("3", nil)
+
+	path := fmt.Sprintf("owner1/repo1/branch-%d", rand.Intn(25))
+	req, err := http.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		t.Fatal("Unexpected error setting up fake HTTP request.", err)
+	}
+
+	rr := httptest.NewRecorder()
+	server.vend(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "Expected OK status code for valid /vend GET request.")
+}

--- a/pkg/kube/pipeline_cache.go
+++ b/pkg/kube/pipeline_cache.go
@@ -86,6 +86,17 @@ func (c *PipelineNamespaceCache) Pipelines() []*v1.PipelineActivity {
 	return answer
 }
 
+func (c *PipelineNamespaceCache) ForEach(callback func(*v1.PipelineActivity)) {
+	onEntry := func(key interface{}, value interface{}) bool {
+		pipeline, ok := value.(*v1.PipelineActivity)
+		if ok && pipeline != nil {
+			callback(pipeline)
+		}
+		return true
+	}
+	c.pipelines.Range(onEntry)
+}
+
 func (c *PipelineNamespaceCache) onPipelineObj(obj interface{}, jxClient versioned.Interface, ns string) {
 	pipeline, ok := obj.(*v1.PipelineActivity)
 	if !ok {

--- a/pkg/kube/pipeline_cache.go
+++ b/pkg/kube/pipeline_cache.go
@@ -86,6 +86,7 @@ func (c *PipelineNamespaceCache) Pipelines() []*v1.PipelineActivity {
 	return answer
 }
 
+// ForEach runs the supplied function on every element in the Map. In no particular order.
 func (c *PipelineNamespaceCache) ForEach(callback func(*v1.PipelineActivity)) {
 	onEntry := func(key interface{}, value interface{}) bool {
 		pipeline, ok := value.(*v1.PipelineActivity)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We've been seeing the build number controller appear to become unresponsive - I've reviewed the code and also created a basic soak test, but I can't reproduce the problem. One possibility is a bug in the locking that was attempting to ensure we don't generate build numbers for the same pipeline concurrently (though as per the test, no evidence yet of this actually failing). So in the absence of anything concrete, I've tried to just simplify the logic and the locking. There is now a single lock, so _all_ generation is serialised. But at the same time I've simplified the processing of the 'PipelineActivity's, so it should actually be no big deal as very quick/short to complete the request.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
