### PR TITLE
Don't bind mount docker.sock if we use Kaniko or Tekton

### DIFF
--- a/pkg/config/helm_values.go
+++ b/pkg/config/helm_values.go
@@ -23,6 +23,11 @@ type ExposeController struct {
 type JenkinsValuesConfig struct {
 	Servers JenkinsServersValuesConfig `json:"Servers,omitempty"`
 	Enabled *bool                      `json:"enabled,omitempty"`
+	Agent   JenkinsAgentValuesConfig   `json:"Agent,omitempty"`
+}
+
+type JenkinsAgentValuesConfig struct {
+	DockerHostPath string  `json:"DockerHostPath,omitempty"`
 }
 
 type ProwValuesConfig struct {

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1078,6 +1078,12 @@ func (options *InstallOptions) configureHelmValues(namespace string) error {
 		enableControllerBuild := true
 		helmConfig.ControllerBuild.Enabled = &enableControllerBuild
 	}
+
+	if options.Flags.Kaniko || options.Flags.Tekton {
+		// As we use Kaniko to build docker images, we don't need docker.sock bind mount in build containers
+		helmConfig.Jenkins.Agent.DockerHostPath = ""
+	}
+
 	return nil
 }
 


### PR DESCRIPTION

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Access to Docker.sock introduce a major security issue, letting build / PR access arbitrary resources on the node. This is required to run `docker build` for classic builds, but once  Kaniko or Tekton is selected during installation, we don't need build pods to bind-mount docker.sock anymore.

#### Special notes for the reviewer(s)

This assumes Tekton always uses Kaniko. Have been told on slack but can't confirm by myself without better understanding of tekton.

