### PR TITLE
feat(vault): prefix the system vault and all the related resources with the short cluster name

### DIFF
--- a/pkg/cloud/gke/gcloud.go
+++ b/pkg/cloud/gke/gcloud.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/jenkins-x/jx/pkg/kube"
 	yaml "gopkg.in/yaml.v2"
 
 	"time"
@@ -35,39 +34,6 @@ var (
 		"roles/storage.objectAdmin",
 		"roles/storage.objectCreator"}
 )
-
-// ClusterName gets the cluster name from the current context
-// Note that this just reads the ClusterName from the local kube config, which can be renamed (but is unlikely to happen)
-func ClusterName(kuber kube.Kuber) (string, error) {
-	config, _, err := kuber.LoadConfig()
-	if err != nil {
-		return "", err
-	}
-
-	context := kube.CurrentContext(config)
-	if context == nil {
-		return "", errors.New("kube context was nil")
-	}
-	// context.Cluster will likely be in the form gke_<accountName>_<region>_<clustername>
-	// Trim off the crud from the beginning context.Cluster
-	return GetSimplifiedClusterName(context.Cluster), nil
-}
-
-// ShortClusterName returns a short clusters name. Eg, if ClusterName would return tweetypie-jenkinsx-dev, ShortClusterName
-// would return tweetypie. This is needed because GCP has character limits on things like service accounts (6-30 chars)
-// and combining a long cluster name and a long vault name exceeds this limit
-func ShortClusterName(kuber kube.Kuber) (string, error) {
-	clusterName, err := ClusterName(kuber)
-	return strings.Split(clusterName, "-")[0], err
-}
-
-// GetSimplifiedClusterName get the simplified cluster name from the long-winded context cluster name that gets generated
-// GKE cluster names as defined in the kube config are of the form gke_<projectname>_<region>_<clustername>
-// This method will return <clustername> in the above
-func GetSimplifiedClusterName(complexClusterName string) string {
-	split := strings.Split(complexClusterName, "_")
-	return split[len(split)-1]
-}
 
 // ClusterZone retrives the zone of GKE cluster description
 func ClusterZone(cluster string) (string, error) {

--- a/pkg/cloud/gke/gcloud_test.go
+++ b/pkg/cloud/gke/gcloud_test.go
@@ -3,10 +3,6 @@ package gke
 import (
 	"testing"
 
-	"github.com/jenkins-x/jx/pkg/kube/mocks"
-	. "github.com/petergtz/pegomock"
-	"k8s.io/client-go/tools/clientcmd/api"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,45 +13,4 @@ func TestGetRegionFromZone(t *testing.T) {
 
 	r = GetRegionFromZone("uswest1-d")
 	assert.Equal(t, r, "uswest1")
-}
-
-func TestGetSimplifiedClusterName(t *testing.T) {
-	t.Parallel()
-	simpleName := GetSimplifiedClusterName("gke_jenkinsx-dev_europe-west1-b_my-cluster-name")
-
-	assert.Equal(t, "my-cluster-name", simpleName)
-}
-
-func TestShortClusterName(t *testing.T) {
-	kuber := kube_test.NewMockKuber()
-
-	config := api.Config{
-		CurrentContext: "myContext",
-		Contexts: map[string]*api.Context{
-			"myContext": {Cluster: "short-cluster-name"},
-		},
-	}
-	When(kuber.LoadConfig()).ThenReturn(&config, nil, nil)
-
-	clusterName, err := ShortClusterName(kuber)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "short", clusterName)
-}
-
-func TestClusterName(t *testing.T) {
-	kuber := kube_test.NewMockKuber()
-
-	config := api.Config{
-		CurrentContext: "myContext",
-		Contexts: map[string]*api.Context{
-			"myContext": {Cluster: "my-cluster-name"},
-		},
-	}
-	When(kuber.LoadConfig()).ThenReturn(&config, nil, nil)
-
-	clusterName, err := ClusterName(kuber)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "my-cluster-name", clusterName)
 }

--- a/pkg/cloud/gke/vault/naming.go
+++ b/pkg/cloud/gke/vault/naming.go
@@ -3,30 +3,35 @@ package vault
 import "fmt"
 
 // BucketName creates a Bucket name for a given vault name and cluster name
