### PR TITLE
refactor: added category 'all' to CRDs

### DIFF
--- a/pkg/jx/cmd/step_changelog.go
+++ b/pkg/jx/cmd/step_changelog.go
@@ -93,6 +93,8 @@ spec:
     shortNames:
     - rel
     singular: release
+    categories:
+    - all
   scope: Namespaced
   version: v1`
 )

--- a/pkg/kube/crds.go
+++ b/pkg/kube/crds.go
@@ -135,6 +135,7 @@ func RegisterEnvironmentRoleBindingCRD(apiClient apiextensionsclientset.Interfac
 		Plural:     "environmentrolebindings",
 		Singular:   "environmentrolebinding",
 		ShortNames: []string{"envrolebindings", "envrolebinding", "envrb"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{}
 	validation := v1beta1.CustomResourceValidation{}
@@ -150,6 +151,7 @@ func RegisterGitServiceCRD(apiClient apiextensionsclientset.Interface) error {
 		Plural:     "gitservices",
 		Singular:   "gitservice",
 		ShortNames: []string{"gits"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{
 		{
@@ -178,6 +180,7 @@ func RegisterPipelineActivityCRD(apiClient apiextensionsclientset.Interface) err
 		Plural:     "pipelineactivities",
 		Singular:   "pipelineactivity",
 		ShortNames: []string{"activity", "act"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{
 		{
@@ -206,6 +209,7 @@ func RegisterExtensionCRD(apiClient apiextensionsclientset.Interface) error {
 		Plural:     "extensions",
 		Singular:   "extensions",
 		ShortNames: []string{"extension", "ext"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{
 		{
@@ -234,6 +238,7 @@ func RegisterBuildPackCRD(apiClient apiextensionsclientset.Interface) error {
 		Plural:     "buildpacks",
 		Singular:   "buildpack",
 		ShortNames: []string{"bp"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{
 		{
@@ -268,6 +273,7 @@ func RegisterAppCRD(apiClient apiextensionsclientset.Interface) error {
 		Plural:     "apps",
 		Singular:   "app",
 		ShortNames: []string{"app"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{}
 	validation := v1beta1.CustomResourceValidation{}
@@ -283,6 +289,7 @@ func RegisterSourceRepositoryCRD(apiClient apiextensionsclientset.Interface) err
 		Plural:     "sourcerepositories",
 		Singular:   "sourcerepository",
 		ShortNames: []string{"sourcerepo", "srcrepo", "sr"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{
 		{
@@ -318,10 +325,11 @@ func RegisterSourceRepositoryCRD(apiClient apiextensionsclientset.Interface) err
 func RegisterPluginCRD(apiClient apiextensionsclientset.Interface) error {
 	name := "plugins." + jenkinsio.GroupName
 	names := &v1beta1.CustomResourceDefinitionNames{
-		Kind:     "Plugin",
-		ListKind: "PluginList",
-		Plural:   "plugins",
-		Singular: "plugin",
+		Kind:       "Plugin",
+		ListKind:   "PluginList",
+		Plural:     "plugins",
+		Singular:   "plugin",
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{
 		{
@@ -350,6 +358,7 @@ func RegisterCommitStatusCRD(apiClient apiextensionsclientset.Interface) error {
 		Plural:     "commitstatuses",
 		Singular:   "commitstatus",
 		ShortNames: []string{"commitstatus"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{}
 	validation := v1beta1.CustomResourceValidation{}
@@ -365,6 +374,7 @@ func RegisterReleaseCRD(apiClient apiextensionsclientset.Interface) error {
 		Plural:     "releases",
 		Singular:   "release",
 		ShortNames: []string{"rel"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{
 		{
@@ -399,6 +409,7 @@ func RegisterUserCRD(apiClient apiextensionsclientset.Interface) error {
 		Plural:     "users",
 		Singular:   "user",
 		ShortNames: []string{"usr"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{
 		{
@@ -427,6 +438,7 @@ func RegisterTeamCRD(apiClient apiextensionsclientset.Interface) error {
 		Plural:     "teams",
 		Singular:   "team",
 		ShortNames: []string{"tm"},
+		Categories: []string{"all"},
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{
 		{
@@ -455,6 +467,8 @@ func RegisterWorkflowCRD(apiClient apiextensionsclientset.Interface) error {
 		Plural:     "workflows",
 		Singular:   "workflow",
 		ShortNames: []string{"flow"},
+		Categories: []string{"all"},
+
 	}
 	columns := []v1beta1.CustomResourceColumnDefinition{}
 	validation := v1beta1.CustomResourceValidation{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Added `all` category to all the CRDs so that jenkins-X resources are displayed when `kubectl get all` is done. 

#### Special notes for the reviewer(s)
I couldn't find any e2e tests where I could add a test for checking output of `kubectl get all` having some of the jenkins-X resource hence I kept the second checkbox un-checked. 

#### Which issue this PR fixes

fixes https://github.com/jenkins-x/jx/issues/2827

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
