### PR TITLE
chore: Switch to sigs.k8s.io/yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -172,6 +172,7 @@ require (
 	k8s.io/kubernetes v1.11.3 // indirect
 	k8s.io/metrics v0.0.0-20180620010437-b11cf31b380b
 	k8s.io/test-infra v0.0.0-20190131093439-a22cef183a8f
+	sigs.k8s.io/yaml v1.1.0
 
 )
 

--- a/pkg/addon/config.go
+++ b/pkg/addon/config.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 //AddonConfig Addon Configuration

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -20,7 +20,7 @@ type User struct {
 	Username    string   `json:"username"`
 	ApiToken    string   `json:"apitoken"`
 	BearerToken string   `json:"bearertoken"`
-	Password    string   `json:"password,omitempty" json:"password"`
+	Password    string   `json:"password,omitempty"`
 	Kind        UserKind `json:"kind"`
 }
 

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -17,11 +17,11 @@ const (
 
 //User store the auth infomation for a user
 type User struct {
-	Username    string   `yaml:"username"`
-	ApiToken    string   `yaml:"apitoken"`
-	BearerToken string   `yaml:"bearertoken"`
-	Password    string   `yaml:"password,omitempty" json:"password"`
-	Kind        UserKind `yaml:"kind"`
+	Username    string   `json:"username"`
+	ApiToken    string   `json:"apitoken"`
+	BearerToken string   `json:"bearertoken"`
+	Password    string   `json:"password,omitempty" json:"password"`
+	Kind        UserKind `json:"kind"`
 }
 
 //ServerKind type of the server
@@ -54,16 +54,16 @@ const (
 
 //Server stores the server configuration for a server
 type Server struct {
-	URL         string      `yaml:"url"`
-	Name        string      `yaml:"name"`
-	Kind        ServerKind  `yaml:"kind"`
-	ServiceKind ServiceKind `yaml:"servicekind"`
-	Users       []*User     `yaml:"users"`
+	URL         string      `json:"url"`
+	Name        string      `json:"name"`
+	Kind        ServerKind  `json:"kind"`
+	ServiceKind ServiceKind `json:"servicekind"`
+	Users       []*User     `json:"users"`
 }
 
 // Config stores the entire auth configuration for a number of sservers
 type Config struct {
-	Servers []*Server `yaml:"servers"`
+	Servers []*Server `json:"servers"`
 }
 
 // Checker verifies if the configuration is valid

--- a/pkg/auth/file_config_saver.go
+++ b/pkg/auth/file_config_saver.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // NewFileAuthConfigService

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -17,7 +17,7 @@ type UserAuth struct {
 	Username    string
 	ApiToken    string
 	BearerToken string
-	Password    string `yaml:"password,omitempty"`
+	Password    string `json:"password,omitempty"`
 }
 
 type AuthConfig struct {

--- a/pkg/binaries/binaries.go
+++ b/pkg/binaries/binaries.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
+
 	"io/ioutil"
 	"os"
 	"os/exec"

--- a/pkg/cloud/gke/gcloud.go
+++ b/pkg/cloud/gke/gcloud.go
@@ -7,13 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 )
 
 // KmsLocation indicates the location used by the Google KMS service
@@ -60,7 +59,7 @@ func ClusterZone(cluster string) (string, error) {
 
 func parseClusterZone(clusterInfo string) (string, error) {
 	ci := struct {
-		Zone string `yaml:"zone"`
+		Zone string `json:"zone"`
 	}{}
 
 	err := yaml.Unmarshal([]byte(clusterInfo), &ci)

--- a/pkg/config/project_config.go
+++ b/pkg/config/project_config.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"github.com/jenkins-x/jx/pkg/jenkinsfile"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
+
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
 
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -20,95 +21,95 @@ const (
 
 type ProjectConfig struct {
 	// List of global environment variables to add to each branch build and each step
-	Env []corev1.EnvVar `yaml:"env,omitempty"`
+	Env []corev1.EnvVar `json:"env,omitempty"`
 
-	Builds              []*BranchBuild              `yaml:"builds,omitempty"`
-	PreviewEnvironments *PreviewEnvironmentConfig   `yaml:"previewEnvironments,omitempty"`
-	IssueTracker        *IssueTrackerConfig         `yaml:"issueTracker,omitempty"`
-	Chat                *ChatConfig                 `yaml:"chat,omitempty"`
-	Wiki                *WikiConfig                 `yaml:"wiki,omitempty"`
-	Addons              []*AddonConfig              `yaml:"addons,omitempty"`
-	BuildPack           string                      `yaml:"buildPack,omitempty"`
-	BuildPackGitURL     string                      `yaml:"buildPackGitURL,omitempty"`
-	BuildPackGitURef    string                      `yaml:"buildPackGitRef,omitempty"`
-	Workflow            string                      `yaml:"workflow,omitempty"`
-	PipelineConfig      *jenkinsfile.PipelineConfig `yaml:"pipelineConfig,omitempty"`
-	NoReleasePrepare    bool                        `yaml:"noReleasePrepare,omitempty"`
+	Builds              []*BranchBuild              `json:"builds,omitempty"`
+	PreviewEnvironments *PreviewEnvironmentConfig   `json:"previewEnvironments,omitempty"`
+	IssueTracker        *IssueTrackerConfig         `json:"issueTracker,omitempty"`
+	Chat                *ChatConfig                 `json:"chat,omitempty"`
+	Wiki                *WikiConfig                 `json:"wiki,omitempty"`
+	Addons              []*AddonConfig              `json:"addons,omitempty"`
+	BuildPack           string                      `json:"buildPack,omitempty"`
+	BuildPackGitURL     string                      `json:"buildPackGitURL,omitempty"`
+	BuildPackGitURef    string                      `json:"buildPackGitRef,omitempty"`
+	Workflow            string                      `json:"workflow,omitempty"`
+	PipelineConfig      *jenkinsfile.PipelineConfig `json:"pipelineConfig,omitempty"`
+	NoReleasePrepare    bool                        `json:"noReleasePrepare,omitempty"`
 }
 
 type PreviewEnvironmentConfig struct {
-	Disabled         bool `yaml:"disabled,omitempty"`
-	MaximumInstances int  `yaml:"maximumInstances,omitempty"`
+	Disabled         bool `json:"disabled,omitempty"`
+	MaximumInstances int  `json:"maximumInstances,omitempty"`
 }
 
 type IssueTrackerConfig struct {
-	Kind    string `yaml:"kind,omitempty"`
-	URL     string `yaml:"url,omitempty"`
-	Project string `yaml:"project,omitempty"`
+	Kind    string `json:"kind,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Project string `json:"project,omitempty"`
 }
 
 type WikiConfig struct {
-	Kind  string `yaml:"kind,omitempty"`
-	URL   string `yaml:"url,omitempty"`
-	Space string `yaml:"space,omitempty"`
+	Kind  string `json:"kind,omitempty"`
+	URL   string `json:"url,omitempty"`
+	Space string `json:"space,omitempty"`
 }
 
 type ChatConfig struct {
-	Kind             string `yaml:"kind,omitempty"`
-	URL              string `yaml:"url,omitempty"`
-	DeveloperChannel string `yaml:"developerChannel,omitempty"`
-	UserChannel      string `yaml:"userChannel,omitempty"`
+	Kind             string `json:"kind,omitempty"`
+	URL              string `json:"url,omitempty"`
+	DeveloperChannel string `json:"developerChannel,omitempty"`
+	UserChannel      string `json:"userChannel,omitempty"`
 }
 
 type AddonConfig struct {
-	Name    string `yaml:"name,omitempty"`
-	Version string `yaml:"version,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 type BranchBuild struct {
-	Build Build `yaml:"build,omitempty"`
+	Build Build `json:"build,omitempty"`
 
 	// Jenkins X extensions to standard Knative builds:
 
 	// which kind of pipeline - like release, pullRequest, feature
-	Kind string `yaml:"kind,omitempty"`
+	Kind string `json:"kind,omitempty"`
 
 	// display name
-	Name string `yaml:"name,omitempty"`
+	Name string `json:"name,omitempty"`
 
 	// List of sources to populate environment variables in all the steps if there is not already
 	// an environment variable defined on that step
-	EnvFrom []corev1.EnvFromSource `yaml:"envFrom,omitempty"`
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// List of environment variables to add to each step if there is not already a environemnt variable of that name
-	Env []corev1.EnvVar `yaml:"env,omitempty"`
+	Env []corev1.EnvVar `json:"env,omitempty"`
 
-	ExcludePodTemplateEnv     bool `yaml:"excludePodTemplateEnv,omitempty"`
-	ExcludePodTemplateVolumes bool `yaml:"excludePodTemplateVolumes,omitempty"`
+	ExcludePodTemplateEnv     bool `json:"excludePodTemplateEnv,omitempty"`
+	ExcludePodTemplateVolumes bool `json:"excludePodTemplateVolumes,omitempty"`
 }
 
 type Build struct {
 	// Steps are the steps of the build; each step is run sequentially with the
 	// source mounted into /workspace.
-	Steps []corev1.Container `yaml:"steps,omitempty"`
+	Steps []corev1.Container `json:"steps,omitempty"`
 
 	// Volumes is a collection of volumes that are available to mount into the
 	// steps of the build.
-	Volumes []corev1.Volume `yaml:"volumes,omitempty"`
+	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
 	// The name of the service account as which to run this build.
-	ServiceAccountName string `yaml:"serviceAccountName,omitempty"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Template, if specified, references a BuildTemplate resource to use to
 	// populate fields in the build, and optional Arguments to pass to the
 	// template.
-	//Template *TemplateInstantiationSpec `yaml:"template,omitempty"`
+	//Template *TemplateInstantiationSpec `json:"template,omitempty"`
 
 	// NodeSelector is a selector which must be true for the pod to fit on a node.
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 	// +optional
-	NodeSelector map[string]string `yaml:"nodeSelector,omitempty"`
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // LoadProjectConfig loads the project configuration if there is a project configuration file

--- a/pkg/config/project_config_test.go
+++ b/pkg/config/project_config_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/tests"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/io/config_readers.go
+++ b/pkg/io/config_readers.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/util"
-	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/io/config_writers.go
+++ b/pkg/io/config_writers.go
@@ -8,10 +8,10 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 )
 
 //ConfigWriter interface for writing auth configuration

--- a/pkg/jenkinsfile/gitresolver/resolvers.go
+++ b/pkg/jenkinsfile/gitresolver/resolvers.go
@@ -5,7 +5,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/jenkinsfile"
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
+
 	"io/ioutil"
 	"path/filepath"
 )

--- a/pkg/jenkinsfile/modules.go
+++ b/pkg/jenkinsfile/modules.go
@@ -18,14 +18,14 @@ type ImportFileResolver func(importFile *ImportFile) (string, error)
 
 // Modules defines the dependent modules for a build pack
 type Modules struct {
-	Modules []*Module `yaml:"modules,omitempty"`
+	Modules []*Module `json:"modules,omitempty"`
 }
 
 // Module defines a dependent module for a build pack
 type Module struct {
-	Name   string `yaml:"name,omitempty"`
-	GitURL string `yaml:"gitUrl,omitempty"`
-	GitRef string `yaml:"gitRef,omitempty"`
+	Name   string `json:"name,omitempty"`
+	GitURL string `json:"gitUrl,omitempty"`
+	GitRef string `json:"gitRef,omitempty"`
 }
 
 // Validate returns an error if any data is missing

--- a/pkg/jenkinsfile/pipeline.go
+++ b/pkg/jenkinsfile/pipeline.go
@@ -13,8 +13,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/tekton/syntax"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -41,51 +41,51 @@ var (
 
 // PipelineAgent contains the agent definition metadata
 type PipelineAgent struct {
-	Label     string `yaml:"label,omitempty"`
-	Container string `yaml:"container,omitempty"`
-	Dir       string `yaml:"dir,omitempty"`
+	Label     string `json:"label,omitempty"`
+	Container string `json:"container,omitempty"`
+	Dir       string `json:"dir,omitempty"`
 }
 
 // Pipelines contains all the different kinds of pipeline for diferent branches
 type Pipelines struct {
-	PullRequest *PipelineLifecycles `yaml:"pullRequest,omitempty"`
-	Release     *PipelineLifecycles `yaml:"release,omitempty"`
-	Feature     *PipelineLifecycles `yaml:"feature,omitempty"`
-	Post        *PipelineLifecycle  `yaml:"post,omitempty"`
+	PullRequest *PipelineLifecycles `json:"pullRequest,omitempty"`
+	Release     *PipelineLifecycles `json:"release,omitempty"`
+	Feature     *PipelineLifecycles `json:"feature,omitempty"`
+	Post        *PipelineLifecycle  `json:"post,omitempty"`
 }
 
 // PipelineStep defines an individual step in a pipeline, either a command (sh) or groovy block
 type PipelineStep struct {
-	Name      string          `yaml:"name,omitempty"`
-	Comment   string          `yaml:"comment,omitempty"`
-	Container string          `yaml:"container,omitempty"`
-	Dir       string          `yaml:"dir,omitempty"`
-	Command   string          `yaml:"sh,omitempty"`
-	Groovy    string          `yaml:"groovy,omitempty"`
-	Steps     []*PipelineStep `yaml:"steps,omitempty"`
-	When      string          `yaml:"when,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Comment   string          `json:"comment,omitempty"`
+	Container string          `json:"container,omitempty"`
+	Dir       string          `json:"dir,omitempty"`
+	Command   string          `json:"sh,omitempty"`
+	Groovy    string          `json:"groovy,omitempty"`
+	Steps     []*PipelineStep `json:"steps,omitempty"`
+	When      string          `json:"when,omitempty"`
 }
 
 // PipelineLifecycles defines the steps of a lifecycle section
 type PipelineLifecycles struct {
-	Setup      *PipelineLifecycle     `yaml:"setup,omitempty"`
-	SetVersion *PipelineLifecycle     `yaml:"setVersion,omitempty"`
-	PreBuild   *PipelineLifecycle     `yaml:"preBuild,omitempty"`
-	Build      *PipelineLifecycle     `yaml:"build,omitempty"`
-	PostBuild  *PipelineLifecycle     `yaml:"postBuild,omitempty"`
-	Promote    *PipelineLifecycle     `yaml:"promote,omitempty"`
-	Pipeline   *syntax.ParsedPipeline `yaml:"pipeline,omitempty"`
+	Setup      *PipelineLifecycle     `json:"setup,omitempty"`
+	SetVersion *PipelineLifecycle     `json:"setVersion,omitempty"`
+	PreBuild   *PipelineLifecycle     `json:"preBuild,omitempty"`
+	Build      *PipelineLifecycle     `json:"build,omitempty"`
+	PostBuild  *PipelineLifecycle     `json:"postBuild,omitempty"`
+	Promote    *PipelineLifecycle     `json:"promote,omitempty"`
+	Pipeline   *syntax.ParsedPipeline `json:"pipeline,omitempty"`
 }
 
 // PipelineLifecycle defines the steps of a lifecycle section
 type PipelineLifecycle struct {
-	Steps []*PipelineStep `yaml:"steps,omitempty"`
+	Steps []*PipelineStep `json:"steps,omitempty"`
 
 	// PreSteps if using inheritance then invoke these steps before the base steps
-	PreSteps []*PipelineStep `yaml:"preSteps,omitempty"`
+	PreSteps []*PipelineStep `json:"preSteps,omitempty"`
 
 	// Replace if using inheritence then replace steps from the base pipeline
-	Replace bool `yaml:"replace,omitempty"`
+	Replace bool `json:"replace,omitempty"`
 }
 
 // NamedLifecycle a lifecycle and its name
@@ -99,8 +99,8 @@ type PipelineLifecycleArray []NamedLifecycle
 
 // PipelineExtends defines the extension (e.g. parent pipeline which is overloaded
 type PipelineExtends struct {
-	Import string `yaml:"import,omitempty"`
-	File   string `yaml:"file,omitempty"`
+	Import string `json:"import,omitempty"`
+	File   string `json:"file,omitempty"`
 }
 
 // ImportFile returns an ImportFile for the given extension
@@ -113,11 +113,11 @@ func (x *PipelineExtends) ImportFile() *ImportFile {
 
 // PipelineConfig defines the pipeline configuration
 type PipelineConfig struct {
-	Extends     *PipelineExtends `yaml:"extends,omitempty"`
-	Agent       PipelineAgent    `yaml:"agent,omitempty"`
-	Env         []corev1.EnvVar  `yaml:"env,omitempty"`
-	Environment string           `yaml:"environment,omitempty"`
-	Pipelines   Pipelines        `yaml:"pipelines,omitempty"`
+	Extends     *PipelineExtends `json:"extends,omitempty"`
+	Agent       PipelineAgent    `json:"agent,omitempty"`
+	Env         []corev1.EnvVar  `json:"env,omitempty"`
+	Environment string           `json:"environment,omitempty"`
+	Pipelines   Pipelines        `json:"pipelines,omitempty"`
 }
 
 // CreateJenkinsfileArguments contains the arguents to generate a Jenkinsfiles dynamically

--- a/pkg/jx/cmd/bdd/bdd_clusters.go
+++ b/pkg/jx/cmd/bdd/bdd_clusters.go
@@ -2,21 +2,22 @@ package bdd
 
 import (
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
+
 	"io/ioutil"
 )
 
 // CreateClusters contains an array of clusters
 type CreateClusters struct {
-	Clusters []*CreateCluster `yaml:"clusters,omitempty"`
+	Clusters []*CreateCluster `json:"clusters,omitempty"`
 }
 
 // CreateCluster defines how to create a cluster
 type CreateCluster struct {
-	Name     string   `yaml:"name,omitempty"`
-	Args     []string `yaml:"args,omitempty"`
-	NoLabels bool     `yaml:"noLabels,omitempty"`
-	Labels   string   `yaml:"labels,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	Args     []string `json:"args,omitempty"`
+	NoLabels bool     `json:"noLabels,omitempty"`
+	Labels   string   `json:"labels,omitempty"`
 }
 
 // LoadBddClusters loads the cluster configuration from the given file

--- a/pkg/jx/cmd/cmd_test_helpers/app_test_helpers.go
+++ b/pkg/jx/cmd/cmd_test_helpers/app_test_helpers.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"github.com/jenkins-x/jx/pkg/environments"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/petergtz/pegomock"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
-	yaml "gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/clients"
 	"github.com/jenkins-x/jx/pkg/vault"
+	"sigs.k8s.io/yaml"
 
 	"github.com/jenkins-x/jx/pkg/expose"
 
@@ -42,7 +43,6 @@ import (
 	"gopkg.in/AlecAivazis/survey.v1"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	gitcfg "gopkg.in/src-d/go-git.v4/config"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/jx/cmd/create_addon_prometheus.go
+++ b/pkg/jx/cmd/create_addon_prometheus.go
@@ -12,10 +12,10 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 type CreateAddonPrometheusOptions struct {

--- a/pkg/jx/cmd/get_eks.go
+++ b/pkg/jx/cmd/get_eks.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/jenkins-x/jx/pkg/cloud/amazon"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/cenkalti/backoff"
 	"github.com/jenkins-x/jx/pkg/cloud/amazon"
@@ -32,7 +33,6 @@ import (
 
 	"github.com/denormal/go-gitignore"
 	"github.com/jenkins-x/jx/pkg/prow"
-	"gopkg.in/yaml.v2"
 )
 
 const (

--- a/pkg/jx/cmd/import_test.go
+++ b/pkg/jx/cmd/import_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/prow"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 const testUsername = "derek_zoolander"

--- a/pkg/jx/cmd/scan_cluster.go
+++ b/pkg/jx/cmd/scan_cluster.go
@@ -12,10 +12,10 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/pkg/jx/cmd/upgrade_platform.go
+++ b/pkg/jx/cmd/upgrade_platform.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cloud"
 	"github.com/jenkins-x/jx/pkg/config"
 	configio "github.com/jenkins-x/jx/pkg/io"
+	"sigs.k8s.io/yaml"
 
 	"io/ioutil"
 	"strings"
@@ -14,9 +15,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/ghodss/yaml"
-	do_not_use "gopkg.in/yaml.v2"
 
 	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
@@ -407,7 +405,7 @@ func (o *UpgradePlatformOptions) repairAdminSecrets(fileName string) error {
 		return errors.Wrap(err, "unable to read file")
 	}
 
-	err = do_not_use.Unmarshal([]byte(data), &admin)
+	err = yaml.Unmarshal([]byte(data), &admin)
 	if err != nil {
 		return errors.Wrap(err, "unable to unmarshall secrets")
 	}

--- a/pkg/prow/config.go
+++ b/pkg/prow/config.go
@@ -2,13 +2,13 @@ package prow
 
 // Owners keeps the prow OWNERS data
 type Owners struct {
-	Approvers []string `yaml:"approvers"`
-	Reviewers []string `yaml:"reviewers"`
+	Approvers []string `json:"approvers"`
+	Reviewers []string `json:"reviewers"`
 }
 
 // OwnersAliases keept the prow OWNERS_ALIASES data
 type OwnersAliases struct {
-	Aliases       []string `yaml:"aliases"`
-	BestApprovers []string `yaml:"best-approvers"`
-	BestReviewers []string `yaml:"best-reviewers"`
+	Aliases       []string `json:"aliases"`
+	BestApprovers []string `json:"best-approvers"`
+	BestReviewers []string `json:"best-reviewers"`
 }

--- a/pkg/reports/project_history.go
+++ b/pkg/reports/project_history.go
@@ -6,32 +6,32 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 type ProjectHistory struct {
-	LastReportDate string           `yaml:"lastReportDate,omitempty"`
-	Reports        []*ProjectReport `yaml:"reports,omitempty"`
-	Contributors   []string         `yaml:"contributors,omitempty"`
-	Committers     []string         `yaml:"committers,omitempty"`
+	LastReportDate string           `json:"lastReportDate,omitempty"`
+	Reports        []*ProjectReport `json:"reports,omitempty"`
+	Contributors   []string         `json:"contributors,omitempty"`
+	Committers     []string         `json:"committers,omitempty"`
 }
 
 type CountMetrics struct {
-	Count int `yaml:"count,omitempty"`
-	Total int `yaml:"total,omitempty"`
+	Count int `json:"count,omitempty"`
+	Total int `json:"total,omitempty"`
 }
 
 type ProjectReport struct {
-	ReportDate            string       `yaml:"reportDate,omitempty"`
-	StarsMetrics          CountMetrics `yaml:"starsMetrics,omitempty"`
-	DownloadMetrics       CountMetrics `yaml:"downloadMetrics,omitempty"`
-	IssueMetrics          CountMetrics `yaml:"issueMetrics,omitempty"`
-	PullRequestMetrics    CountMetrics `yaml:"pullRequestMetrics,omitempty"`
-	CommitMetrics         CountMetrics `yaml:"commitMetrics,omitempty"`
-	NewCommitterMetrics   CountMetrics `yaml:"newCommitterMetrics,omitempty"`
-	NewContributorMetrics CountMetrics `yaml:"newContributorMetrics,omitempty"`
-	DeveloperChatMetrics  CountMetrics `yaml:"developerChatMetrics,omitempty"`
-	UserChatMetrics       CountMetrics `yaml:"userChatMetrics,omitempty"`
+	ReportDate            string       `json:"reportDate,omitempty"`
+	StarsMetrics          CountMetrics `json:"starsMetrics,omitempty"`
+	DownloadMetrics       CountMetrics `json:"downloadMetrics,omitempty"`
+	IssueMetrics          CountMetrics `json:"issueMetrics,omitempty"`
+	PullRequestMetrics    CountMetrics `json:"pullRequestMetrics,omitempty"`
+	CommitMetrics         CountMetrics `json:"commitMetrics,omitempty"`
+	NewCommitterMetrics   CountMetrics `json:"newCommitterMetrics,omitempty"`
+	NewContributorMetrics CountMetrics `json:"newContributorMetrics,omitempty"`
+	DeveloperChatMetrics  CountMetrics `json:"developerChatMetrics,omitempty"`
+	UserChatMetrics       CountMetrics `json:"userChatMetrics,omitempty"`
 }
 
 func (h *ProjectHistory) GetOrCreateReport(reportDate string) *ProjectReport {

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -21,25 +21,25 @@ import (
 
 // ParsedPipeline is the internal representation of the Pipeline, used to validate and create CRDs
 type ParsedPipeline struct {
-	Agent       Agent       `yaml:"agent,omitempty"`
-	Environment []EnvVar    `yaml:"environment,omitempty"`
-	Options     RootOptions `yaml:"options,omitempty"`
-	Stages      []Stage     `yaml:"stages"`
-	Post        []Post      `yaml:"post,omitempty"`
+	Agent       Agent       `json:"agent,omitempty"`
+	Environment []EnvVar    `json:"environment,omitempty"`
+	Options     RootOptions `json:"options,omitempty"`
+	Stages      []Stage     `json:"stages"`
+	Post        []Post      `json:"post,omitempty"`
 }
 
 // Agent defines where the pipeline, stage, or step should run.
 type Agent struct {
 	// One of label or image is required.
-	Label string `yaml:"label,omitempty"`
-	Image string `yaml:"image,omitempty"`
+	Label string `json:"label,omitempty"`
+	Image string `json:"image,omitempty"`
 	// Perhaps we'll eventually want to add something here for specifying a volume to create? Would play into stash.
 }
 
 // EnvVar is a key/value pair defining an environment variable
 type EnvVar struct {
-	Name  string `yaml:"name"`
-	Value string `yaml:"value"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // TimeoutUnit is used for calculating timeout duration
@@ -68,9 +68,9 @@ func allTimeoutUnitsAsStrings() []string {
 
 // Timeout defines how long a stage or pipeline can run before timing out.
 type Timeout struct {
-	Time int64 `yaml:"time"`
+	Time int64 `json:"time"`
 	// Has some sane default - probably seconds
-	Unit TimeoutUnit `yaml:"unit,omitempty"`
+	Unit TimeoutUnit `json:"unit,omitempty"`
 }
 
 func (t Timeout) toDuration() (*metav1.Duration, error) {
@@ -91,58 +91,58 @@ func (t Timeout) toDuration() (*metav1.Duration, error) {
 
 // RootOptions contains options that can be configured on either a pipeline or a stage
 type RootOptions struct {
-	Timeout Timeout `yaml:"timeout,omitempty"`
+	Timeout Timeout `json:"timeout,omitempty"`
 	// TODO: Not yet implemented in build-pipeline
-	Retry int8 `yaml:"retry,omitempty"`
+	Retry int8 `json:"retry,omitempty"`
 }
 
 // Stash defines files to be saved for use in a later stage, marked with a name
 type Stash struct {
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 	// Eventually make this optional so that you can do volumes instead
-	Files string `yaml:"files"`
+	Files string `json:"files"`
 }
 
 // Unstash defines a previously-defined stash to be copied into this stage's workspace
 type Unstash struct {
-	Name string `yaml:"name"`
-	Dir  string `yaml:"dir,omitempty"`
+	Name string `json:"name"`
+	Dir  string `json:"dir,omitempty"`
 }
 
 // StageOptions contains both options that can be configured on either a pipeline or a stage, via
 // RootOptions, or stage-specific options.
 type StageOptions struct {
-	RootOptions `yaml:",inline"`
+	RootOptions `json:",inline"`
 
 	// TODO: Not yet implemented in build-pipeline
-	Stash   Stash   `yaml:"stash,omitempty"`
-	Unstash Unstash `yaml:"unstash,omitempty"`
+	Stash   Stash   `json:"stash,omitempty"`
+	Unstash Unstash `json:"unstash,omitempty"`
 
-	Workspace *string `yaml:"workspace,omitempty"`
+	Workspace *string `json:"workspace,omitempty"`
 }
 
 // Step defines a single step, from the author's perspective, to be executed within a stage.
 type Step struct {
 	// One of command, step, or loop is required.
-	Command string `yaml:"command,omitempty"`
+	Command string `json:"command,omitempty"`
 	// args is optional, but only allowed with command
-	Arguments []string `yaml:"args,omitempty"`
+	Arguments []string `json:"args,omitempty"`
 	// dir is optional, but only allowed with command. Refers to subdirectory of workspace
-	Dir string `yaml:"dir,omitempty"`
+	Dir string `json:"dir,omitempty"`
 
-	Step string `yaml:"step,omitempty"`
+	Step string `json:"step,omitempty"`
 	// options is optional, but only allowed with step
 	// Also, we'll need to do some magic to do type verification during translation - i.e., this step wants a number
 	// for this option, so translate the string value for that option to a number.
-	Options map[string]string `yaml:"options,omitempty"`
+	Options map[string]string `json:"options,omitempty"`
 
-	Loop Loop `yaml:"loop,omitempty"`
+	Loop Loop `json:"loop,omitempty"`
 
 	// agent can be overridden on a step
-	Agent Agent `yaml:"agent,omitempty"`
+	Agent Agent `json:"agent,omitempty"`
 
 	// Image alows the docker image for a step to be specified
-	Image string `yaml:"image,omitempty"`
+	Image string `json:"image,omitempty"`
 }
 
 // Loop is a special step that defines a variable, a list of possible values for that variable, and a set of steps to
@@ -150,24 +150,24 @@ type Step struct {
 // those steps.
 type Loop struct {
 	// The variable name.
-	Variable string `yaml:"variable"`
+	Variable string `json:"variable"`
 	// The list of values to iterate over
-	Values []string `yaml:"values"`
+	Values []string `json:"values"`
 	// The steps to run
-	Steps []Step `yaml:"steps"`
+	Steps []Step `json:"steps"`
 }
 
 // Stage is a unit of work in a pipeline, corresponding either to a Task or a set of Tasks to be run sequentially or in
 // parallel with common configuration.
 type Stage struct {
-	Name        string       `yaml:"name"`
-	Agent       Agent        `yaml:"agent,omitempty"`
-	Options     StageOptions `yaml:"options,omitempty"`
-	Environment []EnvVar     `yaml:"environment,omitempty"`
-	Steps       []Step       `yaml:"steps,omitempty"`
-	Stages      []Stage      `yaml:"stages,omitempty"`
-	Parallel    []Stage      `yaml:"parallel,omitempty"`
-	Post        []Post       `yaml:"post,omitempty"`
+	Name        string       `json:"name"`
+	Agent       Agent        `json:"agent,omitempty"`
+	Options     StageOptions `json:"options,omitempty"`
+	Environment []EnvVar     `json:"environment,omitempty"`
+	Steps       []Step       `json:"steps,omitempty"`
+	Stages      []Stage      `json:"stages,omitempty"`
+	Parallel    []Stage      `json:"parallel,omitempty"`
+	Post        []Post       `json:"post,omitempty"`
 }
 
 // PostCondition is used to specify under what condition a post action should be executed.
@@ -185,17 +185,17 @@ var allPostConditions = []PostCondition{PostConditionAlways, PostConditionSucces
 // Post contains a PostCondition and one more actions to be executed after a pipeline or stage if the condition is met.
 type Post struct {
 	// TODO: Conditional execution of something after a Task or Pipeline completes is not yet implemented
-	Condition PostCondition `yaml:"condition"`
-	Actions   []PostAction  `yaml:"actions"`
+	Condition PostCondition `json:"condition"`
+	Actions   []PostAction  `json:"actions"`
 }
 
 // PostAction contains the name of a built-in post action and options to pass to that action.
 type PostAction struct {
 	// TODO: Notifications are not yet supported in Build Pipeline per se.
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 	// Also, we'll need to do some magic to do type verification during translation - i.e., this action wants a number
 	// for this option, so translate the string value for that option to a number.
-	Options map[string]string `yaml:"options,omitempty"`
+	Options map[string]string `json:"options,omitempty"`
 }
 
 var _ apis.Validatable = (*ParsedPipeline)(nil)

--- a/pkg/tekton/syntax/test_data/loop_step/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/loop_step/jenkins-x.yml
@@ -35,7 +35,7 @@ pipelineConfig:
                             args:
                               - running
                               - ${LANGUAGE}
-                              - on
+                              - "on"
                               - ${DISTRO}
               - command: echo
                 args:

--- a/pkg/version/version_data.go
+++ b/pkg/version/version_data.go
@@ -5,7 +5,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
+
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -42,9 +43,9 @@ var (
 
 // StableVersion stores the stable version information
 type StableVersion struct {
-	Version string `yaml:"version,omitempty"`
-	GitURL  string `yaml:"gitUrl,omitempty"`
-	URL     string `yaml:"url,omitempty"`
+	Version string `json:"version,omitempty"`
+	GitURL  string `json:"gitUrl,omitempty"`
+	URL     string `json:"url,omitempty"`
 }
 
 // LoadStableVersion loads the stable version data from the version configuration directory returning an empty object if there is


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This will let us incorporate k8s and Tekton types directly into
jenkins-x.yml - previously, we'd have trouble with that due to the use
of JSON struct tags in k8s/Tekton/etc, so that the default golang YAML
library would not unmarshal correctly.

This did require changing `loop_step/jenkins-x.yml` - a bare `- on` as
part of a string slice (or `foo: on` for a string field) would end up
unmarshalling as the string `true`, so yeah, `on`, `off`, `t`, `f`,
etc do need to be quoted if they're supposed to result in strings now.

(this will make https://github.com/jenkins-x/jx/issues/3312 and https://github.com/jenkins-x/jx/issues/3366 easier to implement)

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a