### PR TITLE
fix(tekton): Improve error handling when PipelineConfig is nil

### DIFF
--- a/pkg/jx/cmd/step_create_task.go
+++ b/pkg/jx/cmd/step_create_task.go
@@ -308,6 +308,9 @@ func (o *StepCreateTaskOptions) GenerateTektonCRDs(packsDir string, projectConfi
 			pipelineConfig = localPipelineConfig
 		}
 	}
+	if pipelineConfig == nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to find PipelineConfig in file %s", projectConfigFile)
+	}
 
 	// lets allow a `jenkins-x.yml` to specify we want to disable release prepare mode which can be useful for
 	// working with custom jenkins pipelines in custom jenkins servers

--- a/pkg/jx/cmd/test_data/step_create_task/no_pipeline_config/jenkins-x.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/no_pipeline_config/jenkins-x.yml
@@ -1,0 +1,1 @@
+buildPack: javascript


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Previously, running `jx step create task --pack=none` with a `jenkins-x.yml` that did not have a `pipelineConfig` section would fail with a nil pointer error. This PR changes that to a controlled failure with an error message.

#### Special notes for the reviewer(s)

/assign @abayer 

#### Which issue this PR fixes

N/A
<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
