### PR TITLE
fix: Issue 3282 improve error message

### DIFF
--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -421,13 +421,13 @@ func sanitizeLabel(username string) string {
 func validateClusterName(clustername string) error {
 	// Check for length greater than 40.
 	if len(clustername) > 40 {
-		err := fmt.Errorf("Cluster name %v is greater than the maximum 40 characters", clustername)
+		err := fmt.Errorf("cluster name %v is greater than the maximum 40 characters", clustername)
 		return err
 	}
 	// Now we need only make sure that clustername is limited to
 	// lowercase alphanumerics and dashes.
 	if disallowedLabelCharacters.MatchString(clustername) {
-		err := fmt.Errorf("Cluster name %v contains invalid characters. Permitted are lowercase alphanumerics and `-`.", clustername)
+		err := fmt.Errorf("cluster name %v contains invalid characters. Permitted are lowercase alphanumerics and `-`", clustername)
 		return err
 	}
 	return nil

--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -421,13 +421,13 @@ func sanitizeLabel(username string) string {
 func validateClusterName(clustername string) error {
 	// Check for length greater than 40.
 	if len(clustername) > 40 {
-		err := fmt.Errorf("Cluster name %v is greater than 40 characters", clustername)
+		err := fmt.Errorf("Cluster name %v is greater than the maximum 40 characters", clustername)
 		return err
 	}
 	// Now we need only make sure that clustername is limited to
 	// lowercase alphanumerics and dashes.
 	if disallowedLabelCharacters.MatchString(clustername) {
-		err := fmt.Errorf("Cluster name has %v invalid stuff in it", clustername)
+		err := fmt.Errorf("Cluster name %v contains invalid characters. Permitted are lowercase alphanumerics and `-`.", clustername)
 		return err
 	}
 	return nil


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
As described in [Issue 3282](https://github.com/jenkins-x/jx/issues/3282), `jx create cluster gke` now has validation for the cluster name provided via either `--cluster-name` or `-n`. But the wording is all wrong and it's bothering me.

#### Special notes for the reviewer(s)
N/A

#### Which issue this PR fixes

fixes #3282 