### PR TITLE
Support passing --install-dependencies to bdd tests

### DIFF
--- a/pkg/jx/cmd/step_bdd.go
+++ b/pkg/jx/cmd/step_bdd.go
@@ -457,6 +457,9 @@ func (o *StepBDDOptions) createCluster(cluster *bdd.CreateCluster) error {
 	if gitKind != "" {
 		args = append(args, "--git-provider-kind ", gitKind)
 	}
+	if o.CommonOptions.InstallDependencies {
+		args = append(args, "--install-dependencies")
+	}
 	safeArgs := append([]string{}, args...)
 
 	gitToken := o.InstallOptions.GitRepositoryOptions.ApiToken


### PR DESCRIPTION

Make it easier to run the BDD tests locally by allowing dependencies to be installed