-func BucketName(vaultName string, clusterName string) string {
-	return generatePrefix(vaultName, clusterName) + "bucket"
+func BucketName(vaultName string) string {
+	return generateName(vaultName, "bucket")
 }
 
 // ServiceAccountName creates a service account name for a given vault and cluster name
-func ServiceAccountName(vaultName string, clusterName string) string {
-	return generatePrefix(vaultName, clusterName) + "sa"
+func ServiceAccountName(vaultName string) string {
+	return generateName(vaultName, "sa")
 }
 
 // AuthServiceAccountName creates a service account name for a given vault and cluster name
-func AuthServiceAccountName(vaultName string, clusterName string) string {
-	return generatePrefix(vaultName, clusterName) + "auth-sa"
+func AuthServiceAccountName(vaultName string) string {
+	return generateName(vaultName, "auth-sa")
 }
 
 // KeyringName creates a keyring name for a given vault and cluster name
-func KeyringName(vaultName string, clusterName string) string {
-	return generatePrefix(vaultName, clusterName) + "keyring"
+func KeyringName(vaultName string) string {
+	return generateName(vaultName, "keyring")
 }
 
 // KeyName creates a key name for a given vault and cluster name
-func KeyName(vaultName string, clusterName string) string {
-	return generatePrefix(vaultName, clusterName) + "key"
+func KeyName(vaultName string) string {
+	return generateName(vaultName, "key")
 }
 
-func generatePrefix(vaultName string, clusterName string) string {
-	return fmt.Sprintf("%s-%s-", clusterName, vaultName)
+// GcpServiceAccountSecretName builds the secret name where the GCP service account is stored
+func GcpServiceAccountSecretName(vaultName string) string {
+	return generateName(vaultName, "gcp-sa")
+}
+
+func generateName(vaultName string, name string) string {
+	return fmt.Sprintf("%s-%s", vaultName, name)
 }

--- a/pkg/jx/cmd/create_vault.go
+++ b/pkg/jx/cmd/create_vault.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/kube/cluster"
 	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -188,7 +189,7 @@ func (o *CreateVaultOptions) createVault(vaultOperatorClient versioned.Interface
 
 	if o.GKEZone == "" {
 		defaultZone := ""
-		if cluster, err := gke.ClusterName(o.Kube()); err == nil && cluster != "" {
+		if cluster, err := cluster.Name(o.Kube()); err == nil && cluster != "" {
 			if clusterZone, err := gke.ClusterZone(cluster); err == nil {
 				defaultZone = clusterZone
 			}
@@ -201,7 +202,7 @@ func (o *CreateVaultOptions) createVault(vaultOperatorClient versioned.Interface
 		o.GKEZone = zone
 	}
 
-	clusterName, err := gke.ShortClusterName(o.Kube())
+	clusterName, err := cluster.ShortName(o.Kube())
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/delete_vault.go
+++ b/pkg/jx/cmd/delete_vault.go
@@ -86,10 +86,6 @@ func (o *DeleteVaultOptions) Run() error {
 		o.Namespace = ns
 	}
 
-	clusterName, err := gke.ShortClusterName(o.Kube())
-	if err != nil {
-		return err
-	}
 	vaultOperatorClient, err := o.VaultOperatorClient()
 	if err != nil {
 		return errors.Wrap(err, "creating vault operator client")
@@ -116,7 +112,7 @@ func (o *DeleteVaultOptions) Run() error {
 		return errors.Wrapf(err, "deleting the vault auth service account '%s'", authServiceAccountName)
 	}
 
-	gcpServiceAccountSecretName := gkevault.GcpServiceAccountSecretName(vaultName, clusterName)
+	gcpServiceAccountSecretName := gkevault.GcpServiceAccountSecretName(vaultName)
 	err = client.CoreV1().Secrets(o.Namespace).Delete(gcpServiceAccountSecretName, &metav1.DeleteOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "deleting secret '%s' where GCP service account is stored", gcpServiceAccountSecretName)
@@ -175,19 +171,14 @@ func (o *DeleteVaultOptions) removeGCPResources(vaultName string) error {
 		o.GKEZone = zone
 	}
 
-	clusterName, err := gke.ShortClusterName(o.Kube())
-	if err != nil {
-		return err
-	}
-
-	sa := gkevault.ServiceAccountName(vaultName, clusterName)
+	sa := gkevault.ServiceAccountName(vaultName)
 	err = gke.DeleteServiceAccount(sa, o.GKEProjectID, gkevault.ServiceAccountRoles)
 	if err != nil {
 		return errors.Wrapf(err, "deleting the GCP service account '%s'", sa)
 	}
 	log.Infof("GCP service account %s deleted\n", util.ColorInfo(sa))
 
-	bucket := gkevault.BucketName(vaultName, clusterName)
+	bucket := gkevault.BucketName(vaultName)
 	err = gke.DeleteAllObjectsInBucket(bucket)
 	if err != nil {
 		return errors.Wrapf(err, "deleting all objects in GCS bucket '%s'", bucket)

--- a/pkg/jx/cmd/factory.go
+++ b/pkg/jx/cmd/factory.go
@@ -349,7 +349,11 @@ func (f *factory) ResetSecretsLocation() {
 
 // CreateSystemVaultClient gets the system vault client for managing the secrets
 func (f *factory) CreateSystemVaultClient(namespace string) (vault.Client, error) {
-	return f.CreateVaultClient(vault.SystemVaultName, namespace)
+	name, err := kubevault.SystemVaultName(f.kubeConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "building the system vault name from cluster name")
+	}
+	return f.CreateVaultClient(name, namespace)
 }
 
 // CreateVaultClient returns the given vault client for managing secrets
@@ -370,7 +374,10 @@ func (f *factory) CreateVaultClient(name string, namespace string) (vault.Client
 		namespace = devNamespace
 	}
 	if name == "" {
-		name = vault.SystemVaultName
+		name, err = kubevault.SystemVaultName(f.kubeConfig)
+		if err != nil {
+			return nil, errors.Wrap(err, "building the system vault name from cluster name")
+		}
 	}
 
 	if !kubevault.FindVault(vopClient, name, namespace) {

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1978,17 +1978,21 @@ func (options *InstallOptions) createSystemVault(client kubernetes.Interface, na
 			return err
 		}
 
-		if kubevault.FindVault(vaultOperatorClient, vault.SystemVaultName, namespace) {
+		systemVaultName, err := kubevault.SystemVaultName(options.Kube())
+		if err != nil {
+			return errors.Wrap(err, "building the system vault name from cluster name")
+		}
+		if kubevault.FindVault(vaultOperatorClient, systemVaultName, namespace) {
 			log.Infof("System vault named %s in namespace %s already exists\n",
-				util.ColorInfo(vault.SystemVaultName), util.ColorInfo(namespace))
+				util.ColorInfo(systemVaultName), util.ColorInfo(namespace))
 		} else {
 			log.Info("Creating new system vault\n")
-			err = cvo.createVault(vaultOperatorClient, vault.SystemVaultName)
+			err = cvo.createVault(vaultOperatorClient, systemVaultName)
 			if err != nil {
 				return err
 			}
 			log.Infof("System vault created named %s in namespace %s.\n",
-				util.ColorInfo(vault.SystemVaultName), util.ColorInfo(namespace))
+				util.ColorInfo(systemVaultName), util.ColorInfo(namespace))
 		}
 
 		err = options.SetSecretsLocation(secrets.VaultLocationKind, false)

--- a/pkg/kube/cluster/cluster.go
+++ b/pkg/kube/cluster/cluster.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"strings"
+
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/pkg/errors"
+)
+
+// Name gets the cluster name from the current context
+// Note that this just reads the ClusterName from the local kube config, which can be renamed (but is unlikely to happen)
+func Name(kuber kube.Kuber) (string, error) {
+	config, _, err := kuber.LoadConfig()
+	if err != nil {
+		return "", err
+	}
+
+	context := kube.CurrentContext(config)
+	if context == nil {
+		return "", errors.New("kube context was nil")
+	}
+	// context.Cluster will likely be in the form gke_<accountName>_<region>_<clustername>
+	// Trim off the crud from the beginning context.Cluster
+	return SimplifiedClusterName(context.Cluster), nil
+}
+
+// ShortName returns a short clusters name. Eg, if ClusterName would return tweetypie-jenkinsx-dev, ShortClusterName
+// would return tweetypie. This is needed because GCP has character limits on things like service accounts (6-30 chars)
+// and combining a long cluster name and a long vault name exceeds this limit
+func ShortName(kuber kube.Kuber) (string, error) {
+	clusterName, err := Name(kuber)
+	if err != nil {
+		return "", errors.Wrap(err, "retrieveing the cluster name")
+	}
+	end := len(clusterName) - 1
+	if end > 16 {
+		end = 16
+	}
+	shortClusterName := clusterName[0:end]
+	if strings.HasSuffix(shortClusterName, "_") || strings.HasSuffix(shortClusterName, "-") {
+		shortClusterName = shortClusterName[0 : end-1]
+	}
+	return shortClusterName, nil
+}
+
+// GetSimplifiedClusterName get the simplified cluster name from the long-winded context cluster name that gets generated
+// GKE cluster names as defined in the kube config are of the form gke_<projectname>_<region>_<clustername>
+// This method will return <clustername> in the above
+func SimplifiedClusterName(complexClusterName string) string {
+	split := strings.Split(complexClusterName, "_")
+	return split[len(split)-1]
+}

--- a/pkg/kube/cluster/cluster.go
+++ b/pkg/kube/cluster/cluster.go
@@ -43,7 +43,7 @@ func ShortName(kuber kube.Kuber) (string, error) {
 	return shortClusterName, nil
 }
 
-// GetSimplifiedClusterName get the simplified cluster name from the long-winded context cluster name that gets generated
+// SimplifiedClusterName get the simplified cluster name from the long-winded context cluster name that gets generated
 // GKE cluster names as defined in the kube config are of the form gke_<projectname>_<region>_<clustername>
 // This method will return <clustername> in the above
 func SimplifiedClusterName(complexClusterName string) string {

--- a/pkg/kube/cluster/cluster_test.go
+++ b/pkg/kube/cluster/cluster_test.go
@@ -1,0 +1,72 @@
+package cluster_test
+
+import (
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/kube/cluster"
+	kube_test "github.com/jenkins-x/jx/pkg/kube/mocks"
+	. "github.com/petergtz/pegomock"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestGetSimplifiedClusterName(t *testing.T) {
+	t.Parallel()
+	simpleName := cluster.SimplifiedClusterName("gke_jenkinsx-dev_europe-west1-b_my-cluster-name")
+
+	assert.Equal(t, "my-cluster-name", simpleName)
+}
+
+func TestShortClusterName(t *testing.T) {
+	kuber := kube_test.NewMockKuber()
+
+	config := api.Config{
+		CurrentContext: "myContext",
+		Contexts: map[string]*api.Context{
+			"myContext": {Cluster: "short-cluster-name"},
+		},
+	}
+	When(kuber.LoadConfig()).ThenReturn(&config, nil, nil)
+
+	clusterName, err := cluster.ShortName(kuber)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "short-cluster-na", clusterName)
+
+	config = api.Config{
+		CurrentContext: "myContext",
+		Contexts: map[string]*api.Context{
+			"myContext": {Cluster: "short-cluster-na"},
+		},
+	}
+	When(kuber.LoadConfig()).ThenReturn(&config, nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "short-cluster-na", clusterName)
+
+	config = api.Config{
+		CurrentContext: "myContext",
+		Contexts: map[string]*api.Context{
+			"myContext": {Cluster: "short-cluster-na-test"},
+		},
+	}
+	When(kuber.LoadConfig()).ThenReturn(&config, nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "short-cluster-na", clusterName)
+}
+
+func TestClusterName(t *testing.T) {
+	kuber := kube_test.NewMockKuber()
+
+	config := api.Config{
+		CurrentContext: "myContext",
+		Contexts: map[string]*api.Context{
+			"myContext": {Cluster: "my-cluster-name"},
+		},
+	}
+	When(kuber.LoadConfig()).ThenReturn(&config, nil, nil)
+
+	clusterName, err := cluster.Name(kuber)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "my-cluster-name", clusterName)
+}

--- a/pkg/kube/vault/vault.go
+++ b/pkg/kube/vault/vault.go
@@ -6,6 +6,7 @@ import (
 	"github.com/banzaicloud/bank-vaults/operator/pkg/apis/vault/v1alpha1"
 	"github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/cluster"
 	"github.com/jenkins-x/jx/pkg/kube/serviceaccount"
 	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/jenkins-x/jx/pkg/vault"
@@ -101,6 +102,15 @@ type Telemetry struct {
 // Storage configuration for Vault storage
 type Storage struct {
 	GCS GCSConfig `json:"gcs"`
+}
+
+// SystemVaultName returns the name of the system vault based on the cluster name
+func SystemVaultName(kuber kube.Kuber) (string, error) {
+	clusterName, err := cluster.ShortName(kuber)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s", vault.SystemVaultNamePrefix, clusterName), nil
 }
 
 // CreateVault creates a new vault backed by GCP KMS and storage

--- a/pkg/vault/constants.go
+++ b/pkg/vault/constants.go
@@ -1,8 +1,8 @@
 package vault
 
 const (
-	// SystemVaultName name of the system vault used by the jenkins-x platfrom
-	SystemVaultName = "jx-vault"
+	// SystemVaultNamePrefix name prefix of the system vault used by the jenkins-x platfrom
+	SystemVaultNamePrefix = "jx-vault"
 	// GitOpsSecretsPath the path of secrets generated for GitOps
 	GitOpsSecretsPath = "gitops/"
 	// GitOpsTemplatesPath the path of gitops templates secrets


### PR DESCRIPTION
The short cluster name consists of the first 16 characters of the full cluster name. The reason for
this shortcut is to avoid exceeding the GCP limits on resources name such as bucket and keyring.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->