### PR TITLE
jx get lang command

### DIFF
--- a/pkg/jx/cmd/get.go
+++ b/pkg/jx/cmd/get.go
@@ -79,6 +79,7 @@ func NewCmdGet(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.AddCommand(NewCmdGetIssue(commonOpts))
 	cmd.AddCommand(NewCmdGetIssues(commonOpts))
 	cmd.AddCommand(NewCmdGetLimits(commonOpts))
+	cmd.AddCommand(NewCmdGetLang(commonOpts))
 	cmd.AddCommand(NewCmdGetPipeline(commonOpts))
 	cmd.AddCommand(NewCmdGetPostPreviewJob(commonOpts))
 	cmd.AddCommand(NewCmdGetPreview(commonOpts))

--- a/pkg/jx/cmd/get_lang.go
+++ b/pkg/jx/cmd/get_lang.go
@@ -9,7 +9,7 @@ import (
 	"os"
 )
 
-// GetUserOptions containers the CLI options
+// GetLangOptions containers the CLI options
 type GetLangOptions struct {
 	GetOptions
 	StepOptions opts.StepOptions

--- a/pkg/jx/cmd/get_lang.go
+++ b/pkg/jx/cmd/get_lang.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// GetUserOptions containers the CLI options
+type GetLangOptions struct {
+	GetOptions
+	StepOptions opts.StepOptions
+
+	Pending bool
+}
+
+var (
+	getPackLong = templates.LongDesc(`
+		Display the pack of the current directory
+`)
+
+	getPackExample = templates.Examples(`
+		# Print the lang
+		jx get lang
+	`)
+)
+
+// NewCmdGetLang creates the new command for: jx get env
+func NewCmdGetLang(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := &GetLangOptions{
+		GetOptions: GetOptions{
+			CommonOptions: commonOpts,
+		},
+		StepOptions: opts.StepOptions{
+			CommonOptions: commonOpts,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:     "lang",
+		Short:   "Display the pack of the current working directory",
+		Aliases: []string{"lang"},
+		Long:    getPackLong,
+		Example: getPackExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+
+	options.addGetFlags(cmd)
+	return cmd
+}
+
+// Run implements this command
+func (o *GetLangOptions) Run() error {
+	dir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	projectConfig, _, err := config.LoadProjectConfig(dir)
+
+	//args := &opts.InvokeDraftPack{
+	//	Dir:                dir,
+	//	CustomDraftPack:    "",
+	//	DisableAddFiles:    true,
+	//	UseNextGenPipeline: false,
+	//}
+	_, err = o.StepOptions.DiscoverBuildPack(dir, projectConfig, "")
+	//_, err = o.InvokeDraftPack(args)
+	return err
+}


### PR DESCRIPTION
A utility option to determine what pack would be used if you were to `jx import` the current working directory

#### Examples:

<details>
    <summary>Error</summary>


```
SmithBen2289:dev benjaminsmith$ mkdir empty
SmithBen2289:dev benjaminsmith$ cd empty/
SmithBen2289:empty benjaminsmith$ /Users/benjaminsmith/dev/jx/build/jx get lang
error: failed to discover task pack in dir /Users/benjaminsmith/dev/dst/postgres-db/empty: there was an error detecting the language
SmithBen2289:empty benjaminsmith$ 
```

</details>


<details>
    <summary>Success</summary>


```
SmithBen2289:flask benjaminsmith$ ls
performing pack detection in folder /Users/benjaminsmith/dev/quickstart/flask
--> Draft detected Python (47.904483%)
selected pack: /Users/benjaminsmith/.jx/draft/packs/github.com/jenkins-x-buildpacks/jenkins-x-kubernetes/packs/python

```

</details>

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
This is useful when building custom build packs or a ui for your quickstarts. you'll be able to inform the user that 
"the directory (or uploaded project etc.) has been detected to be a **XXX** type project, is this correct?" if yes -> import, if no -> add `--pack="SomeUserInput"` option

#### Special notes for the reviewer(s)
I think this can be cleaned up a little as I recycled code from different functions throughout the jx project. 

