### PR TITLE
chore(bdd): don't use shorthands in tests

### DIFF
--- a/pkg/jx/cmd/step_bdd.go
+++ b/pkg/jx/cmd/step_bdd.go
@@ -429,7 +429,7 @@ func (o *StepBDDOptions) createCluster(cluster *bdd.CreateCluster) error {
 	log.Infof("\nCreating cluster %s\n", util.ColorInfo(cluster.Name))
 	binary := o.Flags.JxBinary
 	args := cluster.Args
-	args = append(args, "-n", cluster.Name)
+	args = append(args, "--cluster-name", cluster.Name)
 
 	if util.StringArrayIndex(args, "-b") < 0 && util.StringArrayIndex(args, "--batch-mode") < 0 {
 		args = append(args, "--batch-mode")

--- a/pkg/jx/cmd/step_bdd.go
+++ b/pkg/jx/cmd/step_bdd.go
@@ -460,6 +460,12 @@ func (o *StepBDDOptions) createCluster(cluster *bdd.CreateCluster) error {
 	if o.CommonOptions.InstallDependencies {
 		args = append(args, "--install-dependencies")
 	}
+
+	// expand any environment variables
+	for i, arg := range args {
+		args[i] = os.ExpandEnv(arg)
+	}
+
 	safeArgs := append([]string{}, args...)
 
 	gitToken := o.InstallOptions.GitRepositoryOptions.ApiToken


### PR DESCRIPTION
The -n flag can't be specified in create terraform so use the longhand version

Also expand environment variables in the arguments list