### PR TITLE
chore: fix delete application so that it tries to intelligently figure what org the associated repo belongs to

### DIFF
--- a/pkg/jx/cmd/delete_application.go
+++ b/pkg/jx/cmd/delete_application.go
@@ -122,12 +122,6 @@ func (o *DeleteApplicationOptions) Run() error {
 		deletedApplications, err = o.deleteJenkinsApplication()
 	}
 
-	for _, deletedApplication := range deletedApplications {
-		err := repoService.DeleteSourceRepository(deletedApplication)
-		if err != nil {
-			log.Warnf("Unable to find application metadata for %s to remove", deletedApplication)
-		}
-	}
 	if err != nil {
 		return errors.Wrapf(err, "deleting application")
 	}
@@ -155,12 +149,27 @@ func (o *DeleteApplicationOptions) deleteProwApplication(repoService kube.Source
 			}
 		}
 		if o.Org == "" {
-			// Fetch the Org from the stored Custom Resource
-			application, err := repoService.GetSourceRepository(applicationName)
+			// fetch the list of sourcerepositories
+			srList, err := repoService.ListSourceRepositories()
 			if err != nil {
-				return deletedApplications, fmt.Errorf("could not get org for %s. use --org", util.ColorInfo(applicationName))
+				return deletedApplications, fmt.Errorf("error in sourcerepository service %s", err.Error())
 			}
-			o.Org = application.Spec.Org
+
+			srObjects := []v1.SourceRepository{}
+			for sr := range srList.Items {
+				if srList.Items[sr].Spec.Repo == applicationName {
+					srObjects = append(srObjects, srList.Items[sr])
+					if len(srObjects) > 1 {
+						return deletedApplications, fmt.Errorf("application %s exists in multiple orgs, use --org to specify the app to delete", util.ColorInfo(applicationName))
+					}
+				}
+			}
+			if len(srObjects) == 0 {
+				return deletedApplications, fmt.Errorf("no sourcerepository object found, unable to delete %s", util.ColorInfo(applicationName))
+			}
+
+			// we only found a single sourceporistory resource, proceed
+			o.Org = srObjects[0].Spec.Org
 		}
 
 		repo := []string{o.Org + "/" + applicationName}
@@ -168,7 +177,12 @@ func (o *DeleteApplicationOptions) deleteProwApplication(repoService kube.Source
 		if err != nil {
 			return deletedApplications, errors.Wrapf(err, "deleting prow config for %s", applicationName)
 		}
-		deletedApplications = append(deletedApplications, applicationName)
+		deletedApplications = append(deletedApplications,applicationName)
+
+		err := repoService.DeleteSourceRepository(o.Org + "-" +applicationName)
+		if err != nil {
+			log.Warnf("Unable to find application metadata for %s to remove", applicationName)
+		}
 	}
 	return
 }


### PR DESCRIPTION
fix delete application so that it tries to intelligently figure what org the associated repo belongs to so that the `sourcerepository` crd object it is associated with can be deleted

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
When deleting an application, `jx` should remove the `sourcerepository` metadata associated with it.  To do this, it needs to know the organization name (because the `sourcerepository` objects are named `<org>-<reponame>`)


#### Special notes for the reviewer(s)
I am not completely happy with this approach, and am creating this PR to solicit some feedback and ideas on how this could be better solved (even if it means revisiting the way we name the object metadata in the `sourcerepository` crd)

It might be worth adding a `--force` option to `jx delete` that could be used to clean up projects that are left in an inconsistent state.  For example, in testing this i was able to delete the prow config for my app, but not the CRD object.  Subsequent re-runs of the same `jx delete application` command abort prior to cleaning up the CRD with:
`error: deleting application: deleting prow config for golang1: removing repo jx-dev-org-mikec/golang1 from branch protection: repo golang1 not found in org jx-dev-org-mikec`
#### Which issue this PR fixes

fixes #
#2849
<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
