### PR TITLE
partial revert of #3406 / #3399

### DIFF
--- a/pkg/jx/cmd/upgrade_addons.go
+++ b/pkg/jx/cmd/upgrade_addons.go
@@ -157,7 +157,7 @@ func (o *UpgradeAddonsOptions) Run() error {
 					return errors.Wrap(err, "backing up the prow config")
 				}
 			}
-			err = o.Helm().UpgradeChart(chart, k, ns, "", false, -1, false, false, values, valueFiles, "", "", "", true)
+			err = o.Helm().UpgradeChart(chart, k, ns, "", false, -1, false, false, values, valueFiles, "", "", "", false)
 			if err != nil {
 				log.Warnf("Failed to upgrade %s chart %s: %v\n", name, chart, err)
 			}


### PR DESCRIPTION
this did not only re-use the values passed by set but also the previous
default values of the chart (and did not even merge with the default
values of the new version of the chart).

#3406 caused a serious regression where it was not the options passed to --set that where re-used but also the previous default values from when the chart was installed.

when this includes the version of the software to install things get a little wonky and you end up upgrading the chart but it keeps the old software.  also any new flags in the chart end up being missing so you can not upgrade the chart.  For now just revert it whilst a better fix is thought about.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->

@amuniz @markawm @pmuir 