### PR TITLE
fix(tekton): Logs and activity should work with upper-case stage names

### DIFF
--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -365,12 +365,11 @@ func (si *StageInfo) SetPodsForStageInfo(kubeClient kubernetes.Interface, tekton
 	if si.Task != "" {
 		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{
 			pipeline.GroupName + pipeline.PipelineRunLabelKey: prName,
-			syntax.LabelStageName:                             si.Name,
+			syntax.LabelStageName:                             syntax.MangleToRfc1035Label(si.Name, ""),
 		}})
 		if err != nil {
 			return err
 		}
-
 		podList, err := kubeClient.CoreV1().Pods(ns).List(metav1.ListOptions{
 			LabelSelector: selector.String(),
 		})

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -204,7 +204,7 @@ func (s *Stage) taskName() string {
 	return strings.ToLower(strings.NewReplacer(" ", "-").Replace(s.Name))
 }
 
-// stageLabelName replaces invalid cahracters in stage names for label usage.
+// stageLabelName replaces invalid characters in stage names for label usage.
 func (s *Stage) stageLabelName() string {
 	return MangleToRfc1035Label(s.Name, "")
 }
@@ -1168,13 +1168,15 @@ func (ts transformedStage) getClosestAncestor() *transformedStage {
 func findDuplicates(names []string) *apis.FieldError {
 	// Count members
 	counts := make(map[string]int)
+	mangled := make(map[string]string)
 	for _, v := range names {
-		counts[v]++
+		counts[MangleToRfc1035Label(v, "")]++
+		mangled[v] = MangleToRfc1035Label(v, "")
 	}
 
 	var duplicateNames []string
-	for k, v := range counts {
-		if v > 1 {
+	for k, v := range mangled {
+		if counts[v] > 1 {
 			duplicateNames = append(duplicateNames, "'"+k+"'")
 		}
 	}

--- a/pkg/tekton/syntax/pipeline_internal_test.go
+++ b/pkg/tekton/syntax/pipeline_internal_test.go
@@ -24,6 +24,10 @@ func TestFindDuplicates(t *testing.T) {
 			name:   "No stage name duplicated",
 			input:  []string{"Stage 0", "Stage 1", "Stage 2", "Stage 3"},
 			errors: nil,
+		}, {
+			name:   "Case-insensitive stage name duplicated",
+			input:  []string{"Stage 1", "stage 1"},
+			errors: []string{"Stage 1"},
 		},
 	}
 
@@ -37,9 +41,9 @@ func TestFindDuplicates(t *testing.T) {
 			}
 
 			if len(tt.errors) > 0 && len(err.Details) > 0 {
-				for _, error := range tt.errors {
-					if !strings.Contains(err.Details, error) {
-						t.Fatal("Not all duplicates found", error)
+				for _, expectedError := range tt.errors {
+					if !strings.Contains(err.Details, expectedError) {
+						t.Fatal("Not all duplicates found", expectedError)
 					}
 				}
 			}

--- a/pkg/tekton/test_data/pipeline_info/from-build-pack/pods.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-build-pack/pods.yml
@@ -9,7 +9,7 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/task-stage-name: From-Build-Pack
+      jenkins.io/task-stage-name: from-build-pack
       owner: abayer
       repo: jx-demo-qs
       tekton.dev/pipeline: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/from-build-pack/taskruns.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-build-pack/taskruns.yml
@@ -8,7 +8,7 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/task-stage-name: From-Build-Pack
+      jenkins.io/task-stage-name: from-build-pack
       owner: abayer
       repo: jx-demo-qs
       tekton.dev/pipeline: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/from-build-pack/tasks.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-build-pack/tasks.yml
@@ -7,7 +7,7 @@ items:
     generation: 1
     labels:
       branch: master
-      jenkins.io/task-stage-name: From-Build-Pack
+      jenkins.io/task-stage-name: from-build-pack
       owner: abayer
       repo: jx-demo-qs
     name: abayer-jx-demo-qs-master

--- a/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/pods.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/pods.yml
@@ -9,7 +9,7 @@ items:
     labels:
       branch: nested
       build-number: "1"
-      jenkins.io/task-stage-name: Build
+      jenkins.io/task-stage-name: build
       owner: abayer
       repo: js-test-repo
       tekton.dev/pipeline: abayer-js-test-repo-nested
@@ -524,7 +524,7 @@ items:
     labels:
       branch: nested
       build-number: "1"
-      jenkins.io/task-stage-name: Second
+      jenkins.io/task-stage-name: second
       owner: abayer
       repo: js-test-repo
       tekton.dev/pipeline: abayer-js-test-repo-nested

--- a/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/taskruns.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/taskruns.yml
@@ -8,7 +8,7 @@ items:
     labels:
       branch: nested
       build-number: "1"
-      jenkins.io/task-stage-name: Build
+      jenkins.io/task-stage-name: build
       owner: abayer
       repo: js-test-repo
       tekton.dev/pipeline: abayer-js-test-repo-nested
@@ -125,7 +125,7 @@ items:
     labels:
       branch: nested
       build-number: "1"
-      jenkins.io/task-stage-name: Second
+      jenkins.io/task-stage-name: second
       owner: abayer
       repo: js-test-repo
       tekton.dev/pipeline: abayer-js-test-repo-nested

--- a/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/tasks.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml-nested-stages/tasks.yml
@@ -6,7 +6,7 @@ items:
     creationTimestamp: 2019-02-21T22:07:36Z
     generation: 1
     labels:
-      jenkins.io/task-stage-name: Build
+      jenkins.io/task-stage-name: build
     name: abayer-js-test-repo-nested-build
     namespace: jx
     resourceVersion: "6978"
@@ -168,7 +168,7 @@ items:
     creationTimestamp: 2019-02-21T22:07:36Z
     generation: 1
     labels:
-      jenkins.io/task-stage-name: Second
+      jenkins.io/task-stage-name: second
     name: abayer-js-test-repo-nested-second
     namespace: jx
     resourceVersion: "6979"

--- a/pkg/tekton/test_data/pipeline_info/from-yaml/pods.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml/pods.yml
@@ -9,7 +9,7 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/task-stage-name: Build
+      jenkins.io/task-stage-name: build
       owner: abayer
       repo: js-test-repo
       tekton.dev/pipeline: abayer-js-test-repo-master
@@ -458,7 +458,7 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/task-stage-name: Second
+      jenkins.io/task-stage-name: second
       owner: abayer
       repo: js-test-repo
       tekton.dev/pipeline: abayer-js-test-repo-master

--- a/pkg/tekton/test_data/pipeline_info/from-yaml/taskruns.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml/taskruns.yml
@@ -8,7 +8,7 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/task-stage-name: Build
+      jenkins.io/task-stage-name: build
       owner: abayer
       repo: js-test-repo
       tekton.dev/pipeline: abayer-js-test-repo-master
@@ -118,7 +118,7 @@ items:
     labels:
       branch: master
       build-number: "1"
-      jenkins.io/task-stage-name: Second
+      jenkins.io/task-stage-name: second
       owner: abayer
       repo: js-test-repo
       tekton.dev/pipeline: abayer-js-test-repo-master

--- a/pkg/tekton/test_data/pipeline_info/from-yaml/tasks.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-yaml/tasks.yml
@@ -6,7 +6,7 @@ items:
     creationTimestamp: 2019-02-21T22:02:43Z
     generation: 1
     labels:
-      jenkins.io/task-stage-name: Build
+      jenkins.io/task-stage-name: build
     name: abayer-js-test-repo-master-build
     namespace: jx
     resourceVersion: "5934"
@@ -129,7 +129,7 @@ items:
     creationTimestamp: 2019-02-21T22:02:43Z
     generation: 1
     labels:
-      jenkins.io/task-stage-name: Second
+      jenkins.io/task-stage-name: second
     name: abayer-js-test-repo-master-second
     namespace: jx
     resourceVersion: "5935"


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Ignore the branch name, I changed directions. =) But basically, we're mangling stage names to RFC1135 strings for use in labels, which created some problems with trying to get logs or activity for stages with upper-case letters, spaces, etc, so let's map that better. Also make the duplicate stage name validation case-insensitive.

#### Special notes for the reviewer(s)

n/a

#### Which issue this PR fixes

n/a