### PR TITLE
jx step split monorepo does not remove files.

### DIFF
--- a/pkg/jx/cmd/step_split_monorepo.go
+++ b/pkg/jx/cmd/step_split_monorepo.go
@@ -150,6 +150,11 @@ func (o *StepSplitMonorepoOptions) Run() error {
 					}
 				}
 
+				err = util.DeleteDirContentsExcept(outPath, ".git")
+				if err != nil {
+					return err
+				}
+
 				err = util.CopyDirOverwrite(path, outPath)
 				if err != nil {
 					return err

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/log"
@@ -409,6 +410,23 @@ func DeleteDirContents(dir string) error {
 	for _, file := range files {
 		// lets ignore the top level dir
 		if dir != file {
+			err = os.RemoveAll(file)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func DeleteDirContentsExcept(dir string, exceptDir string) error {
+	files, err := filepath.Glob(filepath.Join(dir, "*"))
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		// lets ignore the top level dir
+		if dir != file && !strings.HasSuffix(file, exceptDir) {
 			err = os.RemoveAll(file)
 			if err != nil {
 				return err

--- a/pkg/util/files_test.go
+++ b/pkg/util/files_test.go
@@ -86,3 +86,43 @@ func TestDeleteDirContents(t *testing.T) {
 		fmt.Sprintf("Expected tmp dir %s to be empty, but contains %v.", tmpDir, remainingFiles))
 
 }
+
+func TestDeleteDirContentsExcept(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, err := ioutil.TempDir("", "TestDeleteDirContents")
+	require.NoError(t, err, "Failed to create temporary directory.")
+	defer func() {
+		err = os.RemoveAll(tmpDir)
+	}()
+	fmt.Printf("tmpDir=%s\n", tmpDir)
+
+	// Various types
+	var testFileNames = []string{
+		"file1",
+		"file2.out",
+		"file.3.ex-tension",
+	}
+	for _, filename := range testFileNames {
+		//Validate filename deletion as a file, directory, and non-empty directory.
+		filePath := filepath.Join(tmpDir, filename)
+		ioutil.WriteFile(filePath, []byte(filename), os.ModePerm)
+		dirPath := filepath.Join(tmpDir, filename+"-dir")
+		os.Mkdir(dirPath, os.ModeDir)
+		fileInDirPath := filepath.Join(dirPath, filename)
+		ioutil.WriteFile(fileInDirPath, []byte(filename), os.ModePerm)
+	}
+
+	//delete contents
+	util.DeleteDirContentsExcept(tmpDir, "file1")
+
+	//check dir still exists.
+	_, err = os.Stat(tmpDir)
+	require.NoError(t, err, "Directory has been deleted.")
+
+	//check empty
+	remainingFiles, err := filepath.Glob(filepath.Join(tmpDir, "*"))
+	assert.Equal(t, 1, len(remainingFiles),
+		fmt.Sprintf("Expected tmp dir %s to be empty, but contains %v.", tmpDir, remainingFiles))
+
+}


### PR DESCRIPTION
When splitting a monorepo, jx split command clones if the separate repo already created. But if there are files deleted in the monorepo, jx split does not remove it from the separate repo. it only copies files.

To fix this, delete all contents of the separate repo except the ".git" directory after cloning it. Then copy all from monorepo and push it.