### PR TITLE
Add all extensions

### DIFF
--- a/pkg/jx/cmd/step_pre_extend.go
+++ b/pkg/jx/cmd/step_pre_extend.go
@@ -140,7 +140,7 @@ func (o *StepPreExtendOptions) Run() error {
 					if err != nil {
 						return err
 					}
-					a.Spec.PostExtensions = result
+					a.Spec.PostExtensions = append(a.Spec.PostExtensions, result...)
 				}
 			}
 			a, err = client.JenkinsV1().PipelineActivities(ns).Update(a)


### PR DESCRIPTION
Currently, only the last extension defined in the repository is added to
the PipelineActivity by `jx step pre extend`.

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

`PostExtensions` is currently overwritten for each of the extensions defined in the repository YAML so only the last one is actually applied.