### PR TITLE
fix(tekton) make pipelines and tasks unique per-build

### DIFF
--- a/pkg/jx/cmd/step_create_task_test.go
+++ b/pkg/jx/cmd/step_create_task_test.go
@@ -136,6 +136,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 						ServiceAccount: "tekton-bot",
 					},
 				},
+				BuildNumber: "1",
 			}
 			cmd.ConfigureTestOptionsWithResources(createTask.CommonOptions, k8sObjects, jxObjects, gits_test.NewMockGitter(), fakeGitProvider, helm_test.NewMockHelmer(), nil)
 

--- a/pkg/jx/cmd/test_data/step_create_task/from_yaml/pipeline.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/from_yaml/pipeline.yml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1alpha1
 kind: Pipeline
 metadata:
   creationTimestamp: null
-  name: abayer-js-test-repo-really-long
+  name: abayer-js-test-repo-really-long-1
   namespace: jx
 spec:
   params: []
@@ -19,7 +19,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-name
+      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
   - name: second
     resources:
       inputs:
@@ -33,5 +33,5 @@ spec:
     runAfter:
       - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second
+      name: abayer-js-test-repo-really-long-second-1
 status: {}

--- a/pkg/jx/cmd/test_data/step_create_task/from_yaml/pipelinerun.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/from_yaml/pipelinerun.yml
@@ -6,13 +6,13 @@ metadata:
     branch: really-long
     owner: abayer
     repo: js-test-repo
-  name: abayer-js-test-repo-really-long
+  name: abayer-js-test-repo-really-long-1
 spec:
   Status: ""
   params: null
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/jx/cmd/test_data/step_create_task/from_yaml/structure.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/from_yaml/structure.yml
@@ -1,13 +1,13 @@
 metadata:
   creationTimestamp: null
-  name: abayer-js-test-repo-really-long
+  name: abayer-js-test-repo-really-long-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-name
+  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second
+  taskRef: abayer-js-test-repo-really-long-second-1

--- a/pkg/jx/cmd/test_data/step_create_task/from_yaml/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/from_yaml/tasks.yml
@@ -5,7 +5,7 @@ items:
     creationTimestamp: null
     labels:
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-name
+    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
   spec:
     inputs:
@@ -44,6 +44,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -104,6 +106,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -160,7 +164,7 @@ items:
     creationTimestamp: null
     labels:
       jenkins.io/task-stage-name: second
-    name: abayer-js-test-repo-really-long-second
+    name: abayer-js-test-repo-really-long-second-1
     namespace: jx
   spec:
     inputs:
@@ -199,6 +203,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER

--- a/pkg/jx/cmd/test_data/step_create_task/js_build_pack/pipeline.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/js_build_pack/pipeline.yml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1alpha1
 kind: Pipeline
 metadata:
   creationTimestamp: null
-  name: abayer-js-test-repo-build-pack
+  name: abayer-js-test-repo-build-pack-1
   namespace: jx
 spec:
   params: []
@@ -19,5 +19,5 @@ spec:
         - name: workspace
           resource: abayer-js-test-repo-build-pack
     taskRef:
-      name: abayer-js-test-repo-build-pack-from-build-pack
+      name: abayer-js-test-repo-build-pack-from-build-pack-1
 status: {}

--- a/pkg/jx/cmd/test_data/step_create_task/js_build_pack/pipelinerun.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/js_build_pack/pipelinerun.yml
@@ -6,13 +6,13 @@ metadata:
     branch: build-pack
     owner: abayer
     repo: js-test-repo
-  name: abayer-js-test-repo-build-pack
+  name: abayer-js-test-repo-build-pack-1
 spec:
   Status: ""
   params: null
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-build-pack
+    name: abayer-js-test-repo-build-pack-1
   resources:
   - name: abayer-js-test-repo-build-pack
     resourceRef:

--- a/pkg/jx/cmd/test_data/step_create_task/js_build_pack/structure.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/js_build_pack/structure.yml
@@ -1,9 +1,9 @@
 metadata:
   creationTimestamp: null
