### PR TITLE
docs(applications): fix get applications examples

### DIFF
--- a/pkg/jx/cmd/get_applications.go
+++ b/pkg/jx/cmd/get_applications.go
@@ -65,22 +65,22 @@ var (
 
 	get_version_example = templates.Examples(`
 		# List applications, their URL and pod counts for all environments
-		jx get apps
+		jx get applications
 
 		# List applications only in the Staging environment
-		jx get apps -e staging
+		jx get applications -e staging
 
 		# List applications only in the Production environment
-		jx get apps -e production
+		jx get applications -e production
 
 		# List applications only in a specific namespace
-		jx get apps -n jx-staging
+		jx get applications -n jx-staging
 
 		# List applications hiding the URLs
-		jx get apps -u
+		jx get applications -u
 
 		# List applications just showing the versions (hiding urls and pod counts)
-		jx get apps -u -p
+		jx get applications -u -p
 	`)
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This fixes the examples for `jx get applications`. `apps` is not an alias for `applications`. 

```
$ jx get apps -e staging
Error: unknown shorthand flag: 'e' in -e


Aliases:
apps, app
Examples:
  # List all apps
  jx get apps

  # Display details about the app called cheese
  jx get app cheese
Options:
  -o, --output='': The output format such as 'yaml'
Usage:
  jx get apps [flags] [options]
Use "jx options" for a list of global command-line options (applies to all commands).
```

#### Special notes for the reviewer(s)
n/a

#### Which issue this PR fixes
n/a

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
