### PR TITLE
fix: Don't keep trying to get pods for completed PipelineRuns

### DIFF
--- a/pkg/jx/cmd/get_build_logs.go
+++ b/pkg/jx/cmd/get_build_logs.go
@@ -500,7 +500,7 @@ func (o *GetBuildLogsOptions) loadPipelines(kubeClient kubernetes.Interface, tek
 			log.Warnf("Error creating PipelineRunInfo for PipelineRun %s: %s\n", pr.Name, err)
 			return names, defaultName, buildMap, pipelineMap, err
 		}
-		if pri.FindFirstStagePod() != nil {
+		if pri != nil {
 			buildInfos = append(buildInfos, pri)
 		}
 	}

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/knative/build-pipeline/pkg/apis/pipeline"
 	tektonclient "github.com/knative/build-pipeline/pkg/client/clientset/versioned"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,7 +108,7 @@ func getPipelineStructureForPipelineRun(jxClient versioned.Interface, ns, prName
 	return ps, nil
 }
 
-func getBuildPodForPipelineRun(kubeClient kubernetes.Interface, ns, prName string) (*corev1.Pod, error) {
+func getBuildPodForPipelineRun(kubeClient kubernetes.Interface, ns, prName string, prStatus *duckv1alpha1.Condition) (*corev1.Pod, error) {
 	var pod *corev1.Pod
 
 	// The Pod may not exist yet.
@@ -120,7 +121,8 @@ func getBuildPodForPipelineRun(kubeClient kubernetes.Interface, ns, prName strin
 			return err
 		}
 
-		if len(podList.Items) == 0 {
+		// Only retry if there's no pod and the PipelineRun hasn't yet completed.
+		if len(podList.Items) == 0 && prStatus != nil && prStatus.Status == corev1.ConditionUnknown {
 			log.Infof("no Pod found yet for PipelineRun %s\n", util.ColorInfo(prName))
 			return fmt.Errorf("No Pod found yet for PipelineRun %s", prName)
 		}
@@ -204,14 +206,20 @@ func CreatePipelineRunInfo(kubeClient kubernetes.Interface, tektonClient tektonc
 
 	var pod *corev1.Pod
 
+	prStatus := pr.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
 	// TODO: Remove this when we unify generation
 	if pr.Labels[syntax.LabelPipelineFromYaml] != "true" {
-		pod, err = getBuildPodForPipelineRun(kubeClient, ns, prName)
+		pod, err = getBuildPodForPipelineRun(kubeClient, ns, prName, prStatus)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error finding Pod for PipelineRun %s", prName)
 		}
 		if pod == nil {
-			return nil, fmt.Errorf("could not find Pod for PipelineRun %s", prName)
+			if prStatus != nil && prStatus.Status == corev1.ConditionUnknown {
+				return nil, fmt.Errorf("could not find Pod for PipelineRun %s", prName)
+			} else {
+				// The PipelineRun has completed and its pod(s) no longer exist, so just return nil in general.
+				return nil, nil
+			}
 		}
 
 		si := &StageInfo{
@@ -236,7 +244,12 @@ func CreatePipelineRunInfo(kubeClient kubernetes.Interface, tektonClient tektonc
 	pod = pri.FindFirstStagePod()
 
 	if pod == nil {
-		return nil, errors.New(fmt.Sprintf("Couldn't find a Stage with steps for PipelineRun %s", prName))
+		if prStatus != nil && prStatus.Status == corev1.ConditionUnknown {
+			return nil, errors.New(fmt.Sprintf("Couldn't find a Stage with steps for PipelineRun %s", prName))
+		} else {
+			// Just return nil if the pipeline run is completed and its pods have been GCed
+			return nil, nil
+		}
 	}
 
 	for _, initContainer := range pod.Spec.InitContainers {

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -216,10 +216,9 @@ func CreatePipelineRunInfo(kubeClient kubernetes.Interface, tektonClient tektonc
 		if pod == nil {
 			if prStatus != nil && prStatus.Status == corev1.ConditionUnknown {
 				return nil, fmt.Errorf("could not find Pod for PipelineRun %s", prName)
-			} else {
-				// The PipelineRun has completed and its pod(s) no longer exist, so just return nil in general.
-				return nil, nil
 			}
+			// The PipelineRun has completed and its pod(s) no longer exist, so just return nil in general.
+			return nil, nil
 		}
 
 		si := &StageInfo{
@@ -246,10 +245,9 @@ func CreatePipelineRunInfo(kubeClient kubernetes.Interface, tektonClient tektonc
 	if pod == nil {
 		if prStatus != nil && prStatus.Status == corev1.ConditionUnknown {
 			return nil, errors.New(fmt.Sprintf("Couldn't find a Stage with steps for PipelineRun %s", prName))
-		} else {
-			// Just return nil if the pipeline run is completed and its pods have been GCed
-			return nil, nil
 		}
+		// Just return nil if the pipeline run is completed and its pods have been GCed
+		return nil, nil
 	}
 
 	for _, initContainer := range pod.Spec.InitContainers {

--- a/pkg/tekton/pipeline_info_test.go
+++ b/pkg/tekton/pipeline_info_test.go
@@ -141,13 +141,13 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 		},
 		prName: "abayer-js-test-repo-nested-1",
 	}, {
-		name: "completed-from-yaml",
+		name:     "completed-from-yaml",
 		expected: nil,
-		prName: "abayer-js-test-repo-master-1",
+		prName:   "abayer-js-test-repo-master-1",
 	}, {
-		name: "completed-from-build-pack",
+		name:     "completed-from-build-pack",
 		expected: nil,
-		prName: "abayer-jx-demo-qs-master-1",
+		prName:   "abayer-jx-demo-qs-master-1",
 	}}
 
 	for _, tt := range testCases {

--- a/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/activity.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/activity.yml
@@ -1,0 +1,94 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  creationTimestamp: 2019-02-27T19:05:34Z
+  generation: 1
+  labels:
+    branch: master
+    owner: abayer
+    sourcerepository: abayer-jx-demo-qs
+  name: abayer-jx-demo-qs-master-1
+  namespace: jx
+  resourceVersion: "14785"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/abayer-jx-demo-qs-master-1
+  uid: a8c37189-3ac2-11e9-b04e-42010a8a0075
+spec:
+  build: "1"
+  gitBranch: master
+  gitOwner: abayer
+  gitRepository: jx-demo-qs
+  gitUrl: https://github.com/abayer/jx-demo-qs
+  pipeline: abayer/jx-demo-qs/master
+  startedTimestamp: 2019-02-27T19:05:35Z
+  status: Running
+  steps:
+  - kind: Stage
+    stage:
+      completedTimestamp: 2019-02-27T19:05:36Z
+      name: Credential Initializer 2rn7l
+      startedTimestamp: 2019-02-27T19:05:35Z
+      status: Succeeded
+  - kind: Stage
+    stage:
+      completedTimestamp: 2019-02-27T19:05:38Z
+      description: https://github.com/abayer/jx-demo-qs
+      name: Git Source Abayer Jx Demo Qs Master 7745g
+      startedTimestamp: 2019-02-27T19:05:37Z
+      status: Succeeded
+  - kind: Stage
+    stage:
+      completedTimestamp: 2019-02-27T19:05:40Z
+      name: Place Tools
+      startedTimestamp: 2019-02-27T19:05:40Z
+      status: Succeeded
+  - kind: Stage
+    stage:
+      completedTimestamp: 2019-02-27T19:05:42Z
+      name: Setup Jx Git Credentials
+      startedTimestamp: 2019-02-27T19:05:42Z
+      status: Succeeded
+  - kind: Stage
+    stage:
+      completedTimestamp: 2019-02-27T19:05:45Z
+      name: Setversion Next Version
+      startedTimestamp: 2019-02-27T19:05:43Z
+      status: Succeeded
+  - kind: Stage
+    stage:
+      completedTimestamp: 2019-02-27T19:06:11Z
+      name: Setversion Set Version
+      startedTimestamp: 2019-02-27T19:05:47Z
+      status: Failed
+  - kind: Stage
+    stage:
+      name: Setversion Tag Version
+      status: Pending
+  - kind: Stage
+    stage:
+      name: Build Mvn Deploy
+      status: Pending
+  - kind: Stage
+    stage:
+      name: Build Skaffold Version
+      status: Pending
+  - kind: Stage
+    stage:
+      name: Build Container Build
+      status: Pending
+  - kind: Stage
+    stage:
+      name: Build Post Build
+      status: Pending
+  - kind: Stage
+    stage:
+      name: Promote Changelog
+      status: Pending
+  - kind: Stage
+    stage:
+      name: Promote Helm Release
+      status: Pending
+  - kind: Stage
+    stage:
+      name: Promote Jx Promote
+      status: Pending
+status: {}

--- a/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/pipeline.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/pipeline.yml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  annotations:
+    jenkins.io/last-build-number: "1"
+  creationTimestamp: 2019-02-27T19:05:33Z
+  generation: 1
+  name: abayer-jx-demo-qs-master
+  namespace: jx
+  resourceVersion: "14626"
+  selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/abayer-jx-demo-qs-master
+  uid: a86bc50c-3ac2-11e9-b04e-42010a8a0075
+spec:
+  params: []
+  resources:
+  - name: abayer-jx-demo-qs-master
+    type: git
+  tasks:
+  - name: build
+    resources:
+      inputs:
+      - name: source
+        resource: abayer-jx-demo-qs-master
+      outputs: null
+    taskRef:
+      apiVersion: tekton.dev/v1alpha1
+      kind: Task
+      name: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/pipelineresources.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/pipelineresources.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    creationTimestamp: 2019-02-27T19:05:33Z
+    generation: 1
+    name: abayer-jx-demo-qs-master
+    namespace: jx
+    resourceVersion: "14613"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineresources/abayer-jx-demo-qs-master
+    uid: a8309634-3ac2-11e9-b04e-42010a8a0075
+  spec:
+    params:
+    - name: revision
+      value: ""
+    - name: url
+      value: https://github.com/abayer/jx-demo-qs
+    type: git
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/pipelinerun.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/pipelinerun.yml
@@ -1,0 +1,114 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: 2019-02-27T19:05:33Z
+  generation: 1
+  labels:
+    branch: master
+    build-number: "1"
+    owner: abayer
+    repo: jx-demo-qs
+    tekton.dev/pipeline: abayer-jx-demo-qs-master
+  name: abayer-jx-demo-qs-master-1
+  namespace: jx
+  ownerReferences:
+  - apiVersion: tekton.dev/v1alpha1
+    kind: Pipeline
+    name: abayer-jx-demo-qs-master
+    uid: a86bc50c-3ac2-11e9-b04e-42010a8a0075
+  resourceVersion: "14792"
+  selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/abayer-jx-demo-qs-master-1
+  uid: a87ed5ae-3ac2-11e9-b04e-42010a8a0075
+spec:
+  Status: ""
+  params: null
+  pipelineRef:
+    name: abayer-jx-demo-qs-master
+  resources:
+  - name: abayer-jx-demo-qs-master
+    resourceRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: abayer-jx-demo-qs-master
+  serviceAccount: tekton-bot
+  trigger:
+    type: manual
+status:
+  conditions:
+  - lastTransitionTime: 2019-02-27T19:06:14Z
+    message: TaskRun abayer-jx-demo-qs-master-1-build-jllqx has failed
+    reason: Failed
+    status: "False"
+    type: Succeeded
+  startTime: 2019-02-27T19:05:33Z
+  taskRuns:
+    abayer-jx-demo-qs-master-1-build-jllqx:
+      conditions:
+      - lastTransitionTime: 2019-02-27T19:06:14Z
+        message: 'build step "build-step-setversion-set-version" exited with code
+          1 (image: "docker-pullable://jenkinsxio/builder-maven-java11@sha256:3eeb136cdfdf2c4e2a0c2a148a7bd6cdf2f20c70a12f847b91039f4d8ef53452");
+          for logs run: kubectl -n jx logs abayer-jx-demo-qs-master-1-build-jllqx-pod-ff92ac
+          -c build-step-setversion-set-version'
+        status: "False"
+        type: Succeeded
+      podName: abayer-jx-demo-qs-master-1-build-jllqx-pod-ff92ac
+      startTime: 2019-02-27T19:05:33Z
+      steps:
+      - logsURL: ""
+        terminated:
+          containerID: docker://537d36e832e3331ff8a0dad4a8219766166c752e5f081f24618a7b77dff78435
+          exitCode: 0
+          finishedAt: 2019-02-27T19:05:38Z
+          reason: Completed
+          startedAt: 2019-02-27T19:05:37Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://aa5300012396fd1e35037a68631fe81e62763fcd8092ee2e761e8ee7ed0d1a4a
+          exitCode: 0
+          finishedAt: 2019-02-27T19:05:40Z
+          reason: Completed
+          startedAt: 2019-02-27T19:05:40Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://787ce333c6a15d5a6a6ec801a7ebcb5d27aa4dabeb486b5ccb49a95f5b4dc126
+          exitCode: 0
+          finishedAt: 2019-02-27T19:05:42Z
+          reason: Completed
+          startedAt: 2019-02-27T19:05:42Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://41db037440b0c87503363e1d355a392abe6f5453e0fafe7fef62e8359d77205a
+          exitCode: 0
+          finishedAt: 2019-02-27T19:05:45Z
+          reason: Completed
+          startedAt: 2019-02-27T19:05:43Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://fa217f7977da3472bb6949ef395f1411543fda15d79e6a054768653c0de97a62
+          exitCode: 1
+          finishedAt: 2019-02-27T19:06:11Z
+          reason: Error
+          startedAt: 2019-02-27T19:05:47Z
+      - logsURL: ""
+        waiting:
+          reason: PodInitializing
+      - logsURL: ""
+        waiting:
+          reason: PodInitializing
+      - logsURL: ""
+        waiting:
+          reason: PodInitializing
+      - logsURL: ""
+        waiting:
+          reason: PodInitializing
+      - logsURL: ""
+        waiting:
+          reason: PodInitializing
+      - logsURL: ""
+        waiting:
+          reason: PodInitializing
+      - logsURL: ""
+        waiting:
+          reason: PodInitializing
+      - logsURL: ""
+        waiting:
+          reason: PodInitializing

--- a/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/taskruns.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/taskruns.yml
@@ -1,0 +1,118 @@
+apiVersion: v1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: TaskRun
+  metadata:
+    creationTimestamp: 2019-02-27T19:05:33Z
+    generation: 1
+    labels:
+      branch: master
+      build-number: "1"
+      owner: abayer
+      repo: jx-demo-qs
+      tekton.dev/pipeline: abayer-jx-demo-qs-master
+      tekton.dev/pipelineRun: abayer-jx-demo-qs-master-1
+      tekton.dev/task: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-1-build-jllqx
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PipelineRun
+      name: abayer-jx-demo-qs-master-1
+      uid: a87ed5ae-3ac2-11e9-b04e-42010a8a0075
+    resourceVersion: "14791"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/taskruns/abayer-jx-demo-qs-master-1-build-jllqx
+    uid: a883ca5c-3ac2-11e9-b04e-42010a8a0075
+  spec:
+    Status: ""
+    inputs:
+      resources:
+      - name: source
+        paths: null
+        resourceRef:
+          name: abayer-jx-demo-qs-master
+        resourceSpec: null
+    outputs: {}
+    serviceAccount: tekton-bot
+    taskRef:
+      kind: Task
+      name: abayer-jx-demo-qs-master
+    trigger:
+      type: ""
+  status:
+    conditions:
+    - lastTransitionTime: 2019-02-27T19:06:14Z
+      message: 'build step "build-step-setversion-set-version" exited with code 1
+        (image: "docker-pullable://jenkinsxio/builder-maven-java11@sha256:3eeb136cdfdf2c4e2a0c2a148a7bd6cdf2f20c70a12f847b91039f4d8ef53452");
+        for logs run: kubectl -n jx logs abayer-jx-demo-qs-master-1-build-jllqx-pod-ff92ac
+        -c build-step-setversion-set-version'
+      status: "False"
+      type: Succeeded
+    podName: abayer-jx-demo-qs-master-1-build-jllqx-pod-ff92ac
+    startTime: 2019-02-27T19:05:33Z
+    steps:
+    - logsURL: ""
+      terminated:
+        containerID: docker://537d36e832e3331ff8a0dad4a8219766166c752e5f081f24618a7b77dff78435
+        exitCode: 0
+        finishedAt: 2019-02-27T19:05:38Z
+        reason: Completed
+        startedAt: 2019-02-27T19:05:37Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://aa5300012396fd1e35037a68631fe81e62763fcd8092ee2e761e8ee7ed0d1a4a
+        exitCode: 0
+        finishedAt: 2019-02-27T19:05:40Z
+        reason: Completed
+        startedAt: 2019-02-27T19:05:40Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://787ce333c6a15d5a6a6ec801a7ebcb5d27aa4dabeb486b5ccb49a95f5b4dc126
+        exitCode: 0
+        finishedAt: 2019-02-27T19:05:42Z
+        reason: Completed
+        startedAt: 2019-02-27T19:05:42Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://41db037440b0c87503363e1d355a392abe6f5453e0fafe7fef62e8359d77205a
+        exitCode: 0
+        finishedAt: 2019-02-27T19:05:45Z
+        reason: Completed
+        startedAt: 2019-02-27T19:05:43Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://fa217f7977da3472bb6949ef395f1411543fda15d79e6a054768653c0de97a62
+        exitCode: 1
+        finishedAt: 2019-02-27T19:06:11Z
+        reason: Error
+        startedAt: 2019-02-27T19:05:47Z
+    - logsURL: ""
+      waiting:
+        reason: PodInitializing
+    - logsURL: ""
+      waiting:
+        reason: PodInitializing
+    - logsURL: ""
+      waiting:
+        reason: PodInitializing
+    - logsURL: ""
+      waiting:
+        reason: PodInitializing
+    - logsURL: ""
+      waiting:
+        reason: PodInitializing
+    - logsURL: ""
+      waiting:
+        reason: PodInitializing
+    - logsURL: ""
+      waiting:
+        reason: PodInitializing
+    - logsURL: ""
+      waiting:
+        reason: PodInitializing
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/tasks.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/tasks.yml
@@ -1,0 +1,752 @@
+apiVersion: v1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: 2019-02-27T19:05:33Z
+    generation: 1
+    labels:
+      branch: master
+      owner: abayer
+      repo: jx-demo-qs
+    name: abayer-jx-demo-qs-master
+    namespace: jx
+    resourceVersion: "14614"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/tasks/abayer-jx-demo-qs-master
+    uid: a859be20-3ac2-11e9-b04e-42010a8a0075
+  spec:
+    inputs:
+      resources:
+      - name: source
+        targetPath: ""
+        type: git
+    steps:
+    - args:
+      - -c
+      - jx step git credentials
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: setup-jx-git-credentials
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -c
+      - echo $(jx-release-version) > VERSION
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: setversion-next-version
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -c
+      - mvn versions:set -DnewVersion=${VERSION}
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: setversion-set-version
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -c
+      - jx step tag --version ${VERSION}
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: setversion-tag-version
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -c
+      - mvn clean deploy
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: build-mvn-deploy
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -c
+      - skaffold version
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: build-skaffold-version
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -c
+      - skaffold build -f skaffold.yaml
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: build-container-build
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -c
+      - jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:${VERSION}
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: build-post-build
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -c
+      - jx step changelog --version v${VERSION}
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: promote-changelog
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source/charts/jx-demo-qs
+    - args:
+      - -c
+      - jx step helm release
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: promote-helm-release
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source/charts/jx-demo-qs
+    - args:
+      - -c
+      - jx promote -b --all-auto --timeout 1h --version ${VERSION}
+      command:
+      - /bin/sh
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: promote-jx-promote
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source/charts/jx-demo-qs
+    volumes:
+    - emptyDir: {}
+      name: workspace-volume
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-maven-settings
+    - name: volume-1
+      secret:
+        secretName: jenkins-docker-cfg
+    - name: volume-2
+      secret:
+        secretName: jenkins-release-gpg
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/activity.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/activity.yml
@@ -1,0 +1,97 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  creationTimestamp: 2019-02-21T22:02:45Z
+  generation: 1
+  labels:
+    branch: master
+    owner: abayer
+    sourcerepository: abayer-js-test-repo
+  name: abayer-js-test-repo-master-1
+  namespace: jx
+  resourceVersion: "6304"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/abayer-js-test-repo-master-1
+  uid: 6ad71a67-3624-11e9-b776-42010a8a00ac
+spec:
+  build: "1"
+  completedTimestamp: 2019-02-21T22:04:12Z
+  gitBranch: master
+  gitOwner: abayer
+  gitRepository: js-test-repo
+  gitUrl: https://github.com/abayer/js-test-repo
+  pipeline: abayer/js-test-repo/master
+  startedTimestamp: 2019-02-21T22:02:59Z
+  status: Succeeded
+  steps:
+  - kind: Stage
+    stage:
+      completedTimestamp: 2019-02-21T22:03:42Z
+      name: Build
+      startedTimestamp: 2019-02-21T22:02:59Z
+      status: Succeeded
+      steps:
+      - completedTimestamp: 2019-02-21T22:02:59Z
+        name: Credential Initializer 5h4vq
+        startedTimestamp: 2019-02-21T22:02:59Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:03:04Z
+        description: https://github.com/abayer/js-test-repo
+        name: Git Source Abayer Js Test Repo Master 52jsl
+        startedTimestamp: 2019-02-21T22:03:01Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:03:07Z
+        name: Place Tools
+        startedTimestamp: 2019-02-21T22:03:07Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:03:37Z
+        name: Step2
+        startedTimestamp: 2019-02-21T22:03:36Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:03:38Z
+        name: Step3
+        startedTimestamp: 2019-02-21T22:03:38Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:03:40Z
+        name: Source Mkdir Abayer Js Test Repo Master Dcxpj
+        startedTimestamp: 2019-02-21T22:03:40Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:03:42Z
+        name: Source Copy Abayer Js Test Repo Master S468q
+        startedTimestamp: 2019-02-21T22:03:42Z
+        status: Succeeded
+  - kind: Stage
+    stage:
+      completedTimestamp: 2019-02-21T22:04:12Z
+      name: Second
+      startedTimestamp: 2019-02-21T22:04:06Z
+      status: Succeeded
+      steps:
+      - completedTimestamp: 2019-02-21T22:04:06Z
+        name: Credential Initializer 225gh
+        startedTimestamp: 2019-02-21T22:04:06Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:04:07Z
+        name: Create Dir Workspace 5fvxn
+        startedTimestamp: 2019-02-21T22:04:07Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:04:08Z
+        name: Source Copy Workspace 0 Txgkz
+        startedTimestamp: 2019-02-21T22:04:08Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:04:09Z
+        name: Place Tools
+        startedTimestamp: 2019-02-21T22:04:09Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:04:10Z
+        name: Step2
+        startedTimestamp: 2019-02-21T22:04:10Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:04:11Z
+        name: Source Mkdir Abayer Js Test Repo Master Wknf8
+        startedTimestamp: 2019-02-21T22:04:11Z
+        status: Succeeded
+      - completedTimestamp: 2019-02-21T22:04:12Z
+        name: Source Copy Abayer Js Test Repo Master B9f8b
+        startedTimestamp: 2019-02-21T22:04:12Z
+        status: Succeeded
+status: {}

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipeline.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipeline.yml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  annotations:
+    jenkins.io/last-build-number: "1"
+  creationTimestamp: 2019-02-21T22:02:43Z
+  generation: 1
+  labels:
+    jenkins.io/pipeline-from-yaml: "true"
+  name: abayer-js-test-repo-master
+  namespace: jx
+  resourceVersion: "5950"
+  selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/abayer-js-test-repo-master
+  uid: 69ec9014-3624-11e9-b776-42010a8a00ac
+spec:
+  params: null
+  resources:
+  - name: abayer-js-test-repo-master
+    type: git
+  - name: temp-ordering-resource
+    type: image
+  tasks:
+  - name: build
+    resources:
+      inputs:
+      - name: workspace
+        resource: abayer-js-test-repo-master
+      - name: temp-ordering-resource
+        resource: temp-ordering-resource
+      outputs:
+      - name: workspace
+        resource: abayer-js-test-repo-master
+      - name: temp-ordering-resource
+        resource: temp-ordering-resource
+    taskRef:
+      name: abayer-js-test-repo-master-build
+  - name: second
+    resources:
+      inputs:
+      - from:
+        - build
+        name: workspace
+        resource: abayer-js-test-repo-master
+      - from:
+        - build
+        name: temp-ordering-resource
+        resource: temp-ordering-resource
+      outputs:
+      - name: workspace
+        resource: abayer-js-test-repo-master
+      - name: temp-ordering-resource
+        resource: temp-ordering-resource
+    taskRef:
+      name: abayer-js-test-repo-master-second

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipelineresources.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipelineresources.yml
@@ -1,0 +1,42 @@
+apiVersion: v1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    creationTimestamp: 2019-02-21T22:02:43Z
+    generation: 1
+    labels:
+      jenkins.io/pipeline-from-yaml: "true"
+    name: abayer-js-test-repo-master
+    namespace: jx
+    resourceVersion: "5932"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineresources/abayer-js-test-repo-master
+    uid: 69ad6e69-3624-11e9-b776-42010a8a00ac
+  spec:
+    params:
+    - name: revision
+      value: ""
+    - name: url
+      value: https://github.com/abayer/js-test-repo
+    type: git
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    creationTimestamp: 2019-02-21T22:02:43Z
+    generation: 1
+    labels:
+      jenkins.io/pipeline-from-yaml: "true"
+    name: temp-ordering-resource
+    namespace: jx
+    resourceVersion: "5933"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineresources/temp-ordering-resource
+    uid: 69be522d-3624-11e9-b776-42010a8a00ac
+  spec:
+    params:
+    - name: url
+      value: alpine
+    type: image
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipelinerun.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipelinerun.yml
@@ -1,0 +1,148 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: 2019-02-21T22:02:43Z
+  generation: 1
+  labels:
+    branch: master
+    build-number: "1"
+    jenkins.io/pipeline-from-yaml: "true"
+    owner: abayer
+    repo: js-test-repo
+    tekton.dev/pipeline: abayer-js-test-repo-master
+  name: abayer-js-test-repo-master-1
+  namespace: jx
+  ownerReferences:
+  - apiVersion: tekton.dev/v1alpha1
+    kind: Pipeline
+    name: abayer-js-test-repo-master
+    uid: 69ec9014-3624-11e9-b776-42010a8a00ac
+  resourceVersion: "6344"
+  selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/abayer-js-test-repo-master-1
+  uid: 69fb89f5-3624-11e9-b776-42010a8a00ac
+spec:
+  Status: ""
+  params: null
+  pipelineRef:
+    name: abayer-js-test-repo-master
+  resources:
+  - name: abayer-js-test-repo-master
+    resourceRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: abayer-js-test-repo-master
+  - name: temp-ordering-resource
+    resourceRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: temp-ordering-resource
+  serviceAccount: tekton-bot
+  trigger:
+    type: manual
+status:
+  conditions:
+  - lastTransitionTime: 2019-02-21T22:04:24Z
+    message: All Tasks have completed executing
+    reason: Succeeded
+    status: "True"
+    type: Succeeded
+  startTime: 2019-02-21T22:02:43Z
+  taskRuns:
+    abayer-js-test-repo-master-1-build-ttvzf:
+      conditions:
+      - lastTransitionTime: 2019-02-21T22:03:54Z
+        status: "True"
+        type: Succeeded
+      podName: abayer-js-test-repo-master-1-build-ttvzf-pod-937200
+      startTime: 2019-02-21T22:02:43Z
+      steps:
+      - logsURL: ""
+        terminated:
+          containerID: docker://ed2e0600af698c48c12c02aacdfd76c5a02ca8ebdf9849bc4df1f4c093fa327f
+          exitCode: 0
+          finishedAt: 2019-02-21T22:03:04Z
+          reason: Completed
+          startedAt: 2019-02-21T22:03:01Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://8aee17337d7eab04996c91717012e103bfb0510184a3ca20bcab01eb21e4d432
+          exitCode: 0
+          finishedAt: 2019-02-21T22:03:07Z
+          reason: Completed
+          startedAt: 2019-02-21T22:03:07Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://a1713f8af2bd6d0ac007f39482feec7206a1d164f5b2c329be267f4836ef110d
+          exitCode: 0
+          finishedAt: 2019-02-21T22:03:37Z
+          reason: Completed
+          startedAt: 2019-02-21T22:03:36Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://aaa2a796eb46ab3eae0053a300ce9a0964f81b3b41eadd2b2794873f2617817c
+          exitCode: 0
+          finishedAt: 2019-02-21T22:03:38Z
+          reason: Completed
+          startedAt: 2019-02-21T22:03:38Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://68a65e3ca44fd47c149aebd64190273c480b7f83c020bd579d14cd3d25a1ef6b
+          exitCode: 0
+          finishedAt: 2019-02-21T22:03:40Z
+          reason: Completed
+          startedAt: 2019-02-21T22:03:40Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://7f9f6a78dd471731997a63013872f617cb0da785bbcca244f9ba2b356296901a
+          exitCode: 0
+          finishedAt: 2019-02-21T22:03:42Z
+          reason: Completed
+          startedAt: 2019-02-21T22:03:42Z
+    abayer-js-test-repo-master-1-second-9czt5:
+      conditions:
+      - lastTransitionTime: 2019-02-21T22:04:24Z
+        status: "True"
+        type: Succeeded
+      podName: abayer-js-test-repo-master-1-second-9czt5-pod-62d12d
+      startTime: 2019-02-21T22:03:56Z
+      steps:
+      - logsURL: ""
+        terminated:
+          containerID: docker://557e7e7571f62c607c854f3ffa654b10f82196101d46f20939829fbdc6a1320e
+          exitCode: 0
+          finishedAt: 2019-02-21T22:04:07Z
+          reason: Completed
+          startedAt: 2019-02-21T22:04:07Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://3b4150a8ad7e8c6b171e57188fbfb74ffc794aafaeb6073d5997a46d9d399004
+          exitCode: 0
+          finishedAt: 2019-02-21T22:04:08Z
+          reason: Completed
+          startedAt: 2019-02-21T22:04:08Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://c98db7ca8b2ff5566605deddaa22694009fc5f23bdf7a56bb1efa4c92fd0a222
+          exitCode: 0
+          finishedAt: 2019-02-21T22:04:09Z
+          reason: Completed
+          startedAt: 2019-02-21T22:04:09Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://130a294841624b138d801306a7bf6923e9d6f18dbb2d161bb9d18107bffc896f
+          exitCode: 0
+          finishedAt: 2019-02-21T22:04:10Z
+          reason: Completed
+          startedAt: 2019-02-21T22:04:10Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://712659711fe0dd07add0740d22898207768bfeb823a2dc11b062092a3fbb5110
+          exitCode: 0
+          finishedAt: 2019-02-21T22:04:11Z
+          reason: Completed
+          startedAt: 2019-02-21T22:04:11Z
+      - logsURL: ""
+        terminated:
+          containerID: docker://b7dd7d255a48ef595b47206f247d1b49ea33b3aed21c126b24fa1db3a22c91c3
+          exitCode: 0
+          finishedAt: 2019-02-21T22:04:12Z
+          reason: Completed
+          startedAt: 2019-02-21T22:04:12Z

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/structure.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/structure.yml
@@ -1,0 +1,25 @@
+apiVersion: jenkins.io/v1
+kind: PipelineStructure
+metadata:
+  creationTimestamp: 2019-02-21T22:02:44Z
+  generation: 1
+  name: abayer-js-test-repo-master-1
+  namespace: jx
+  ownerReferences:
+  - apiVersion: tekton.dev/v1alpha1
+    kind: Pipeline
+    name: abayer-js-test-repo-master
+    uid: 69ec9014-3624-11e9-b776-42010a8a00ac
+  resourceVersion: "5956"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/abayer-js-test-repo-master-1
+  uid: 6a4d8b07-3624-11e9-b776-42010a8a00ac
+pipelineRef: abayer-js-test-repo-master
+pipelineRunRef: abayer-js-test-repo-master-1
+stages:
+- depth: 0
+  name: Build
+  taskRef: abayer-js-test-repo-master-build
+- depth: 0
+  name: Second
+  previous: Build
+  taskRef: abayer-js-test-repo-master-second

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/taskruns.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/taskruns.yml
@@ -1,0 +1,230 @@
+apiVersion: v1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: TaskRun
+  metadata:
+    creationTimestamp: 2019-02-21T22:02:43Z
+    generation: 1
+    labels:
+      branch: master
+      build-number: "1"
+      jenkins.io/pipeline-from-yaml: "true"
+      jenkins.io/task-stage-name: Build
+      owner: abayer
+      repo: js-test-repo
+      tekton.dev/pipeline: abayer-js-test-repo-master
+      tekton.dev/pipelineRun: abayer-js-test-repo-master-1
+      tekton.dev/task: abayer-js-test-repo-master-build
+    name: abayer-js-test-repo-master-1-build-ttvzf
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PipelineRun
+      name: abayer-js-test-repo-master-1
+      uid: 69fb89f5-3624-11e9-b776-42010a8a00ac
+    resourceVersion: "6218"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/taskruns/abayer-js-test-repo-master-1-build-ttvzf
+    uid: 6a01fd37-3624-11e9-b776-42010a8a00ac
+  spec:
+    Status: ""
+    inputs:
+      resources:
+      - name: temp-ordering-resource
+        paths: null
+        resourceRef:
+          name: temp-ordering-resource
+        resourceSpec: null
+      - name: workspace
+        paths: null
+        resourceRef:
+          name: abayer-js-test-repo-master
+        resourceSpec: null
+    outputs:
+      resources:
+      - name: workspace
+        paths:
+        - /pvc/build/workspace
+        resourceRef:
+          name: abayer-js-test-repo-master
+        resourceSpec: null
+      - name: temp-ordering-resource
+        paths:
+        - /pvc/build/temp-ordering-resource
+        resourceRef:
+          name: temp-ordering-resource
+        resourceSpec: null
+    serviceAccount: tekton-bot
+    taskRef:
+      kind: Task
+      name: abayer-js-test-repo-master-build
+    trigger:
+      type: ""
+  status:
+    conditions:
+    - lastTransitionTime: 2019-02-21T22:03:54Z
+      status: "True"
+      type: Succeeded
+    podName: abayer-js-test-repo-master-1-build-ttvzf-pod-937200
+    startTime: 2019-02-21T22:02:43Z
+    steps:
+    - logsURL: ""
+      terminated:
+        containerID: docker://ed2e0600af698c48c12c02aacdfd76c5a02ca8ebdf9849bc4df1f4c093fa327f
+        exitCode: 0
+        finishedAt: 2019-02-21T22:03:04Z
+        reason: Completed
+        startedAt: 2019-02-21T22:03:01Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://8aee17337d7eab04996c91717012e103bfb0510184a3ca20bcab01eb21e4d432
+        exitCode: 0
+        finishedAt: 2019-02-21T22:03:07Z
+        reason: Completed
+        startedAt: 2019-02-21T22:03:07Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://a1713f8af2bd6d0ac007f39482feec7206a1d164f5b2c329be267f4836ef110d
+        exitCode: 0
+        finishedAt: 2019-02-21T22:03:37Z
+        reason: Completed
+        startedAt: 2019-02-21T22:03:36Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://aaa2a796eb46ab3eae0053a300ce9a0964f81b3b41eadd2b2794873f2617817c
+        exitCode: 0
+        finishedAt: 2019-02-21T22:03:38Z
+        reason: Completed
+        startedAt: 2019-02-21T22:03:38Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://68a65e3ca44fd47c149aebd64190273c480b7f83c020bd579d14cd3d25a1ef6b
+        exitCode: 0
+        finishedAt: 2019-02-21T22:03:40Z
+        reason: Completed
+        startedAt: 2019-02-21T22:03:40Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://7f9f6a78dd471731997a63013872f617cb0da785bbcca244f9ba2b356296901a
+        exitCode: 0
+        finishedAt: 2019-02-21T22:03:42Z
+        reason: Completed
+        startedAt: 2019-02-21T22:03:42Z
+- apiVersion: tekton.dev/v1alpha1
+  kind: TaskRun
+  metadata:
+    creationTimestamp: 2019-02-21T22:03:54Z
+    generation: 1
+    labels:
+      branch: master
+      build-number: "1"
+      jenkins.io/pipeline-from-yaml: "true"
+      jenkins.io/task-stage-name: Second
+      owner: abayer
+      repo: js-test-repo
+      tekton.dev/pipeline: abayer-js-test-repo-master
+      tekton.dev/pipelineRun: abayer-js-test-repo-master-1
+      tekton.dev/task: abayer-js-test-repo-master-second
+    name: abayer-js-test-repo-master-1-second-9czt5
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PipelineRun
+      name: abayer-js-test-repo-master-1
+      uid: 69fb89f5-3624-11e9-b776-42010a8a00ac
+    resourceVersion: "6343"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/taskruns/abayer-js-test-repo-master-1-second-9czt5
+    uid: 94397268-3624-11e9-b776-42010a8a00ac
+  spec:
+    Status: ""
+    inputs:
+      resources:
+      - name: workspace
+        paths:
+        - /pvc/build/workspace
+        resourceRef:
+          name: abayer-js-test-repo-master
+        resourceSpec: null
+      - name: temp-ordering-resource
+        paths:
+        - /pvc/build/temp-ordering-resource
+        resourceRef:
+          name: temp-ordering-resource
+        resourceSpec: null
+    outputs:
+      resources:
+      - name: workspace
+        paths:
+        - /pvc/second/workspace
+        resourceRef:
+          name: abayer-js-test-repo-master
+        resourceSpec: null
+      - name: temp-ordering-resource
+        paths:
+        - /pvc/second/temp-ordering-resource
+        resourceRef:
+          name: temp-ordering-resource
+        resourceSpec: null
+    serviceAccount: tekton-bot
+    taskRef:
+      kind: Task
+      name: abayer-js-test-repo-master-second
+    trigger:
+      type: ""
+  status:
+    conditions:
+    - lastTransitionTime: 2019-02-21T22:04:24Z
+      status: "True"
+      type: Succeeded
+    podName: abayer-js-test-repo-master-1-second-9czt5-pod-62d12d
+    startTime: 2019-02-21T22:03:56Z
+    steps:
+    - logsURL: ""
+      terminated:
+        containerID: docker://557e7e7571f62c607c854f3ffa654b10f82196101d46f20939829fbdc6a1320e
+        exitCode: 0
+        finishedAt: 2019-02-21T22:04:07Z
+        reason: Completed
+        startedAt: 2019-02-21T22:04:07Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://3b4150a8ad7e8c6b171e57188fbfb74ffc794aafaeb6073d5997a46d9d399004
+        exitCode: 0
+        finishedAt: 2019-02-21T22:04:08Z
+        reason: Completed
+        startedAt: 2019-02-21T22:04:08Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://c98db7ca8b2ff5566605deddaa22694009fc5f23bdf7a56bb1efa4c92fd0a222
+        exitCode: 0
+        finishedAt: 2019-02-21T22:04:09Z
+        reason: Completed
+        startedAt: 2019-02-21T22:04:09Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://130a294841624b138d801306a7bf6923e9d6f18dbb2d161bb9d18107bffc896f
+        exitCode: 0
+        finishedAt: 2019-02-21T22:04:10Z
+        reason: Completed
+        startedAt: 2019-02-21T22:04:10Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://712659711fe0dd07add0740d22898207768bfeb823a2dc11b062092a3fbb5110
+        exitCode: 0
+        finishedAt: 2019-02-21T22:04:11Z
+        reason: Completed
+        startedAt: 2019-02-21T22:04:11Z
+    - logsURL: ""
+      terminated:
+        containerID: docker://b7dd7d255a48ef595b47206f247d1b49ea33b3aed21c126b24fa1db3a22c91c3
+        exitCode: 0
+        finishedAt: 2019-02-21T22:04:12Z
+        reason: Completed
+        startedAt: 2019-02-21T22:04:12Z
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/tasks.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/tasks.yml
@@ -1,0 +1,215 @@
+apiVersion: v1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: 2019-02-21T22:02:43Z
+    generation: 1
+    labels:
+      jenkins.io/pipeline-from-yaml: "true"
+      jenkins.io/task-stage-name: Build
+    name: abayer-js-test-repo-master-build
+    namespace: jx
+    resourceVersion: "5934"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/tasks/abayer-js-test-repo-master-build
+    uid: 69cdbaff-3624-11e9-b776-42010a8a00ac
+  spec:
+    inputs:
+      resources:
+      - name: workspace
+        targetPath: workspace
+        type: git
+      - name: temp-ordering-resource
+        targetPath: ""
+        type: image
+    outputs:
+      resources:
+      - name: workspace
+        targetPath: ""
+        type: git
+      - name: temp-ordering-resource
+        targetPath: ""
+        type: image
+    steps:
+    - args:
+      - echo hello world
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_REGISTRY
+        value: 10.3.245.235:5000
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step2
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/workspace
+    - args:
+      - ls -la
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_REGISTRY
+        value: 10.3.245.235:5000
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step3
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/workspace
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: 2019-02-21T22:02:43Z
+    generation: 1
+    labels:
+      jenkins.io/pipeline-from-yaml: "true"
+      jenkins.io/task-stage-name: Second
+    name: abayer-js-test-repo-master-second
+    namespace: jx
+    resourceVersion: "5935"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/tasks/abayer-js-test-repo-master-second
+    uid: 69dd2a16-3624-11e9-b776-42010a8a00ac
+  spec:
+    inputs:
+      resources:
+      - name: workspace
+        targetPath: ""
+        type: git
+      - name: temp-ordering-resource
+        targetPath: ""
+        type: image
+    outputs:
+      resources:
+      - name: workspace
+        targetPath: ""
+        type: git
+      - name: temp-ordering-resource
+        targetPath: ""
+        type: image
+    steps:
+    - args:
+      - echo hi everybody
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_REGISTRY
+        value: 10.3.245.235:5000
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/master
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step2
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/workspace
+    volumes:
+    - emptyDir: {}
+      name: workspace-volume
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-docker-cfg
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

When a PipelineRun has finished and its pods have been GC'd, we should
just ignore it for the purposes of `PipelineActivity` and `jx get
build logs`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a