### PR TITLE
feat: Add urltemplate option to install and upgrade ingress

### DIFF
--- a/pkg/config/helm_values.go
+++ b/pkg/config/helm_values.go
@@ -22,7 +22,7 @@ type ExposeController struct {
 
 type JenkinsValuesConfig struct {
 	Servers JenkinsServersValuesConfig `json:"Servers,omitempty"`
-	Enabled *bool                      `json:"enabled"`
+	Enabled *bool                      `json:"enabled,omitempty"`
 }
 
 type ProwValuesConfig struct {
@@ -58,7 +58,7 @@ type JenkinsPipelineSecretsValuesConfig struct {
 
 // ControllerBuildConfig to configure the build controller
 type ControllerBuildConfig struct {
-	Enabled *bool `json:"enabled"`
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 type HelmValuesConfig struct {

--- a/pkg/expose/exposecontroller.go
+++ b/pkg/expose/exposecontroller.go
@@ -90,6 +90,7 @@ func RunExposecontroller(devNamespace, targetNamespace string, ic kube.IngressCo
 		"config.exposer=" + ic.Exposer,
 		"config.domain=" + ic.Domain,
 		"config.tlsacme=" + strconv.FormatBool(ic.TLS),
+		"config.urltemplate=" + ic.UrlTemplate,
 	}
 
 	if !ic.TLS && ic.Issuer != "" {

--- a/pkg/jx/cmd/upgrade_ingress.go
+++ b/pkg/jx/cmd/upgrade_ingress.go
@@ -502,6 +502,10 @@ func (o *UpgradeIngressOptions) confirmExposecontrollerConfig() error {
 				}
 			}
 		}
+		o.IngressConfig.UrlTemplate, err = util.PickValue("UrlTemplate:", o.IngressConfig.UrlTemplate, true, "", o.In, o.Out, o.Err)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Adds `urltemplate` option to install and upgrade ingress. This allows the caller to specify `--exposecontroller-urltemplate` option during the install process with commands such as
```
$ jx install --provider=gke \
--git-username=my-bot-user \
--git-api-token=my-bot-token \
--default-admin-password=myPW \
--no-default-environments=true \
--git-private=true \
--no-tiller=false \
--domain=my-domain \
--exposecontroller-urltemplate="\"{{.Service}}-{{.Namespace}}.{{.Domain}}"\"
```

Then running `jx upgrade ingress` will use the same `urltemplate`

#### Special notes for the reviewer(s)

@jstrachan / @rawlingsj - discussed indirectly on the slack channels https://kubernetes.slack.com/archives/C9MBGQJRH/p1553108179054500?thread_ts=1553073542.008000&cid=C9MBGQJRH and https://kubernetes.slack.com/archives/C9LTHT2BB/p1553507621379200 

#### Which issue this PR fixes

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
