### PR TITLE
fix(devpod): 'delete devpod' was not using the right pod name

### DIFF
--- a/pkg/jx/cmd/delete_devpod.go
+++ b/pkg/jx/cmd/delete_devpod.go
@@ -75,14 +75,18 @@ func (o *DeleteDevPodOptions) Run() error {
 		return err
 	}
 	userName, err := o.getUsername(o.CommonDevPodOptions.Username)
-	names, err := kube.GetPodNames(client, ns, userName)
+	if err != nil {
+		return err
+	}
+	name := kube.ToValidName(userName)
+	names, err := kube.GetPodNames(client, ns, name)
 	if err != nil {
 		return err
 	}
 
 	info := util.ColorInfo
 	if len(names) == 0 {
-		return fmt.Errorf("There are no DevPods for user %s in namespace %s. You can create one via: %s\n", info(username), info(ns), info("jx create devpod"))
+		return fmt.Errorf("There are no DevPods for user %s in namespace %s. You can create one via: %s\n", info(userName), info(ns), info("jx create devpod"))
 	}
 
 	if len(args) == 0 {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

when creating the devpod, the username is converted to a "valid kubernetes name".
but when deleting it, the same conversion was missing. so people could not easily delete a devpod they created with default values.

also fixing a missing error check, and an error message
