### PR TITLE
fix: (init.go) enable both  ports for EKS NLB

### DIFF
--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -468,10 +468,9 @@ func (o *InitOptions) initIngress() error {
 		if o.Flags.Provider == cloud.AWS || o.Flags.Provider == cloud.EKS {
 			// For EKS enable both ports for NLBs to be able to use TLS on Nginx ingresses 
 			// Fix for https://github.com/jenkins-x/jx/issues/3079
-			if o.Flags.Provider == cloud.EKS {
-				enableHTTP := "true"
-				enableHTTPS := "true"
-			} 
+			enableHTTP := "true"
+			enableHTTPS := "true"
+
 			// For AWS we can only enable one port for NLBs right now?
 			if o.Flags.Provider == cloud.AWS {
 				enableHTTP = "false"

--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -466,7 +466,7 @@ func (o *InitOptions) initIngress() error {
 			return errors.Wrap(err, "failed to append the myvalues file")
 		}
 		if o.Flags.Provider == cloud.AWS || o.Flags.Provider == cloud.EKS {
-			// For EKS enable both ports for NLBs to be able to use TLS on Nginx ingresses 
+			// For EKS enable both ports for NLBs to be able to use TLS on Nginx ingresses
 			// Fix for https://github.com/jenkins-x/jx/issues/3079
 			enableHTTP := "true"
 			enableHTTPS := "true"

--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -466,12 +466,19 @@ func (o *InitOptions) initIngress() error {
 			return errors.Wrap(err, "failed to append the myvalues file")
 		}
 		if o.Flags.Provider == cloud.AWS || o.Flags.Provider == cloud.EKS {
-			// we can only enable one port for NLBs right now
-			enableHTTP := "false"
-			enableHTTPS := "true"
-			if o.Flags.Http {
-				enableHTTP = "true"
-				enableHTTPS = "false"
+			// For EKS enable both ports for NLBs to be able to use TLS on Nginx ingresses 
+			// Fix for https://github.com/jenkins-x/jx/issues/3079
+			if o.Flags.Provider == cloud.EKS {
+				enableHTTP := "true"
+				enableHTTPS := "true"
+			} // For AWS we can only enable one port for NLBs right now?
+			else if o.Flags.Provider == cloud.AWS {
+				enableHTTP = "false"
+				enableHTTPS = "true"
+				if o.Flags.Http {
+					enableHTTP = "true"
+					enableHTTPS = "false"
+				}
 			}
 			yamlText := `---
 rbac:

--- a/pkg/jx/cmd/init.go
+++ b/pkg/jx/cmd/init.go
@@ -471,8 +471,9 @@ func (o *InitOptions) initIngress() error {
 			if o.Flags.Provider == cloud.EKS {
 				enableHTTP := "true"
 				enableHTTPS := "true"
-			} // For AWS we can only enable one port for NLBs right now?
-			else if o.Flags.Provider == cloud.AWS {
+			} 
+			// For AWS we can only enable one port for NLBs right now?
+			if o.Flags.Provider == cloud.AWS {
 				enableHTTP = "false"
 				enableHTTPS = "true"
 				if o.Flags.Http {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

There is only one listener created on EKS NLB controlled by `--http=true|false` option for `jx install --provider eks` command. This causes problems when creating cluster in EKS with a single TCP 80 listener enabled on NLB and then trying to do `jx upgrade ingress --cluster` to enable TLS on nginx ingresses with domain name. The ingress upgrade then fails, because there is no TCP 443 listener on NLB.

There is a hack workaround described in https://github.com/jenkins-x/jx/issues/3079 to make it work, but it requires manual steps to patch Nginx controller service and fix EC2 security groups which is not ideal experience. 

#### Special notes for the reviewer(s)

I have successfully installed Nginx ingress manually after creating new EKS cluster with `eksctl create cluster` command with the following values, so I am confident you can enable both ports on EKS NLB. 

```sh
$ helm get values jxing                                                         
controller:                                                                     
  service:                                                                      
    annotations:                                                                
      service.beta.kubernetes.io/aws-load-balancer-type: nlb                    
    enableHttp: true                                                            
    enableHttps: true                                                           
rbac:                                                                           
  create: true                                                                                                                                                 
```

```sh
$ kubectl describe svc -n kube-system jxing-nginx-ingress-controller
Name:                     jxing-nginx-ingress-controller
Namespace:                kube-system
Labels:                   app=nginx-ingress
                          chart=nginx-ingress-1.3.0
                          component=controller
                          heritage=Tiller
                          release=jxing
Annotations:              service.beta.kubernetes.io/aws-load-balancer-type: nlb
Selector:                 app=nginx-ingress,component=controller,release=jxing
Type:                     LoadBalancer
IP:                       10.100.78.171
LoadBalancer Ingress:     af1f212dc366411e995e00e3beb995aa-79a86f645433cf82.elb.us-west-2.amazonaws.com
Port:                     http  80/TCP
TargetPort:               http/TCP
NodePort:                 http  30844/TCP
Endpoints:                192.168.119.81:80
Port:                     https  443/TCP
TargetPort:               https/TCP
NodePort:                 https  32262/TCP
Endpoints:                192.168.119.81:443
Session Affinity:         None
External Traffic Policy:  Cluster
Events:                   <none>
```

I don't know if the same works for AWS provider, so I left previous behavior with single port intact for AWS provider option.

#### Which issue this PR fixes

fixes #3079 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
