### PR TITLE
fix (import) : Defaults from team settings for create quickstart and spring

### DIFF
--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -1346,6 +1346,9 @@ func (options *ImportOptions) DefaultsFromTeamSettings() error {
 	if options.Organisation == "" {
 		options.Organisation = settings.Organisation
 	}
+	if options.GitRepositoryOptions.Owner == "" {
+		options.GitRepositoryOptions.Owner = settings.Organisation
+	}
 	if options.DockerRegistryOrg == "" {
 		options.DockerRegistryOrg = settings.DockerRegistryOrg
 	}
@@ -1396,6 +1399,10 @@ func (options *ImportOptions) ConfigureImportOptions(repoData *gits.CreateRepoDa
 
 // GetGitRepositoryDetails determines the git repository details to use during the import command
 func (options *ImportOptions) GetGitRepositoryDetails() (*gits.CreateRepoData, error) {
+	err := options.DefaultsFromTeamSettings()
+	if err != nil {
+		return nil, err
+	}
 	authConfigSvc, err := options.CreateGitAuthConfigService()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is covered by existing or new tests.

#### Description

With pull request #2771 git repo was created before default options where read from team settings. The most severe effect i.m.h.o. being that that the setting to make the repository private didn't take effect. But also having to choose organisation despite it being set in Team Settings was annoying.

This PR fixes these regressions.

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
