### PR TITLE
Make Ambassador add on does respect the -f flag

### DIFF
--- a/pkg/jx/cmd/create_addon_ambassador.go
+++ b/pkg/jx/cmd/create_addon_ambassador.go
@@ -96,7 +96,7 @@ func (o *CreateAddonAmbassadorOptions) Run() error {
 	}
 
 	values := strings.Split(o.SetValues, ",")
-	err = o.installChart(o.ReleaseName, o.Chart, o.Version, o.Namespace, true, values, nil, "")
+	err = o.installChart(o.ReleaseName, o.Chart, o.Version, o.Namespace, true, values, o.ValueFiles, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ambassador addon ignored the -f flag

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
This makes the ambassador add on respect the -f flag
