### PR TITLE
Eksctl version should not be hardcoded

### DIFF
--- a/pkg/binaries/binaries.go
+++ b/pkg/binaries/binaries.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const EksctlVersion = "0.1.19"
 const IBMCloudVersion = "0.10.1"
 const HeptioAuthenticatorAwsVersion = "1.10.3"
 const KubectlVersion = "1.13.2"
@@ -96,7 +95,16 @@ func LoadInstalledPackages() (map[string]string, error) {
 	return map[string]string{}, nil
 }
 
+// RememberInstalledPackage writes the version of package into local file system. This allows to identify
+// what version of package is currently installed in ~/.jx/bin .
 func RememberInstalledPackage(packageName string, version string) error {
+	if packageName == "" {
+		return errors.New("package name cannot be empty")
+	}
+	if version == "" {
+		return errors.New("package version cannot be empty")
+	}
+
 	versions, err := LoadInstalledPackages()
 	if err != nil {
 		return err

--- a/pkg/jx/cmd/common_install.go
+++ b/pkg/jx/cmd/common_install.go
@@ -1237,7 +1237,7 @@ func (o *CommonOptions) installAws() error {
 }
 
 func (o *CommonOptions) installEksCtl(skipPathScan bool) error {
-	return o.installEksCtlWithVersion(binaries.EksctlVersion, skipPathScan)
+	return o.installEksCtlWithVersion("", skipPathScan)
 }
 
 func (o *CommonOptions) installEksCtlWithVersion(version string, skipPathScan bool) error {


### PR DESCRIPTION
Now when we have ekctl version defined in external repository (https://github.com/jenkins-x/jenkins-x-versions/blob/master/packages/eksctl.yml) we can remove static version.

Also added some extra code comments and parameter checks.