### PR TITLE
Ignore flagger canary auxiliary deployments from get apps

### DIFF
--- a/pkg/flagger/flagger.go
+++ b/pkg/flagger/flagger.go
@@ -1,0 +1,16 @@
+package flagger
+
+import (
+	"k8s.io/api/apps/v1beta1"
+)
+
+// IsCanaryAuxiliaryDeployment returns whether this deployment has been created automatically by Flagger from a Canary object
+func IsCanaryAuxiliaryDeployment(d v1beta1.Deployment) bool {
+	ownerReferences := d.GetObjectMeta().GetOwnerReferences()
+	for i := range ownerReferences {
+		if ownerReferences[i].Kind == "Canary" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/jx/cmd/get_applications.go
+++ b/pkg/jx/cmd/get_applications.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/flagger"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -263,6 +264,12 @@ func (o *GetApplicationsOptions) getAppData(kubeClient kubernetes.Interface) (na
 						} else if env.Spec.Kind == v1.EnvironmentKindTypePreview {
 							appName = env.Spec.PullRequestURL
 						}
+
+						// Ignore flagger canary auxiliary deployments
+						if flagger.IsCanaryAuxiliaryDeployment(d) {
+							continue
+						}
+
 						envApp.Apps[appName] = d
 						if util.StringArrayIndex(apps, appName) < 0 {
 							apps = append(apps, appName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Flagger creates new deployments to manage canaries and they get printed in `jx get apps`

    ```
    $ jx get apps
    APPLICATION                  STAGING PODS URL                                                 PRODUCTION PODS URL
    croc-hunter-jenkinsx         0.0.126 1/1  https://croc-hunter-jenkinsx.jx-staging.example.com 0.0.126         http://croc-hunter-jenkinsx.jx-production.example.com
    croc-hunter-jenkinsx-primary
    ```

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->