### PR TITLE
fix(import): use the org from a github repo when importing

### DIFF
--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -587,6 +587,9 @@ func (options *ImportOptions) getCurrentUser() string {
 	return currentUser
 }
 
+// GetOrganisation gets the organisation from the RepoURL (if in the github format of github.com/org/repo). It will
+// do this in preference to the Organisation field (if set). If the repo URL does not implicitly specify an organisation
+// then the Organisation specified in the options is used.
 func (options *ImportOptions) GetOrganisation() string {
 	org := ""
 	gitInfo, err := gits.ParseGitURL(options.RepoURL)

--- a/pkg/jx/cmd/import_test.go
+++ b/pkg/jx/cmd/import_test.go
@@ -159,3 +159,49 @@ func TestCreateProwOwnersAliasesFileCreateWhenDoesNotExistAndNoGitUserSet(t *tes
 	err = cmd.CreateProwOwnersAliasesFile()
 	assert.Error(t, err, "There should an error")
 }
+
+func TestImportOptions_GetOrganisation(t *testing.T) {
+	tests := []struct {
+		name    string
+		options cmd.ImportOptions
+		want    string
+	}{
+		{
+			name: "Get org from github URL (ignore user-specified org)",
+			options: cmd.ImportOptions{
+				RepoURL:      "https://github.com/orga/myrepo",
+				Organisation: "orgb",
+			},
+			want: "orga",
+		},
+		{
+			name: "Get org from github URL (no user-specified org)",
+			options: cmd.ImportOptions{
+				RepoURL: "https://github.com/orga/myrepo",
+			},
+			want: "orga",
+		},
+		{
+			name: "Get org from user flag",
+			options: cmd.ImportOptions{
+				RepoURL:      "https://myrepo.com/myrepo", // No org here
+				Organisation: "orgb",
+			},
+			want: "orgb",
+		},
+		{
+			name: "No org specified",
+			options: cmd.ImportOptions{
+				RepoURL: "https://myrepo.com/myrepo", // No org here
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.options.GetOrganisation(); got != tt.want {
+				t.Errorf("ImportOptions.GetOrganisation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`jx import https://github.com/orga/myrepo` should automatically set the
organisation to be 'orga'. If an additional `--org orgb` is specified,
this should be ignored.


fixes #3073

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
