### PR TITLE
fix: typo backupJeninsfile to backupJenkinsfile

### DIFF
--- a/pkg/jx/cmd/common_buildpacks.go
+++ b/pkg/jx/cmd/common_buildpacks.go
@@ -59,7 +59,7 @@ func (o *CommonOptions) invokeDraftPack(i *InvokeDraftPack) (string, error) {
 	dir := i.Dir
 	customDraftPack := i.CustomDraftPack
 	disableJenkinsfileCheck := i.DisableJenkinsfileCheck
-	backupJeninsfile := true
+	backupJenkinsfile := true
 	initialisedGit := i.InitialisedGit
 	withRename := i.WithRename
 	jenkinsfilePath := i.Jenkinsfile
@@ -172,7 +172,7 @@ func (o *CommonOptions) invokeDraftPack(i *InvokeDraftPack) (string, error) {
 					if exists && err2 == nil {
 						i.CreateJenkinsxYamlIfMissing = true
 						disableJenkinsfileCheck = false
-						backupJeninsfile = false
+						backupJenkinsfile = false
 						jenkinsfilePath = defaultJenkinsfile
 						lpack = filepath.Join(packsDir, "custom-jenkins")
 						err = nil
@@ -216,7 +216,7 @@ func (o *CommonOptions) invokeDraftPack(i *InvokeDraftPack) (string, error) {
 	generateJenkinsPath := jenkinsfilePath
 	jenkinsfileBackup := ""
 	defaultJenkinsfileExists, err := util.FileExists(defaultJenkinsfile)
-	if defaultJenkinsfileExists && !disableJenkinsfileCheck && backupJeninsfile {
+	if defaultJenkinsfileExists && !disableJenkinsfileCheck && backupJenkinsfile {
 		// lets copy the old Jenkinsfile in case we override it
 		jenkinsfileBackup = defaultJenkinsfile + jenkinsfile.BackupSuffix
 		err = util.RenameFile(defaultJenkinsfile, jenkinsfileBackup)


### PR DESCRIPTION
Signed-off-by: Wei Cheng <calvinpohwc@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
Fixes typo for `backupJeninsfile` to `backupJenkinsfile` in previous commit.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
