### PR TITLE
fix: various issues around SourceRepository

### DIFF
--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1941,6 +1941,13 @@ func (options *InstallOptions) saveClusterConfig() error {
 		if err != nil {
 			return errors.Wrap(err, "retrieving the current kube config")
 		}
+
+		if options.installValues != nil {
+			if options.installValues["jx-install-version"] == "" {
+				options.installValues["jx-install-version"] = version2.GetVersion()
+			}
+		}
+
 		if kubeConfig != nil {
 			kubeConfigContext := kube.CurrentContext(kubeConfig)
 			if kubeConfigContext != nil {

--- a/pkg/jx/cmd/upgrade_platform.go
+++ b/pkg/jx/cmd/upgrade_platform.go
@@ -154,11 +154,11 @@ func (o *UpgradePlatformOptions) Run() error {
 		io := &InstallOptions{}
 		io.CommonOptions = o.CommonOptions
 		io.Flags = o.InstallFlags
-		wrkDir, err = io.cloneJXVersionsRepo(o.Flags.VersionsRepository)
+		versionsDir, err := io.cloneJXVersionsRepo(o.Flags.VersionsRepository)
 		if err != nil {
 			return err
 		}
-		targetVersion, err = LoadVersionFromCloudEnvironmentsDir(wrkDir, configStore)
+		targetVersion, err = LoadVersionFromCloudEnvironmentsDir(versionsDir, configStore)
 		if err != nil {
 			return err
 		}

--- a/pkg/kube/activity.go
+++ b/pkg/kube/activity.go
@@ -227,6 +227,7 @@ func (k *PipelineActivityKey) GetOrCreate(jxClient versioned.Interface, ns strin
 	}
 }
 
+// GitOwner returns the git owner (person / organisation) or blank string if it cannot be found
 func (k *PipelineActivityKey) GitOwner() string {
 	if k.GitInfo != nil {
 		return k.GitInfo.Organisation
@@ -242,6 +243,7 @@ func (k *PipelineActivityKey) GitOwner() string {
 	return ""
 }
 
+// GitRepository returns the git repository name or blank string if it cannot be found
 func (k *PipelineActivityKey) GitRepository() string {
 	if k.GitInfo != nil {
 		return k.GitInfo.Name
@@ -257,6 +259,7 @@ func (k *PipelineActivityKey) GitRepository() string {
 	return ""
 }
 
+// GitURL returns the git URL or blank string if it cannot be found
 func (k *PipelineActivityKey) GitURL() string {
 	if k.GitInfo != nil {
 		return k.GitInfo.URL

--- a/pkg/kube/activity.go
+++ b/pkg/kube/activity.go
@@ -321,7 +321,6 @@ func updateActivitySpec(k *PipelineActivityKey, spec *v1.PipelineActivitySpec) {
 	}
 }
 
-
 // GetOrCreatePreview gets or creates the Preview step for the key
 func (k *PromoteStepActivityKey) GetOrCreatePreview(jxClient versioned.Interface, ns string) (*v1.PipelineActivity, *v1.PipelineActivityStep, *v1.PreviewActivityStep, bool, error) {
 	a, _, err := k.GetOrCreate(jxClient, ns)

--- a/pkg/kube/activity.go
+++ b/pkg/kube/activity.go
@@ -163,21 +163,23 @@ func GenerateBuildNumber(activities typev1.PipelineActivityInterface, pipelines 
 }
 
 func createSourceRepositoryIfMissing(jxClient versioned.Interface, ns string, activityKey *PipelineActivityKey) error {
+	repoName := activityKey.GitRepository()
+	owner := activityKey.GitOwner()
+	gitURL := activityKey.GitURL()
+
+	if repoName == "" || owner == "" || gitURL == "" {
+		return nil;
+	}
 	srs := NewSourceRepositoryService(jxClient, ns)
-
 	if srs == nil {
-		return fmt.Errorf("failed to create sourcerepository service")
+		return fmt.Errorf("failed to create sourcerepository resource")
 	}
 
-	resourceName := ToValidName(activityKey.GitInfo.Organisation + "-" + activityKey.Name)
-
+	resourceName := ToValidName(owner + "-" + repoName)
 	_, err := srs.GetSourceRepository(resourceName)
-
 	if err != nil {
-		log.Warnf("Creating missing sourcerepository object %s\n", resourceName)
-		err = srs.CreateOrUpdateSourceRepository(activityKey.Name, activityKey.GitInfo.Organisation, activityKey.GitInfo.URL)
+		err = srs.CreateOrUpdateSourceRepository(repoName, owner, gitURL)
 	}
-
 	return err
 }
 
@@ -223,6 +225,43 @@ func (k *PipelineActivityKey) GetOrCreate(jxClient versioned.Interface, ns strin
 		}
 		return a, false, nil
 	}
+}
+
+func (k *PipelineActivityKey) GitOwner() string {
+	if k.GitInfo != nil {
+		return k.GitInfo.Organisation
+	}
+	pipeline := k.Pipeline
+	if pipeline == "" {
+		return ""
+	}
+	paths := strings.Split(pipeline, "/")
+	if len(paths) > 1 {
+		return paths[0]
+	}
+	return ""
+}
+
+func (k *PipelineActivityKey) GitRepository() string {
+	if k.GitInfo != nil {
+		return k.GitInfo.Name
+	}
+	pipeline := k.Pipeline
+	if pipeline == "" {
+		return ""
+	}
+	paths := strings.Split(pipeline, "/")
+	if len(paths) > 1 {
+		return paths[len(paths)-2]
+	}
+	return ""
+}
+
+func (k *PipelineActivityKey) GitURL() string {
+	if k.GitInfo != nil {
+		return k.GitInfo.URL
+	}
+	return ""
 }
 
 func updateActivity(k *PipelineActivityKey, activity *v1.PipelineActivity) {

--- a/pkg/kube/sourcerepository_impl.go
+++ b/pkg/kube/sourcerepository_impl.go
@@ -48,7 +48,7 @@ func (service *SourceRepositoryService) CreateOrUpdateSourceRepository(name, org
 		// lets see if it already exists
 		sr, err2 := repositories.Get(resourceName, metav1.GetOptions{})
 		if err2 != nil {
-		  return errors.Wrapf(err, "failed to create SourceRepository %s and cannot get it either: %s", resourceName, err2.Error())
+			return errors.Wrapf(err, "failed to create SourceRepository %s and cannot get it either: %s", resourceName, err2.Error())
 		}
 		copy := *sr
 		copy.Spec.Description = description
@@ -57,11 +57,10 @@ func (service *SourceRepositoryService) CreateOrUpdateSourceRepository(name, org
 		copy.Spec.Repo = name
 		if reflect.DeepEqual(&copy.Spec, sr.Spec) {
 			return nil
-		} else {
-			_, err = repositories.Update(&copy)
-			if err != nil {
-				return errors.Wrapf(err, "failed to update SourceRepository %s", resourceName)
-			}
+		}
+		_, err = repositories.Update(&copy)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update SourceRepository %s", resourceName)
 		}
 	}
 	return nil

--- a/pkg/kube/sourcerepository_impl.go
+++ b/pkg/kube/sourcerepository_impl.go
@@ -46,16 +46,18 @@ func (service *SourceRepositoryService) CreateOrUpdateSourceRepository(name, org
 	})
 	if err != nil {
 		// lets see if it already exists
-		sr, err := repositories.Get(resourceName, metav1.GetOptions{})
-		if err != nil {
-		  return errors.Wrapf(err, "failed to get SourceRepository %s after failing to create a new one", resourceName)
+		sr, err2 := repositories.Get(resourceName, metav1.GetOptions{})
+		if err2 != nil {
+		  return errors.Wrapf(err, "failed to create SourceRepository %s and cannot get it either: %s", resourceName, err2.Error())
 		}
 		copy := *sr
 		copy.Spec.Description = description
 		copy.Spec.Org = organisation
 		copy.Spec.Provider = providerURL
 		copy.Spec.Repo = name
-		if !reflect.DeepEqual(&copy.Spec, sr.Spec) {
+		if reflect.DeepEqual(&copy.Spec, sr.Spec) {
+			return nil
+		} else {
 			_, err = repositories.Update(&copy)
 			if err != nil {
 				return errors.Wrapf(err, "failed to update SourceRepository %s", resourceName)


### PR DESCRIPTION
we were using the PipelineActivity Name as the repo name (which is actually
    the orgName-repoName) which ended up with a double org name also fixed up
    logic that was losing the actual error when trying to create a
    SourceRepository