### PR TITLE
Issue 3251: Cluster name validation for jx create cluster gke

### DIFF
--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -123,7 +123,13 @@ func NewCmdCreateClusterGKE(commonOpts *CommonOptions) *cobra.Command {
 }
 
 func (o *CreateClusterGKEOptions) Run() error {
-	err := o.installRequirements(cloud.GKE)
+	// Issue 3251
+	err := validateClusterName(o.Flags.ClusterName)
+	if err != nil {
+		return err
+	}
+
+	err = o.installRequirements(cloud.GKE)
 	if err != nil {
 		return err
 	}
@@ -408,4 +414,21 @@ func addLabel(labels string, name string, value string) string {
 func sanitizeLabel(username string) string {
 	sanitized := strings.ToLower(username)
 	return disallowedLabelCharacters.ReplaceAllString(sanitized, "-")
+}
+
+// validateClusterName checks for compliance of a user supplied
+// cluster name against GKE's rules for these names.
+func validateClusterName(clustername string) error {
+	// Check for length greater than 40.
+	if len(clustername) > 40 {
+		err := fmt.Errorf("Cluster name %v is greater than 40 characters", clustername)
+		return err
+	}
+	// Now we need only make sure that clustername is limited to
+	// lowercase alphanumerics and dashes.
+	if disallowedLabelCharacters.MatchString(clustername) {
+		err := fmt.Errorf("Cluster name has %v invalid stuff in it", clustername)
+		return err
+	}
+	return nil
 }

--- a/pkg/jx/cmd/create_cluster_gke_test.go
+++ b/pkg/jx/cmd/create_cluster_gke_test.go
@@ -24,3 +24,33 @@ func Test_sanitizeLabel(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateClusterName(t *testing.T) {
+	var bigLongName = string("this-name-is-too-long-to-be-used-by-2chars")
+	var capitalName = string("NameWithCapitalLetters")
+	var gibberishName = string("l337n@me")
+	var goodName = string("good-name-for-cluster")
+	t.Parallel()
+	tests := []struct {
+		name        string
+		clusterName string
+		want        bool
+	}{
+		// Negative tests for bad names. Should return false.
+		{"Fails when too long", bigLongName, false},
+		{"Fails with capital letters", capitalName, false},
+		{"Fails with gibberish name", gibberishName, false},
+		// Positive tests with good names. Should return true.
+		{"Passes with good name", goodName, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateClusterName(tt.clusterName)
+			nameIsValid := false
+			if err == nil {
+				nameIsValid = true
+			}
+			assert.Equal(t, nameIsValid, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
As described in [Issue 3251](https://github.com/jenkins-x/jx/issues/3251), `jx create cluster gke` needs some validation of the `--cluster-name` / `-n` option. This PR introduces validation which checks against [Google's current requirements](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create) for cluster names. 

#### Special notes for the reviewer(s)
N/A

#### Which issue this PR fixes

fixes #3251 