### PR TITLE
Improve Bitbucket server webhook support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/fatih/structs v1.0.0
 	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
-	github.com/gfleury/go-bitbucket-v1 v0.0.0-20181102191809-4910839b609e
+	github.com/gfleury/go-bitbucket-v1 v0.0.0-20190216152406-3a732135aa4d
 	github.com/ghodss/yaml v1.0.0
 	github.com/gliderlabs/ssh v0.1.1 // indirect
 	github.com/go-ldap/ldap v3.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsouza/fake-gcs-server v0.0.0-20180612165233-e85be23bdaa8/go.mod h1:1/HufuJ+eaDf4KTnYdS6HJMGvMRU8d4cYTuu/1QaBbI=
 github.com/gfleury/go-bitbucket-v1 v0.0.0-20181102191809-4910839b609e h1:EN5E7DmE2qREZ+v41UUTH2cCtgrgbiLllaH1P0MUz50=
 github.com/gfleury/go-bitbucket-v1 v0.0.0-20181102191809-4910839b609e/go.mod h1:Se0U4YUmRkRAOh8kD7KXz+3VCUBmvTFcdWP2QYYRjjc=
+github.com/gfleury/go-bitbucket-v1 v0.0.0-20190216152406-3a732135aa4d h1:aE3u10gkuR/X7ibh9PkbHFdtkBWGwpekBUT/O7lgbOs=
+github.com/gfleury/go-bitbucket-v1 v0.0.0-20190216152406-3a732135aa4d/go.mod h1:Se0U4YUmRkRAOh8kD7KXz+3VCUBmvTFcdWP2QYYRjjc=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1 h1:j3L6gSLQalDETeEg/Jg0mGY0/y/N6zI2xX1978P0Uqw=

