### PR TITLE
Delete go.mod when running create client docs

### DIFF
--- a/pkg/kube/client_generator.go
+++ b/pkg/kube/client_generator.go
@@ -417,7 +417,9 @@ func InstallGenApiDocs(version string, gitter gits.Gitter) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// reference-docs has no dependency managemnt, but it will work with modules
+
+	// reference-docs has no dependency management, but it will work with modules
+	_ = os.Remove(dir + "/go.mod") // if go mod init was already ran
 	modInitCmd := util.Command{
 		Dir:  dir,
 		Name: "go",


### PR DESCRIPTION
a second time, or it will fail

```
jx create client docs
Generating docs to /Users/csanchez/dev/jenkins-x/jx/docs/apidocs
Installing https://github.com/kubernetes-incubator/reference-docs.git 096940c697f8b79873e2cfd2c1c4da1f6df76c40 to /Users/csanchez/.jx/bin
error: running go mod init, output go mod init: go.mod already exists: failed to run 'go mod init' command in directory '/Users/csanchez/.jx/codegen/src/github.com/kubernetes-incubator/reference-docs', output: 'go mod init: go.mod already exists'
make: *** [generate-docs] Error 1
```