### PR TITLE
fix: run 'jx step git credentials' on each pipeline trigger

### DIFF
--- a/pkg/jx/cmd/common_git.go
+++ b/pkg/jx/cmd/common_git.go
@@ -346,8 +346,8 @@ func (o *CommonOptions) createGitProviderForURLWithoutKind(gitURL string) (gits.
 	return provider, gitInfo, err
 }
 
-// setupGitCredentails validates we have git setup
-func (o *CommonOptions) setupGitCredentails() error {
+// initGitConfigAndUser validates we have git setup
+func (o *CommonOptions) initGitConfigAndUser() error {
 	// lets validate we have git configured
 	_, _, err := gits.EnsureUserAndEmailSetup(o.Git())
 	if err != nil {

--- a/pkg/jx/cmd/controller_build.go
+++ b/pkg/jx/cmd/controller_build.go
@@ -106,7 +106,7 @@ func (o *ControllerBuildOptions) Run() error {
 	o.EnvironmentCache = kube.CreateEnvironmentCache(jxClient, ns)
 
 	if o.InitGitCredentials {
-		err = o.setupGitCredentails()
+		err = o.initGitConfigAndUser()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
as the secrets can get created after the pipelinerunner starts and can change at any time