### PR TITLE
chore: Add support for secrets for env vars in tekton syntax

### DIFF
--- a/pkg/tekton/syntax/test_data/environment_at_top_and_in_stage/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/environment_at_top_and_in_stage/jenkins-x.yml
@@ -7,11 +7,19 @@ pipelineConfig:
         environment:
           - name: SOME_VAR
             value: A value for the env var
+          - name: SOME_SECRET
+            fromSecret:
+              key: SOME_KEY
+              configMap: some-config-map
         stages:
           - name: A stage with environment
             environment:
                 - name: SOME_OTHER_VAR
                   value: A value for the other env var
+                - name: SOME_OTHER_SECRET
+                  fromSecret:
+                    configMap: some-config-map
+                    key: SOME_OTHER_KEY
             steps:
               - command: echo
                 args: ['hello', '${SOME_OTHER_VAR}']


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

I don't love this, but I couldn't just use `corev1.EnvVarSource` since
that's using `json:"..."` and we use `yaml:"..."` for `jenkins-x.yml`.

#### Special notes for the reviewer(s)

/assign @dwnusbaum 
/assign @warrenbailey 

#### Which issue this PR fixes

Fixes #3366

