### PR TITLE
fix: jx step next-version update the package.json

### DIFF
--- a/pkg/jx/cmd/step_next_version.go
+++ b/pkg/jx/cmd/step_next_version.go
@@ -383,7 +383,7 @@ func (o *StepNextVersionOptions) SetVersion() error {
 		// lets not commit to git as we do that in the tag step
 		return nil
 	}
-	err = o.Git().Add(o.Dir, o.Filename, "VERSION")
+	err = o.Git().Add(o.Dir, o.Filename)
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/step_next_version.go
+++ b/pkg/jx/cmd/step_next_version.go
@@ -379,7 +379,11 @@ func (o *StepNextVersionOptions) SetVersion() error {
 		return err
 	}
 
-	err = o.Git().Add(o.Dir, o.Filename)
+	if o.Tag {
+		// lets not commit to git as we do that in the tag step
+		return nil
+	}
+	err = o.Git().Add(o.Dir, o.Filename, "VERSION")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
this change allows us to use `jx step next-version --filename package.json --tag` in a pipeline to update the package.json and optionally the `Chart.yaml` and then push the commit to a tag