### PR TITLE
(feat) Add `jx step verify pod` to output status of all kubernetes pods

### DIFF
--- a/pkg/jx/cmd/step.go
+++ b/pkg/jx/cmd/step.go
@@ -68,6 +68,7 @@ func NewCmdStep(f Factory, in terminal.FileReader, out terminal.FileWriter, errO
 	cmd.AddCommand(NewCmdStepStash(f, in, out, errOut))
 	cmd.AddCommand(NewCmdStepUnstash(f, in, out, errOut))
 
+
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_verify.go
+++ b/pkg/jx/cmd/step_verify.go
@@ -62,6 +62,8 @@ func NewCmdStepVerify(f Factory, in terminal.FileReader, out terminal.FileWriter
 		},
 	}
 
+	cmd.AddCommand(NewCmdStepVerifyPod(f, in, out, errOut))
+
 	cmd.Flags().Int32VarP(&options.After, "after", "", 60, "The time in seconds after which the application should be ready")
 	cmd.Flags().Int32VarP(&options.Pods, "pods", "p", 1, "Number of expected pods to be running")
 	cmd.Flags().Int32VarP(&options.Restarts, "restarts", "r", 0, "Maximum number of restarts which are acceptable within the given time")

--- a/pkg/jx/cmd/step_verify_pod.go
+++ b/pkg/jx/cmd/step_verify_pod.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"os/exec"
+)
+
+var (
+	stepStatusLong = templates.LongDesc(`
+		This step checks the status of all kubernetes pods
+	`)
+
+	stepStatusExample = templates.Examples(`
+		jx step verify pod
+	`)
+)
+
+type StepVerifyPodOptions struct {
+	StepOptions
+	Debug    bool
+}
+
+// NewCmdStepVerifyPod creates the `jx step verify pod` command
+func NewCmdStepVerifyPod(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+
+	options := StepVerifyPodOptions{
+		StepOptions: StepOptions{
+			CommonOptions: CommonOptions{
+				Factory: f,
+				In:      in,
+				Out:     out,
+				Err:     errOut,
+			},
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "pod",
+		Short:   "status of kubernetes pods",
+		Long:    stepStatusLong,
+		Example: stepStatusExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			CheckErr(err)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&options.Debug, "debug", "", false, "Output logs of any failed pod")
+
+	return cmd
+}
+
+// Run the `jx step verify pod` command
+func (o *StepVerifyPodOptions) Run() error {
+	kubeClient, ns, err := o.KubeClientAndNamespace()
+	if err != nil {
+		return errors.Wrap(err, "failed to get the Kube client")
+	}
+
+	pods, err := kubeClient.CoreV1().Pods(ns).List(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to list the PODs in namespace '%s'", ns)
+	}
+
+	fmt.Println("Checking pod statuses")
+
+	table := o.createTable()
+	table.AddRow("POD", "STATUS")
+
+	var f *os.File
+
+	if o.Debug {
+		fmt.Println("Creating verify-pod.log file")
+		f, err = os.Create("verify-pod.log")
+		if err != nil {
+			return errors.Wrap(err, "error creating log file")
+		}
+		defer f.Close()
+	}
+
+	for _, pod := range pods.Items {
+		podName := pod.ObjectMeta.Name
+		phase := pod.Status.Phase
+
+		if phase == corev1.PodFailed && o.Debug {
+			args := []string{"logs", podName }
+			name := "kubectl"
+			e := exec.Command(name, args...)
+			e.Stderr = o.Err
+			var out bytes.Buffer
+			e.Stdout = &out
+			err := e.Run()
+			if err != nil {
+				return errors.Wrap(err, "failed to get the Kube pod logs")
+			}
+			_, err = f.WriteString(fmt.Sprintf("Logs for pod %s:\n", podName))
+			if err != nil {
+				return errors.Wrap(err, "error writing log file")
+			}
+			_, err = f.Write(out.Bytes())
+			if err != nil {
+				return errors.Wrap(err, "error writing log file")
+			}
+		}
+		table.AddRow(podName, string(phase))
+	}
+	table.Render()
+	return nil
+}

--- a/pkg/jx/cmd/step_verify_pod_test.go
+++ b/pkg/jx/cmd/step_verify_pod_test.go
@@ -1,0 +1,65 @@
+package cmd_test
+
+import (
+	"github.com/jenkins-x/jx/pkg/gits/mocks"
+	"github.com/jenkins-x/jx/pkg/helm/mocks"
+	"github.com/jenkins-x/jx/pkg/jx/cmd"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestStepVerifyPod(t *testing.T) {
+	t.Parallel()
+
+	options := cmd.StepVerifyPodOptions{}
+	// fake the output stream to be checked later
+	r, fakeStdout, _ := os.Pipe()
+	options.CommonOptions = cmd.CommonOptions{
+		Out: fakeStdout,
+		Err: os.Stderr,
+	}
+
+	cmd.ConfigureTestOptions(&options.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
+	err := options.Run()
+	assert.NoError(t, err, "Command failed: %#v", options)
+
+	// check output
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	assert.Contains(t, string(outBytes), "POD STATUS")
+
+}
+
+func TestStepVerifyPodDebug(t *testing.T) {
+	t.Parallel()
+
+	options := cmd.StepVerifyPodOptions{Debug: true}
+	// fake the output stream to be checked later
+	r, fakeStdout, _ := os.Pipe()
+	options.CommonOptions = cmd.CommonOptions{
+		Out: fakeStdout,
+		Err: os.Stderr,
+	}
+
+	cmd.ConfigureTestOptions(&options.CommonOptions, gits_test.NewMockGitter(), helm_test.NewMockHelmer())
+	err := options.Run()
+	assert.NoError(t, err, "Command failed: %#v", options)
+
+	// check output
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	assert.Contains(t, string(outBytes), "POD STATUS")
+
+	//check DEBUG file created
+	filename := "verify-pod.log"
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		t.Error("Debug log does not exist")
+	}
+
+	assert.NoError(t, err, "Command failed: %#v", options)
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Output the status of all kubernetes pods, i.e. running, successful, failed etc. The idea being that this can then be used by the BDD tests to determine if all CronJobs have been success and hence fix issue 2806.

To run:

`jx step verify pod`

Also to create a log file with the log output from any failed pods:

`jx step verify pod --debug`

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

Relates to #2806 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
