### PR TITLE
fix: allow a context to be used to run a different pipeline YAML file

### DIFF
--- a/pkg/config/project_config.go
+++ b/pkg/config/project_config.go
@@ -115,20 +115,26 @@ func LoadProjectConfig(projectDir string) (*ProjectConfig, string, error) {
 	if projectDir != "" {
 		fileName = filepath.Join(projectDir, fileName)
 	}
+	config, err := LoadProjectConfigFile(fileName)
+	return config, fileName, err
+}
+
+// LoadProjectConfigFile loads a specific project YAML configuration file
+func LoadProjectConfigFile(fileName string) (*ProjectConfig, error) {
 	config := ProjectConfig{}
 	exists, err := util.FileExists(fileName)
 	if err != nil || !exists {
-		return &config, fileName, err
+		return &config, err
 	}
 	data, err := ioutil.ReadFile(fileName)
 	if err != nil {
-		return &config, fileName, fmt.Errorf("Failed to load file %s due to %s", fileName, err)
+		return &config, fmt.Errorf("Failed to load file %s due to %s", fileName, err)
 	}
 	err = yaml.Unmarshal(data, &config)
 	if err != nil {
-		return &config, fileName, fmt.Errorf("Failed to unmarshal YAML file %s due to %s", fileName, err)
+		return &config, fmt.Errorf("Failed to unmarshal YAML file %s due to %s", fileName, err)
 	}
-	return &config, fileName, nil
+	return &config, nil
 }
 
 // IsEmpty returns true if this configuration is empty

--- a/pkg/jx/cmd/controller_pipelinerunner.go
+++ b/pkg/jx/cmd/controller_pipelinerunner.go
@@ -94,7 +94,7 @@ func (o *ControllerPipelineRunnerOptions) Run() error {
 	mux.Handle(HealthPath, http.HandlerFunc(o.health))
 	mux.Handle(ReadyPath, http.HandlerFunc(o.ready))
 
-	logrus.Infof("Serving build numbers at http://%s:%d%s", o.BindAddress, o.Port, o.Path)
+	logrus.Infof("Waiting for Knative Pipelines to run at http://%s:%d%s", o.BindAddress, o.Port, o.Path)
 	return http.ListenAndServe(":"+strconv.Itoa(o.Port), mux)
 }
 
@@ -135,6 +135,7 @@ func (o *ControllerPipelineRunnerOptions) startPipelineRun(w http.ResponseWriter
 	err := o.unmarshalBody(w, r, arguments)
 	o.onError(err)
 	if err != nil {
+		o.returnError("could not parse body: " + err.Error(), w, r)
 		return
 	}
 	if o.Verbose {

--- a/pkg/jx/cmd/step_create_task.go
+++ b/pkg/jx/cmd/step_create_task.go
@@ -199,7 +199,7 @@ func (o *StepCreateTaskOptions) Run() error {
 	if o.PipelineKind == "" {
 		return util.MissingOption("kind")
 	}
-	projectConfig, projectConfigFile, err := config.LoadProjectConfig(o.Dir)
+	projectConfig, projectConfigFile, err := o.loadProjectConfig()
 	if err != nil {
 		return errors.Wrapf(err, "failed to load project config in dir %s", o.Dir)
 	}
@@ -263,6 +263,21 @@ func (o *StepCreateTaskOptions) Run() error {
 		return errors.Wrapf(err, "failed to generate Task for build pack pipeline YAML: %s", pipelineFile)
 	}
 	return err
+}
+
+func (o *StepCreateTaskOptions) loadProjectConfig() (*config.ProjectConfig, string, error) {
+	if o.Context != "" {
+		fileName := filepath.Join(o.Dir, fmt.Sprintf("jenkins-x-%s.yml", o.Context))
+		exists, err := util.FileExists(fileName)
+		if err != nil {
+		  return nil, fileName, errors.Wrapf(err, "failed to check if file exists %s", fileName)
+		}
+		if exists {
+			config, err := config.LoadProjectConfigFile(fileName)
+			return config, fileName, err
+		}
+	}
+	return config.LoadProjectConfig(o.Dir)
 }
 
 func (o *StepCreateTaskOptions) loadPodTemplates(kubeClient kubernetes.Interface, ns string) error {


### PR DESCRIPTION
if we pass a prow context name lets use it to try discover a custom
    pipeline YAML file