### PR TITLE
feat: Allow specifying container configuration in pipeline YAML

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c
 	github.com/hpcloud/tail v1.0.0
 	github.com/iancoleman/orderedmap v0.0.0-20181121102841-22c6ecc9fe13
+	github.com/imdario/mergo v0.3.6
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jbrukh/bayesian v0.0.0-20161210175230-bf3f261f9a9c // indirect
 	github.com/jefferai/jsonx v1.0.0 // indirect

--- a/pkg/jx/cmd/step_create_task_test.go
+++ b/pkg/jx/cmd/step_create_task_test.go
@@ -11,6 +11,7 @@ import (
 	gits_test "github.com/jenkins-x/jx/pkg/gits/mocks"
 	helm_test "github.com/jenkins-x/jx/pkg/helm/mocks"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/knative/pkg/kmp"
 	uuid "github.com/satori/go.uuid"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -167,7 +168,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 				if d := cmp.Diff(tekton_helpers_test.AssertLoadPipeline(t, caseDir), pipeline); d != "" {
 					t.Errorf("Generated Pipeline did not match expected: %s", d)
 				}
-				if d := cmp.Diff(tekton_helpers_test.AssertLoadTasks(t, caseDir), taskList, cmpopts.IgnoreFields(corev1.ResourceRequirements{}, "Requests")); d != "" {
+				if d, _ := kmp.SafeDiff(tekton_helpers_test.AssertLoadTasks(t, caseDir), taskList, cmpopts.IgnoreFields(corev1.ResourceRequirements{}, "Requests")); d != "" {
 					t.Errorf("Generated Tasks did not match expected: %s", d)
 				}
 				if d := cmp.Diff(tekton_helpers_test.AssertLoadPipelineResources(t, caseDir), resourceList); d != "" {

--- a/pkg/jx/cmd/test_data/step_create_task/from_yaml/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/from_yaml/tasks.yml
@@ -47,8 +47,8 @@ items:
       name: step2
       resources:
         requests:
-          cpu: 400m
-          memory: 512Mi
+          cpu: 0.1
+          memory: 64Mi
       securityContext:
         privileged: true
       volumeMounts:
@@ -90,8 +90,8 @@ items:
       name: step3
       resources:
         requests:
-          cpu: 400m
-          memory: 512Mi
+          cpu: 0.1
+          memory: 64Mi
       securityContext:
         privileged: true
       volumeMounts:
@@ -168,8 +168,11 @@ items:
       name: step2
       resources:
         requests:
-          cpu: 400m
-          memory: 512Mi
+          cpu: 0.1
+          memory: 64Mi
+        limits:
+          cpu: 0.4
+          memory: 256Mi
       securityContext:
         privileged: true
       volumeMounts:

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -461,6 +461,45 @@ func validateRootOptions(o RootOptions) *apis.FieldError {
 				Paths:   []string{"retry"},
 			}
 		}
+
+		return validateContainerOptions(o.ContainerOptions).ViaField("containerOptions")
+	}
+
+	return nil
+}
+
+func validateContainerOptions(c *corev1.Container) *apis.FieldError {
+	if c != nil {
+		if len(c.Command) != 0 {
+			return &apis.FieldError{
+				Message: "Command cannot be specified in containerOptions",
+				Paths:   []string{"command"},
+			}
+		}
+		if len(c.Args) != 0 {
+			return &apis.FieldError{
+				Message: "Arguments cannot be specified in containerOptions",
+				Paths:   []string{"args"},
+			}
+		}
+		if c.Image != "" {
+			return &apis.FieldError{
+				Message: "Image cannot be specified in containerOptions",
+				Paths:   []string{"image"},
+			}
+		}
+		if c.WorkingDir != "" {
+			return &apis.FieldError{
+				Message: "WorkingDir cannot be specified in containerOptions",
+				Paths:   []string{"workingDir"},
+			}
+		}
+		if len(c.VolumeMounts) != 0 {
+			return &apis.FieldError{
+				Message: "VolumeMounts cannot be specified in containerOptions",
+				Paths:   []string{"volumeMounts"},
+			}
+		}
 	}
 
 	return nil

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -1278,6 +1278,13 @@ func TestFailedValidation(t *testing.T) {
 			name:          "loop_without_values",
 			expectedError: apis.ErrMissingField("values").ViaField("loop").ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
 		},
+		{
+			name: "top_level_container_options_with_command",
+			expectedError: (&apis.FieldError{
+				Message: "Command cannot be specified in containerOptions",
+				Paths:   []string{"command"},
+			}).ViaField("containerOptions").ViaField("options"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tekton/syntax/test_data/container_options_env_merge/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/container_options_env_merge/jenkins-x.yml
@@ -1,0 +1,37 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        options:
+          containerOptions:
+            env:
+              - name: SOME_VAR
+                value: A value for the env var
+              - name: OVERRIDE_ENV
+                value: Original value
+              - name: OVERRIDE_STAGE_ENV
+                value: Original value
+        environment:
+          - name: SOME_OTHER_VAR
+            value: A value for the other env var
+          - name: OVERRIDE_ENV
+            value: New value
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            options:
+              containerOptions:
+                env:
+                  - name: ANOTHER_OVERRIDE_STAGE_ENV
+                    value: Original value
+            environment:
+              - name: OVERRIDE_STAGE_ENV
+                value: New value
+              - name: ANOTHER_OVERRIDE_STAGE_ENV
+                value: New value
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world

--- a/pkg/tekton/syntax/test_data/merge_container_options/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/merge_container_options/jenkins-x.yml
@@ -1,7 +1,4 @@
 pipelineConfig:
-  env:
-    - name: FRUIT
-      value: BANANA
   pipelines:
     release:
       pipeline:
@@ -12,21 +9,14 @@ pipelineConfig:
                 cpu: 0.1
                 memory: 64Mi
         agent:
-          image: nodejs
+          image: some-image
         stages:
-          - name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+          - name: A Working Stage
             steps:
               - command: echo
                 args:
-                  - hello world
-              - command: ls
-                args:
-                  - -la
-          - name: Second
-            steps:
-              - command: echo
-                args:
-                  - hi ${FRUIT}
+                  - hello
+                  - world
             options:
               containerOptions:
                 resources:

--- a/pkg/tekton/syntax/test_data/stage_level_container_options/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/stage_level_container_options/jenkins-x.yml
@@ -1,0 +1,22 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+            options:
+              containerOptions:
+                resources:
+                  limits:
+                    cpu: 0.2
+                    memory: 128Mi
+                  requests:
+                    cpu: 0.1
+                    memory: 64Mi

--- a/pkg/tekton/syntax/test_data/stage_overrides_top_level_container_options/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/stage_overrides_top_level_container_options/jenkins-x.yml
@@ -1,35 +1,31 @@
 pipelineConfig:
-  env:
-    - name: FRUIT
-      value: BANANA
   pipelines:
     release:
       pipeline:
         options:
           containerOptions:
             resources:
+              limits:
+                cpu: 0.2
+                memory: 128Mi
               requests:
                 cpu: 0.1
                 memory: 64Mi
         agent:
-          image: nodejs
+          image: some-image
         stages:
-          - name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+          - name: A Working Stage
             steps:
               - command: echo
                 args:
-                  - hello world
-              - command: ls
-                args:
-                  - -la
-          - name: Second
-            steps:
-              - command: echo
-                args:
-                  - hi ${FRUIT}
+                  - hello
+                  - world
             options:
               containerOptions:
                 resources:
                   limits:
                     cpu: 0.4
                     memory: 256Mi
+                  requests:
+                    cpu: 0.2
+                    memory: 128Mi

--- a/pkg/tekton/syntax/test_data/top_level_container_options/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/top_level_container_options/jenkins-x.yml
@@ -1,0 +1,22 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 0.2
+                memory: 128Mi
+              requests:
+                cpu: 0.1
+                memory: 64Mi
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world

--- a/pkg/tekton/syntax/test_data/validation_failures/top_level_container_options_with_command/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/top_level_container_options_with_command/jenkins-x.yml
@@ -1,0 +1,17 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        options:
+          containerOptions:
+            command:
+              - invalid
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Adds a new `containerOptions` to both `pipeline` and `stage`
`options`, which takes a `Container`. All steps underneath that
context then start with that `Container`'s configuration, with
`pipeline` configuration merged into `stage` configuration (and parent
`stage` merged into child `stage`).

Down the road, we may choose to add this for steps as well, but let's
see if what this adds is sufficient first.

#### Special notes for the reviewer(s)

/assign @rawlingsj 
/assign @warrenbailey 
/assign @jstrachan 
/assign @dwnusbaum 
cc @kshultzCB @joseblas 

#### Which issue this PR fixes

Fixes #3312, #3366
