### PR TITLE
fix: Make capital letters lowercase when creating resource names

### DIFF
--- a/pkg/kube/names.go
+++ b/pkg/kube/names.go
@@ -32,6 +32,9 @@ func toValidName(name string, allowDots bool, maxLength int) string {
 			break
 		}
 		if first {
+			if ch >= 'A' && ch <= 'Z' {
+				ch += 'a' - 'A' // Offset to make letter lowercase
+			}
 			// strip non letters at start
 			if ch >= 'a' && ch <= 'z' {
 				buffer.WriteRune(ch)
@@ -40,6 +43,9 @@ func toValidName(name string, allowDots bool, maxLength int) string {
 		} else {
 			if !allowDots && ch == '.' {
 				ch = '-'
+			}
+			if ch >= 'A' && ch <= 'Z' {
+				ch += 'a' - 'A' // Offset to make letter lowercase
 			}
 			if !(ch >= 'a' && ch <= 'z') && !(ch >= '0' && ch <= '9') && ch != '-' && ch != '.' {
 				ch = '-'

--- a/pkg/kube/names_valid_test.go
+++ b/pkg/kube/names_valid_test.go
@@ -10,8 +10,10 @@ import (
 func TestToValidName(t *testing.T) {
 	t.Parallel()
 	assertToValidName(t, "foo", "foo")
+	assertToValidName(t, "FOO", "foo")
 	assertToValidName(t, "foo-bar", "foo-bar")
 	assertToValidName(t, "foo-bar-", "foo-bar")
+	assertToValidName(t, "Foo Bar", "foo-bar")
 	assertToValidName(t, "foo-bar-0.1.0", "foo-bar-0-1-0")
 	assertToValidName(t, "---foo-bar-", "foo-bar")
 	assertToValidName(t, "foo/bar_*123", "foo-bar-123")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Instead of converting uppercase characters into `-`, it seems better to convert them into their lowercase equivalent. I don't have any specific justification for the change, but in future Pipeline-related work we anticipate using this function for user-specified names, which may include capital letters, and the change seems harmless enough. Happy to hold off on it for now and open an issue instead if desired.