### PR TITLE
fix: Add webhook triggers for PR events in bitbucket

### DIFF
--- a/pkg/gits/bitbucket_cloud.go
+++ b/pkg/gits/bitbucket_cloud.go
@@ -659,6 +659,10 @@ func (b *BitbucketCloudProvider) CreateWebHook(data *GitWebHookArguments) error 
 			"active": true,
 			"events": []string{
 				"repo:push",
+				"pullrequest:created",
+				"pullrequest:updated",
+				"pullrequest:fulfilled",
+				"pullrequest:rejected",
 			},
 			"description": "Jenkins X Web Hook",
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Bitbucket webhook on project import was missing triggers for PR events - created, updated,rejected and fulfilled(merged) 

#### Special notes for the reviewer(s)
None

#### Which issue this PR fixes

fixes #2238

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