--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -745,6 +745,21 @@ func (b *BitbucketServerProvider) MergePullRequest(pr *GitPullRequest, message s
 func (b *BitbucketServerProvider) CreateWebHook(data *GitWebHookArguments) error {
 	projectKey, repo := parseBitBucketServerURL(data.Repo.URL)
 
+	if data.URL == "" {
+		return errors.New("missing property URL")
+	}
+
+	hooks, err := b.ListWebHooks(projectKey, repo)
+	if err != nil {
+		log.Errorf("Error querying webhooks on %s/%s: %s\n", projectKey, repo, err)
+	}
+	for _, hook := range hooks {
+		if data.URL == hook.URL {
+			log.Warnf("Already has a webhook registered for %s\n", data.URL)
+			return nil
+		}
+	}
+
 	var options = map[string]interface{}{
 		"url":    data.URL,
 		"name":   "Jenkins X Web Hook",

--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -784,7 +784,10 @@ func (b *BitbucketServerProvider) CreateWebHook(data *GitWebHookArguments) error
 
 	_, err = b.Client.DefaultApi.CreateWebhook(projectKey, repo, requestBody, []string{"application/json"})
 
-	return errors.Wrapf(err, "create webhook request failed on %s/%s", projectKey, repo)
+	if err != nil {
+		return errors.Wrapf(err, "create webhook request failed on %s/%s", projectKey, repo)
+	}
+	return nil
 }
 
 // ListWebHooks lists all of the webhooks on a given git repository
@@ -882,7 +885,10 @@ func (b *BitbucketServerProvider) UpdateWebHook(data *GitWebHookArguments) error
 	log.Infof("Updating Bitbucket server webhook for %s/%s for url %s\n", util.ColorInfo(projectKey), util.ColorInfo(repo), util.ColorInfo(data.URL))
 	_, err = b.Client.DefaultApi.UpdateWebhook(projectKey, repo, id, requestBody, []string{"application/json"})
 
-	return errors.Wrapf(err, "failed to update webhook on %s/%s", projectKey, repo)
+	if err != nil {
+		return errors.Wrapf(err, "failed to update webhook on %s/%s", projectKey, repo)
+	}
+	return nil
 }
 
 func (b *BitbucketServerProvider) SearchIssues(org string, name string, query string) ([]*GitIssue, error) {

--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -755,7 +755,7 @@ func (b *BitbucketServerProvider) CreateWebHook(data *GitWebHookArguments) error
 
 	hooks, err := b.ListWebHooks(projectKey, repo)
 	if err != nil {
-		return errors.Wrapf(err, "error querying webhooks on %s/%s: %s\n", projectKey, repo)
+		return errors.Wrapf(err, "error querying webhooks on %s/%s\n", projectKey, repo)
 	}
 	for _, hook := range hooks {
 		if data.URL == hook.URL {

--- a/pkg/gits/bitbucket_server_test.go
+++ b/pkg/gits/bitbucket_server_test.go
@@ -60,6 +60,7 @@ var bitbucketServerRouter = util.Router{
 	},
 	"/rest/api/1.0/projects/TEST-ORG/repos/test-repo/webhooks": util.MethodMap{
 		"POST": "webhook.json",
+		"GET":  "webhooks.json",
 	},
 	"/rest/api/1.0/users/test-user": util.MethodMap{
 		"GET": "user.json",
@@ -292,6 +293,23 @@ func (suite *BitbucketServerProviderTestSuite) TestCreateWebHook() {
 	err := suite.provider.CreateWebHook(data)
 
 	suite.Require().Nil(err)
+}
+
+func (suite *BitbucketServerProviderTestSuite) TestListWebHooks() {
+
+	webHooks, err := suite.provider.ListWebHooks("TEST-ORG", "test-repo")
+
+	suite.Require().Nil(err)
+	suite.Require().Len(webHooks, 1)
+
+	webHook := webHooks[0]
+	suite.Require().Equal(gits.GitWebHookArguments{
+		ID:     123,
+		Owner:  "TEST-ORG",
+		Repo:   nil,
+		URL:    "http://jenkins.example.com/bitbucket-scmsource-hook/notify",
+		Secret: "abc123",
+	}, *webHook)
 }
 
 func (suite *BitbucketServerProviderTestSuite) TestUserInfo() {

--- a/pkg/gits/bitbucket_server_test.go
+++ b/pkg/gits/bitbucket_server_test.go
@@ -60,8 +60,10 @@ var bitbucketServerRouter = util.Router{
 	},
 	"/rest/api/1.0/projects/TEST-ORG/repos/test-repo/webhooks": util.MethodMap{
 		"POST": "webhook.json",
-		"PUT":  "webhook.json",
 		"GET":  "webhooks.json",
+	},
+	"/rest/api/1.0/projects/TEST-ORG/repos/test-repo/webhooks/123": util.MethodMap{
+		"PUT": "webhook.json",
 	},
 	"/rest/api/1.0/users/test-user": util.MethodMap{
 		"GET": "user.json",

--- a/pkg/gits/bitbucket_server_test.go
+++ b/pkg/gits/bitbucket_server_test.go
@@ -60,6 +60,7 @@ var bitbucketServerRouter = util.Router{
 	},
 	"/rest/api/1.0/projects/TEST-ORG/repos/test-repo/webhooks": util.MethodMap{
 		"POST": "webhook.json",
+		"PUT":  "webhook.json",
 		"GET":  "webhooks.json",
 	},
 	"/rest/api/1.0/users/test-user": util.MethodMap{
@@ -310,6 +311,19 @@ func (suite *BitbucketServerProviderTestSuite) TestListWebHooks() {
 		URL:    "http://jenkins.example.com/bitbucket-scmsource-hook/notify",
 		Secret: "abc123",
 	}, *webHook)
+}
+
+func (suite *BitbucketServerProviderTestSuite) TestUpdateWebHook() {
+
+	data := &gits.GitWebHookArguments{
+		Repo:        &gits.GitRepository{URL: "https://auth.example.com/projects/TEST-ORG/repos/test-repo"},
+		URL:         "http://jenkins.example.com/bitbucket-scmsource-hook/notify",
+		ExistingURL: "http://jenkins.example.com/bitbucket-scmsource-hook/notify",
+		Secret:      "someSecret",
+	}
+	err := suite.provider.UpdateWebHook(data)
+
+	suite.Require().Nil(err)
 }
 
 func (suite *BitbucketServerProviderTestSuite) TestUserInfo() {

--- a/pkg/gits/test_data/bitbucket_server/webhooks.json
+++ b/pkg/gits/test_data/bitbucket_server/webhooks.json
@@ -1,0 +1,37 @@
+{
+  "size": 1,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "id": 123,
+      "name": "Jenkins X Web Hook",
+      "createdDate": 1550258395908,
+      "updatedDate": 1550258395908,
+      "events": [
+        "repo:modified",
+        "pr:reviewer:needs_work",
+        "pr:reviewer:unapproved",
+        "pr:comment:edited",
+        "repo:refs_changed",
+        "pr:declined",
+        "pr:comment:added",
+        "repo:forked",
+        "pr:deleted",
+        "repo:comment:added",
+        "pr:reviewer:approved",
+        "pr:merged",
+        "repo:comment:deleted",
+        "pr:opened",
+        "pr:comment:deleted",
+        "repo:comment:edited"
+      ],
+      "configuration": {
+        "secret": "abc123"
+      },
+      "url": "http://jenkins.example.com/bitbucket-scmsource-hook/notify",
+      "active": true
+    }
+  ],
+  "start": 0
+}

--- a/pkg/jx/cmd/update_webhooks.go
+++ b/pkg/jx/cmd/update_webhooks.go
@@ -142,6 +142,7 @@ func (options *UpdateWebhooksOptions) updateRepoHook(git gits.GitProvider, repoN
 
 				// update
 				webHookArgs := &gits.GitWebHookArguments{
+					ID:    webHook.ID,
 					Owner: options.Org,
 					Repo: &gits.GitRepository{
 						Name: repoName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Improve support for web hooks for Bitbucket Server:
* Implement `ListWebHooks`
* Implement `UpdateWebHook`
* On `CreateWebHook`, make sure there isn't an existing web hook with the same URL.  Prevents duplicates.
* Random fix: pass in web hook ID when updating web hooks via `jx update webhooks`.  Without this, it is possible that the `UpdateWebHook` method may not find the appropriate web hook to update.

#### Special notes for the reviewer(s)

I specifically tested re-importing a project and I did not get a duplicate web hook, but instead got the log message `Already has a webhook registered for...`

#### Which issue this PR fixes

None that I could find.