### PR TITLE
feat(upgrade): new 'upgrade crd' cmd to upgrade all jenkinsx CRDs

### DIFF
--- a/pkg/jx/cmd/upgrade.go
+++ b/pkg/jx/cmd/upgrade.go
@@ -63,6 +63,7 @@ func NewCmdUpgrade(f Factory, in terminal.FileReader, out terminal.FileWriter, e
 	cmd.AddCommand(NewCmdUpgradePlatform(f, in, out, errOut))
 	cmd.AddCommand(NewCmdUpgradeExtensions(f, in, out, errOut))
 	cmd.AddCommand(NewCmdUpgradeApps(f, in, out, errOut))
+	cmd.AddCommand(NewCmdUpgradeCRDs(f, in, out, errOut))
 	return cmd
 }
 

--- a/pkg/jx/cmd/upgrade_crd.go
+++ b/pkg/jx/cmd/upgrade_crd.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"io"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+var (
+	upgradeCRDsLong = templates.LongDesc(`
+		Upgrades the Jenkins X Custom Resource Definitions in the Kubernetes Cluster
+`)
+
+	upgradeCRDsExample = templates.Examples(`
+		# Upgrades the Custom Resource Definitions 
+		jx upgrade crd
+	`)
+)
+
+// UpgradeCRDsOptions the options for the upgrade CRDs command
+type UpgradeCRDsOptions struct {
+	UpgradeOptions
+}
+
+// NewCmdUpgradeCRDs defines the command
+func NewCmdUpgradeCRDs(f Factory, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) *cobra.Command {
+	options := &UpgradeCRDsOptions{
+		UpgradeOptions: UpgradeOptions{
+			CommonOptions: CommonOptions{
+				Factory: f,
+				In:      in,
+				Out:     out,
+				Err:     errOut,
+			},
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "crd",
+		Short:   "Upgrades the Jenkins X Custom Resource Definitions in the Kubernetes Cluster",
+		Long:    upgradeCRDsLong,
+		Example: upgradeCRDsExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			CheckErr(err)
+		},
+	}
+	return cmd
+}
+
+// Run implements the command
+func (o *UpgradeCRDsOptions) Run() error {
+	apisClient, err := o.ApiExtensionsClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to create the API extensions client")
+	}
+	err = kube.RegisterAllCRDs(apisClient)
+	if err != nil {
+		return errors.Wrap(err, "failed to register all CRDs")
+	}
+	log.Info("Jenkins X CRDs upgraded with success\n")
+	return nil
+}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Introduce a new `jx upgrade crd` command that will make sure all jenkinsx CRDs are registered in Kubernetes, and updated to the latest version.

This can be used if you want to upgrade the jenkins-x-platform charts without using the `jx upgrade platform` command, for example using a tool like https://github.com/roboll/helmfile, but still making sure you get the latest CRDs registered.
