### PR TITLE
chore: Populate PipelineStructure for build pack-generated runs

### DIFF
--- a/pkg/jx/cmd/controller_build.go
+++ b/pkg/jx/cmd/controller_build.go
@@ -543,7 +543,6 @@ func (o *ControllerBuildOptions) updatePipelineActivityForRun(kubeClient kuberne
 
 func updateForStage(si *tekton.StageInfo, a *v1.PipelineActivity) {
 	_, stage, _ := kube.GetOrCreateStage(a, si.GetStageNameIncludingParents())
-
 	initContainersTerminated := false
 
 	if si.Pod != nil {

--- a/pkg/jx/cmd/step_create_task.go
+++ b/pkg/jx/cmd/step_create_task.go
@@ -818,8 +818,6 @@ func (o *StepCreateTaskOptions) applyPipeline(pipeline *pipelineapi.Pipeline, ta
 	}
 
 	for _, task := range tasks {
-		task.ObjectMeta.Namespace = ns
-
 		if !o.NoApply {
 			_, err = tekton.CreateOrUpdateTask(tektonClient, ns, task)
 			if err != nil {
@@ -829,7 +827,6 @@ func (o *StepCreateTaskOptions) applyPipeline(pipeline *pipelineapi.Pipeline, ta
 		}
 	}
 
-	pipeline.ObjectMeta.Namespace = ns
 	if pipeline.APIVersion == "" {
 		pipeline.APIVersion = syntax.TektonAPIVersion
 	}

--- a/pkg/jx/cmd/step_create_task.go
+++ b/pkg/jx/cmd/step_create_task.go
@@ -282,7 +282,7 @@ func (o *StepCreateTaskOptions) Run() error {
 		return errors.Wrapf(err, "failed to set the version on release pipelines")
 	}
 
-	err = o.generateTask(name, pipelineConfig)
+	err = o.generateTask(name, pipelineConfig, ns)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate Task for build pack pipeline YAML: %s", pipelineFile)
 	}
@@ -325,7 +325,7 @@ func (o *StepCreateTaskOptions) loadPodTemplates(kubeClient kubernetes.Interface
 	return nil
 }
 
-func (o *StepCreateTaskOptions) generateTask(name string, pipelineConfig *jenkinsfile.PipelineConfig) error {
+func (o *StepCreateTaskOptions) generateTask(name string, pipelineConfig *jenkinsfile.PipelineConfig, ns string) error {
 	var lifecycles *jenkinsfile.PipelineLifecycles
 	kind := o.PipelineKind
 	pipelines := pipelineConfig.Pipelines
@@ -352,16 +352,16 @@ func (o *StepCreateTaskOptions) generateTask(name string, pipelineConfig *jenkin
 	default:
 		return fmt.Errorf("Unknown pipeline kind %s. Supported values are %s", kind, strings.Join(jenkinsfile.PipelineKinds, ", "))
 	}
-	return o.generatePipeline(name, pipelineConfig, lifecycles, kind)
+	return o.generatePipeline(name, pipelineConfig, lifecycles, kind, ns)
 }
 
-func (o *StepCreateTaskOptions) generatePipeline(languageName string, pipelineConfig *jenkinsfile.PipelineConfig, lifecycles *jenkinsfile.PipelineLifecycles, templateKind string) error {
+func (o *StepCreateTaskOptions) generatePipeline(languageName string, pipelineConfig *jenkinsfile.PipelineConfig, lifecycles *jenkinsfile.PipelineLifecycles, templateKind, ns string) error {
 	if lifecycles == nil {
 		return nil
 	}
 
 	var err error
-	err = o.setBuildValues(false)
+	err = o.setBuildValues()
 	if err != nil {
 		return err
 	}
@@ -378,10 +378,6 @@ func (o *StepCreateTaskOptions) generatePipeline(languageName string, pipelineCo
 		if validateErr := lifecycles.Pipeline.Validate(); validateErr != nil {
 			return errors.Wrapf(validateErr, "Validation failed for Pipeline")
 		}
-		err = o.setBuildValues(true)
-		if err != nil {
-			return err
-		}
 		// TODO: use org-name-branch for pipeline name? Create client now to get
 		// namespace? Set namespace when applying rather than during generation?
 		name := tekton.PipelineResourceName(o.gitInfo, o.Branch, o.Context)
@@ -394,7 +390,7 @@ func (o *StepCreateTaskOptions) generatePipeline(languageName string, pipelineCo
 			name = kube.ToValidName(shortName)
 		}
 
-		pipeline, tasks, structure, err := lifecycles.Pipeline.GenerateCRDs(name, o.buildNumber, "will-be-replaced", "abcd", o.PodTemplates, taskParams)
+		pipeline, tasks, structure, err := lifecycles.Pipeline.GenerateCRDs(name, o.buildNumber, ns, o.PodTemplates, taskParams)
 		if err != nil {
 			return errors.Wrapf(err, "Generation failed for Pipeline")
 		}
@@ -432,7 +428,7 @@ func (o *StepCreateTaskOptions) generatePipeline(languageName string, pipelineCo
 
 		// TODO: where should this be created? In GenerateCRDs?
 		var resources []*pipelineapi.PipelineResource
-		resources = append(resources, o.generateSourceRepoResource(name, true), o.generateTempOrderingResource())
+		resources = append(resources, o.generateSourceRepoResource(name), o.generateTempOrderingResource())
 
 		err = o.applyPipeline(pipeline, tasks, resources, structure, o.gitInfo, o.Branch)
 		if err != nil {
@@ -484,7 +480,7 @@ func (o *StepCreateTaskOptions) generatePipeline(languageName string, pipelineCo
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
-			Labels: o.labels,
+			Labels: util.MergeMaps(o.labels, map[string]string{syntax.LabelStageName: syntax.DefaultStageNameForBuildPack}),
 		},
 		Spec: pipelineapi.TaskSpec{
 			Steps:   steps,
@@ -568,7 +564,7 @@ func (o *StepCreateTaskOptions) createPipelineTaskParams() []pipelineapi.Param {
 	return ptp
 }
 
-func (o *StepCreateTaskOptions) generateSourceRepoResource(name string, fromYaml bool) *pipelineapi.PipelineResource {
+func (o *StepCreateTaskOptions) generateSourceRepoResource(name string) *pipelineapi.PipelineResource {
 	var resource *pipelineapi.PipelineResource
 	if o.gitInfo != nil {
 		gitURL := o.gitInfo.HttpsURL()
@@ -595,9 +591,6 @@ func (o *StepCreateTaskOptions) generateSourceRepoResource(name string, fromYaml
 					},
 				},
 			}
-			if fromYaml {
-				resource.Labels = syntax.DefaultFromYamlCRDLabels()
-			}
 		}
 	}
 	return resource
@@ -612,8 +605,7 @@ func (o *StepCreateTaskOptions) generateTempOrderingResource() *pipelineapi.Pipe
 			Kind:       "PipelineResource",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "temp-ordering-resource",
-			Labels: syntax.DefaultFromYamlCRDLabels(),
+			Name: "temp-ordering-resource",
 		},
 		Spec: pipelineapi.PipelineResourceSpec{
 			Type: pipelineapi.PipelineResourceTypeImage,
@@ -627,16 +619,13 @@ func (o *StepCreateTaskOptions) generateTempOrderingResource() *pipelineapi.Pipe
 	}
 }
 
-func (o *StepCreateTaskOptions) setBuildValues(fromYaml bool) error {
+func (o *StepCreateTaskOptions) setBuildValues() error {
 	labels := map[string]string{}
 	if o.gitInfo != nil {
 		labels["owner"] = o.gitInfo.Organisation
 		labels["repo"] = o.gitInfo.Name
 	}
 	labels["branch"] = o.Branch
-	if fromYaml {
-		labels[syntax.LabelPipelineFromYaml] = "true"
-	}
 
 	return o.combineLabels(labels)
 }
@@ -732,7 +721,7 @@ func (o *StepCreateTaskOptions) applyTask(task *pipelineapi.Task, gitInfo *gits.
 	name := gitInfo.Name
 	resourceName := kube.ToValidName(organisation + "-" + name + "-" + branch)
 	var pipelineResources []*pipelineapi.PipelineResource
-	resource := o.generateSourceRepoResource(resourceName, false)
+	resource := o.generateSourceRepoResource(resourceName)
 	if resource != nil {
 		pipelineResources = append(pipelineResources, resource)
 	}
@@ -750,7 +739,7 @@ func (o *StepCreateTaskOptions) applyTask(task *pipelineapi.Task, gitInfo *gits.
 	}
 	tasks := []pipelineapi.PipelineTask{
 		{
-			Name: "build",
+			Name: strings.ToLower(syntax.DefaultStageNameForBuildPack),
 			Resources: &pipelineapi.PipelineTaskResources{
 				Inputs: taskInputResources,
 			},
@@ -773,7 +762,19 @@ func (o *StepCreateTaskOptions) applyTask(task *pipelineapi.Task, gitInfo *gits.
 			Params:    o.createPipelineParams(),
 		},
 	}
-	return o.applyPipeline(pipeline, []*pipelineapi.Task{task}, pipelineResources, nil, gitInfo, branch)
+
+	structure := &v1.PipelineStructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pipeline.Name,
+		},
+		Stages: []v1.PipelineStructureStage{{
+			Name:    syntax.DefaultStageNameForBuildPack,
+			Depth:   0,
+			TaskRef: &task.Name,
+		}},
+	}
+
+	return o.applyPipeline(pipeline, []*pipelineapi.Task{task}, pipelineResources, structure, gitInfo, branch)
 }
 
 // Given a Pipeline and its Tasks, applies the Tasks and Pipeline to the cluster

--- a/pkg/tekton/pipeline_info_test.go
+++ b/pkg/tekton/pipeline_info_test.go
@@ -12,6 +12,7 @@ import (
 	v1fake "github.com/jenkins-x/jx/pkg/client/clientset/versioned/fake"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/tekton"
+	"github.com/jenkins-x/jx/pkg/tekton/syntax"
 	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/jenkins-x/jx/pkg/util"
 	tektonv1alpha1 "github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
@@ -50,11 +51,13 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 			PipelineRun:  "abayer-jx-demo-qs-master-1",
 			Repository:   "jx-demo-qs",
 			Stages: []*tekton.StageInfo{{
+				Name:           syntax.DefaultStageNameForBuildPack,
 				CreatedTime:    *parseTime(t, "2019-02-21T17:10:48-05:00"),
 				FirstStepImage: "gcr.io/k8s-prow/entrypoint@sha256:7c7cd8906ce4982ffee326218e9fc75da2d4896d53cabc9833b9cc8d2d6b2b8f",
 				PodName:        "abayer-jx-demo-qs-master-1-build-vhz8d-pod-cd8cba",
 				Task:           "abayer-jx-demo-qs-master",
 				TaskRun:        "abayer-jx-demo-qs-master-1-build-vhz8d",
+				Parents:        []string{},
 			}},
 		},
 		prName: "abayer-jx-demo-qs-master-1",

--- a/pkg/tekton/syntax/constants.go
+++ b/pkg/tekton/syntax/constants.go
@@ -7,6 +7,6 @@ const (
 	// LabelStageName - the name for the label that will have the stage name on the Task.
 	LabelStageName = "jenkins.io/task-stage-name"
 
-	// LabelPipelineFromYaml - if true, the CRD was created by translation from YAML, rather than from a build pack.
-	LabelPipelineFromYaml = "jenkins.io/pipeline-from-yaml"
+	// DefaultStageNameForBuildPack - the name we use for the single stage created from build packs currently.
+	DefaultStageNameForBuildPack = "From-Build-Pack"
 )

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -201,11 +201,12 @@ type PostAction struct {
 var _ apis.Validatable = (*ParsedPipeline)(nil)
 
 func (s *Stage) taskName() string {
-	return strings.ToLower(s.stageLabelName())
+	return strings.ToLower(strings.NewReplacer(" ", "-").Replace(s.Name))
 }
 
+// stageLabelName replaces invalid cahracters in stage names for label usage.
 func (s *Stage) stageLabelName() string {
-	return strings.NewReplacer(" ", "-").Replace(s.Name)
+	return MangleToRfc1035Label(s.Name, "")
 }
 
 // MangleToRfc1035Label - Task/Step names need to be RFC 1035/1123 compliant DNS labels, so we mangle

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -44,7 +44,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -53,7 +53,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "somenamespace", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -82,7 +82,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						StepCmd("echo"),
 						StepArg("again"))),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -98,7 +98,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "somenamespace", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -108,7 +108,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 							tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 						tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world"), workingDir("/workspace/workspace")),
 					)),
-				tb.Task("somepipeline-another-stage", "somenamespace", TaskStageLabel("Another stage"), tb.TaskSpec(
+				tb.Task("somepipeline-another-stage", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -134,7 +134,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						StageStep(StepCmd("echo"), StepArg("again"))),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -150,7 +150,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "somenamespace", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -160,7 +160,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 							tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 						tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world"), workingDir("/workspace/workspace")),
 					)),
-				tb.Task("somepipeline-another-stage", "somenamespace", TaskStageLabel("Another stage"), tb.TaskSpec(
+				tb.Task("somepipeline-another-stage", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -196,7 +196,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				PipelineStage("Last Stage",
 					StageStep(StepCmd("echo"), StepArg("last"))),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("first-stage", "somepipeline-first-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -225,7 +225,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-first-stage", "somenamespace", TaskStageLabel("First Stage"), tb.TaskSpec(
+				tb.Task("somepipeline-first-stage", "jx", TaskStageLabel("First Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
@@ -234,7 +234,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("first"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-a-working-stage", "somenamespace", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
@@ -243,7 +243,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 							tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 						tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world"), workingDir("/workspace/workspace")),
 					)),
-				tb.Task("somepipeline-another-stage", "somenamespace", TaskStageLabel("Another stage"), tb.TaskSpec(
+				tb.Task("somepipeline-another-stage", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -251,7 +251,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("again"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-last-stage", "somenamespace", TaskStageLabel("Last Stage"), tb.TaskSpec(
+				tb.Task("somepipeline-last-stage", "jx", TaskStageLabel("Last Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -297,7 +297,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				PipelineStage("Last Stage",
 					StageStep(StepCmd("echo"), StepArg("last"))),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("first-stage", "somepipeline-first-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -335,7 +335,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-first-stage", "somenamespace", TaskStageLabel("First Stage"), tb.TaskSpec(
+				tb.Task("somepipeline-first-stage", "jx", TaskStageLabel("First Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
@@ -344,7 +344,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("first"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-a-working-stage", "somenamespace", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
@@ -353,7 +353,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 							tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 						tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world"), workingDir("/workspace/workspace")),
 					)),
-				tb.Task("somepipeline-another-stage", "somenamespace", TaskStageLabel("Another stage"), tb.TaskSpec(
+				tb.Task("somepipeline-another-stage", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -361,7 +361,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("again"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-some-other-stage", "somenamespace", TaskStageLabel("Some other stage"), tb.TaskSpec(
+				tb.Task("somepipeline-some-other-stage", "jx", TaskStageLabel("Some other stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -369,7 +369,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("otherwise"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-last-stage", "somenamespace", TaskStageLabel("Last Stage"), tb.TaskSpec(
+				tb.Task("somepipeline-last-stage", "jx", TaskStageLabel("Last Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -432,7 +432,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("ls")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("stage1", "somepipeline-stage1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -459,7 +459,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-stage1", "somenamespace", TaskStageLabel("stage1"), tb.TaskSpec(
+				tb.Task("somepipeline-stage1", "jx", TaskStageLabel("stage1"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
@@ -468,7 +468,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage2", "somenamespace", TaskStageLabel("stage2"), tb.TaskSpec(
+				tb.Task("somepipeline-stage2", "jx", TaskStageLabel("stage2"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -476,7 +476,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage3", "somenamespace", TaskStageLabel("stage3"), tb.TaskSpec(
+				tb.Task("somepipeline-stage3", "jx", TaskStageLabel("stage3"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -484,7 +484,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage4", "somenamespace", TaskStageLabel("stage4"), tb.TaskSpec(
+				tb.Task("somepipeline-stage4", "jx", TaskStageLabel("stage4"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -525,7 +525,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("stage1", "somepipeline-stage1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -554,7 +554,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-stage1", "somenamespace", TaskStageLabel("stage1"), tb.TaskSpec(
+				tb.Task("somepipeline-stage1", "jx", TaskStageLabel("stage1"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
@@ -563,7 +563,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage3", "somenamespace", TaskStageLabel("stage3"), tb.TaskSpec(
+				tb.Task("somepipeline-stage3", "jx", TaskStageLabel("stage3"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -571,7 +571,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage4", "somenamespace", TaskStageLabel("stage4"), tb.TaskSpec(
+				tb.Task("somepipeline-stage4", "jx", TaskStageLabel("stage4"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -579,7 +579,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage5", "somenamespace", TaskStageLabel("stage5"), tb.TaskSpec(
+				tb.Task("somepipeline-stage5", "jx", TaskStageLabel("stage5"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
 						tb.InputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
@@ -617,7 +617,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("hello"), StepArg("${SOME_OTHER_VAR}")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-stage-with-environment", "somepipeline-a-stage-with-environment",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -626,7 +626,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-stage-with-environment", "somenamespace",
+				tb.Task("somepipeline-a-stage-with-environment", "jx",
 					TaskStageLabel("A stage with environment"),
 					tb.TaskSpec(
 						tb.TaskInputs(
@@ -714,7 +714,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("goodbye")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -723,7 +723,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "somenamespace", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -750,7 +750,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("ls")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask(".--a--.", "somepipeline-a",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -766,7 +766,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a", "somenamespace", TaskStageLabel(". -a- ."), tb.TaskSpec(
+				tb.Task("somepipeline-a", "jx", TaskStageLabel(". -a- ."), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
@@ -775,7 +775,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.OutputsResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-wh-this-is-cool", "somenamespace", TaskStageLabel("Wööh!!!! - This is cool."),
+				tb.Task("somepipeline-wh-this-is-cool", "jx", TaskStageLabel("Wööh!!!! - This is cool."),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit),
@@ -802,7 +802,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				),
 			),
 			/* TODO: Stop erroring out once we figure out how to handle task timeouts again
-						pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+						pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 							tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 								tb.PipelineTaskInputResource("workspace", "somepipeline"),
 								tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -811,7 +811,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 							tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 							tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 						tasks: []*tektonv1alpha1.Task{
-												tb.Task("somepipeline-a-working-stage", "somenamespace", TaskStageLabel("A Working Stage"),
+												tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
 								tb.TaskSpec(
 			tb.TaskTimeout(50*time.Minute),
 								tb.TaskInputs(
@@ -836,7 +836,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("hello"), StepArg("world")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -845,7 +845,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "somenamespace", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -880,7 +880,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("hello"), StepArg("after")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "somenamespace", tb.PipelineSpec(
+			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -889,7 +889,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit),
 				tb.PipelineDeclaredResource("temp-ordering-resource", tektonv1alpha1.PipelineResourceTypeImage))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "somenamespace", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -983,7 +983,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				}
 			}
 
-			pipeline, tasks, structure, err := parsed.GenerateCRDs("somepipeline", "somebuild", "somenamespace", "abcd", nil, nil)
+			pipeline, tasks, structure, err := parsed.GenerateCRDs("somepipeline", "somebuild", "jx", nil, nil)
 
 			if err != nil {
 				if tt.expectedErrorMsg != "" {
@@ -1736,7 +1736,6 @@ func TaskStageLabel(value string) tb.TaskOp {
 			t.ObjectMeta.Labels = map[string]string{}
 		}
 		t.ObjectMeta.Labels[syntax.LabelStageName] = value
-		t.ObjectMeta.Labels[syntax.LabelPipelineFromYaml] = "true"
 	}
 }
 
@@ -1745,7 +1744,6 @@ func PipelineWithLabels(name, namespace string, ops ...tb.PipelineOp) *tektonv1a
 	if pipeline.ObjectMeta.Labels == nil {
 		pipeline.ObjectMeta.Labels = map[string]string{}
 	}
-	pipeline.Labels[syntax.LabelPipelineFromYaml] = "true"
 
 	return pipeline
 }

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -44,7 +44,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -82,7 +82,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						StepCmd("echo"),
 						StepArg("again"))),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -134,7 +134,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						StageStep(StepCmd("echo"), StepArg("again"))),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -196,7 +196,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				PipelineStage("Last Stage",
 					StageStep(StepCmd("echo"), StepArg("last"))),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("first-stage", "somepipeline-first-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -297,7 +297,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				PipelineStage("Last Stage",
 					StageStep(StepCmd("echo"), StepArg("last"))),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("first-stage", "somepipeline-first-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -432,7 +432,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("ls")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("stage1", "somepipeline-stage1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -525,7 +525,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("stage1", "somepipeline-stage1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -617,7 +617,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("hello"), StepArg("${SOME_OTHER_VAR}")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-stage-with-environment", "somepipeline-a-stage-with-environment",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -714,7 +714,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("goodbye")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -750,7 +750,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("ls")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask(".--a--.", "somepipeline-a",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -802,7 +802,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				),
 			),
 			/* TODO: Stop erroring out once we figure out how to handle task timeouts again
-						pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+						pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 							tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 								tb.PipelineTaskInputResource("workspace", "somepipeline"),
 								tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -836,7 +836,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("hello"), StepArg("world")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -880,7 +880,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("hello"), StepArg("after")),
 				),
 			),
-			pipeline: PipelineWithLabels("somepipeline", "jx", tb.PipelineSpec(
+			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
@@ -1735,17 +1735,8 @@ func TaskStageLabel(value string) tb.TaskOp {
 		if t.ObjectMeta.Labels == nil {
 			t.ObjectMeta.Labels = map[string]string{}
 		}
-		t.ObjectMeta.Labels[syntax.LabelStageName] = value
+		t.ObjectMeta.Labels[syntax.LabelStageName] = syntax.MangleToRfc1035Label(value, "")
 	}
-}
-
-func PipelineWithLabels(name, namespace string, ops ...tb.PipelineOp) *tektonv1alpha1.Pipeline {
-	pipeline := tb.Pipeline(name, namespace, ops...)
-	if pipeline.ObjectMeta.Labels == nil {
-		pipeline.ObjectMeta.Labels = map[string]string{}
-	}
-
-	return pipeline
 }
 
 func TestParsedPipelineHelpers(t *testing.T) {

--- a/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/pipeline.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/pipeline.yml
@@ -16,7 +16,7 @@ spec:
   - name: abayer-jx-demo-qs-master
     type: git
   tasks:
-  - name: build
+  - name: from-build-pack
     resources:
       inputs:
       - name: source

--- a/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/structure.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/structure.yml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: PipelineStructure
+metadata:
+  creationTimestamp: 2019-02-28T14:37:39Z
+  generation: 1
+  name: abayer-jx-demo-qs-master-1
+  namespace: jx
+  ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: Pipeline
+      name: abayer-jx-demo-qs-master
+      uid: a86bc50c-3ac2-11e9-b04e-42010a8a0075
+  resourceVersion: "224258"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/abayer-jx-demo-qs-master-1
+  uid: 8ac56b37-3625-11e9-b776-42010a8a00ac
+pipelineRef: abayer-jx-demo-qs-master
+pipelineRunRef: abayer-jx-demo-qs-master-1
+stages:
+  - depth: 0
+    name: From-Build-Pack
+    taskRef: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/taskruns.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/taskruns.yml
@@ -8,6 +8,7 @@ items:
     labels:
       branch: master
       build-number: "1"
+      jenkins.io/task-stage-name: From-Build-Pack
       owner: abayer
       repo: jx-demo-qs
       tekton.dev/pipeline: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/tasks.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-build-pack/tasks.yml
@@ -7,6 +7,7 @@ items:
     generation: 1
     labels:
       branch: master
+      jenkins.io/task-stage-name: From-Build-Pack
       owner: abayer
       repo: jx-demo-qs
     name: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipeline.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipeline.yml
@@ -5,8 +5,6 @@ metadata:
     jenkins.io/last-build-number: "1"
   creationTimestamp: 2019-02-21T22:02:43Z
   generation: 1
-  labels:
-    jenkins.io/pipeline-from-yaml: "true"
   name: abayer-js-test-repo-master
   namespace: jx
   resourceVersion: "5950"

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipelineresources.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipelineresources.yml
@@ -5,8 +5,6 @@ items:
   metadata:
     creationTimestamp: 2019-02-21T22:02:43Z
     generation: 1
-    labels:
-      jenkins.io/pipeline-from-yaml: "true"
     name: abayer-js-test-repo-master
     namespace: jx
     resourceVersion: "5932"
@@ -24,8 +22,6 @@ items:
   metadata:
     creationTimestamp: 2019-02-21T22:02:43Z
     generation: 1
-    labels:
-      jenkins.io/pipeline-from-yaml: "true"
     name: temp-ordering-resource
     namespace: jx
     resourceVersion: "5933"

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipelinerun.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/pipelinerun.yml
@@ -6,7 +6,6 @@ metadata:
   labels:
     branch: master
     build-number: "1"
-    jenkins.io/pipeline-from-yaml: "true"
     owner: abayer
     repo: js-test-repo
     tekton.dev/pipeline: abayer-js-test-repo-master

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/taskruns.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/taskruns.yml
@@ -8,7 +8,6 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Build
       owner: abayer
       repo: js-test-repo
@@ -119,7 +118,6 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Second
       owner: abayer
       repo: js-test-repo

--- a/pkg/tekton/test_data/pipeline_info/completed-from-yaml/tasks.yml
+++ b/pkg/tekton/test_data/pipeline_info/completed-from-yaml/tasks.yml
@@ -6,7 +6,6 @@ items:
     creationTimestamp: 2019-02-21T22:02:43Z
     generation: 1
     labels:
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Build
     name: abayer-js-test-repo-master-build
     namespace: jx
@@ -130,7 +129,6 @@ items:
     creationTimestamp: 2019-02-21T22:02:43Z
     generation: 1
     labels:
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Second
     name: abayer-js-test-repo-master-second
     namespace: jx

--- a/pkg/tekton/test_data/pipeline_info/from-build-pack/pipeline.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-build-pack/pipeline.yml
@@ -16,7 +16,7 @@ spec:
   - name: abayer-jx-demo-qs-master
     type: git
   tasks:
-  - name: build
+  - name: from-build-pack
     resources:
       inputs:
       - name: source

--- a/pkg/tekton/test_data/pipeline_info/from-build-pack/pods.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-build-pack/pods.yml
@@ -9,6 +9,7 @@ items:
     labels:
       branch: master
       build-number: "1"
+      jenkins.io/task-stage-name: From-Build-Pack
       owner: abayer
       repo: jx-demo-qs
       tekton.dev/pipeline: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/from-build-pack/structure.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-build-pack/structure.yml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: PipelineStructure
+metadata:
+  creationTimestamp: 2019-02-28T14:37:39Z
+  generation: 1
+  name: abayer-jx-demo-qs-master-1
+  namespace: jx
+  ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: Pipeline
+      name: abayer-jx-demo-qs-master
+      uid: 65966cc7-3b66-11e9-b317-42010a8a0165
+  resourceVersion: "224258"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/abayer-jx-demo-qs-master-1
+  uid: 8ac56b37-3625-11e9-b776-42010a8a00ac
+pipelineRef: abayer-jx-demo-qs-master
+pipelineRunRef: abayer-jx-demo-qs-master-1
+stages:
+  - depth: 0
+    name: From-Build-Pack
+    taskRef: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/from-build-pack/taskruns.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-build-pack/taskruns.yml
@@ -8,6 +8,7 @@ items:
     labels:
       branch: master
       build-number: "1"
+      jenkins.io/task-stage-name: From-Build-Pack
       owner: abayer
       repo: jx-demo-qs
       tekton.dev/pipeline: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/from-build-pack/tasks.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-build-pack/tasks.yml
@@ -7,6 +7,7 @@ items:
     generation: 1
     labels:
       branch: master
+      jenkins.io/task-stage-name: From-Build-Pack
       owner: abayer
       repo: jx-demo-qs
     name: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/pipeline.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/pipeline.yml
@@ -5,8 +5,6 @@ metadata:
     jenkins.io/last-build-number: "1"
   creationTimestamp: 2019-02-21T22:07:36Z
   generation: 1
-  labels:
-    jenkins.io/pipeline-from-yaml: "true"
   name: abayer-js-test-repo-nested
   namespace: jx
   resourceVersion: "6988"

--- a/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/pipelineresources.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/pipelineresources.yml
@@ -5,8 +5,6 @@ items:
   metadata:
     creationTimestamp: 2019-02-21T22:07:36Z
     generation: 1
-    labels:
-      jenkins.io/pipeline-from-yaml: "true"
     name: abayer-js-test-repo-nested
     namespace: jx
     resourceVersion: "6975"
@@ -24,8 +22,6 @@ items:
   metadata:
     creationTimestamp: 2019-02-21T22:07:36Z
     generation: 1
-    labels:
-      jenkins.io/pipeline-from-yaml: "true"
     name: temp-ordering-resource
     namespace: jx
     resourceVersion: "6977"

--- a/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/pipelinerun.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/pipelinerun.yml
@@ -6,7 +6,6 @@ metadata:
   labels:
     branch: nested
     build-number: "1"
-    jenkins.io/pipeline-from-yaml: "true"
     owner: abayer
     repo: js-test-repo
     tekton.dev/pipeline: abayer-js-test-repo-nested

--- a/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/pods.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/pods.yml
@@ -9,7 +9,6 @@ items:
     labels:
       branch: nested
       build-number: "1"
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Build
       owner: abayer
       repo: js-test-repo
@@ -525,7 +524,6 @@ items:
     labels:
       branch: nested
       build-number: "1"
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Second
       owner: abayer
       repo: js-test-repo

--- a/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/taskruns.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/taskruns.yml
@@ -8,7 +8,6 @@ items:
     labels:
       branch: nested
       build-number: "1"
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Build
       owner: abayer
       repo: js-test-repo
@@ -126,7 +125,6 @@ items:
     labels:
       branch: nested
       build-number: "1"
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Second
       owner: abayer
       repo: js-test-repo

--- a/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/tasks.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/tasks.yml
@@ -6,7 +6,6 @@ items:
     creationTimestamp: 2019-02-21T22:07:36Z
     generation: 1
     labels:
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Build
     name: abayer-js-test-repo-nested-build
     namespace: jx
@@ -169,7 +168,6 @@ items:
     creationTimestamp: 2019-02-21T22:07:36Z
     generation: 1
     labels:
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Second
     name: abayer-js-test-repo-nested-second
     namespace: jx

--- a/pkg/tekton/test_data/pipeline_info/from-yaml/pipeline.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml/pipeline.yml
@@ -5,8 +5,6 @@ metadata:
     jenkins.io/last-build-number: "1"
   creationTimestamp: 2019-02-21T22:02:43Z
   generation: 1
-  labels:
-    jenkins.io/pipeline-from-yaml: "true"
   name: abayer-js-test-repo-master
   namespace: jx
   resourceVersion: "5950"

--- a/pkg/tekton/test_data/pipeline_info/from-yaml/pipelineresources.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml/pipelineresources.yml
@@ -5,8 +5,6 @@ items:
   metadata:
     creationTimestamp: 2019-02-21T22:02:43Z
     generation: 1
-    labels:
-      jenkins.io/pipeline-from-yaml: "true"
     name: abayer-js-test-repo-master
     namespace: jx
     resourceVersion: "5932"
@@ -24,8 +22,6 @@ items:
   metadata:
     creationTimestamp: 2019-02-21T22:02:43Z
     generation: 1
-    labels:
-      jenkins.io/pipeline-from-yaml: "true"
     name: temp-ordering-resource
     namespace: jx
     resourceVersion: "5933"

--- a/pkg/tekton/test_data/pipeline_info/from-yaml/pipelinerun.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml/pipelinerun.yml
@@ -6,7 +6,6 @@ metadata:
   labels:
     branch: master
     build-number: "1"
-    jenkins.io/pipeline-from-yaml: "true"
     owner: abayer
     repo: js-test-repo
     tekton.dev/pipeline: abayer-js-test-repo-master

--- a/pkg/tekton/test_data/pipeline_info/from-yaml/pods.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml/pods.yml
@@ -9,7 +9,6 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Build
       owner: abayer
       repo: js-test-repo
@@ -459,7 +458,6 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Second
       owner: abayer
       repo: js-test-repo

--- a/pkg/tekton/test_data/pipeline_info/from-yaml/taskruns.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml/taskruns.yml
@@ -8,7 +8,6 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Build
       owner: abayer
       repo: js-test-repo
@@ -119,7 +118,6 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Second
       owner: abayer
       repo: js-test-repo

--- a/pkg/tekton/test_data/pipeline_info/from-yaml/tasks.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml/tasks.yml
@@ -6,7 +6,6 @@ items:
     creationTimestamp: 2019-02-21T22:02:43Z
     generation: 1
     labels:
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Build
     name: abayer-js-test-repo-master-build
     namespace: jx
@@ -130,7 +129,6 @@ items:
     creationTimestamp: 2019-02-21T22:02:43Z
     generation: 1
     labels:
-      jenkins.io/pipeline-from-yaml: "true"
       jenkins.io/task-stage-name: Second
     name: abayer-js-test-repo-master-second
     namespace: jx


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This unifies logging/activity handling for both from-build-pack and
from-yaml paths, so yay. Also I cleaned up the GenerateCRDs arguments
a little.

#### Special notes for the reviewer(s)

n/a

#### Which issue this PR fixes

n/a