### PR TITLE
fix: add support for tagging git before we trigger tekton releases

### DIFF
--- a/pkg/jx/cmd/step_create_task.go
+++ b/pkg/jx/cmd/step_create_task.go
@@ -1147,7 +1147,7 @@ func (o *StepCreateTaskOptions) setVersionOnReleasePipelines(pipelineConfig *jen
 	if o.PipelineKind == jenkinsfile.PipelineKindRelease {
 		release := pipelineConfig.Pipelines.Release
 		if release == nil {
-			return fmt.Errorf("no Release pipeline available!")
+			return fmt.Errorf("no Release pipeline available")
 		}
 		sv := release.SetVersion
 		if sv == nil {


### PR DESCRIPTION
we can then pass the `version` in as a pipeline parameter for easier interop with tools like kankio