### PR TITLE
chore: Different message for no Tekton pipelines logs found

### DIFF
--- a/pkg/jx/cmd/get_build_logs.go
+++ b/pkg/jx/cmd/get_build_logs.go
@@ -506,7 +506,7 @@ func (o *GetBuildLogsOptions) loadPipelines(kubeClient kubernetes.Interface, tek
 	}
 	tekton.SortPipelineRunInfos(buildInfos)
 	if len(buildInfos) == 0 {
-		return names, defaultName, buildMap, pipelineMap, fmt.Errorf("no knative builds have been triggered which match the current filter")
+		return names, defaultName, buildMap, pipelineMap, fmt.Errorf("no Tekton pipelines have been triggered which match the current filter")
 	}
 
 	for _, build := range buildInfos {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Got annoyed at `jx get build logs` giving the same message when it can't find any builds, regardless of whether it's looking for Knative Builds or Tekton pipelines. So...

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a