-  name: abayer-js-test-repo-build-pack
+  name: abayer-js-test-repo-build-pack-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-js-test-repo-build-pack-from-build-pack
+  taskRef: abayer-js-test-repo-build-pack-from-build-pack-1

--- a/pkg/jx/cmd/test_data/step_create_task/js_build_pack/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/js_build_pack/tasks.yml
@@ -5,7 +5,7 @@ items:
     creationTimestamp: null
     labels:
       jenkins.io/task-stage-name: from-build-pack
-    name: abayer-js-test-repo-build-pack-from-build-pack
+    name: abayer-js-test-repo-build-pack-from-build-pack-1
     namespace: jx
   spec:
     inputs:
@@ -44,6 +44,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -102,6 +104,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -160,6 +164,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -218,6 +224,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -276,6 +284,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -334,6 +344,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -392,6 +404,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -450,6 +464,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -508,6 +524,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -566,6 +584,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER

--- a/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/pipeline.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/pipeline.yml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1alpha1
 kind: Pipeline
 metadata:
   creationTimestamp: null
-  name: abayer-jx-demo-qs-master
+  name: abayer-jx-demo-qs-master-1
   namespace: jx
 spec:
   params: []
@@ -19,5 +19,5 @@ spec:
       - name: workspace
         resource: abayer-jx-demo-qs-master
     taskRef:
-      name: abayer-jx-demo-qs-master-from-build-pack
+      name: abayer-jx-demo-qs-master-from-build-pack-1
 status: {}

--- a/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/pipelinerun.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/pipelinerun.yml
@@ -6,13 +6,13 @@ metadata:
     branch: master
     owner: abayer
     repo: jx-demo-qs
-  name: abayer-jx-demo-qs-master
+  name: abayer-jx-demo-qs-master-1
 spec:
   Status: ""
   params: null
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-1
   resources:
   - name: abayer-jx-demo-qs-master
     resourceRef:

--- a/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/structure.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/structure.yml
@@ -1,9 +1,9 @@
 metadata:
   creationTimestamp: null
-  name: abayer-jx-demo-qs-master
+  name: abayer-jx-demo-qs-master-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master-from-build-pack
+  taskRef: abayer-jx-demo-qs-master-from-build-pack-1

--- a/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/tasks.yml
@@ -5,7 +5,7 @@ items:
     creationTimestamp: null
     labels:
       jenkins.io/task-stage-name: from-build-pack
-    name: abayer-jx-demo-qs-master-from-build-pack
+    name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx
   spec:
     inputs:
@@ -48,6 +48,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -116,6 +118,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -184,6 +188,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -252,6 +258,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -320,6 +328,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -388,6 +398,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -456,6 +468,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -524,6 +538,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -592,6 +608,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -660,6 +678,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -728,6 +748,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER

--- a/pkg/tekton/constants.go
+++ b/pkg/tekton/constants.go
@@ -1,6 +1,6 @@
 package tekton
 
 const (
-	// LastBuildNumberAnnotation used to annotate the Pipeline with the latest build number
-	LastBuildNumberAnnotation = "jenkins.io/last-build-number"
+	// LastBuildNumberAnnotationPrefix used to annotate SourceRepository with the latest build number for a branch
+	LastBuildNumberAnnotationPrefix = "jenkins.io/last-build-number-for-"
 )

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -46,13 +46,13 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -61,8 +61,8 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world"), workingDir("/workspace/workspace")),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1")),
 			),
 		},
 		{
@@ -79,33 +79,33 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						StepCmd("echo"),
 						StepArg("again"))),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
-				tb.PipelineTask("another-stage", "somepipeline-another-stage",
+				tb.PipelineTask("another-stage", "somepipeline-another-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline",
 						tb.From("a-working-stage")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("a-working-stage")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"), tb.TaskSpec(
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace"))),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-another-stage", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
+				tb.Task("somepipeline-another-stage-1", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)), tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("again"), workingDir("/workspace/workspace")),
 				)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage")),
