### PR TITLE
fix: check if jenkins-x-versions repository is already up to date, if not fetch the latest version

### DIFF
--- a/pkg/jx/cmd/common_helm.go
+++ b/pkg/jx/cmd/common_helm.go
@@ -182,7 +182,7 @@ func (o *CommonOptions) cloneJXVersionsRepo(versionRepository string) (string, e
 		}
 	}
 
-	// If there exists a this stage most likely its content is incosisten
+	// If it exists a this stage most likely its content is not consistent
 	if exists, err := util.DirExists(wrkDir); err == nil && exists {
 		err := util.DeleteDirContents(wrkDir)
 		if err != nil {


### PR DESCRIPTION
It clones the repository if not folder exists at all or something goes wrong with the fetching.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->