### PR TITLE
fix(import): Honour the --environment-git-owner flag doing create terraform

### DIFF
--- a/pkg/jx/cmd/create_terraform.go
+++ b/pkg/jx/cmd/create_terraform.go
@@ -392,6 +392,7 @@ func (options *CreateTerraformOptions) Run() error {
 		}
 	}
 
+	options.InstallOptions.Owner = options.InstallOptions.Flags.EnvironmentGitOwner
 	err = options.createOrganisationGitRepo()
 	if err != nil {
 		return err


### PR DESCRIPTION
the --environment-git-owner flag on `jx create terraform` was not being used to create the environment repos