### PR TITLE
feat(windows) Make `jx shell` work on vanilla windows

### DIFF
--- a/pkg/jx/cmd/shell.go
+++ b/pkg/jx/cmd/shell.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 
 	"github.com/spf13/cobra"
 
@@ -130,27 +131,23 @@ func (o *ShellOptions) Run() error {
 	newConfig := *config
 	newConfig.CurrentContext = ctxName
 
-	//clean old folders
-	files, err := filepath.Glob("/tmp/.jx-shell-*")
-	if err != nil {
-		panic(err)
-	}
-	for _, f := range files {
-		if err := os.RemoveAll(f); err != nil {
-			panic(err)
-		}
-	}
-	tmpDirName, err := ioutil.TempDir("/tmp", ".jx-shell-")
+	tmpDirName, err := ioutil.TempDir("", ".jx-shell-")
 	if err != nil {
 		return err
 	}
-	tmpConfigFileName := tmpDirName + "/config"
+	tmpConfigFileName := filepath.Join(tmpDirName, "/config")
 	err = clientcmd.WriteToFile(newConfig, tmpConfigFileName)
 	if err != nil {
 		return err
 	}
 
-	shell := filepath.Base(os.Getenv("SHELL"))
+	fullShell := os.Getenv("SHELL")
+	shell := filepath.Base(fullShell)
+	if fullShell == "" && runtime.GOOS == "windows" {
+		// SHELL is set by git-bash but not cygwin :-(
+		shell = "cmd.exe"
+	}
+
 	prompt := o.createNewBashPrompt(os.Getenv("PS1"))
 	rcFile := defaultRcFile + "\nexport PS1=" + prompt + "\nexport KUBECONFIG=\"" + tmpConfigFileName + "\"\n"
 	tmpRCFileName := tmpDirName + "/.bashrc"
@@ -167,7 +164,9 @@ func (o *ShellOptions) Run() error {
 
 	info := util.ColorInfo
 	log.Infof("Creating a new shell using the Kubernetes context %s\n", info(ctxName))
-	log.Infof("Shell RC file is %s\n\n", tmpRCFileName)
+	if shell != "cmd.exe" {
+		log.Infof("Shell RC file is %s\n\n", tmpRCFileName)
+	}
 	log.Infof("All changes to the Kubernetes context like changing environment, namespace or context will be local to this shell\n")
 	log.Infof("To return to the global context use the command: exit\n\n")
 
@@ -177,12 +176,22 @@ func (o *ShellOptions) Run() error {
 		env = append(env, fmt.Sprintf("ZDOTDIR=%s", tmpDirName))
 		e = exec.Command(shell, "-i")
 		e.Env = env
+	} else if shell == "cmd.exe" {
+		env := os.Environ()
+		env = append(env, fmt.Sprintf("KUBECONFIG=%s", tmpConfigFileName))
+		e = exec.Command(shell)
+		e.Env = env
 	}
 
 	e.Stdout = o.Out
 	e.Stderr = o.Err
 	e.Stdin = os.Stdin
-	return e.Run()
+	err = e.Run()
+	if deleteError := os.RemoveAll(tmpDirName); deleteError != nil {
+		panic(err)
+	}
+	return err
+
 }
 
 func (o *ShellOptions) PickContext(names []string, defaultValue string) (string, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Allows JX Shell to use cmd.exe as the shell on windows.


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #2183

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
