### PR TITLE
NotExecuted is not a failure

### DIFF
--- a/pkg/apis/jenkins.io/v1/types_pipeline.go
+++ b/pkg/apis/jenkins.io/v1/types_pipeline.go
@@ -169,6 +169,8 @@ const (
 	ActivityStatusTypeError ActivityStatusType = "Error"
 	// ActivityStatusTypeAborted if the workflow was aborted
 	ActivityStatusTypeAborted ActivityStatusType = "Aborted"
+	// ActivityStatusTypeNotExecuted if the workflow was not executed
+	ActivityStatusTypeNotExecuted ActivityStatusType = "NotExecuted"
 )
 
 type Attachment struct {

--- a/pkg/jx/cmd/controller_build.go
+++ b/pkg/jx/cmd/controller_build.go
@@ -511,7 +511,10 @@ func (o *ControllerBuildOptions) updatePipelineActivityForRun(kubeClient kuberne
 				}
 			}
 			if stageFinished {
-				if stage.Status != v1.ActivityStatusTypeSucceeded {
+				switch stage.Status {
+				case v1.ActivityStatusTypeSucceeded, v1.ActivityStatusTypeNotExecuted:
+					// stage did not fail
+				default:
 					failed = true
 				}
 			} else {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Skipped pipeline steps have a status of `NotExecuted` which should not result in a `PipelineActivity` being marked as `Failed`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #3175