### PR TITLE
include flag to enable passing the release name to cli.

### DIFF
--- a/pkg/jx/cmd/step_env_apply.go
+++ b/pkg/jx/cmd/step_env_apply.go
@@ -78,7 +78,7 @@ func NewCmdStepEnvApply(f Factory, in terminal.FileReader, out terminal.FileWrit
 		},
 	}
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The Kubernetes namespace to apply the helm charts to")
-	cmd.Flags().StringVarP(&options.ReleaseName, "name", "n", "", "The name of the release")
+	cmd.Flags().StringVarP(&options.ReleaseName, "name", "r", "", "The name of the release")
 	cmd.Flags().StringVarP(&options.Dir, "dir", "d", "", "The directory to look for the environment chart")
 	cmd.Flags().BoolVarP(&options.ChangeNs, "change-namespace", "", false, "Set the given namespace as the current namespace in Kubernetes configuration")
 	cmd.Flags().BoolVarP(&options.Vault, "vault", "", false, "Environment secrets are stored in vault")

--- a/pkg/jx/cmd/step_env_apply.go
+++ b/pkg/jx/cmd/step_env_apply.go
@@ -78,6 +78,7 @@ func NewCmdStepEnvApply(f Factory, in terminal.FileReader, out terminal.FileWrit
 		},
 	}
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The Kubernetes namespace to apply the helm charts to")
+	cmd.Flags().StringVarP(&options.ReleaseName, "name", "n", "", "The name of the release")
 	cmd.Flags().StringVarP(&options.Dir, "dir", "d", "", "The directory to look for the environment chart")
 	cmd.Flags().BoolVarP(&options.ChangeNs, "change-namespace", "", false, "Set the given namespace as the current namespace in Kubernetes configuration")
 	cmd.Flags().BoolVarP(&options.Vault, "vault", "", false, "Environment secrets are stored in vault")


### PR DESCRIPTION
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This pr will expose the flag to override the release name used when using the command `jx step env apply`.

Currently the release is set to jenkins-x and there is no way to override it, `jx helm apply`.

The flag named used here is the same from `jx helm apply`

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #3215
