### PR TITLE
fix: Don't discard secrets in non-gitops helm chart install

### DIFF
--- a/pkg/jx/cmd/common_helm.go
+++ b/pkg/jx/cmd/common_helm.go
@@ -313,7 +313,7 @@ func (o *CommonOptions) installChartOrGitOps(isGitOps bool, gitOpsDir string, gi
 
 	if !isGitOps {
 		return o.installChartOptions(helm.InstallChartOptions{ReleaseName: releaseName, Chart: chart, Version: version,
-			Ns: ns, HelmUpdate: helmUpdate, SetValues: setValues, ValueFiles: valueFiles, Repository: repo})
+			Ns: ns, HelmUpdate: helmUpdate, SetValues: append(setValues, setSecrets...), ValueFiles: valueFiles, Repository: repo})
 	}
 
 	if gitOpsEnvDir == "" {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We were discarding secrets passed to `installChartOrGitOps` if we weren't using gitops. Which was bad. So don't do that.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #3190 
