### PR TITLE
fix: Properly mangle/to-lower-case build pack stage name

### DIFF
--- a/pkg/jx/cmd/step_create_task.go
+++ b/pkg/jx/cmd/step_create_task.go
@@ -490,7 +490,7 @@ func (o *StepCreateTaskOptions) CreateTaskForBuildPack(languageName string, pipe
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
-			Labels: util.MergeMaps(o.labels, map[string]string{syntax.LabelStageName: syntax.DefaultStageNameForBuildPack}),
+			Labels: util.MergeMaps(o.labels, map[string]string{syntax.LabelStageName: syntax.MangleToRfc1035Label(syntax.DefaultStageNameForBuildPack, "")}),
 		},
 		Spec: pipelineapi.TaskSpec{
 			Steps:   steps,
@@ -536,7 +536,7 @@ func (o *StepCreateTaskOptions) CreatePipelineAndStructureForBuildPack(task *pip
 	}
 	tasks := []pipelineapi.PipelineTask{
 		{
-			Name: strings.ToLower(syntax.DefaultStageNameForBuildPack),
+			Name: syntax.MangleToRfc1035Label(syntax.DefaultStageNameForBuildPack, ""),
 			Resources: &pipelineapi.PipelineTaskResources{
 				Inputs: taskInputResources,
 			},

--- a/pkg/jx/cmd/test_data/step_create_task/js_build_pack/structure.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/js_build_pack/structure.yml
@@ -5,5 +5,5 @@ pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
-  name: from-build-pack
+  name: From Build Pack
   taskRef: abayer-js-test-repo-build-pack

--- a/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/structure.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/structure.yml
@@ -5,5 +5,5 @@ pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
-  name: from-build-pack
+  name: From Build Pack
   taskRef: abayer-jx-demo-qs-master

--- a/pkg/tekton/syntax/constants.go
+++ b/pkg/tekton/syntax/constants.go
@@ -8,5 +8,5 @@ const (
 	LabelStageName = "jenkins.io/task-stage-name"
 
 	// DefaultStageNameForBuildPack - the name we use for the single stage created from build packs currently.
-	DefaultStageNameForBuildPack = "from-build-pack"
+	DefaultStageNameForBuildPack = "From Build Pack"
 )

--- a/pkg/tekton/test_data/pipeline_info/from-build-pack-init-containers/structure.yml
+++ b/pkg/tekton/test_data/pipeline_info/from-build-pack-init-containers/structure.yml
@@ -17,5 +17,5 @@ pipelineRef: abayer-jx-demo-qs-master
 pipelineRunRef: abayer-jx-demo-qs-master-1
 stages:
   - depth: 0
-    name: from-build-pack
+    name: From Build Pack
     taskRef: abayer-jx-demo-qs-master


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Fixes the issue @jstrachan stumbled over w.r.t. build pack stage name and `jx get build logs` and `PipelineActivity` population for real.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a