### PR TITLE
fix(windows) make ansi escape sequences render correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,9 @@ arm: version
 win: version
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=windows GOARCH=amd64 $(GO) build $(BUILDFLAGS) -o build/$(NAME).exe cmd/jx/jx.go
 
+win32: version
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=windows GOARCH=386 $(GO) build $(BUILDFLAGS) -o build/$(NAME)-386.exe cmd/jx/jx.go
+
 darwin: version
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=amd64 $(GO) build $(BUILDFLAGS) -o build/darwin/jx cmd/jx/jx.go
 

--- a/cmd/jx/app/jx-win.go
+++ b/cmd/jx/app/jx-win.go
@@ -12,7 +12,6 @@ import (
 
 // Run runs the command
 func Run() error {
-	// if windows
 	configureTerminalForAnsiEscapes()
 	cmd := cmd.NewJXCommand(clients.NewFactory(), os.Stdin, os.Stdout, os.Stderr, nil)
 	return cmd.Execute()
@@ -20,21 +19,25 @@ func Run() error {
 
 const (
 	// https://docs.microsoft.com/en-us/windows/console/setconsolemode
-	enableProcessedOutput = 0x1
-	enableWrapAtEOLOutput = 0x2
-	enableVirtualTermainalProcessing = 0x4
-
+	enableProcessedOutput           = 0x1
+	enableWrapAtEOLOutput           = 0x2
+	enableVirtualTerminalProcessing = 0x4
 )
+
+
+// configureTerminalForAnsiEscapes enables the windows 10 console to translate ansi escape sequences
+// requires windows 10 1511 or higher and fails gracefully on older versions (and prior releases like windows 7)
+// https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
 func configureTerminalForAnsiEscapes() {
 
-	kernel32  := syscall.NewLazyDLL("kernel32.dll")
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
 	kern32SetConsoleMode := kernel32.NewProc("SetConsoleMode")
 
 	// stderr
 	handle := syscall.Handle(os.Stderr.Fd())
-	kern32SetConsoleMode.Call(uintptr(handle), enableProcessedOutput|enableWrapAtEOLOutput|enableVirtualTermainalProcessing)
+	kern32SetConsoleMode.Call(uintptr(handle), enableProcessedOutput|enableWrapAtEOLOutput|enableVirtualTerminalProcessing)
 
 	// stdout
 	handle = syscall.Handle(os.Stdout.Fd())
-	kern32SetConsoleMode.Call(uintptr(handle), enableProcessedOutput|enableWrapAtEOLOutput|enableVirtualTermainalProcessing)
+	kern32SetConsoleMode.Call(uintptr(handle), enableProcessedOutput|enableWrapAtEOLOutput|enableVirtualTerminalProcessing)
 }

--- a/cmd/jx/app/jx-win.go
+++ b/cmd/jx/app/jx-win.go
@@ -1,0 +1,40 @@
+// +build windows
+
+package app
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/clients"
+)
+
+// Run runs the command
+func Run() error {
+	// if windows
+	configureTerminalForAnsiEscapes()
+	cmd := cmd.NewJXCommand(clients.NewFactory(), os.Stdin, os.Stdout, os.Stderr, nil)
+	return cmd.Execute()
+}
+
+const (
+	// https://docs.microsoft.com/en-us/windows/console/setconsolemode
+	enableProcessedOutput = 0x1
+	enableWrapAtEOLOutput = 0x2
+	enableVirtualTermainalProcessing = 0x4
+
+)
+func configureTerminalForAnsiEscapes() {
+
+	kernel32  := syscall.NewLazyDLL("kernel32.dll")
+	kern32SetConsoleMode := kernel32.NewProc("SetConsoleMode")
+
+	// stderr
+	handle := syscall.Handle(os.Stderr.Fd())
+	kern32SetConsoleMode.Call(uintptr(handle), enableProcessedOutput|enableWrapAtEOLOutput|enableVirtualTermainalProcessing)
+
+	// stdout
+	handle = syscall.Handle(os.Stdout.Fd())
+	kern32SetConsoleMode.Call(uintptr(handle), enableProcessedOutput|enableWrapAtEOLOutput|enableVirtualTermainalProcessing)
+}

--- a/cmd/jx/app/jx.go
+++ b/cmd/jx/app/jx.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package app
 
 import (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

On modern windows 10 (and server) variants windows supports native ansi
escape code handling.  We just need to enable it :-o

#### Special notes for the reviewer(s)

before and after

![image](https://user-images.githubusercontent.com/494726/54551596-4e62b000-49a6-11e9-9586-a46718322ceb.png)


#### Which issue this PR fixes

fixes #711 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
