### PR TITLE
feat: Add support for defining Build Pipeline pipeline in jenkins-x.yml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.2.0
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
+	github.com/google/go-cmp v0.2.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 // indirect
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
@@ -95,8 +96,8 @@ require (
 	github.com/kevinburke/ssh_config v0.0.0-20180317175531-9fc7bb800b55 // indirect
 	github.com/keybase/go-crypto v0.0.0-20181127160227-255a5089e85a // indirect
 	github.com/knative/build v0.3.0
-	github.com/knative/build-pipeline v0.0.0-20190127035435-3b5fe38dbd3d
-	github.com/knative/pkg v0.0.0-20190125193334-994b801b03ef // indirect
+	github.com/knative/build-pipeline v0.0.0-20190203191138-7b5938be3a54
+	github.com/knative/pkg v0.0.0-20190125193334-994b801b03ef
 	github.com/knq/snaker v0.0.0-20180306023312-d9ad1e7f342a // indirect
 	github.com/kr/pty v1.1.2 // indirect
 	github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -466,6 +466,10 @@ github.com/knative/build-pipeline v0.0.0-20190125190534-405702f93a25 h1:/pdYwA3T
 github.com/knative/build-pipeline v0.0.0-20190125190534-405702f93a25/go.mod h1:mfaenlZ8/tw23y+Pck3qWpCVNTPMiFSZ0uqQkscBEAI=
 github.com/knative/build-pipeline v0.0.0-20190127035435-3b5fe38dbd3d h1:Oprlt+k5bg1iP3Qgj8whGlebonRUeuCRUeoNxzWuVv4=
 github.com/knative/build-pipeline v0.0.0-20190127035435-3b5fe38dbd3d/go.mod h1:mfaenlZ8/tw23y+Pck3qWpCVNTPMiFSZ0uqQkscBEAI=
+github.com/knative/build-pipeline v0.0.0-20190131183337-3cd318b51868 h1:L2PJOvstlcqXfhUFaIeIDO1cscumyabppnpymFn5wrk=
+github.com/knative/build-pipeline v0.0.0-20190131183337-3cd318b51868/go.mod h1:mfaenlZ8/tw23y+Pck3qWpCVNTPMiFSZ0uqQkscBEAI=
+github.com/knative/build-pipeline v0.0.0-20190203191138-7b5938be3a54 h1:gnbk07EMURuv6FAIyc7Ig5DI9bUfdxz8wI3rZCKxkMs=
+github.com/knative/build-pipeline v0.0.0-20190203191138-7b5938be3a54/go.mod h1:mfaenlZ8/tw23y+Pck3qWpCVNTPMiFSZ0uqQkscBEAI=
 github.com/knative/caching v0.0.0-20180907165633-f0d7bb60956f/go.mod h1:D6ynAUa79yFRVWCEogSqhRRNi2SooyDBf1ucp02CFKg=
 github.com/knative/pkg v0.0.0-20181205230426-0e41760cea1d/go.mod h1:7Ijfhw7rfB+H9VtosIsDYvZQ+qYTz7auK3fHW/5z4ww=
 github.com/knative/pkg v0.0.0-20190118011331-076ebf4e5675/go.mod h1:7Ijfhw7rfB+H9VtosIsDYvZQ+qYTz7auK3fHW/5z4ww=
@@ -814,6 +818,7 @@ google.golang.org/api v0.0.0-20181017004218-3f6e8463aa1d h1:oaIeWl/4IkZN1PMjqNOf
 google.golang.org/api v0.0.0-20181017004218-3f6e8463aa1d/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181021000519-a2651947f503 h1:UK7/bFlIoP9xre0fwSiXFaZZSpzmaen5MKp1sppNJ9U=
 google.golang.org/api v0.0.0-20181021000519-a2651947f503/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
+google.golang.org/api v0.1.0 h1:K6z2u68e86TPdSdefXdzvXgR1zEMa+459vBSfWYAZkI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.3.0 h1:FBSsiFRMz3LBeXIomRnVzrQwSDj4ibvcRexLG0LZGQk=

--- a/pkg/builds/build_info.go
+++ b/pkg/builds/build_info.go
@@ -56,7 +56,7 @@ func CreateBuildPodInfo(pod *corev1.Pod) *BuildPodInfo {
 	}
 	gitURL := ""
 	for _, initContainer := range pod.Spec.InitContainers {
-		if initContainer.Name == "build-step-git-source" || initContainer.Name == "build-step-git-source-source" {
+		if strings.HasPrefix(initContainer.Name, "build-step-git-source") {
 			args := initContainer.Args
 			for i := 0; i <= len(args)-2; i += 2 {
 				key := args[i]

--- a/pkg/jenkinsfile/pipeline.go
+++ b/pkg/jenkinsfile/pipeline.go
@@ -66,13 +66,13 @@ type PipelineStep struct {
 
 // PipelineLifecycles defines the steps of a lifecycle section
 type PipelineLifecycles struct {
-	Setup      *PipelineLifecycle  `yaml:"setup,omitempty"`
-	SetVersion *PipelineLifecycle  `yaml:"setVersion,omitempty"`
-	PreBuild   *PipelineLifecycle  `yaml:"preBuild,omitempty"`
-	Build      *PipelineLifecycle  `yaml:"build,omitempty"`
-	PostBuild  *PipelineLifecycle  `yaml:"postBuild,omitempty"`
-	Promote    *PipelineLifecycle  `yaml:"promote,omitempty"`
-	Pipeline   *syntax.Jenkinsfile `yaml:"pipeline,omitempty"`
+	Setup      *PipelineLifecycle        `yaml:"setup,omitempty"`
+	SetVersion *PipelineLifecycle        `yaml:"setVersion,omitempty"`
+	PreBuild   *PipelineLifecycle        `yaml:"preBuild,omitempty"`
+	Build      *PipelineLifecycle        `yaml:"build,omitempty"`
+	PostBuild  *PipelineLifecycle        `yaml:"postBuild,omitempty"`
+	Promote    *PipelineLifecycle        `yaml:"promote,omitempty"`
+	Pipeline   *syntax.PipelineStructure `yaml:"pipeline,omitempty"`
 }
 
 // PipelineLifecycle defines the steps of a lifecycle section
@@ -608,7 +608,7 @@ func (a *CreateJenkinsfileArguments) GenerateJenkinsfile(resolver ImportFileReso
 	if outDir != "" {
 		err = os.MkdirAll(outDir, util.DefaultWritePermissions)
 		if err != nil {
-			return errors.Wrapf(err, "failed to make directory %s when creating Jenkinsfile %s", outDir, outFile)
+			return errors.Wrapf(err, "failed to make directory %s when creating PipelineStructure %s", outDir, outFile)
 		}
 	}
 	file, err := os.Create(outFile)

--- a/pkg/jenkinsfile/pipeline.go
+++ b/pkg/jenkinsfile/pipeline.go
@@ -3,6 +3,7 @@ package jenkinsfile
 import (
 	"bytes"
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/kpipelines/syntax"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -65,12 +66,13 @@ type PipelineStep struct {
 
 // PipelineLifecycles defines the steps of a lifecycle section
 type PipelineLifecycles struct {
-	Setup      *PipelineLifecycle `yaml:"setup,omitempty"`
-	SetVersion *PipelineLifecycle `yaml:"setVersion,omitempty"`
-	PreBuild   *PipelineLifecycle `yaml:"preBuild,omitempty"`
-	Build      *PipelineLifecycle `yaml:"build,omitempty"`
-	PostBuild  *PipelineLifecycle `yaml:"postBuild,omitempty"`
-	Promote    *PipelineLifecycle `yaml:"promote,omitempty"`
+	Setup      *PipelineLifecycle  `yaml:"setup,omitempty"`
+	SetVersion *PipelineLifecycle  `yaml:"setVersion,omitempty"`
+	PreBuild   *PipelineLifecycle  `yaml:"preBuild,omitempty"`
+	Build      *PipelineLifecycle  `yaml:"build,omitempty"`
+	PostBuild  *PipelineLifecycle  `yaml:"postBuild,omitempty"`
+	Promote    *PipelineLifecycle  `yaml:"promote,omitempty"`
+	Pipeline   *syntax.Jenkinsfile `yaml:"pipeline,omitempty"`
 }
 
 // PipelineLifecycle defines the steps of a lifecycle section
@@ -554,6 +556,8 @@ func ExtendPipelines(parent *PipelineLifecycles, base *PipelineLifecycles) *Pipe
 		Build:      ExtendLifecycle(parent.Build, base.Build),
 		PostBuild:  ExtendLifecycle(parent.PostBuild, base.PostBuild),
 		Promote:    ExtendLifecycle(parent.Promote, base.Promote),
+		// TODO: Actually do extension for Pipeline rather than just copying it wholesale
+		Pipeline: parent.Pipeline,
 	}
 }
 

--- a/pkg/jx/cmd/step_create_build.go
+++ b/pkg/jx/cmd/step_create_build.go
@@ -16,10 +16,10 @@ import (
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
+	buildapi "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	buildapi "github.com/knative/build/pkg/apis/build/v1alpha1"
 )
 
 var (

--- a/pkg/kpipelines/constants.go
+++ b/pkg/kpipelines/constants.go
@@ -3,7 +3,4 @@ package kpipelines
 const (
 	// LastBuildNumberAnnotation used to annotate the Pipeline with the latest build number
 	LastBuildNumberAnnotation = "jenkins.io/last-build-number"
-
-	// PipelineAPIVersion the APIVersion for using knative pipeline
-	PipelineAPIVersion = "pipeline.knative.dev/v1alpha1"
 )

--- a/pkg/kpipelines/syntax/constants.go
+++ b/pkg/kpipelines/syntax/constants.go
@@ -1,0 +1,7 @@
+package syntax
+
+const (
+	// PipelineAPIVersion the APIVersion for using Build Pipeline
+	PipelineAPIVersion = "pipeline.knative.dev/v1alpha1"
+)
+

--- a/pkg/kpipelines/syntax/constants.go
+++ b/pkg/kpipelines/syntax/constants.go
@@ -4,4 +4,3 @@ const (
 	// PipelineAPIVersion the APIVersion for using Build Pipeline
 	PipelineAPIVersion = "pipeline.knative.dev/v1alpha1"
 )
-

--- a/pkg/kpipelines/syntax/pipeline.go
+++ b/pkg/kpipelines/syntax/pipeline.go
@@ -1,0 +1,985 @@
+package syntax
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	pipelinev1alpha1 "github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/knative/pkg/apis"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Jenkinsfile struct {
+	Agent       Agent       `yaml:"agent,omitempty"`
+	Environment []EnvVar    `yaml:"environment,omitempty"`
+	Options     RootOptions `yaml:"options,omitempty"`
+	Stages      []Stage     `yaml:"stages"`
+	Post        []Post      `yaml:"post,omitempty"`
+}
+
+type Agent struct {
+	// One of label or image is required.
+	Label string `yaml:"label,omitempty"`
+	Image string `yaml:"image,omitempty"`
+	// Perhaps we'll eventually want to add something here for specifying a volume to create? Would play into stash.
+}
+
+type EnvVar struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+type TimeoutUnit string
+
+const (
+	TimeoutUnitSeconds TimeoutUnit = "seconds"
+	TimeoutUnitMinutes TimeoutUnit = "minutes"
+	TimeoutUnitHours   TimeoutUnit = "hours"
+	TimeoutUnitDays    TimeoutUnit = "days"
+)
+
+var AllTimeoutUnits = []TimeoutUnit{TimeoutUnitSeconds, TimeoutUnitMinutes, TimeoutUnitHours, TimeoutUnitDays}
+
+func allTimeoutUnitsAsStrings() []string {
+	tu := make([]string, len(AllTimeoutUnits))
+
+	for i, u := range AllTimeoutUnits {
+		tu[i] = string(u)
+	}
+
+	return tu
+}
+
+type Timeout struct {
+	Time int64 `yaml:"time"`
+	// Has some sane default - probably seconds
+	Unit TimeoutUnit `yaml:"unit,omitempty"`
+}
+
+func (t Timeout) ToDuration() (*metav1.Duration, error) {
+	durationStr := ""
+	// TODO: Populate a default timeout unit, most likely seconds.
+	if t.Unit != "" {
+		durationStr = fmt.Sprintf("%d%c", t.Time, t.Unit[0])
+	} else {
+		durationStr = fmt.Sprintf("%ds", t.Time)
+	}
+
+	if d, err := time.ParseDuration(durationStr); err != nil {
+		return nil, err
+	} else {
+		return &metav1.Duration{Duration: d}, nil
+	}
+}
+
+type RootOptions struct {
+	Timeout Timeout `yaml:"timeout,omitempty"`
+	// TODO: Not yet implemented in build-pipeline
+	Retry int8 `yaml:"retry,omitempty"`
+}
+
+type Stash struct {
+	Name string `yaml:"name"`
+	// Eventually make this optional so that you can do volumes instead
+	Files string `yaml:"files"`
+}
+
+type Unstash struct {
+	Name string `yaml:"name"`
+	Dir  string `yaml:"dir,omitempty"`
+}
+
+type StageOptions struct {
+	RootOptions `yaml:",inline"`
+
+	// TODO: Not yet implemented in build-pipeline
+	Stash   Stash   `yaml:"stash,omitempty"`
+	Unstash Unstash `yaml:"unstash,omitempty"`
+
+	Workspace *string `yaml:"workspace,omitempty"`
+}
+
+type Step struct {
+	// One of command or step is required.
+	Command string `yaml:"command,omitempty"`
+	// args is optional, but only allowed with command
+	Arguments []string `yaml:"args,omitempty"`
+	// dir is optional, but only allowed with command. Refers to subdirectory of workspace
+	Dir string `yaml:"dir,omitempty"`
+
+	Step string `yaml:"step,omitempty"`
+	// options is optional, but only allowed with step
+	// Also, we'll need to do some magic to do type verification during translation - i.e., this step wants a number
+	// for this option, so translate the string value for that option to a number.
+	Options map[string]string `yaml:"options,omitempty"`
+
+	// agent can be overridden on a step
+	Agent Agent `yaml:"agent,omitempty"`
+}
+
+type Stage struct {
+	Name        string       `yaml:"name"`
+	Agent       Agent        `yaml:"agent,omitempty"`
+	Options     StageOptions `yaml:"options,omitempty"`
+	Environment []EnvVar     `yaml:"environment,omitempty"`
+	Steps       []Step       `yaml:"steps,omitempty"`
+	Stages      []Stage      `yaml:"stages,omitempty"`
+	Parallel    []Stage      `yaml:"parallel,omitempty"`
+	Post        []Post       `yaml:"post,omitempty"`
+}
+
+type PostCondition string
+
+// Probably extensible down the road
+const (
+	PostConditionSuccess PostCondition = "success"
+	PostConditionFailure PostCondition = "failure"
+	PostConditionAlways  PostCondition = "always"
+)
+
+var allPostConditions = []PostCondition{PostConditionAlways, PostConditionSuccess, PostConditionFailure}
+
+type Post struct {
+	// TODO: Conditional execution of something after a Task or Pipeline completes is not yet implemented
+	Condition PostCondition `yaml:"condition"`
+	Actions   []PostAction  `yaml:"actions"`
+}
+
+type PostAction struct {
+	// TODO: Notifications are not yet supported in Build Pipeline per se.
+	Name string `yaml:"name"`
+	// Also, we'll need to do some magic to do type verification during translation - i.e., this action wants a number
+	// for this option, so translate the string value for that option to a number.
+	Options map[string]string `yaml:"options,omitempty"`
+}
+
+var _ apis.Validatable = (*Jenkinsfile)(nil)
+
+func (s *Stage) taskName() string {
+	return strings.ToLower(strings.NewReplacer(" ", "-").Replace(s.Name))
+}
+
+// TODO: Combine with kube.ToValidName (that function needs to handle lengths)
+// MangleToRfc1035Label - Task/Step names need to be RFC 1035/1123 compliant DNS labels, so we mangle
+// them to make them compliant. Results should match the following regex and be
+// no more than 63 characters long:
+//     [a-z]([-a-z0-9]*[a-z0-9])?
+// cf. https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+// body is assumed to have at least one ASCII letter.
+// suffix is assumed to be alphanumeric and non-empty.
+func MangleToRfc1035Label(body string, suffix string) string {
+	const maxLabelLength = 63
+	maxBodyLength := maxLabelLength - len(suffix) - 1 // Add an extra hyphen before the suffix
+
+	var sb strings.Builder
+	bufferedHyphen := false // Used to make sure we don't output consecutive hyphens.
+	for _, codepoint := range body {
+		toWrite := 0
+		if sb.Len() != 0 { // Digits and hyphens aren't allowed to be the first character
+			if codepoint == ' ' || codepoint == '-' || codepoint == '.' {
+				bufferedHyphen = true
+			} else if codepoint >= '0' && codepoint <= '9' {
+				toWrite = 1
+			}
+		}
+
+		if codepoint >= 'A' && codepoint <= 'Z' {
+			codepoint += ('a' - 'A') // Offset to make character lowercase
+			toWrite = 1
+		} else if codepoint >= 'a' && codepoint <= 'z' {
+			toWrite = 1
+		}
+
+		if toWrite > 0 {
+			if bufferedHyphen {
+				toWrite++
+			}
+			if sb.Len()+toWrite > maxBodyLength {
+				break
+			}
+			if bufferedHyphen {
+				sb.WriteRune('-')
+				bufferedHyphen = false
+			}
+			sb.WriteRune(codepoint)
+		}
+	}
+
+	if suffix != "" {
+		sb.WriteRune('-')
+		sb.WriteString(suffix)
+	}
+	return sb.String()
+}
+
+// ParseJenkinsfileYaml takes a YAML string and parses it.
+func ParseJenkinsfileYaml(jenkinsfileYaml string) (*Jenkinsfile, error) {
+	jf := Jenkinsfile{}
+
+	err := yaml.Unmarshal([]byte(jenkinsfileYaml), &jf)
+	if err != nil {
+		return &jf, errors.Wrapf(err, "Failed to unmarshal string %s", jenkinsfileYaml)
+	}
+
+	return &jf, nil
+}
+
+// TODO: Improve validation to actually return all the errors via the nested errors?
+// TODO: Add validation for the not-yet-supported-for-CRD-generation sections
+// Validate checks the parsed Jenkinsfile to find any errors in it.
+func (j *Jenkinsfile) Validate() *apis.FieldError {
+	if err := validateAgent(j.Agent).ViaField("agent"); err != nil {
+		return err
+	}
+
+	if err := validateStages(j.Stages, j.Agent); err != nil {
+		return err
+	}
+
+	if err := validateRootOptions(j.Options).ViaField("options"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateAgent(a Agent) *apis.FieldError {
+	// TODO: This is the same whether you specify an agent without label or image, or if you don't specify an agent
+	// at all, which is nonoptimal.
+	if !equality.Semantic.DeepEqual(a, Agent{}) {
+		if a.Image != "" && a.Label != "" {
+			return apis.ErrMultipleOneOf("label", "image")
+		}
+
+		if a.Image == "" && a.Label == "" {
+			return apis.ErrMissingOneOf("label", "image")
+		}
+	}
+
+	return nil
+}
+
+var containsASCIILetter = regexp.MustCompile(`[a-zA-Z]`).MatchString
+
+func validateStage(s Stage, parentAgent Agent) *apis.FieldError {
+	if len(s.Steps) == 0 && len(s.Stages) == 0 && len(s.Parallel) == 0 {
+		return apis.ErrMissingOneOf("steps", "stages", "parallel")
+	}
+
+	if !containsASCIILetter(s.Name) {
+		return &apis.FieldError{
+			Message: "Stage name must contain at least one ASCII letter",
+			Paths:   []string{"name"},
+		}
+	}
+
+	stageAgent := s.Agent
+	if equality.Semantic.DeepEqual(stageAgent, Agent{}) {
+		stageAgent = parentAgent
+	}
+
+	if equality.Semantic.DeepEqual(stageAgent, Agent{}) {
+		return &apis.FieldError{
+			Message: "No agent specified for stage or for its parent(s)",
+			Paths:   []string{"agent"},
+		}
+	}
+
+	if len(s.Steps) > 0 {
+		if len(s.Stages) > 0 || len(s.Parallel) > 0 {
+			return apis.ErrMultipleOneOf("steps", "stages", "parallel")
+		}
+		for i, step := range s.Steps {
+			if err := validateStep(step).ViaFieldIndex("steps", i); err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(s.Stages) > 0 {
+		if len(s.Parallel) > 0 {
+			return apis.ErrMultipleOneOf("steps", "stages", "parallel")
+		}
+		for i, stage := range s.Stages {
+			if err := validateStage(stage, parentAgent).ViaFieldIndex("stages", i); err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(s.Parallel) > 0 {
+		for i, stage := range s.Parallel {
+			return validateStage(stage, parentAgent).ViaFieldIndex("parallel", i)
+		}
+	}
+
+	return validateStageOptions(s.Options).ViaField("options")
+}
+
+func validateStep(s Step) *apis.FieldError {
+	if s.Command == "" && s.Step == "" {
+		return apis.ErrMissingOneOf("command", "step")
+	}
+
+	if s.Command != "" {
+		if s.Step != "" {
+			return apis.ErrMultipleOneOf("command", "step")
+		} else if len(s.Options) > 0 {
+			return &apis.FieldError{
+				Message: "Cannot set options for a command",
+				Paths:   []string{"options"},
+			}
+		}
+	}
+
+	if s.Step != "" && len(s.Arguments) != 0 {
+		return &apis.FieldError{
+			Message: "Cannot set command-line arguments for a step",
+			Paths:   []string{"args"},
+		}
+	}
+
+	return validateAgent(s.Agent).ViaField("agent")
+}
+
+func validateStages(stages []Stage, parentAgent Agent) *apis.FieldError {
+	if len(stages) == 0 {
+		return apis.ErrMissingField("stages")
+	}
+
+	for i, s := range stages {
+		if err := validateStage(s, parentAgent).ViaFieldIndex("stages", i); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateRootOptions(o RootOptions) *apis.FieldError {
+	if !equality.Semantic.DeepEqual(o, RootOptions{}) {
+		if !equality.Semantic.DeepEqual(o.Timeout, Timeout{}) {
+			if err := validateTimeout(o.Timeout); err != nil {
+				return err.ViaField("timeout")
+			}
+		}
+
+		// TODO: retry will default to 0, so we're kinda stuck checking if it's less than zero here.
+		if o.Retry < 0 {
+			return &apis.FieldError{
+				Message: "Retry count cannot be negative",
+				Paths:   []string{"retry"},
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateStageOptions(o StageOptions) *apis.FieldError {
+	if !equality.Semantic.DeepEqual(o.Stash, Stash{}) {
+		if err := validateStash(o.Stash); err != nil {
+			return err.ViaField("stash")
+		}
+	}
+
+	if !equality.Semantic.DeepEqual(o.Unstash, Unstash{}) {
+		if err := validateUnstash(o.Unstash); err != nil {
+			return err.ViaField("unstash")
+		}
+	}
+
+	if o.Workspace != nil {
+		if err := validateWorkspace(*o.Workspace); err != nil {
+			return err
+		}
+	}
+
+	return validateRootOptions(o.RootOptions)
+}
+
+func validateTimeout(t Timeout) *apis.FieldError {
+	if !equality.Semantic.DeepEqual(t, Timeout{}) {
+		isAllowed := false
+		for _, allowed := range AllTimeoutUnits {
+			if t.Unit == allowed {
+				isAllowed = true
+			}
+		}
+
+		if !isAllowed {
+			return &apis.FieldError{
+				Message: fmt.Sprintf("%s is not a valid time unit. Valid time units are %s", string(t.Unit),
+					strings.Join(allTimeoutUnitsAsStrings(), ", ")),
+				Paths: []string{"unit"},
+			}
+		}
+
+		if t.Time < 1 {
+			return &apis.FieldError{
+				Message: "Timeout must be greater than zero",
+				Paths:   []string{"time"},
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateUnstash(u Unstash) *apis.FieldError {
+	if !equality.Semantic.DeepEqual(u, Unstash{}) {
+		// TODO: Check to make sure the corresponding stash is defined somewhere
+		if u.Name == "" {
+			return &apis.FieldError{
+				Message: "The unstash name must be provided",
+				Paths:   []string{"name"},
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateStash(s Stash) *apis.FieldError {
+	if !equality.Semantic.DeepEqual(s, Stash{}) {
+		if s.Name == "" {
+			return &apis.FieldError{
+				Message: "The stash name must be provided",
+				Paths:   []string{"name"},
+			}
+		}
+		if s.Files == "" {
+			return &apis.FieldError{
+				Message: "files to stash must be provided",
+				Paths:   []string{"files"},
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateWorkspace(w string) *apis.FieldError {
+	if w == "" {
+		return &apis.FieldError{
+			Message: "The workspace name must be unspecified or non-empty",
+			Paths:   []string{"workspace"},
+		}
+	}
+
+	return nil
+}
+
+var randReader = rand.Reader
+
+func scopedEnv(s Stage, parentEnv []corev1.EnvVar) []corev1.EnvVar {
+	if len(parentEnv) == 0 && len(s.Environment) == 0 {
+		return nil
+	}
+	envMap := make(map[string]corev1.EnvVar)
+
+	for _, e := range parentEnv {
+		envMap[e.Name] = e
+	}
+
+	for _, e := range s.Environment {
+		envMap[e.Name] = corev1.EnvVar{
+			Name:  e.Name,
+			Value: e.Value,
+		}
+	}
+
+	env := make([]corev1.EnvVar, 0, len(envMap))
+
+	for _, value := range envMap {
+		env = append(env, value)
+	}
+
+	return env
+}
+
+func (j *Jenkinsfile) toStepEnvVars() []corev1.EnvVar {
+	env := make([]corev1.EnvVar, 0, len(j.Environment))
+
+	for _, e := range j.Environment {
+		env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})
+	}
+
+	return env
+}
+
+type transformedStage struct {
+	Stage Stage
+	// Only one of Sequential, Parallel, and Task is non-empty
+	Sequential []*transformedStage
+	Parallel   []*transformedStage
+	Task       *pipelinev1alpha1.Task
+	// PipelineTask is non-empty only if Task is non-empty, but it is populated
+	// after Task is populated so the reverse is not true.
+	PipelineTask *pipelinev1alpha1.PipelineTask
+	// The depth of this stage in the full tree of stages
+	Depth int8
+	// The parallel or sequntial stage enclosing this stage, or nil if this stage is at top level
+	EnclosingStage *transformedStage
+	// The stage immediately before this stage at the same depth, or nil if there is no such stage
+	PreviousSiblingStage *transformedStage
+	// TODO: Add the equivalent reverse relationship
+}
+
+func (ts transformedStage) isSequential() bool {
+	return len(ts.Sequential) > 0
+}
+
+func (ts transformedStage) isParallel() bool {
+	return len(ts.Parallel) > 0
+}
+
+func (ts transformedStage) getLinearTasks() []*pipelinev1alpha1.Task {
+	if ts.isSequential() {
+		var tasks []*pipelinev1alpha1.Task
+		for _, seqTs := range ts.Sequential {
+			tasks = append(tasks, seqTs.getLinearTasks()...)
+		}
+		return tasks
+	} else if ts.isParallel() {
+		var tasks []*pipelinev1alpha1.Task
+		for _, parTs := range ts.Parallel {
+			tasks = append(tasks, parTs.getLinearTasks()...)
+		}
+		return tasks
+	} else {
+		return []*pipelinev1alpha1.Task{ts.Task}
+	}
+}
+
+// If the workspace is nil, sets it to the parent's workspace
+func (ts *transformedStage) computeWorkspace(parentWorkspace string) {
+	if ts.Stage.Options.Workspace == nil {
+		ts.Stage.Options.Workspace = &parentWorkspace
+	}
+}
+
+func stageToTask(s Stage, pipelineIdentifier string, buildIdentifier string, namespace string, wsPath string, parentEnv []corev1.EnvVar, parentAgent Agent, parentWorkspace string, suffix string, depth int8, enclosingStage *transformedStage, previousSiblingStage *transformedStage, podTemplates map[string]*corev1.Pod) (*transformedStage, error) {
+	if len(s.Post) != 0 {
+		return nil, errors.New("post on stages not yet supported")
+	}
+
+	if !equality.Semantic.DeepEqual(s.Options, StageOptions{}) {
+		o := s.Options
+		if !equality.Semantic.DeepEqual(o.Timeout, Timeout{}) {
+			return nil, errors.New("Timeout on stage not yet supported")
+		}
+		if o.Retry != 0 {
+			return nil, errors.New("Retry on stage not yet supported")
+		}
+		if !equality.Semantic.DeepEqual(o.Stash, Stash{}) {
+			return nil, errors.New("Stash on stage not yet supported")
+		}
+		if !equality.Semantic.DeepEqual(o.Unstash, Unstash{}) {
+			return nil, errors.New("Unstash on stage not yet supported")
+		}
+	}
+
+	env := scopedEnv(s, parentEnv)
+
+	agent := s.Agent
+
+	if equality.Semantic.DeepEqual(agent, Agent{}) {
+		agent = parentAgent
+	}
+
+	stepCounter := 0
+
+	if len(s.Steps) > 0 {
+		if suffix == "" {
+			// Generate a short random hex string.
+			b, err := ioutil.ReadAll(io.LimitReader(randReader, 3))
+			if err != nil {
+				return nil, err
+			}
+			suffix = hex.EncodeToString(b)
+		}
+
+		t := &pipelinev1alpha1.Task{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: PipelineAPIVersion,
+				Kind:       "Task",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      MangleToRfc1035Label(fmt.Sprintf("%s-%s", pipelineIdentifier, s.Name), ""),
+			},
+		}
+		t.SetDefaults()
+
+		ws := &pipelinev1alpha1.TaskResource{
+			Name: "workspace",
+			Type: pipelinev1alpha1.PipelineResourceTypeGit,
+		}
+
+		if wsPath != "" {
+			ws.TargetPath = wsPath
+		}
+
+		t.Spec.Inputs = &pipelinev1alpha1.Inputs{
+			Resources: []pipelinev1alpha1.TaskResource{*ws,
+				{
+					Name: "temp-ordering-resource",
+					Type: pipelinev1alpha1.PipelineResourceTypeImage,
+				},
+			},
+		}
+
+		t.Spec.Outputs = &pipelinev1alpha1.Outputs{
+			Resources: []pipelinev1alpha1.TaskResource{
+				{
+					Name: "workspace",
+					Type: pipelinev1alpha1.PipelineResourceTypeGit,
+				},
+				{
+					Name: "temp-ordering-resource",
+					Type: pipelinev1alpha1.PipelineResourceTypeImage,
+				},
+			},
+		}
+
+		// We don't want to dupe volumes for the Task if there are multiple steps
+		volumes := make(map[string]corev1.Volume)
+		for _, step := range s.Steps {
+			// TODO: Ignoring everything but commands right now, but will eventually need to handle syntactic sugar steps too
+			if step.Command != "" {
+				stepImage := agent.Image
+				if !equality.Semantic.DeepEqual(step.Agent, Agent{}) {
+					stepImage = step.Agent.Image
+				}
+
+				var c corev1.Container
+
+				if podTemplates != nil && podTemplates[stepImage] != nil {
+					podTemplate := podTemplates[stepImage]
+					containers := podTemplate.Spec.Containers
+					for _, volume := range podTemplate.Spec.Volumes {
+						volumes[volume.Name] = volume
+					}
+					c = containers[0]
+					c.Args = append([]string{step.Command}, step.Arguments...)
+				} else {
+					c = corev1.Container{
+						Image:   stepImage,
+						Command: []string{step.Command},
+						Args:    step.Arguments,
+					}
+				}
+				stepCounter++
+				c.Name = "step" + strconv.Itoa(1+stepCounter)
+
+				c.Stdin = false
+				c.TTY = false
+
+				c.Env = env
+
+				t.Spec.Steps = append(t.Spec.Steps, c)
+
+				/*				t.Spec.Steps = append(t.Spec.Steps, corev1.Container{
+								Name:    MangleToRfc1035Label(fmt.Sprintf("stage-%s-step-%d", s.Name, i), suffix),
+								Env:     env,
+								Image:   stepImage,
+								Command: []string{step.Command},
+								Args:    step.Arguments,
+							})*/
+			} else {
+				return nil, errors.New("syntactic sugar steps not yet supported")
+			}
+		}
+		for _, volume := range volumes {
+			t.Spec.Volumes = append(t.Spec.Volumes, volume)
+		}
+		ts := transformedStage{Stage: s, Task: t, Depth: depth, EnclosingStage: enclosingStage, PreviousSiblingStage: previousSiblingStage}
+		ts.computeWorkspace(parentWorkspace)
+		return &ts, nil
+	}
+
+	if len(s.Stages) > 0 {
+		var tasks []*transformedStage
+		ts := transformedStage{Stage: s, Depth: depth, EnclosingStage: enclosingStage, PreviousSiblingStage: previousSiblingStage}
+		ts.computeWorkspace(parentWorkspace)
+
+		for i, nested := range s.Stages {
+			nestedWsPath := ""
+			if wsPath != "" && i == 0 {
+				nestedWsPath = wsPath
+			}
+			var nestedPreviousSibling *transformedStage
+			if i > 0 {
+				nestedPreviousSibling = tasks[i-1]
+			}
+			nestedTask, err := stageToTask(nested, pipelineIdentifier, buildIdentifier, namespace, nestedWsPath, env, agent, *ts.Stage.Options.Workspace, suffix, depth+1, &ts, nestedPreviousSibling, podTemplates)
+			if err != nil {
+				return nil, err
+			}
+			tasks = append(tasks, nestedTask)
+		}
+		ts.Sequential = tasks
+
+		return &ts, nil
+	}
+
+	if len(s.Parallel) > 0 {
+		var tasks []*transformedStage
+		ts := transformedStage{Stage: s, Depth: depth, EnclosingStage: enclosingStage, PreviousSiblingStage: previousSiblingStage}
+		ts.computeWorkspace(parentWorkspace)
+
+		for i, nested := range s.Parallel {
+			nestedWsPath := ""
+			if wsPath != "" && i == 0 {
+				nestedWsPath = wsPath
+			}
+			nestedTask, err := stageToTask(nested, pipelineIdentifier, buildIdentifier, namespace, nestedWsPath, env, agent, *ts.Stage.Options.Workspace, suffix, depth+1, &ts, nil, podTemplates)
+			if err != nil {
+				return nil, err
+			}
+			tasks = append(tasks, nestedTask)
+		}
+		ts.Parallel = tasks
+
+		return &ts, nil
+	}
+
+	return nil, errors.New("no steps, sequential stages, or parallel stages")
+}
+
+// GenerateCRDs translates the Pipeline structure into the corresponding Pipeline and Task CRDs
+func (j *Jenkinsfile) GenerateCRDs(pipelineIdentifier string, buildIdentifier string, namespace string, suffix string, podTemplates map[string]*corev1.Pod) (*pipelinev1alpha1.Pipeline, []*pipelinev1alpha1.Task, error) {
+	if len(j.Post) != 0 {
+		return nil, nil, errors.New("Post at top level not yet supported")
+	}
+
+	if !equality.Semantic.DeepEqual(j.Options, RootOptions{}) {
+		o := j.Options
+		if o.Retry != 0 {
+			return nil, nil, errors.New("Retry at top level not yet supported")
+		}
+	}
+
+	if suffix == "" {
+		// Generate a short random hex string.
+		b, err := ioutil.ReadAll(io.LimitReader(randReader, 3))
+		if err != nil {
+			return nil, nil, err
+		}
+		suffix = hex.EncodeToString(b)
+	}
+
+	p := &pipelinev1alpha1.Pipeline{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: PipelineAPIVersion,
+			Kind:       "Pipeline",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      fmt.Sprintf("%s", pipelineIdentifier),
+		},
+		Spec: pipelinev1alpha1.PipelineSpec{
+			Resources: []pipelinev1alpha1.PipelineDeclaredResource{
+				{
+					Name: pipelineIdentifier,
+					Type: pipelinev1alpha1.PipelineResourceTypeGit,
+				},
+				{
+					// TODO: Switch from this kind of hackish approach to non-resource-based dependencies once they land.
+					Name: "temp-ordering-resource",
+					Type: pipelinev1alpha1.PipelineResourceTypeImage,
+				},
+			},
+		},
+	}
+
+	p.SetDefaults()
+
+	var previousStage *transformedStage
+
+	var tasks []*pipelinev1alpha1.Task
+
+	baseEnv := j.toStepEnvVars()
+
+	for _, s := range j.Stages {
+		wsPath := ""
+		if len(tasks) == 0 {
+			wsPath = "workspace"
+		}
+		stage, err := stageToTask(s, pipelineIdentifier, buildIdentifier, namespace, wsPath, baseEnv, j.Agent, "default", suffix, 0, nil, previousStage, podTemplates)
+		if err != nil {
+			return nil, nil, err
+		}
+		previousStage = stage
+
+		tasks = append(tasks, stage.getLinearTasks()...)
+		p.Spec.Tasks = append(p.Spec.Tasks, createPipelineTasks(stage, pipelineIdentifier)...)
+	}
+
+	return p, tasks, nil
+}
+
+func createPipelineTasks(stage *transformedStage, pipelineIdentifier string) []pipelinev1alpha1.PipelineTask {
+	if stage.isSequential() {
+		var pTasks []pipelinev1alpha1.PipelineTask
+		for _, nestedStage := range stage.Sequential {
+			pTasks = append(pTasks, createPipelineTasks(nestedStage, pipelineIdentifier)...)
+		}
+		return pTasks
+	} else if stage.isParallel() {
+		var pTasks []pipelinev1alpha1.PipelineTask
+		for _, nestedStage := range stage.Parallel {
+			pTasks = append(pTasks, createPipelineTasks(nestedStage, pipelineIdentifier)...)
+		}
+		return pTasks
+	} else {
+		pTask := pipelinev1alpha1.PipelineTask{
+			Name: stage.Stage.taskName(), // TODO: What should this actually be named?
+			TaskRef: pipelinev1alpha1.TaskRef{
+				Name: stage.Task.Name,
+			},
+		}
+
+		_, provider := findWorkspaceProvider(stage, stage.getEnclosing(0))
+		var previousStageNames []string
+		for _, previousStage := range findPreviousNonBlockStages(*stage) {
+			previousStageNames = append(previousStageNames, previousStage.PipelineTask.Name)
+		}
+		pTask.Resources = &pipelinev1alpha1.PipelineTaskResources{
+			Inputs: []pipelinev1alpha1.PipelineTaskInputResource{
+				{
+					Name:     "workspace",
+					Resource: pipelineIdentifier,
+					From:     provider,
+				},
+				{
+					// TODO: Switch from this kind of hackish approach to non-resource-based dependencies once they land.
+					Name:     "temp-ordering-resource",
+					Resource: "temp-ordering-resource",
+					From:     previousStageNames,
+				},
+			},
+			Outputs: []pipelinev1alpha1.PipelineTaskOutputResource{
+				{
+					Name:     "workspace",
+					Resource: pipelineIdentifier,
+				},
+				{
+					// TODO: Switch from this kind of hackish approach to non-resource-based dependencies once they land.
+					Name:     "temp-ordering-resource",
+					Resource: "temp-ordering-resource",
+				},
+			},
+		}
+		stage.PipelineTask = &pTask
+
+		return []pipelinev1alpha1.PipelineTask{pTask}
+	}
+}
+
+// Looks for the most recent Task using the desired workspace that was not in the
+// same parallel stage and returns the name of the corresponding Task.
+func findWorkspaceProvider(stage, sibling *transformedStage) (bool, []string) {
+	if *stage.Stage.Options.Workspace == "empty" {
+		return true, nil
+	}
+
+	for sibling != nil {
+		if sibling.isSequential() {
+			found, provider := findWorkspaceProvider(stage, sibling.Sequential[len(sibling.Sequential)-1])
+			if found {
+				return true, provider
+			}
+		} else if sibling.isParallel() {
+			// We don't want to use a workspace from a parallel stage outside of that stage,
+			// but we do need to descend inwards in case stage is in that same stage.
+			if stage.getEnclosing(sibling.Depth) == sibling {
+				for _, nested := range sibling.Parallel {
+					// Pick the parallel branch that has stage
+					if stage.getEnclosing(nested.Depth) == nested {
+						found, provider := findWorkspaceProvider(stage, nested)
+						if found {
+							return true, provider
+						}
+					}
+				}
+			}
+			// TODO: What to do about custom workspaces? Check for erroneous uses specially?
+			// Allow them if only one of the parallel tasks uses the same resource?
+		} else if sibling.PipelineTask != nil {
+			if *sibling.Stage.Options.Workspace == *stage.Stage.Options.Workspace {
+				return true, []string{sibling.PipelineTask.Name}
+			}
+		} else {
+			// We are in a sequential stage and sibling has not had its PipelineTask created.
+			// Check the task before it so we don't use a workspace of a later task.
+		}
+		sibling = sibling.PreviousSiblingStage
+	}
+
+	return false, nil
+}
+
+// Find the end tasks for this stage, traversing down to the end stages of any
+// nested sequential or parallel stages as well.
+func findEndStages(stage transformedStage) []*transformedStage {
+	if stage.isSequential() {
+		return findEndStages(*stage.Sequential[len(stage.Sequential)-1])
+	} else if stage.isParallel() {
+		var endTasks []*transformedStage
+		for _, pStage := range stage.Parallel {
+			endTasks = append(endTasks, findEndStages(*pStage)...)
+		}
+		return endTasks
+	} else {
+		return []*transformedStage{&stage}
+	}
+}
+
+// Find the tasks that run immediately before this stage, not including
+// sequential or parallel wrapper stages.
+func findPreviousNonBlockStages(stage transformedStage) []*transformedStage {
+	if stage.PreviousSiblingStage != nil {
+		return findEndStages(*stage.PreviousSiblingStage)
+	} else if stage.EnclosingStage != nil {
+		return findPreviousNonBlockStages(*stage.EnclosingStage)
+	} else {
+		return []*transformedStage{}
+	}
+}
+
+// Return the stage that encloses this stage at the given depth, or nil if there is no such stage.
+// Depth must be >= 0. Returns the stage itself if depth == stage.Depth
+func (ts *transformedStage) getEnclosing(depth int8) *transformedStage {
+	if ts.Depth == depth {
+		return ts
+	} else if ts.EnclosingStage == nil {
+		return nil
+	} else {
+		return ts.EnclosingStage.getEnclosing(depth)
+	}
+}
+
+// Return the first stage that will execute before this stage
+// Depth must be >= 0
+func (ts transformedStage) getClosestAncestor() *transformedStage {
+	if ts.PreviousSiblingStage != nil {
+		return ts.PreviousSiblingStage
+	} else if ts.EnclosingStage == nil {
+		return nil
+	} else {
+		return ts.EnclosingStage.getClosestAncestor()
+	}
+}

--- a/pkg/kpipelines/syntax/pipeline_test.go
+++ b/pkg/kpipelines/syntax/pipeline_test.go
@@ -1,0 +1,1311 @@
+package syntax_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/kpipelines/syntax"
+	pipelinev1alpha1 "github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/knative/build-pipeline/test/builder"
+	"github.com/knative/pkg/apis"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TODO: Write a builder for generating the expected objects. Because
+// as this is now, there are way too many lines here.
+func TestParseJenkinsfileYaml(t *testing.T) {
+	// Needed to take address of strings since workspace is *string. Is there a better way to handle optional values?
+	defaultWorkspace := "default"
+	customWorkspace := "custom"
+
+	tests := []struct {
+		name             string
+		expected         *syntax.Jenkinsfile
+		pipeline         *pipelinev1alpha1.Pipeline
+		tasks            []*pipelinev1alpha1.Task
+		expectedErrorMsg string
+	}{
+		{
+			name: "simple_jenkinsfile",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{{
+					Name: "A Working Stage",
+					Steps: []syntax.Step{{
+						Command:   "echo",
+						Arguments: []string{"hello", "world"},
+					}},
+				}},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-a-working-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
+				)),
+			},
+		},
+		{
+			name: "multiple_stages",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{
+					{
+						Name: "A Working Stage",
+						Steps: []syntax.Step{{
+							Command:   "echo",
+							Arguments: []string{"hello", "world"},
+						}},
+					},
+					{
+						Name: "Another stage",
+						Steps: []syntax.Step{{
+							Command:   "echo",
+							Arguments: []string{"again"},
+						}},
+					},
+				},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("another-stage", "somepipeline-another-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline",
+						tb.From("a-working-stage")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("a-working-stage")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-a-working-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
+				)),
+				tb.Task("somepipeline-another-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("again")),
+				)),
+			},
+		},
+		{
+			name: "nested_stages",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{
+					{
+						Name: "Parent Stage",
+						Stages: []syntax.Stage{
+							{
+								Name: "A Working Stage",
+								Steps: []syntax.Step{{
+									Command:   "echo",
+									Arguments: []string{"hello", "world"},
+								}},
+							},
+							{
+								Name: "Another stage",
+								Steps: []syntax.Step{{
+									Command:   "echo",
+									Arguments: []string{"again"},
+								}},
+							},
+						},
+					},
+				},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("another-stage", "somepipeline-another-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline",
+						tb.From("a-working-stage")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("a-working-stage")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-a-working-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
+				)),
+				tb.Task("somepipeline-another-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("again")),
+				)),
+			},
+		},
+		{
+			name: "parallel_stages",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{
+					{
+						Name: "First Stage",
+						Steps: []syntax.Step{{
+							Command:   "echo",
+							Arguments: []string{"first"},
+						}},
+					},
+					{
+						Name: "Parent Stage",
+						Parallel: []syntax.Stage{
+							{
+								Name: "A Working Stage",
+								Steps: []syntax.Step{{
+									Command:   "echo",
+									Arguments: []string{"hello", "world"},
+								}},
+							},
+							{
+								Name: "Another stage",
+								Steps: []syntax.Step{{
+									Command:   "echo",
+									Arguments: []string{"again"},
+								}},
+							},
+						},
+					},
+					{
+						Name: "Last Stage",
+						Steps: []syntax.Step{{
+							Command:   "echo",
+							Arguments: []string{"last"},
+						}},
+					},
+				},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("first-stage", "somepipeline-first-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline", tb.From("first-stage")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("first-stage")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("another-stage", "somepipeline-another-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline",
+						tb.From("first-stage")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("first-stage")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("last-stage", "somepipeline-last-stage",
+					// TODO: Switch from this kind of hackish approach to non-resource-based dependencies once they land.
+					tb.PipelineTaskInputResource("workspace", "somepipeline", tb.From("first-stage")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("a-working-stage", "another-stage")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-first-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("first")),
+				)),
+				tb.Task("somepipeline-a-working-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
+				)),
+				tb.Task("somepipeline-another-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("again")),
+				)),
+				tb.Task("somepipeline-last-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("last")),
+				)),
+			},
+		},
+		{
+			name: "parallel_and_nested_stages",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{
+					{
+						Name: "First Stage",
+						Steps: []syntax.Step{{
+							Command:   "echo",
+							Arguments: []string{"first"},
+						}},
+					},
+					{
+						Name: "Parent Stage",
+						Parallel: []syntax.Stage{
+							{
+								Name: "A Working Stage",
+								Steps: []syntax.Step{{
+									Command:   "echo",
+									Arguments: []string{"hello", "world"},
+								}},
+							},
+							{
+								Name: "Nested In Parallel",
+								Stages: []syntax.Stage{
+									{
+										Name: "Another stage",
+										Steps: []syntax.Step{{
+											Command:   "echo",
+											Arguments: []string{"again"},
+										}},
+									},
+									{
+										Name: "Some other stage",
+										Steps: []syntax.Step{{
+											Command:   "echo",
+											Arguments: []string{"otherwise"},
+										}},
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "Last Stage",
+						Steps: []syntax.Step{{
+							Command:   "echo",
+							Arguments: []string{"last"},
+						}},
+					},
+				},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("first-stage", "somepipeline-first-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline",
+						tb.From("first-stage")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("first-stage")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("another-stage", "somepipeline-another-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline",
+						tb.From("first-stage")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("first-stage")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("some-other-stage", "somepipeline-some-other-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline",
+						tb.From("another-stage")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("another-stage")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("last-stage", "somepipeline-last-stage",
+					// TODO: Switch from this kind of hackish approach to non-resource-based dependencies once they land.
+					tb.PipelineTaskInputResource("workspace", "somepipeline",
+						tb.From("first-stage")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("a-working-stage", "some-other-stage")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-first-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("first")),
+				)),
+				tb.Task("somepipeline-a-working-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
+				)),
+				tb.Task("somepipeline-another-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("again")),
+				)),
+				tb.Task("somepipeline-some-other-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("otherwise")),
+				)),
+				tb.Task("somepipeline-last-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("last")),
+				)),
+			},
+		},
+		{
+			name: "custom_workspaces",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{
+					{
+						Name: "stage1",
+						Steps: []syntax.Step{{
+							Command: "ls",
+						}},
+					},
+					{
+						Name: "stage2",
+						Options: syntax.StageOptions{
+							Workspace: &customWorkspace,
+						},
+						Steps: []syntax.Step{{
+							Command: "ls",
+						}},
+					},
+					{
+						Name: "stage3",
+						Options: syntax.StageOptions{
+							Workspace: &defaultWorkspace,
+						},
+						Steps: []syntax.Step{{
+							Command: "ls",
+						}},
+					},
+					{
+						Name: "stage4",
+						Options: syntax.StageOptions{
+							Workspace: &customWorkspace,
+						},
+						Steps: []syntax.Step{{
+							Command: "ls",
+						}},
+					},
+				},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("stage1", "somepipeline-stage1",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("stage2", "somepipeline-stage2",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("stage1")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("stage3", "somepipeline-stage3",
+					tb.PipelineTaskInputResource("workspace", "somepipeline", tb.From("stage1")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("stage2")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("stage4", "somepipeline-stage4",
+					tb.PipelineTaskInputResource("workspace", "somepipeline", tb.From("stage2")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("stage3")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-stage1", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("ls")),
+				)),
+				tb.Task("somepipeline-stage2", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("ls")),
+				)),
+				tb.Task("somepipeline-stage3", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("ls")),
+				)),
+				tb.Task("somepipeline-stage4", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("ls")),
+				)),
+			},
+		},
+		{
+			name: "inherited_custom_workspaces",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{
+					{
+						Name: "stage1",
+						Steps: []syntax.Step{{
+							Command: "ls",
+						}},
+					},
+					{
+						Name: "stage2",
+						Options: syntax.StageOptions{
+							Workspace: &customWorkspace,
+						},
+						Stages: []syntax.Stage{
+							{
+								Name: "stage3",
+								Steps: []syntax.Step{{
+									Command: "ls",
+								}},
+							},
+							{
+								Name: "stage4",
+								Options: syntax.StageOptions{
+									Workspace: &defaultWorkspace,
+								},
+								Steps: []syntax.Step{{
+									Command: "ls",
+								}},
+							},
+							{
+								Name: "stage5",
+								Steps: []syntax.Step{{
+									Command: "ls",
+								}},
+							},
+						},
+					},
+				},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("stage1", "somepipeline-stage1",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("stage3", "somepipeline-stage3",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("stage1")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("stage4", "somepipeline-stage4",
+					tb.PipelineTaskInputResource("workspace", "somepipeline",
+						tb.From("stage1")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("stage3")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("stage5", "somepipeline-stage5",
+					tb.PipelineTaskInputResource("workspace", "somepipeline",
+						tb.From("stage3")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("stage4")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-stage1", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("ls")),
+				)),
+				tb.Task("somepipeline-stage3", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("ls")),
+				)),
+				tb.Task("somepipeline-stage4", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("ls")),
+				)),
+				tb.Task("somepipeline-stage5", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("ls")),
+				)),
+			},
+		},
+		{
+			name: "environment_at_top_and_in_stage",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Environment: []syntax.EnvVar{{
+					Name:  "SOME_VAR",
+					Value: "A value for the env var",
+				}},
+				Stages: []syntax.Stage{{
+					Name: "A stage with environment",
+					Environment: []syntax.EnvVar{{
+						Name:  "SOME_OTHER_VAR",
+						Value: "A value for the other env var",
+					}},
+					Steps: []syntax.Step{{
+						Command:   "echo",
+						Arguments: []string{"hello", "${SOME_OTHER_VAR}"},
+					}},
+				}},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("a-stage-with-environment", "somepipeline-a-stage-with-environment",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-a-stage-with-environment", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "${SOME_OTHER_VAR}"),
+						// TODO: Ordering doesn't seem to be deterministic.
+						tb.EnvVar("SOME_VAR", "A value for the env var"), tb.EnvVar("SOME_OTHER_VAR", "A value for the other env var")),
+				)),
+			},
+		},
+		{
+			name: "syntactic_sugar_step_and_a_command",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{{
+					Name: "A Working Stage",
+					Steps: []syntax.Step{
+						{
+							Command:   "echo",
+							Arguments: []string{"hello", "world"},
+						},
+						{
+							Step: "some-step",
+							Options: map[string]string{
+								"firstParam":  "some value",
+								"secondParam": "some other value",
+							},
+						},
+					},
+				}},
+			},
+			expectedErrorMsg: "syntactic sugar steps not yet supported",
+		},
+		{
+			name: "post",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{{
+					Name: "A Working Stage",
+					Steps: []syntax.Step{{
+						Command:   "echo",
+						Arguments: []string{"hello", "world"},
+					}},
+					Post: []syntax.Post{
+						{
+							Condition: "success",
+							Actions: []syntax.PostAction{{
+								Name: "mail",
+								Options: map[string]string{
+									"to":      "foo@bar.com",
+									"subject": "Yay, it passed",
+								},
+							}},
+						},
+						{
+							Condition: "failure",
+							Actions: []syntax.PostAction{{
+								Name: "slack",
+								Options: map[string]string{
+									"whatever": "the",
+									"slack":    "config",
+									"actually": "is. =)",
+								},
+							}},
+						},
+						{
+							Condition: "always",
+							Actions: []syntax.PostAction{{
+								Name: "junit",
+								Options: map[string]string{
+									"pattern": "target/surefire-reports/**/*.xml",
+								},
+							}},
+						},
+					},
+				}},
+			},
+			expectedErrorMsg: "post on stages not yet supported",
+		},
+		{
+			name: "top_level_and_stage_options",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Options: syntax.RootOptions{
+					Timeout: syntax.Timeout{
+						Time: 50,
+						Unit: "minutes",
+					},
+					Retry: 3,
+				},
+				Stages: []syntax.Stage{{
+					Name: "A Working Stage",
+					Options: syntax.StageOptions{
+						RootOptions: syntax.RootOptions{
+							Timeout: syntax.Timeout{
+								Time: 5,
+								Unit: "seconds",
+							},
+							Retry: 4,
+						},
+						Stash: syntax.Stash{
+							Name:  "Some Files",
+							Files: "somedir/**/*",
+						},
+						Unstash: syntax.Unstash{
+							Name: "Earlier Files",
+							Dir:  "some/sub/dir",
+						},
+					},
+					Steps: []syntax.Step{{
+						Command:   "echo",
+						Arguments: []string{"hello", "world"},
+					}},
+				}},
+			},
+			expectedErrorMsg: "Retry at top level not yet supported",
+		},
+		{
+			name: "stage_and_step_agent",
+			expected: &syntax.Jenkinsfile{
+				Stages: []syntax.Stage{{
+					Name: "A Working Stage",
+					Agent: syntax.Agent{
+						Image: "some-image",
+					},
+					Steps: []syntax.Step{
+						{
+							Command:   "echo",
+							Arguments: []string{"hello", "world"},
+							Agent: syntax.Agent{
+								Image: "some-other-image",
+							},
+						},
+						{
+							Command:   "echo",
+							Arguments: []string{"goodbye"},
+						},
+					},
+				}},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-a-working-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-other-image", tb.Command("echo"), tb.Args("hello", "world")),
+					tb.Step("step3", "some-image", tb.Command("echo"), tb.Args("goodbye")),
+				)),
+			},
+		},
+		{
+			name: "mangled_task_names",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{
+					{
+						Name: ". -a- .",
+						Steps: []syntax.Step{{
+							Command:   "ls",
+							Arguments: nil,
+						}},
+					},
+					{
+						Name: "Wööh!!!! - This is cool.",
+						Steps: []syntax.Step{{
+							Command:   "ls",
+							Arguments: nil,
+						}},
+					},
+				},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask(".--a--.", "somepipeline-a",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("wööh!!!!---this-is-cool.", "somepipeline-wh-this-is-cool",
+					tb.PipelineTaskInputResource("workspace", "somepipeline",
+						tb.From(".--a--.")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From(".--a--.")),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-a", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("ls")),
+				)),
+				tb.Task("somepipeline-wh-this-is-cool", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("ls")),
+				)),
+			},
+		},
+		{
+			name: "stage_timeout",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Stages: []syntax.Stage{{
+					Name: "A Working Stage",
+					Options: syntax.StageOptions{
+						RootOptions: syntax.RootOptions{
+							Timeout: syntax.Timeout{
+								Time: 50,
+								Unit: "minutes",
+							},
+						},
+					},
+					Steps: []syntax.Step{{
+						Command:   "echo",
+						Arguments: []string{"hello", "world"},
+					}},
+				}},
+			},
+			/* TODO: Stop erroring out once we figure out how to handle task timeouts again
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-a-working-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskTimeout(50*time.Minute),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
+				)),
+			},*/
+			expectedErrorMsg: "Timeout on stage not yet supported",
+		},
+		{
+			name: "top_level_timeout",
+			expected: &syntax.Jenkinsfile{
+				Agent: syntax.Agent{
+					Image: "some-image",
+				},
+				Options: syntax.RootOptions{
+					Timeout: syntax.Timeout{
+						Time: 50,
+						Unit: "minutes",
+					},
+				},
+				Stages: []syntax.Stage{{
+					Name: "A Working Stage",
+					Steps: []syntax.Step{{
+						Command:   "echo",
+						Arguments: []string{"hello", "world"},
+					}},
+				}},
+			},
+			pipeline: tb.Pipeline("somepipeline", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+					tb.PipelineTaskInputResource("workspace", "somepipeline"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
+					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
+					tb.PipelineTaskOutputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("somepipeline", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-a-working-stage", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
+					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
+				)),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectConfig, fn, err := config.LoadProjectConfig("test_data/" + tt.name)
+			if err != nil {
+				t.Fatalf("Failed to parse YAML for %s: %q", tt.name, err)
+			}
+
+			if projectConfig.PipelineConfig == nil {
+				t.Fatalf("PipelineConfig at %s is nil: %+v", fn, projectConfig)
+			}
+			if &projectConfig.PipelineConfig.Pipelines == nil {
+				t.Fatalf("Pipelines at %s is nil: %+v", fn, projectConfig.PipelineConfig)
+			}
+			if projectConfig.PipelineConfig.Pipelines.Release == nil {
+				t.Fatalf("Release at %s is nil: %+v", fn, projectConfig.PipelineConfig.Pipelines)
+			}
+			if projectConfig.PipelineConfig.Pipelines.Release.Pipeline == nil {
+				t.Fatalf("Pipeline at %s is nil: %+v", fn, projectConfig.PipelineConfig.Pipelines.Release)
+			}
+			parsed := projectConfig.PipelineConfig.Pipelines.Release.Pipeline
+
+			if d := cmp.Diff(tt.expected, parsed); d != "" {
+				t.Errorf("Parsed Jenkinsfile did not match expected: %s", d)
+			}
+
+			validateErr := parsed.Validate()
+			if validateErr != nil {
+				t.Errorf("Validation failed: %s", validateErr)
+			}
+
+			pipeline, tasks, err := parsed.GenerateCRDs("somepipeline", "somebuild", "somenamespace", "abcd", nil)
+
+			if err != nil {
+				if tt.expectedErrorMsg != "" {
+					if d := cmp.Diff(tt.expectedErrorMsg, err.Error()); d != "" {
+						t.Fatalf("CRD generation error did not meet expectation: %s", d)
+					}
+				} else {
+					t.Fatalf("Error generating CRDs: %s", err)
+				}
+			}
+
+			if tt.expectedErrorMsg == "" {
+				pipeline.TypeMeta = metav1.TypeMeta{}
+				if d := cmp.Diff(tt.pipeline, pipeline); d != "" {
+					t.Errorf("Generated Pipeline did not match expected: %s", d)
+				}
+
+				if err := pipeline.Spec.Validate(); err != nil {
+					t.Errorf("PipelineSpec.Validate() = %v", err)
+				}
+
+				for _, task := range tasks {
+					task.TypeMeta = metav1.TypeMeta{}
+				}
+				if d := cmp.Diff(tt.tasks, tasks); d != "" {
+					t.Errorf("Generated Tasks did not match expected: %s", d)
+				}
+
+				for _, task := range tasks {
+					if err := task.Spec.Validate(); err != nil {
+						t.Errorf("TaskSpec.Validate() = %v", err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFailedValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		expectedError *apis.FieldError
+	}{
+		/* TODO: Once we figure out how to differentiate between an empty agent and no agent specified...
+		{
+			name: "empty_agent",
+			expectedError: &apis.FieldError{
+				Message: "Invalid apiVersion format: must be 'v(digits).(digits)",
+				Paths:   []string{"apiVersion"},
+			},
+		},
+		*/
+		{
+			name: "agent_with_both_image_and_label",
+			expectedError: apis.ErrMultipleOneOf("label", "image").
+				ViaField("agent"),
+		},
+		{
+			name:          "no_stages",
+			expectedError: apis.ErrMissingField("stages"),
+		},
+		{
+			name:          "no_steps_stages_or_parallel",
+			expectedError: apis.ErrMissingOneOf("steps", "stages", "parallel").ViaFieldIndex("stages", 0),
+		},
+		{
+			name:          "steps_and_stages",
+			expectedError: apis.ErrMultipleOneOf("steps", "stages", "parallel").ViaFieldIndex("stages", 0),
+		},
+		{
+			name:          "steps_and_parallel",
+			expectedError: apis.ErrMultipleOneOf("steps", "stages", "parallel").ViaFieldIndex("stages", 0),
+		},
+		{
+			name:          "stages_and_parallel",
+			expectedError: apis.ErrMultipleOneOf("steps", "stages", "parallel").ViaFieldIndex("stages", 0),
+		},
+		{
+			name:          "step_without_command_or_step",
+			expectedError: apis.ErrMissingOneOf("command", "step").ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
+		},
+		{
+			name:          "step_with_both_command_and_step",
+			expectedError: apis.ErrMultipleOneOf("command", "step").ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "step_with_command_and_options",
+			expectedError: (&apis.FieldError{
+				Message: "Cannot set options for a command",
+				Paths:   []string{"options"},
+			}).ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "step_with_step_and_arguments",
+			expectedError: (&apis.FieldError{
+				Message: "Cannot set command-line arguments for a step",
+				Paths:   []string{"args"},
+			}).ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "no_parent_or_stage_agent",
+			expectedError: (&apis.FieldError{
+				Message: "No agent specified for stage or for its parent(s)",
+				Paths:   []string{"agent"},
+			}).ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "top_level_timeout_without_time",
+			expectedError: (&apis.FieldError{
+				Message: "Timeout must be greater than zero",
+				Paths:   []string{"time"},
+			}).ViaField("timeout").ViaField("options"),
+		},
+		{
+			name: "stage_timeout_without_time",
+			expectedError: (&apis.FieldError{
+				Message: "Timeout must be greater than zero",
+				Paths:   []string{"time"},
+			}).ViaField("timeout").ViaField("options").ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "top_level_timeout_with_invalid_unit",
+			expectedError: (&apis.FieldError{
+				Message: "years is not a valid time unit. Valid time units are seconds, minutes, hours, days",
+				Paths:   []string{"unit"},
+			}).ViaField("timeout").ViaField("options"),
+		},
+		{
+			name: "stage_timeout_with_invalid_unit",
+			expectedError: (&apis.FieldError{
+				Message: "years is not a valid time unit. Valid time units are seconds, minutes, hours, days",
+				Paths:   []string{"unit"},
+			}).ViaField("timeout").ViaField("options").ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "top_level_timeout_with_invalid_time",
+			expectedError: (&apis.FieldError{
+				Message: "Timeout must be greater than zero",
+				Paths:   []string{"time"},
+			}).ViaField("timeout").ViaField("options"),
+		},
+		{
+			name: "stage_timeout_with_invalid_time",
+			expectedError: (&apis.FieldError{
+				Message: "Timeout must be greater than zero",
+				Paths:   []string{"time"},
+			}).ViaField("timeout").ViaField("options").ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "top_level_retry_with_invalid_count",
+			expectedError: (&apis.FieldError{
+				Message: "Retry count cannot be negative",
+				Paths:   []string{"retry"},
+			}).ViaField("options"),
+		},
+		{
+			name: "stage_retry_with_invalid_count",
+			expectedError: (&apis.FieldError{
+				Message: "Retry count cannot be negative",
+				Paths:   []string{"retry"},
+			}).ViaField("options").ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "stash_without_name",
+			expectedError: (&apis.FieldError{
+				Message: "The stash name must be provided",
+				Paths:   []string{"name"},
+			}).ViaField("stash").ViaField("options").ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "stash_without_files",
+			expectedError: (&apis.FieldError{
+				Message: "files to stash must be provided",
+				Paths:   []string{"files"},
+			}).ViaField("stash").ViaField("options").ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "unstash_without_name",
+			expectedError: (&apis.FieldError{
+				Message: "The unstash name must be provided",
+				Paths:   []string{"name"},
+			}).ViaField("unstash").ViaField("options").ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "blank_stage_name",
+			expectedError: (&apis.FieldError{
+				Message: "Stage name must contain at least one ASCII letter",
+				Paths:   []string{"name"},
+			}).ViaFieldIndex("stages", 0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yamlFile := filepath.Join("test_data", "validation_failures", tt.name+".yaml")
+			YamlToRead, YamlReadErr := ioutil.ReadFile(yamlFile)
+			if YamlReadErr != nil {
+				t.Fatalf("Could not read yaml file: %s ", yamlFile)
+			}
+			tt.name = string(YamlToRead)
+
+			parsed, parseErr := syntax.ParseJenkinsfileYaml(tt.name)
+			if parseErr != nil {
+				t.Fatalf("Failed to parse YAML for %s: %q", tt.name, parseErr)
+			}
+
+			err := parsed.Validate()
+
+			if err == nil {
+				t.Fatalf("Expected a validation failure but none occurred")
+			}
+
+			if d := cmp.Diff(tt.expectedError, err, cmp.AllowUnexported(apis.FieldError{})); d != "" {
+				t.Fatalf("Validation error did not meet expectation: %s", d)
+			}
+		})
+	}
+}
+
+func TestRfc1035LabelMangling(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "unmodified",
+			input:    "unmodified",
+			expected: "unmodified-suffix",
+		},
+		{
+			name:     "spaces",
+			input:    "A Simple Test.",
+			expected: "a-simple-test-suffix",
+		},
+		{
+			name:     "no leading digits",
+			input:    "0123456789no-leading-digits",
+			expected: "no-leading-digits-suffix",
+		},
+		{
+			name:     "no leading hyphens",
+			input:    "----no-leading-hyphens",
+			expected: "no-leading-hyphens-suffix",
+		},
+		{
+			name:     "no consecutive hyphens",
+			input:    "no--consecutive- hyphens",
+			expected: "no-consecutive-hyphens-suffix",
+		},
+		{
+			name:     "no trailing hyphens",
+			input:    "no-trailing-hyphens----",
+			expected: "no-trailing-hyphens-suffix",
+		},
+		{
+			name:     "no symbols",
+			input:    "&$^#@(*&$^-whoops",
+			expected: "whoops-suffix",
+		},
+		{
+			name:     "no unprintable characters",
+			input:    "a\n\t\x00b",
+			expected: "ab-suffix",
+		},
+		{
+			name:     "no unicode",
+			input:    "japan-日本",
+			expected: "japan-suffix",
+		},
+		{
+			name:     "no non-bmp characters",
+			input:    "happy 😃",
+			expected: "happy-suffix",
+		},
+		{
+			name:     "truncated to 63",
+			input:    "a0123456789012345678901234567890123456789012345678901234567890123456789",
+			expected: "a0123456789012345678901234567890123456789012345678901234-suffix",
+		},
+		{
+			name:     "truncated to 62",
+			input:    "a012345678901234567890123456789012345678901234567890123-567890123456789",
+			expected: "a012345678901234567890123456789012345678901234567890123-suffix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mangled := syntax.MangleToRfc1035Label(tt.input, "suffix")
+			if d := cmp.Diff(tt.expected, mangled); d != "" {
+				t.Fatalf("Mangled output did not match expected output: %s", d)
+			}
+		})
+	}
+}

--- a/pkg/kpipelines/syntax/pipeline_test.go
+++ b/pkg/kpipelines/syntax/pipeline_test.go
@@ -23,14 +23,14 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		expected         *syntax.Jenkinsfile
+		expected         *syntax.PipelineStructure
 		pipeline         *pipelinev1alpha1.Pipeline
 		tasks            []*pipelinev1alpha1.Task
 		expectedErrorMsg string
 	}{
 		{
 			name: "simple_jenkinsfile",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -64,7 +64,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "multiple_stages",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -122,7 +122,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "nested_stages",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -185,7 +185,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "parallel_stages",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -291,7 +291,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "parallel_and_nested_stages",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -426,7 +426,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "custom_workspaces",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -530,7 +530,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "inherited_custom_workspaces",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -638,7 +638,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "environment_at_top_and_in_stage",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -682,7 +682,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "syntactic_sugar_step_and_a_command",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -707,7 +707,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "post",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -755,7 +755,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "top_level_and_stage_options",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -795,7 +795,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "stage_and_step_agent",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Stages: []syntax.Stage{{
 					Name: "A Working Stage",
 					Agent: syntax.Agent{
@@ -839,7 +839,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "mangled_task_names",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -897,7 +897,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "stage_timeout",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -942,7 +942,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 		},
 		{
 			name: "top_level_timeout",
-			expected: &syntax.Jenkinsfile{
+			expected: &syntax.PipelineStructure{
 				Agent: syntax.Agent{
 					Image: "some-image",
 				},
@@ -1004,7 +1004,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 			parsed := projectConfig.PipelineConfig.Pipelines.Release.Pipeline
 
 			if d := cmp.Diff(tt.expected, parsed); d != "" {
-				t.Errorf("Parsed Jenkinsfile did not match expected: %s", d)
+				t.Errorf("Parsed PipelineStructure did not match expected: %s", d)
 			}
 
 			validateErr := parsed.Validate()

--- a/pkg/kpipelines/syntax/test_data/custom_workspaces/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/custom_workspaces/jenkins-x.yml
@@ -1,0 +1,25 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: stage1
+            steps:
+              - command: ls
+          - name: stage2
+            options:
+              workspace: custom
+            steps:
+              - command: ls
+          - name: stage3
+            options:
+              workspace: default
+            steps:
+              - command: ls
+          - name: stage4
+            options:
+              workspace: custom
+            steps:
+              - command: ls

--- a/pkg/kpipelines/syntax/test_data/environment_at_top_and_in_stage/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/environment_at_top_and_in_stage/jenkins-x.yml
@@ -1,0 +1,17 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        environment:
+          - name: SOME_VAR
+            value: A value for the env var
+        stages:
+          - name: A stage with environment
+            environment:
+                - name: SOME_OTHER_VAR
+                  value: A value for the other env var
+            steps:
+              - command: echo
+                args: ['hello', '${SOME_OTHER_VAR}']

--- a/pkg/kpipelines/syntax/test_data/inherited_custom_workspaces/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/inherited_custom_workspaces/jenkins-x.yml
@@ -1,0 +1,25 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: stage1
+            steps:
+              - command: ls
+          - name: stage2
+            options:
+              workspace: custom
+            stages:
+              - name: stage3
+                steps:
+                  - command: ls
+              - name: stage4
+                options:
+                  workspace: default
+                steps:
+                  - command: ls
+              - name: stage5
+                steps:
+                  - command: ls

--- a/pkg/kpipelines/syntax/test_data/mangled_task_names/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/mangled_task_names/jenkins-x.yml
@@ -1,0 +1,13 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: . -a- .
+            steps:
+              - command: ls
+          - name: Wööh!!!! - This is cool.
+            steps:
+              - command: ls

--- a/pkg/kpipelines/syntax/test_data/multiple_stages/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/multiple_stages/jenkins-x.yml
@@ -1,0 +1,17 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+          - name: Another stage
+            steps:
+              - command: echo
+                args: ['again']

--- a/pkg/kpipelines/syntax/test_data/nested_stages/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/nested_stages/jenkins-x.yml
@@ -1,0 +1,19 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: Parent Stage
+            stages:
+              - name: A Working Stage
+                steps:
+                  - command: echo
+                    args:
+                      - hello
+                      - world
+              - name: Another stage
+                steps:
+                  - command: echo
+                    args: ['again']

--- a/pkg/kpipelines/syntax/test_data/parallel_and_nested_stages/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/parallel_and_nested_stages/jenkins-x.yml
@@ -1,0 +1,33 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: First Stage
+            steps:
+              - command: echo
+                args: ['first']
+          - name: Parent Stage
+            parallel:
+              - name: A Working Stage
+                steps:
+                  - command: echo
+                    args:
+                      - hello
+                      - world
+              - name: Nested In Parallel
+                stages:
+                  - name: Another stage
+                    steps:
+                      - command: echo
+                        args: ['again']
+                  - name: Some other stage
+                    steps:
+                      - command: echo
+                        args: ['otherwise']
+          - name: Last Stage
+            steps:
+              - command: echo
+                args: ['last']

--- a/pkg/kpipelines/syntax/test_data/parallel_stages/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/parallel_stages/jenkins-x.yml
@@ -1,0 +1,27 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: First Stage
+            steps:
+              - command: echo
+                args: ['first']
+          - name: Parent Stage
+            parallel:
+              - name: A Working Stage
+                steps:
+                  - command: echo
+                    args:
+                      - hello
+                      - world
+              - name: Another stage
+                steps:
+                  - command: echo
+                    args: ['again']
+          - name: Last Stage
+            steps:
+              - command: echo
+                args: ['last']

--- a/pkg/kpipelines/syntax/test_data/post/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/post/jenkins-x.yml
@@ -1,0 +1,32 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+            post:
+              - condition: success
+                actions:
+                  - name: mail
+                    options:
+                      to: foo@bar.com
+                      subject: "Yay, it passed"
+              - condition: failure
+                actions:
+                  - name: slack
+                    options:
+                      whatever: the
+                      slack: config
+                      actually: "is. =)"
+              - condition: always
+                actions:
+                  - name: junit
+                    options:
+                      pattern: "target/surefire-reports/**/*.xml"

--- a/pkg/kpipelines/syntax/test_data/simple_jenkinsfile/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/simple_jenkinsfile/jenkins-x.yml
@@ -1,0 +1,13 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world

--- a/pkg/kpipelines/syntax/test_data/stage_and_step_agent/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/stage_and_step_agent/jenkins-x.yml
@@ -1,0 +1,17 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        stages:
+          - name: A Working Stage
+            agent:
+              image: some-image
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                agent:
+                  image: some-other-image
+              - command: echo
+                args: ['goodbye']

--- a/pkg/kpipelines/syntax/test_data/stage_timeout/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/stage_timeout/jenkins-x.yml
@@ -1,0 +1,17 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            options:
+              timeout:
+                time: 50
+                unit: minutes
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world

--- a/pkg/kpipelines/syntax/test_data/syntactic_sugar_step_and_a_command/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/syntactic_sugar_step_and_a_command/jenkins-x.yml
@@ -1,0 +1,17 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+              - step: "some-step"
+                options:
+                  firstParam: "some value"
+                  secondParam: "some other value"

--- a/pkg/kpipelines/syntax/test_data/top_level_and_stage_options/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/top_level_and_stage_options/jenkins-x.yml
@@ -1,0 +1,29 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        options:
+          timeout:
+            time: 50
+            unit: minutes
+          retry: 3
+        stages:
+          - name: A Working Stage
+            options:
+              timeout:
+                time: 5
+                unit: seconds
+              retry: 4
+              stash:
+                name: Some Files
+                files: "somedir/**/*"
+              unstash:
+                name: Earlier Files
+                dir: some/sub/dir
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world

--- a/pkg/kpipelines/syntax/test_data/top_level_timeout/jenkins-x.yml
+++ b/pkg/kpipelines/syntax/test_data/top_level_timeout/jenkins-x.yml
@@ -1,0 +1,17 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        options:
+          timeout:
+            time: 50
+            unit: minutes
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/agent_with_both_image_and_label.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/agent_with_both_image_and_label.yaml
@@ -1,0 +1,10 @@
+agent:
+  image: some-image
+  label: some-label
+stages:
+  - name: A Working Stage
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/bad_apiVersion.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/bad_apiVersion.yaml
@@ -1,0 +1,10 @@
+apiVersion: baaaad
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/blank_stage_name.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/blank_stage_name.yaml
@@ -1,0 +1,6 @@
+agent:
+  image: some-image
+stages:
+  - name: .-  ^ ö
+    steps:
+      - command: ls

--- a/pkg/kpipelines/syntax/test_data/validation_failures/empty_agent.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/empty_agent.yaml
@@ -1,0 +1,8 @@
+agent:
+stages:
+  - name: A Working Stage
+    steps:
+      - command: echo
+        args:
+    - hello
+    - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/no_parent_or_stage_agent.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/no_parent_or_stage_agent.yaml
@@ -1,0 +1,7 @@
+stages:
+  - name: A Working Stage
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/no_stages.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/no_stages.yaml
@@ -1,0 +1,2 @@
+agent:
+  image: some-image

--- a/pkg/kpipelines/syntax/test_data/validation_failures/no_steps_stages_or_parallel.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/no_steps_stages_or_parallel.yaml
@@ -1,0 +1,4 @@
+agent:
+  image: some-image
+stages:
+  - name: A Broken Stage

--- a/pkg/kpipelines/syntax/test_data/validation_failures/stage_retry_with_invalid_count.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/stage_retry_with_invalid_count.yaml
@@ -1,0 +1,11 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    options:
+      retry: -5
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/stage_timeout_with_invalid_time.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/stage_timeout_with_invalid_time.yaml
@@ -1,0 +1,13 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    options:
+      timeout:
+        time: 0
+        unit: minutes
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/stage_timeout_with_invalid_unit.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/stage_timeout_with_invalid_unit.yaml
@@ -1,0 +1,13 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    options:
+      timeout:
+        time: 5
+        unit: years
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/stage_timeout_without_time.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/stage_timeout_without_time.yaml
@@ -1,0 +1,12 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    options:
+      timeout:
+        unit: seconds
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/stages_and_parallel.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/stages_and_parallel.yaml
@@ -1,0 +1,14 @@
+agent:
+  image: some-image
+stages:
+  - name: A Broken Stage
+    stages:
+      - name: Nested
+        steps:
+          - command: echo
+            arguments: ['oops']
+    parallel:
+      - name: Other Nested
+        steps:
+          - command: echo
+            arguments: again

--- a/pkg/kpipelines/syntax/test_data/validation_failures/stash_without_files.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/stash_without_files.yaml
@@ -1,0 +1,12 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    options:
+      stash:
+        name: a-stash
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/stash_without_name.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/stash_without_name.yaml
@@ -1,0 +1,12 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    options:
+      stash:
+        files: "foo/**/*"
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/step_with_both_command_and_step.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/step_with_both_command_and_step.yaml
@@ -1,0 +1,7 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    steps:
+      - command: echo
+        step: some-step

--- a/pkg/kpipelines/syntax/test_data/validation_failures/step_with_command_and_options.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/step_with_command_and_options.yaml
@@ -1,0 +1,8 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    steps:
+      - command: echo
+        options:
+          someOptions: someValue

--- a/pkg/kpipelines/syntax/test_data/validation_failures/step_with_step_and_arguments.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/step_with_step_and_arguments.yaml
@@ -1,0 +1,7 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    steps:
+      - step: some-step
+        args: ['some', 'args']

--- a/pkg/kpipelines/syntax/test_data/validation_failures/step_without_command_or_step.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/step_without_command_or_step.yaml
@@ -1,0 +1,6 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    steps:
+      - args: ['hello','world']

--- a/pkg/kpipelines/syntax/test_data/validation_failures/steps_and_parallel.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/steps_and_parallel.yaml
@@ -1,0 +1,12 @@
+agent:
+  image: some-image
+stages:
+  - name: A Broken Stage
+    steps:
+      - command: echo
+        arguments: ["hello","world"]
+    parallel:
+      - name: Nested
+        steps:
+          - command: echo
+            arguments: ['oops']

--- a/pkg/kpipelines/syntax/test_data/validation_failures/steps_and_stages.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/steps_and_stages.yaml
@@ -1,0 +1,12 @@
+agent:
+  image: some-image
+stages:
+  - name: A Broken Stage
+    steps:
+      - command: echo
+        arguments: ["hello","world"]
+    stages:
+      - name: Nested
+        steps:
+          - command: echo
+            arguments: ['oops']

--- a/pkg/kpipelines/syntax/test_data/validation_failures/top_level_retry_with_invalid_count.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/top_level_retry_with_invalid_count.yaml
@@ -1,0 +1,11 @@
+agent:
+  image: some-image
+options:
+  retry: -5
+stages:
+  - name: A Working Stage
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/top_level_timeout_with_invalid_time.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/top_level_timeout_with_invalid_time.yaml
@@ -1,0 +1,13 @@
+agent:
+  image: some-image
+options:
+  timeout:
+    time: 0
+    unit: minutes
+stages:
+  - name: A Working Stage
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/top_level_timeout_with_invalid_unit.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/top_level_timeout_with_invalid_unit.yaml
@@ -1,0 +1,13 @@
+agent:
+  image: some-image
+options:
+  timeout:
+    time: 5
+    unit: years
+stages:
+  - name: A Working Stage
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/top_level_timeout_without_time.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/top_level_timeout_without_time.yaml
@@ -1,0 +1,12 @@
+agent:
+  image: some-image
+options:
+  timeout:
+    unit: seconds
+stages:
+  - name: A Working Stage
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world

--- a/pkg/kpipelines/syntax/test_data/validation_failures/unstash_without_name.yaml
+++ b/pkg/kpipelines/syntax/test_data/validation_failures/unstash_without_name.yaml
@@ -1,0 +1,12 @@
+agent:
+  image: some-image
+stages:
+  - name: A Working Stage
+    options:
+      unstash:
+        dir: some/dir
+    steps:
+      - command: echo
+        args:
+          - hello
+          - world


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests. (NOTE: No bdd tests yet - will build those out for `jx step create task` in general shortly)

#### Description

This adds the ability to define the Pipeline in `jenkins-x.yml`, as a
new field under `release` et al called `pipeline`. If `jenkins-x.yml`
is found in the repo when running `jx step create task` and it has a
`pipeline` field defined, that will be transformed into Build Pipeline
CRDs and applied, rather than using a build pack.

Co-authored-by: Devin Nusbaum <d.w.nusbaum@gmail.com>
Co-authored-by: Karl Shultz <kshultz@cloudbees.com>

#### Special notes for the reviewer(s)

Not sure if this (and `jx step create task` in general) should be hidden behind a feature flag - there's definitely going to be some rough edges here that we'll iterate on rapidly, but I didn't want to keep working on this in isolation any longer.

cc @rawlingsj and @jstrachan in particular

#### Which issue this PR fixes

n/a