### PR TITLE
fix: Use login not CRD name / Remove roles from deleted user

### DIFF
--- a/pkg/jx/cmd/get_user.go
+++ b/pkg/jx/cmd/get_user.go
@@ -79,12 +79,11 @@ There are no Users yet. Try create one via: jx create user
 		if user != nil {
 			spec := &user.Spec
 			userKind := user.SubjectKind()
-			userName := user.Name
-			roleNames, err := kube.GetUserRoles(jxClient, ns, userKind, userName)
+			roleNames, err := kube.GetUserRoles(jxClient, ns, userKind, name)
 			if err != nil {
-				log.Warnf("Failed to find User roles in namespace %s for User %s kind %s: %s\n", ns, userName, userKind, err)
+				log.Warnf("Failed to find User roles in namespace %s for User %s kind %s: %s\n", ns, name, userKind, err)
 			}
-			table.AddRow(userName, spec.Name, spec.Email, spec.URL, strings.Join(roleNames, ", "))
+			table.AddRow(name, spec.Name, spec.Email, spec.URL, strings.Join(roleNames, ", "))
 		}
 	}
 	table.Render()

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -22,7 +22,10 @@ func GetUsers(jxClient versioned.Interface, ns string) (map[string]*jenkinsv1.Us
 		return m, names, err
 	}
 	for _, user := range userList.Items {
-		n := user.Name
+		n := user.Spec.Login
+		if n == "" {
+			n = user.Name
+		}
 		copy := user
 		m[n] = &copy
 		if n != "" {
@@ -68,10 +71,11 @@ func AddAccountReference(user *jenkinsv1.User, gitProviderKey string, id string)
 
 // DeleteUser deletes the user resource but does not uninstall the underlying namespaces
 func DeleteUser(jxClient versioned.Interface, ns string, userName string) error {
+	id := kube.ToValidName(userName)
 	userInterface := jxClient.JenkinsV1().Users(ns)
-	_, err := userInterface.Get(userName, metav1.GetOptions{})
+	_, err := userInterface.Get(id, metav1.GetOptions{})
 	if err == nil {
-		err = userInterface.Delete(userName, nil)
+		err = userInterface.Delete(id, nil)
 	}
 	return err
 }


### PR DESCRIPTION
CRD name needs to be valid k8s identifier (which is handled in users.CreateUser),
but the other user commands didn't support if CRD Name was different from Login.

Also fixed removal of roles for deleted user. The old code seemed unfinished.

A case that will be common for having logins that are illegal names in k8s is when using aws-iam-authenticator configured to map all users in an AWS account to users in the cluster. Then authenticated name of the user becomes the AWS ARN of the user, so something like `arn:aws:iam::123456789012:user/Bob`.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
