### PR TITLE
expose the defaultRole option in the Cloudbees addon

### DIFF
--- a/pkg/jx/cmd/create_addon_cloudbees.go
+++ b/pkg/jx/cmd/create_addon_cloudbees.go
@@ -45,9 +45,10 @@ var (
 // CreateAddonCloudBeesOptions the options for the create spring command
 type CreateAddonCloudBeesOptions struct {
 	CreateAddonOptions
-	Sso      bool
-	Basic    bool
-	Password string
+	Sso         bool
+	DefaultRole string
+	Basic       bool
+	Password    string
 }
 
 // NewCmdCreateAddonCloudBees creates a command object for the "create" command
@@ -75,6 +76,7 @@ func NewCmdCreateAddonCloudBees(commonOpts *CommonOptions) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&options.Sso, "sso", "", false, "Enable single sign-on")
+	cmd.Flags().StringVarP(&options.DefaultRole, "default-role", "", "", "The default role to apply to new users. Defaults to no role and applies to the admin namespace only")
 	cmd.Flags().BoolVarP(&options.Basic, "basic", "", false, "Enable basic auth")
 	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "Password to access UI when using basic auth.  Defaults to default Jenkins X admin password.")
 	options.addFlags(cmd, defaultCloudBeesNamespace, defaultCloudBeesReleaseName, defaultCloudBeesVersion)
@@ -86,6 +88,9 @@ func (o *CreateAddonCloudBeesOptions) Run() error {
 
 	if o.Sso == false && o.Basic == false {
 		return fmt.Errorf("please use --sso or --basic flag")
+	}
+	if o.Sso == false && o.DefaultRole != "" {
+		return fmt.Errorf("--default-role can not be used in conjunction with --basic flag")
 	}
 
 	surveyOpts := survey.WithStdio(o.In, o.Out, o.Err)
@@ -177,6 +182,13 @@ To register to get your username/password to to: %s
 			o.SetValues = o.SetValues + "," + strings.Join(values, ",")
 		} else {
 			o.SetValues = strings.Join(values, ",")
+		}
+		if o.DefaultRole != "" {
+			if len(o.SetValues) > 0 {
+				o.SetValues = o.SetValues + "," + "defaultRole=" + o.DefaultRole
+			} else {
+				o.SetValues = "defaultRole=" + o.DefaultRole
+			}
 		}
 	} else {
 		// Disable SSO for basic auth


### PR DESCRIPTION
the CloudBees addon can create users with a default role assigned.

This is useful for some projects like Jenkins-X who want all users to be
able to sign on and see the build result of pull-requests (and even
smaller companies that only have one team where everyone should have
committer type access.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
