### PR TITLE
feat(terraform): Added --cluster-name and --cloud-provider

### DIFF
--- a/pkg/jx/cmd/create_cluster.go
+++ b/pkg/jx/cmd/create_cluster.go
@@ -42,7 +42,9 @@ const (
 
 	optionKubernetesVersion = "kubernetes-version"
 	optionNodes             = "nodes"
+	optionCluster           = "cluster"
 	optionClusterName       = "cluster-name"
+	optionCloudProvider     = "cloud-provider"
 )
 
 var KUBERNETES_PROVIDERS = []string{MINIKUBE, GKE, OKE, AKS, AWS, EKS, KUBERNETES, IKS, OPENSHIFT, MINISHIFT, JX_INFRA, PKS, ICP}

--- a/pkg/jx/cmd/create_terraform.go
+++ b/pkg/jx/cmd/create_terraform.go
@@ -382,14 +382,12 @@ func (options *CreateTerraformOptions) Run() error {
 		return err
 	}
 
-	if len(options.Flags.Cluster) >= 1 {
-		err := options.ValidateClusterDetails()
-		if err != nil {
-			return err
-		}
+	err = options.ValidateClusterDetails()
+	if err != nil {
+		return err
 	}
 
-	if len(options.Flags.Cluster) == 0 {
+	if len(options.Clusters) == 0 {
 		err := options.ClusterDetailsWizard()
 		if err != nil {
 			return err
@@ -500,7 +498,7 @@ func (options *CreateTerraformOptions) ValidateClusterDetails() error {
 			c := &GKECluster{name: pair[0], provider: pair[1]}
 			options.Clusters = append(options.Clusters, c)
 		}
-	} else {
+	} else if options.Flags.ClusterName != "" || options.Flags.CloudProvider != "" {
 		options.Clusters = []Cluster{&GKECluster{name: options.Flags.ClusterName, provider: options.Flags.CloudProvider}}
 	}
 	return nil

--- a/pkg/jx/cmd/create_terraform.go
+++ b/pkg/jx/cmd/create_terraform.go
@@ -326,7 +326,7 @@ func (options *CreateTerraformOptions) addFlags(cmd *cobra.Command, addSharedFla
 		cmd.Flags().BoolVarP(&options.Flags.SkipLogin, "skip-login", "", false, "Skip Google auth if already logged in via gcloud auth")
 	}
 	cmd.Flags().StringArrayVarP(&options.Flags.Cluster, optionCluster, "c", []string{}, "Name and Kubernetes provider (gke, aks, eks) of clusters to be created in the form --cluster foo=gke")
-	cmd.Flags().StringVarP(&options.Flags.ClusterName, optionClusterName, "n", "", "The name of a single cluster to create - cannot be used in conjunction with --"+optionCluster)
+	cmd.Flags().StringVarP(&options.Flags.ClusterName, optionClusterName, "", "", "The name of a single cluster to create - cannot be used in conjunction with --"+optionCluster)
 	cmd.Flags().StringVarP(&options.Flags.CloudProvider, optionCloudProvider, "", "", "The cloud provider (eg gke, aws) - cannot be used in conjunction with --"+optionCluster)
 	cmd.Flags().BoolVarP(&options.Flags.SkipTerraformApply, "skip-terraform-apply", "", false, "Skip applying the generated Terraform plans")
 	cmd.Flags().BoolVarP(&options.Flags.IgnoreTerraformWarnings, "ignore-terraform-warnings", "", false, "Ignore any warnings about the Terraform plan being potentially destructive")

--- a/pkg/jx/cmd/create_terraform_test.go
+++ b/pkg/jx/cmd/create_terraform_test.go
@@ -47,3 +47,25 @@ func TestValidateClusterDetailsFail(t *testing.T) {
 	err := o.ValidateClusterDetails()
 	assert.Error(t, err)
 }
+
+func TestValidateClusterDetailsForInvalidParameterCombination(t *testing.T) {
+	t.Parallel()
+	o := cmd.CreateTerraformOptions{
+		Flags: cmd.Flags{
+			Cluster:     []string{"foo=jx-infra"},
+			ClusterName: "foo",
+		},
+	}
+	err := o.ValidateClusterDetails()
+	assert.EqualError(t, err, "--cluster cannot be used in conjunction with --cluster-name or --cloud-provider")
+
+	o = cmd.CreateTerraformOptions{
+		Flags: cmd.Flags{
+			Cluster:       []string{"foo=jx-infra"},
+			CloudProvider: "gke",
+		},
+	}
+	err = o.ValidateClusterDetails()
+	assert.EqualError(t, err, "--cluster cannot be used in conjunction with --cluster-name or --cloud-provider")
+
+}

--- a/pkg/jx/cmd/create_terraform_test.go
+++ b/pkg/jx/cmd/create_terraform_test.go
@@ -28,6 +28,11 @@ func TestValidateClusterDetails(t *testing.T) {
 	}
 	err := o.ValidateClusterDetails()
 	assert.NoError(t, err)
+	assert.Equal(t, 2, len(o.Clusters))
+	assert.Equal(t, "foo", o.Clusters[0].Name())
+	assert.Equal(t, "gke", o.Clusters[0].Provider())
+	assert.Equal(t, "bar", o.Clusters[1].Name())
+	assert.Equal(t, "gke", o.Clusters[1].Provider())
 }
 
 func TestValidateClusterDetailsForJxInfra(t *testing.T) {
@@ -37,6 +42,9 @@ func TestValidateClusterDetailsForJxInfra(t *testing.T) {
 	}
 	err := o.ValidateClusterDetails()
 	assert.NoError(t, err)
+	assert.Equal(t, 1, len(o.Clusters))
+	assert.Equal(t, "foo", o.Clusters[0].Name())
+	assert.Equal(t, "jx-infra", o.Clusters[0].Provider())
 }
 
 func TestValidateClusterDetailsFail(t *testing.T) {
@@ -45,27 +53,38 @@ func TestValidateClusterDetailsFail(t *testing.T) {
 		Flags: cmd.Flags{Cluster: []string{"foo=gke", "bar=aks"}},
 	}
 	err := o.ValidateClusterDetails()
-	assert.Error(t, err)
+	assert.EqualError(t, err, "invalid cluster provider type bar=aks, must be one of [gke jx-infra]")
+	assert.Equal(t, 1, len(o.Clusters))
+	assert.Equal(t, "foo", o.Clusters[0].Name())
+	assert.Equal(t, "gke", o.Clusters[0].Provider())
+
+	o = cmd.CreateTerraformOptions{
+		Flags: cmd.Flags{ClusterName: "baz", CloudProvider: "gke"},
+	}
+	err = o.ValidateClusterDetails()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(o.Clusters))
+	assert.Equal(t, "baz", o.Clusters[0].Name())
+	assert.Equal(t, "gke", o.Clusters[0].Provider())
 }
 
 func TestValidateClusterDetailsForInvalidParameterCombination(t *testing.T) {
 	t.Parallel()
-	o := cmd.CreateTerraformOptions{
-		Flags: cmd.Flags{
+
+	tests := []cmd.Flags{
+		{
 			Cluster:     []string{"foo=jx-infra"},
 			ClusterName: "foo",
 		},
-	}
-	err := o.ValidateClusterDetails()
-	assert.EqualError(t, err, "--cluster cannot be used in conjunction with --cluster-name or --cloud-provider")
-
-	o = cmd.CreateTerraformOptions{
-		Flags: cmd.Flags{
+		{
 			Cluster:       []string{"foo=jx-infra"},
 			CloudProvider: "gke",
 		},
 	}
-	err = o.ValidateClusterDetails()
-	assert.EqualError(t, err, "--cluster cannot be used in conjunction with --cluster-name or --cloud-provider")
 
+	for _, flags := range tests {
+		o := cmd.CreateTerraformOptions{Flags: flags}
+		err := o.ValidateClusterDetails()
+		assert.EqualError(t, err, "--cluster cannot be used in conjunction with --cluster-name or --cloud-provider")
+	}
 }


### PR DESCRIPTION
This adds the similar --cluster-name (shorthand: -n) flag that create cluster
and create terraform gke have.

This allows compatibility with the jx step bdd config files that specify
a cluster name, eg https://github.com/jenkins-x/jenkins-x-versions/blob/master/jx/bdd/prow.yaml#L2
