### PR TITLE
feature:  add new command 'get quickstarts' that returns a list of available quickstarts

### DIFF
--- a/pkg/jx/cmd/get.go
+++ b/pkg/jx/cmd/get.go
@@ -86,6 +86,7 @@ func NewCmdGet(f Factory, in terminal.FileReader, out terminal.FileWriter, errOu
 	cmd.AddCommand(NewCmdGetPostPreviewJob(f, in, out, errOut))
 	cmd.AddCommand(NewCmdGetPreview(f, in, out, errOut))
 	cmd.AddCommand(NewCmdGetQuickstartLocation(f, in, out, errOut))
+	cmd.AddCommand(NewCmdGetQuickstarts(f, in, out, errOut))
 	cmd.AddCommand(NewCmdGetRelease(f, in, out, errOut))
 	cmd.AddCommand(NewCmdGetStorage(f, in, out, errOut))
 	cmd.AddCommand(NewCmdGetTeam(f, in, out, errOut))

--- a/pkg/jx/cmd/get_quickstarts.go
+++ b/pkg/jx/cmd/get_quickstarts.go
@@ -20,6 +20,7 @@ type GetQuickstartsOptions struct {
 	GetOptions
 	GitHubOrganisations []string
 	Filter              quickstarts.QuickstartFilter
+	ShortFormat			bool
 }
 
 var (
@@ -67,6 +68,7 @@ func NewCmdGetQuickstarts(f Factory, in terminal.FileReader, out terminal.FileWr
 	cmd.Flags().StringVarP(&options.Filter.Owner, "owner", "", "", "The owner to filter on")
 	cmd.Flags().StringVarP(&options.Filter.Language, "language", "l", "", "The language to filter on")
 	cmd.Flags().StringVarP(&options.Filter.Framework, "framework", "", "", "The framework to filter on")
+	cmd.Flags().BoolVarP(&options.ShortFormat, "short", "s", false, "return minimal details")
 
 	return cmd
 }
@@ -144,8 +146,13 @@ func (o *GetQuickstartsOptions) Run() error {
 	}
 
 	//output list of available quickstarts and exit
-	for qs := range model.Quickstarts {
-		fmt.Fprintf(o.Out, "%s\n", qs)
+	filteredQuickstarts := model.Filter(&o.Filter)
+	for _, qs := range filteredQuickstarts {
+		if o.ShortFormat {
+			fmt.Fprintf(o.Out, "%s\n", qs.Name)
+		} else {
+			fmt.Fprintf(o.Out,"%s/%s/%s\n",qs.GitProvider.ServerURL(), qs.Owner, qs.Name)
+		}
 	}
 	return nil
 }

--- a/pkg/jx/cmd/get_quickstarts.go
+++ b/pkg/jx/cmd/get_quickstarts.go
@@ -75,14 +75,6 @@ func NewCmdGetQuickstarts(f Factory, in terminal.FileReader, out terminal.FileWr
 
 // Run implements this command
 func (o *GetQuickstartsOptions) Run() error {
-
-	//authConfigSvc, err := o.CreateGitAuthConfigService()
-	//if err != nil {
-	//	return err
-	//}
-	//
-	//config := authConfigSvc.Config()
-
 	var locations []v1.QuickStartLocation
 	jxClient, ns, err := o.JXClientAndDevNamespace()
 	if err != nil {

--- a/pkg/jx/cmd/get_quickstarts.go
+++ b/pkg/jx/cmd/get_quickstarts.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/quickstarts"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/jenkins-x/jx/pkg/kube"
+)
+
+// GetAddonOptions the command line options
+type GetQuickstartsOptions struct {
+	GetOptions
+	GitHubOrganisations []string
+	Filter              quickstarts.QuickstartFilter
+}
+
+var (
+	get_quickstarts_long = templates.LongDesc(`
+		Display the available quickstarts
+
+`)
+
+	get_quickstarts_example = templates.Examples(`
+		# List all the available quickstarts
+		jx get quickstarts
+	`)
+)
+
+// NewCmdGetAddon creates the command
+func NewCmdGetQuickstarts(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+	options := &GetQuickstartsOptions{
+		GetOptions: GetOptions{
+			CommonOptions: CommonOptions{
+				Factory: f,
+				In:      in,
+				Out:     out,
+				Err:     errOut,
+			},
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "quickstarts [flags]",
+		Short:   "Lists the available quickstarts",
+		Long:    get_quickstarts_long,
+		Example: get_quickstarts_example,
+		Aliases: []string{"quickstart", "qs"},
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			CheckErr(err)
+		},
+	}
+
+	cmd.Flags().StringArrayVarP(&options.GitHubOrganisations, "organisations", "g", []string{}, "The GitHub organisations to query for quickstarts")
+	cmd.Flags().StringArrayVarP(&options.Filter.Tags, "tag", "t", []string{}, "The tags on the quickstarts to filter")
+	cmd.Flags().StringVarP(&options.Filter.Text, "filter", "f", "", "The text filter")
+	cmd.Flags().StringVarP(&options.Filter.Owner, "owner", "", "", "The owner to filter on")
+	cmd.Flags().StringVarP(&options.Filter.Language, "language", "l", "", "The language to filter on")
+	cmd.Flags().StringVarP(&options.Filter.Framework, "framework", "", "", "The framework to filter on")
+
+	return cmd
+}
+
+// Run implements this command
+func (o *GetQuickstartsOptions) Run() error {
+
+	//authConfigSvc, err := o.CreateGitAuthConfigService()
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//config := authConfigSvc.Config()
+
+	var locations []v1.QuickStartLocation
+	jxClient, ns, err := o.JXClientAndDevNamespace()
+	if err != nil {
+		return err
+	}
+
+	locations, err = kube.GetQuickstartLocations(jxClient, ns)
+	if err != nil {
+		return err
+	}
+
+	// lets add any extra github organisations if they are not already configured
+	for _, org := range o.GitHubOrganisations {
+		found := false
+		for _, loc := range locations {
+			if loc.GitURL == gits.GitHubURL && loc.Owner == org {
+				found = true
+				break
+			}
+		}
+		if !found {
+			locations = append(locations, v1.QuickStartLocation{
+				GitURL:   gits.GitHubURL,
+				GitKind:  gits.KindGitHub,
+				Owner:    org,
+				Includes: []string{"*"},
+				Excludes: []string{"WIP-*"},
+			})
+		}
+	}
+
+	gitMap := map[string]map[string]v1.QuickStartLocation{}
+	for _, loc := range locations {
+		m := gitMap[loc.GitURL]
+		if m == nil {
+			m = map[string]v1.QuickStartLocation{}
+			gitMap[loc.GitURL] = m
+		}
+		m[loc.Owner] = loc
+	}
+
+
+	model := quickstarts.NewQuickstartModel()
+
+	for gitURL, m := range gitMap {
+		for _, location := range m {
+			kind := location.GitKind
+			if kind == "" {
+				kind = gits.KindGitHub
+			}
+			gitProvider, err := o.gitProviderForGitServerURL(gitURL, kind)
+			if err != nil {
+				return err
+			}
+			o.Debugf("Searching for repositories in Git server %s owner %s includes %s excludes %s as user %s \n", gitProvider.ServerURL(), location.Owner, strings.Join(location.Includes, ", "), strings.Join(location.Excludes, ", "), gitProvider.CurrentUsername())
+			err = model.LoadGithubQuickstarts(gitProvider, location.Owner, location.Includes, location.Excludes)
+			if err != nil {
+				o.Debugf("Quickstart load error: %s\n", err.Error())
+			}
+		}
+	}
+
+	//output list of available quickstarts and exit
+	for qs := range model.Quickstarts {
+		fmt.Fprintf(o.Out, "%s\n", qs)
+	}
+	return nil
+}

--- a/pkg/jx/cmd/get_quickstarts.go
+++ b/pkg/jx/cmd/get_quickstarts.go
@@ -35,7 +35,7 @@ var (
 	`)
 )
 
-//NewCmdGetAddon creates the command
+//NewCmdGetQuickstarts creates the command
 func NewCmdGetQuickstarts(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
 	options := &GetQuickstartsOptions{
 		GetOptions: GetOptions{

--- a/pkg/jx/cmd/get_quickstarts.go
+++ b/pkg/jx/cmd/get_quickstarts.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 )
 
-// GetAddonOptions the command line options
+//GetQuickstartsOptions -  the command line options
 type GetQuickstartsOptions struct {
 	GetOptions
 	GitHubOrganisations []string
@@ -24,18 +24,18 @@ type GetQuickstartsOptions struct {
 }
 
 var (
-	get_quickstarts_long = templates.LongDesc(`
+	getQuickstartsLong = templates.LongDesc(`
 		Display the available quickstarts
 
 `)
 
-	get_quickstarts_example = templates.Examples(`
+	getQuickstartsExample = templates.Examples(`
 		# List all the available quickstarts
 		jx get quickstarts
 	`)
 )
 
-// NewCmdGetAddon creates the command
+//NewCmdGetAddon creates the command
 func NewCmdGetQuickstarts(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
 	options := &GetQuickstartsOptions{
 		GetOptions: GetOptions{
@@ -51,8 +51,8 @@ func NewCmdGetQuickstarts(f Factory, in terminal.FileReader, out terminal.FileWr
 	cmd := &cobra.Command{
 		Use:     "quickstarts [flags]",
 		Short:   "Lists the available quickstarts",
-		Long:    get_quickstarts_long,
-		Example: get_quickstarts_example,
+		Long:    getQuickstartsLong,
+		Example: getQuickstartsExample,
 		Aliases: []string{"quickstart", "qs"},
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Cmd = cmd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
Adds a new command `get quickstarts` that will output a list of all available quickstart types.

```
>$ ./build/jx get quickstarts
jenkins-x-quickstarts/golang-http
jenkins-x-quickstarts/node-http
jenkins-x-quickstarts/spring-boot-rest-prometheus
jenkins-x-quickstarts/rails-shopping-cart
jenkins-x-quickstarts/spring-boot-http-gradle
jenkins-x-quickstarts/android-quickstart
jenkins-x-quickstarts/dlang-http
jenkins-x-quickstarts/python-http
jenkins-x-quickstarts/rust-http
jenkins-x-quickstarts/open-liberty
jenkins-x-quickstarts/node-http-watch-pipeline-activity
jenkins-x-quickstarts/spring-boot-watch-pipeline-activity
jenkins-x-quickstarts/angular-io-quickstart
jenkins-x-quickstarts/vertx-rest-prometheus
jenkins-x-quickstarts/react-quickstart
jenkins-x-quickstarts/aspnet-app
jenkins-x-quickstarts/scala-akka-http-quickstart
jenkins-x-quickstarts/jenkins-quickstart
jenkins-x-quickstarts/jenkins-cwp-quickstart
```

#### Special notes for the reviewer(s)
Part of the intent with adding this command is to use it in a BDD test that will get the list of available quickstarts and validate that each one can be built successfully.  This will help us catch broken quickstarts in a more proactive fashion.

replaces #3111 

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