-				StructureStage("Another stage", StructureStageTaskRef("somepipeline-another-stage"),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1")),
+				StructureStage("Another stage", StructureStageTaskRef("somepipeline-another-stage-1"),
 					StructureStagePrevious("A Working Stage")),
 			),
 		},
@@ -120,38 +120,38 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						StageStep(StepCmd("echo"), StepArg("again"))),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
-				tb.PipelineTask("another-stage", "somepipeline-another-stage",
+				tb.PipelineTask("another-stage", "somepipeline-another-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline",
 						tb.From("a-working-stage")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("a-working-stage")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit, tb.ResourceTargetPath("workspace"))),
 						tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 						tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world"), workingDir("/workspace/workspace")),
 					)),
-				tb.Task("somepipeline-another-stage", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
+				tb.Task("somepipeline-another-stage-1", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("again"), workingDir("/workspace/workspace")),
 				)),
 			},
-			structure: PipelineStructure("somepipeline",
+			structure: PipelineStructure("somepipeline-1",
 				StructureStage("Parent Stage",
 					StructureStageStages("A Working Stage", "Another stage")),
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage"),
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1"),
 					StructureStageDepth(1),
 					StructureStageParent("Parent Stage")),
-				StructureStage("Another stage", StructureStageTaskRef("somepipeline-another-stage"),
+				StructureStage("Another stage", StructureStageTaskRef("somepipeline-another-stage-1"),
 					StructureStageDepth(1),
 					StructureStageParent("Parent Stage"),
 					StructureStagePrevious("A Working Stage")),
@@ -172,65 +172,65 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				PipelineStage("Last Stage",
 					StageStep(StepCmd("echo"), StepArg("last"))),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("first-stage", "somepipeline-first-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("first-stage", "somepipeline-first-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline", tb.From("first-stage")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("first-stage")),
-				tb.PipelineTask("another-stage", "somepipeline-another-stage",
+				tb.PipelineTask("another-stage", "somepipeline-another-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline",
 						tb.From("first-stage")), tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("first-stage")),
-				tb.PipelineTask("last-stage", "somepipeline-last-stage",
+				tb.PipelineTask("last-stage", "somepipeline-last-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline", tb.From("first-stage")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("a-working-stage", "another-stage")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-first-stage", "jx", TaskStageLabel("First Stage"), tb.TaskSpec(
+				tb.Task("somepipeline-first-stage-1", "jx", TaskStageLabel("First Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace"))),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("first"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 						tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 						tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world"), workingDir("/workspace/workspace")),
 					)),
-				tb.Task("somepipeline-another-stage", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
+				tb.Task("somepipeline-another-stage-1", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("again"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-last-stage", "jx", TaskStageLabel("Last Stage"), tb.TaskSpec(
+				tb.Task("somepipeline-last-stage-1", "jx", TaskStageLabel("Last Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)), tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("last"), workingDir("/workspace/workspace")),
 				)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("First Stage", StructureStageTaskRef("somepipeline-first-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("First Stage", StructureStageTaskRef("somepipeline-first-stage-1")),
 				StructureStage("Parent Stage",
 					StructureStageParallel("A Working Stage", "Another stage"),
 					StructureStagePrevious("First Stage"),
 				),
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage"),
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1"),
 					StructureStageDepth(1),
 					StructureStageParent("Parent Stage"),
 				),
-				StructureStage("Another stage", StructureStageTaskRef("somepipeline-another-stage"),
+				StructureStage("Another stage", StructureStageTaskRef("somepipeline-another-stage-1"),
 					StructureStageDepth(1),
 					StructureStageParent("Parent Stage"),
 				),
-				StructureStage("Last Stage", StructureStageTaskRef("somepipeline-last-stage"),
+				StructureStage("Last Stage", StructureStageTaskRef("somepipeline-last-stage-1"),
 					StructureStagePrevious("Parent Stage")),
 			),
 		},
@@ -253,72 +253,72 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				PipelineStage("Last Stage",
 					StageStep(StepCmd("echo"), StepArg("last"))),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("first-stage", "somepipeline-first-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("first-stage", "somepipeline-first-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline",
 						tb.From("first-stage")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("first-stage")),
-				tb.PipelineTask("another-stage", "somepipeline-another-stage",
+				tb.PipelineTask("another-stage", "somepipeline-another-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline",
 						tb.From("first-stage")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("first-stage")),
-				tb.PipelineTask("some-other-stage", "somepipeline-some-other-stage",
+				tb.PipelineTask("some-other-stage", "somepipeline-some-other-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline",
 						tb.From("another-stage")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("another-stage")),
-				tb.PipelineTask("last-stage", "somepipeline-last-stage",
+				tb.PipelineTask("last-stage", "somepipeline-last-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline",
 						tb.From("first-stage")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("a-working-stage", "some-other-stage")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-first-stage", "jx", TaskStageLabel("First Stage"), tb.TaskSpec(
+				tb.Task("somepipeline-first-stage-1", "jx", TaskStageLabel("First Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace"))),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("first"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 						tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 						tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world"), workingDir("/workspace/workspace")),
 					)),
-				tb.Task("somepipeline-another-stage", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
+				tb.Task("somepipeline-another-stage-1", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("again"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-some-other-stage", "jx", TaskStageLabel("Some other stage"), tb.TaskSpec(
+				tb.Task("somepipeline-some-other-stage-1", "jx", TaskStageLabel("Some other stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("otherwise"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-last-stage", "jx", TaskStageLabel("Last Stage"), tb.TaskSpec(
+				tb.Task("somepipeline-last-stage-1", "jx", TaskStageLabel("Last Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("last"), workingDir("/workspace/workspace")),
 				)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("First Stage", StructureStageTaskRef("somepipeline-first-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("First Stage", StructureStageTaskRef("somepipeline-first-stage-1")),
 				StructureStage("Parent Stage",
 					StructureStageParallel("A Working Stage", "Nested In Parallel"),
 					StructureStagePrevious("First Stage"),
 				),
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage"),
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1"),
 					StructureStageDepth(1),
 					StructureStageParent("Parent Stage"),
 				),
@@ -327,16 +327,16 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StructureStageDepth(1),
 					StructureStageStages("Another stage", "Some other stage"),
 				),
-				StructureStage("Another stage", StructureStageTaskRef("somepipeline-another-stage"),
+				StructureStage("Another stage", StructureStageTaskRef("somepipeline-another-stage-1"),
 					StructureStageDepth(2),
 					StructureStageParent("Nested In Parallel"),
 				),
-				StructureStage("Some other stage", StructureStageTaskRef("somepipeline-some-other-stage"),
+				StructureStage("Some other stage", StructureStageTaskRef("somepipeline-some-other-stage-1"),
 					StructureStageDepth(2),
 					StructureStageParent("Nested In Parallel"),
 					StructureStagePrevious("Another stage"),
 				),
-				StructureStage("Last Stage", StructureStageTaskRef("somepipeline-last-stage"),
+				StructureStage("Last Stage", StructureStageTaskRef("somepipeline-last-stage-1"),
 					StructureStagePrevious("Parent Stage")),
 			),
 		},
@@ -366,55 +366,55 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("ls")),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("stage1", "somepipeline-stage1",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("stage1", "somepipeline-stage1-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
-				tb.PipelineTask("stage2", "somepipeline-stage2",
+				tb.PipelineTask("stage2", "somepipeline-stage2-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("stage1")),
-				tb.PipelineTask("stage3", "somepipeline-stage3",
+				tb.PipelineTask("stage3", "somepipeline-stage3-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline", tb.From("stage1")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("stage2")),
-				tb.PipelineTask("stage4", "somepipeline-stage4",
+				tb.PipelineTask("stage4", "somepipeline-stage4-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline", tb.From("stage2")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("stage3")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-stage1", "jx", TaskStageLabel("stage1"), tb.TaskSpec(
+				tb.Task("somepipeline-stage1-1", "jx", TaskStageLabel("stage1"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace"))),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage2", "jx", TaskStageLabel("stage2"), tb.TaskSpec(
+				tb.Task("somepipeline-stage2-1", "jx", TaskStageLabel("stage2"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage3", "jx", TaskStageLabel("stage3"), tb.TaskSpec(
+				tb.Task("somepipeline-stage3-1", "jx", TaskStageLabel("stage3"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage4", "jx", TaskStageLabel("stage4"), tb.TaskSpec(
+				tb.Task("somepipeline-stage4-1", "jx", TaskStageLabel("stage4"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("stage1", StructureStageTaskRef("somepipeline-stage1")),
-				StructureStage("stage2", StructureStageTaskRef("somepipeline-stage2"), StructureStagePrevious("stage1")),
-				StructureStage("stage3", StructureStageTaskRef("somepipeline-stage3"), StructureStagePrevious("stage2")),
-				StructureStage("stage4", StructureStageTaskRef("somepipeline-stage4"), StructureStagePrevious("stage3")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("stage1", StructureStageTaskRef("somepipeline-stage1-1")),
+				StructureStage("stage2", StructureStageTaskRef("somepipeline-stage2-1"), StructureStagePrevious("stage1")),
+				StructureStage("stage3", StructureStageTaskRef("somepipeline-stage3-1"), StructureStagePrevious("stage2")),
+				StructureStage("stage4", StructureStageTaskRef("somepipeline-stage4-1"), StructureStagePrevious("stage3")),
 			),
 		},
 		{
@@ -442,66 +442,66 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("stage1", "somepipeline-stage1",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("stage1", "somepipeline-stage1-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
-				tb.PipelineTask("stage3", "somepipeline-stage3",
+				tb.PipelineTask("stage3", "somepipeline-stage3-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("stage1")),
-				tb.PipelineTask("stage4", "somepipeline-stage4",
+				tb.PipelineTask("stage4", "somepipeline-stage4-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline",
 						tb.From("stage1")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("stage3")),
-				tb.PipelineTask("stage5", "somepipeline-stage5",
+				tb.PipelineTask("stage5", "somepipeline-stage5-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline",
 						tb.From("stage3")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter("stage4")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-stage1", "jx", TaskStageLabel("stage1"), tb.TaskSpec(
+				tb.Task("somepipeline-stage1-1", "jx", TaskStageLabel("stage1"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace"))),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage3", "jx", TaskStageLabel("stage3"), tb.TaskSpec(
+				tb.Task("somepipeline-stage3-1", "jx", TaskStageLabel("stage3"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage4", "jx", TaskStageLabel("stage4"), tb.TaskSpec(
+				tb.Task("somepipeline-stage4-1", "jx", TaskStageLabel("stage4"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-stage5", "jx", TaskStageLabel("stage5"), tb.TaskSpec(
+				tb.Task("somepipeline-stage5-1", "jx", TaskStageLabel("stage5"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("stage1", StructureStageTaskRef("somepipeline-stage1")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("stage1", StructureStageTaskRef("somepipeline-stage1-1")),
 				StructureStage("stage2",
 					StructureStagePrevious("stage1"),
 					StructureStageStages("stage3", "stage4", "stage5"),
 				),
-				StructureStage("stage3", StructureStageTaskRef("somepipeline-stage3"),
+				StructureStage("stage3", StructureStageTaskRef("somepipeline-stage3-1"),
 					StructureStageDepth(1),
 					StructureStageParent("stage2")),
-				StructureStage("stage4", StructureStageTaskRef("somepipeline-stage4"),
+				StructureStage("stage4", StructureStageTaskRef("somepipeline-stage4-1"),
 					StructureStagePrevious("stage3"),
 					StructureStageDepth(1),
 					StructureStageParent("stage2")),
-				StructureStage("stage5", StructureStageTaskRef("somepipeline-stage5"),
+				StructureStage("stage5", StructureStageTaskRef("somepipeline-stage5-1"),
 					StructureStagePrevious("stage4"),
 					StructureStageDepth(1),
 					StructureStageParent("stage2")),
@@ -517,13 +517,13 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("hello"), StepArg("${SOME_OTHER_VAR}")),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-stage-with-environment", "somepipeline-a-stage-with-environment",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-stage-with-environment", "somepipeline-a-stage-with-environment-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-stage-with-environment", "jx",
+				tb.Task("somepipeline-a-stage-with-environment-1", "jx",
 					TaskStageLabel("A stage with environment"),
 					tb.TaskSpec(
 						tb.TaskInputs(
@@ -534,8 +534,8 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 							tb.EnvVar("SOME_OTHER_VAR", "A value for the other env var"), tb.EnvVar("SOME_VAR", "A value for the env var")),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A stage with environment", StructureStageTaskRef("somepipeline-a-stage-with-environment")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A stage with environment", StructureStageTaskRef("somepipeline-a-stage-with-environment-1")),
 			),
 		},
 		{
@@ -609,13 +609,13 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("goodbye")),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -625,8 +625,8 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.Step("step3", "some-image", tb.Command("echo"), tb.Args("goodbye"), workingDir("/workspace/workspace")),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1")),
 			),
 		},
 		{
@@ -640,25 +640,25 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("ls")),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask(".--a--.", "somepipeline-a",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask(".--a--.", "somepipeline-a-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
-				tb.PipelineTask("wööh!!!!---this-is-cool.", "somepipeline-wh-this-is-cool",
+				tb.PipelineTask("wööh!!!!---this-is-cool.", "somepipeline-wh-this-is-cool-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline",
 						tb.From(".--a--.")),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline"),
 					tb.RunAfter(".--a--.")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a", "jx", TaskStageLabel(". -a- ."), tb.TaskSpec(
+				tb.Task("somepipeline-a-1", "jx", TaskStageLabel(". -a- ."), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace"))),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 				)),
-				tb.Task("somepipeline-wh-this-is-cool", "jx", TaskStageLabel("Wööh!!!! - This is cool."),
+				tb.Task("somepipeline-wh-this-is-cool-1", "jx", TaskStageLabel("Wööh!!!! - This is cool."),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
@@ -666,9 +666,9 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.Step("step2", "some-image", tb.Command("ls"), workingDir("/workspace/workspace")),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage(". -a- .", StructureStageTaskRef("somepipeline-a")),
-				StructureStage("Wööh!!!! - This is cool.", StructureStageTaskRef("somepipeline-wh-this-is-cool"), StructureStagePrevious(". -a- .")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage(". -a- .", StructureStageTaskRef("somepipeline-a-1")),
+				StructureStage("Wööh!!!! - This is cool.", StructureStageTaskRef("somepipeline-wh-this-is-cool-1"), StructureStagePrevious(". -a- .")),
 			),
 		},
 		{
@@ -683,14 +683,14 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				),
 			),
 			/* TODO: Stop erroring out once we figure out how to handle task timeouts again
-															pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-																tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+															pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+																tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 																	tb.PipelineTaskInputResource("workspace", "somepipeline"),
 																	tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource"),
 																	tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 									tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-																					tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+																					tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 																	tb.TaskSpec(
 												tb.TaskTimeout(50*time.Minute),
 																	tb.TaskInputs(
@@ -713,13 +713,13 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("hello"), StepArg("world")),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -728,8 +728,8 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.Step("step2", "some-image", tb.Command("echo"), tb.Args("hello", "world"), workingDir("/workspace/workspace")),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1")),
 			),
 		},
 		{
@@ -752,13 +752,13 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageStep(StepCmd("echo"), StepArg("hello"), StepArg("after")),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -792,8 +792,8 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 							tb.EnvVar("DISTRO", "gentoo"), tb.EnvVar("LANGUAGE", "rust")),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1")),
 			),
 		},
 		{
@@ -829,13 +829,13 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -847,8 +847,8 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1")),
 			),
 		},
 		{
@@ -874,13 +874,13 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -892,8 +892,8 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1")),
 			),
 		},
 		{
@@ -917,13 +917,13 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -935,8 +935,8 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1")),
 			),
 		},
 		{
@@ -956,13 +956,13 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx", TaskStageLabel("A Working Stage"),
+				tb.Task("somepipeline-a-working-stage-1", "jx", TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit,
@@ -974,8 +974,8 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1")),
 			),
 		},
 		{
@@ -1002,13 +1002,13 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					StageEnvVar("ANOTHER_OVERRIDE_STAGE_ENV", "New value"),
 				),
 			),
-			pipeline: tb.Pipeline("somepipeline", "jx", tb.PipelineSpec(
-				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage",
+			pipeline: tb.Pipeline("somepipeline-1", "jx", tb.PipelineSpec(
+				tb.PipelineTask("a-working-stage", "somepipeline-a-working-stage-1",
 					tb.PipelineTaskInputResource("workspace", "somepipeline"),
 					tb.PipelineTaskOutputResource("workspace", "somepipeline")),
 				tb.PipelineDeclaredResource("somepipeline", tektonv1alpha1.PipelineResourceTypeGit))),
 			tasks: []*tektonv1alpha1.Task{
-				tb.Task("somepipeline-a-working-stage", "jx",
+				tb.Task("somepipeline-a-working-stage-1", "jx",
 					TaskStageLabel("A Working Stage"),
 					tb.TaskSpec(
 						tb.TaskInputs(
@@ -1024,8 +1024,8 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						),
 					)),
 			},
-			structure: PipelineStructure("somepipeline",
-				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage")),
+			structure: PipelineStructure("somepipeline-1",
+				StructureStage("A Working Stage", StructureStageTaskRef("somepipeline-a-working-stage-1")),
 			),
 		},
 	}
@@ -1066,7 +1066,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				}
 			}
 
-			pipeline, tasks, structure, err := parsed.GenerateCRDs("somepipeline", "somebuild", "jx", nil, nil, "workspace")
+			pipeline, tasks, structure, err := parsed.GenerateCRDs("somepipeline", "1", "jx", nil, nil, "workspace")
 
 			if err != nil {
 				if tt.expectedErrorMsg != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests. (I'm not sure how much work it would be to add functional tests here for concurrent builds, but it seems like we'd want BDD tests for this kind of thing. The change is partially covered by existing tests, but we are not testing the relevant edge cases (multiple concurrent builds))

#### Description

Otherwise, updating a Pipeline while a build is in progress causes the running Pipeline to adjust the rest of its execution to match the new state, which means the build would execute partly using the old version and partly using the new version, which is a little confusing in most cases but could be a serious correctness issue depending on the nature of the changes to the Pipeline.

[Here](https://gist.github.com/dwnusbaum/8e7222372c789f3e863138b1b2efee71) is an example Gist showing the build logs for a Pipeline where one of the Tasks was updated while the Pipeline was still running. The logs show that the Pipeline ran the original version of the first Task, but the updated version of the second Task.

Uniqueness is handled by adding build numbers to Pipelines and Tasks. Build numbers are tracked per-branch using annotations on SourceRepository resources. _There is no migration code that looks at PipelineActivity_, so anyone currently running pipelines via Tekton will see the build numbers reset to 0. If this seems like a serious problem to reviewers I can try to add some kind of migration code. 

Note that right now we have a lot of pipeline-related resources without owner references that are presumably not getting GC'd in any timely manner, and this PR doesn't fix that, and it probably makes it a little worse because now each build will have its own versions of Pipelines and Tasks (see [here](https://drive.google.com/file/d/1wDd7uz-Bty67s93cS0Sp54NUjwIvRaoF/view?usp=sharing) (click through to draw.io to see the full diagram) for diagrams of the state of resources before and after this patch, and a diagram of what I think would make more sense for the future).

#### Special notes for the reviewer(s)

/assign @abayer

#### Which issue this PR fixes

N/A

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
