### PR TITLE
chore: Unify build pack and YAML syntax Tekton CRD generation

### DIFF
--- a/pkg/jx/cmd/test_data/step_create_task/from_yaml/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/from_yaml/tasks.yml
@@ -25,8 +25,25 @@ items:
       - /bin/sh
       - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
-        value:
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -68,8 +85,25 @@ items:
       - /bin/sh
       - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
-        value:
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER
@@ -146,8 +180,25 @@ items:
       - /bin/sh
       - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
-        value:
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
       - name: PIPELINE_KIND
         value: release
       - name: REPO_OWNER

--- a/pkg/jx/cmd/test_data/step_create_task/js_build_pack/pipeline.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/js_build_pack/pipeline.yml
@@ -3,6 +3,7 @@ kind: Pipeline
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-build-pack
+  namespace: jx
 spec:
   params: []
   resources:
@@ -12,11 +13,11 @@ spec:
   - name: from-build-pack
     resources:
       inputs:
-      - name: source
+      - name: workspace
         resource: abayer-js-test-repo-build-pack
-      outputs: null
+      outputs:
+        - name: workspace
+          resource: abayer-js-test-repo-build-pack
     taskRef:
-      apiVersion: tekton.dev/v1alpha1
-      kind: Task
-      name: abayer-js-test-repo-build-pack
+      name: abayer-js-test-repo-build-pack-from-build-pack
 status: {}

--- a/pkg/jx/cmd/test_data/step_create_task/js_build_pack/structure.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/js_build_pack/structure.yml
@@ -6,4 +6,4 @@ pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-js-test-repo-build-pack
+  taskRef: abayer-js-test-repo-build-pack-from-build-pack

--- a/pkg/jx/cmd/test_data/step_create_task/js_build_pack/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/js_build_pack/tasks.yml
@@ -4,33 +4,34 @@ items:
   metadata:
     creationTimestamp: null
     labels:
-      branch: build-pack
       jenkins.io/task-stage-name: from-build-pack
-      owner: abayer
-      repo: js-test-repo
-    name: abayer-js-test-repo-build-pack
+    name: abayer-js-test-repo-build-pack-from-build-pack
+    namespace: jx
   spec:
     inputs:
       resources:
-      - name: source
-        targetPath: ""
+      - name: workspace
+        targetPath: source
         type: git
+    outputs:
+      resources:
+        - name: workspace
+          targetPath: ""
+          type: git
     steps:
     - args:
-      - -c
       - jx step git credentials
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -39,6 +40,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: PIPELINE_KIND
@@ -75,20 +78,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - echo $(jx-release-version) > VERSION
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -97,6 +98,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: PIPELINE_KIND
@@ -116,7 +119,7 @@ items:
       image: jenkinsxio/builder-nodejs:0.1.235
       name: setversion-next-version
       resources:
-        requests:
+       requests:
           cpu: 400m
           memory: 512Mi
       securityContext:
@@ -133,20 +136,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - jx step tag --version ${VERSION}
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -155,6 +156,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: PIPELINE_KIND
@@ -191,20 +194,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - npm install
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -213,6 +214,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: PIPELINE_KIND
@@ -249,20 +252,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - CI=true DISPLAY=:99 npm test
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -271,6 +272,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: PIPELINE_KIND
@@ -307,20 +310,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - skaffold build -f skaffold.yaml
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -329,6 +330,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: PIPELINE_KIND
@@ -365,20 +368,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:${VERSION}
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -387,6 +388,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: PIPELINE_KIND
@@ -423,20 +426,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - jx step changelog --batch-mode --version v${VERSION}
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -445,6 +446,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: PIPELINE_KIND
@@ -481,20 +484,18 @@ items:
         readOnly: true
       workingDir: /workspace/source/charts/js-test-repo
     - args:
-      - -c
       - jx step helm release
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -503,6 +504,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: PIPELINE_KIND
@@ -539,20 +542,18 @@ items:
         readOnly: true
       workingDir: /workspace/source/charts/js-test-repo
     - args:
-      - -c
       - jx promote -b --all-auto --timeout 1h --version ${VERSION}
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -561,6 +562,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: PIPELINE_KIND
@@ -597,14 +600,14 @@ items:
         readOnly: true
       workingDir: /workspace/source/charts/js-test-repo
     volumes:
-    - emptyDir: {}
-      name: workspace-volume
     - hostPath:
         path: /var/run/docker.sock
       name: docker-daemon
     - name: volume-0
       secret:
         secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
     - downwardAPI:
         items:
         - fieldRef:

--- a/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/pipeline.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/pipeline.yml
@@ -3,6 +3,7 @@ kind: Pipeline
 metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master
+  namespace: jx
 spec:
   params: []
   resources:
@@ -12,11 +13,11 @@ spec:
   - name: from-build-pack
     resources:
       inputs:
-      - name: source
+      - name: workspace
         resource: abayer-jx-demo-qs-master
-      outputs: null
+      outputs:
+      - name: workspace
+        resource: abayer-jx-demo-qs-master
     taskRef:
-      apiVersion: tekton.dev/v1alpha1
-      kind: Task
-      name: abayer-jx-demo-qs-master
+      name: abayer-jx-demo-qs-master-from-build-pack
 status: {}

--- a/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/structure.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/structure.yml
@@ -6,4 +6,4 @@ pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master
+  taskRef: abayer-jx-demo-qs-master-from-build-pack

--- a/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/tasks.yml
@@ -4,33 +4,34 @@ items:
   metadata:
     creationTimestamp: null
     labels:
-      branch: master
       jenkins.io/task-stage-name: from-build-pack
-      owner: abayer
-      repo: jx-demo-qs
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-from-build-pack
+    namespace: jx
   spec:
     inputs:
       resources:
-      - name: source
-        targetPath: ""
+      - name: workspace
+        targetPath: source
         type: git
+    outputs:
+      resources:
+        - name: workspace
+          targetPath: ""
+          type: git
     steps:
     - args:
-      - -c
       - jx step git credentials
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -39,6 +40,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -85,20 +88,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - echo $(jx-release-version) > VERSION
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -107,6 +108,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -153,20 +156,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - mvn versions:set -DnewVersion=${VERSION}
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -175,6 +176,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -221,20 +224,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - jx step tag --version ${VERSION}
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -243,6 +244,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -289,20 +292,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - mvn clean deploy
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -311,6 +312,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -357,20 +360,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - skaffold version
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -379,6 +380,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -425,20 +428,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - skaffold build -f skaffold.yaml
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -447,6 +448,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -493,20 +496,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:${VERSION}
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -515,6 +516,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -561,20 +564,18 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - -c
       - jx step changelog --version v${VERSION}
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -583,6 +584,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -629,20 +632,18 @@ items:
         readOnly: true
       workingDir: /workspace/source/charts/jx-demo-qs
     - args:
-      - -c
       - jx step helm release
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -651,6 +652,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -697,20 +700,18 @@ items:
         readOnly: true
       workingDir: /workspace/source/charts/jx-demo-qs
     - args:
-      - -c
       - jx promote -b --all-auto --timeout 1h --version ${VERSION}
       command:
       - /bin/sh
+      - -c
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -719,6 +720,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
@@ -765,8 +768,6 @@ items:
         readOnly: true
       workingDir: /workspace/source/charts/jx-demo-qs
     volumes:
-    - emptyDir: {}
-      name: workspace-volume
     - hostPath:
         path: /var/run/docker.sock
       name: docker-daemon
@@ -779,6 +780,8 @@ items:
     - name: volume-2
       secret:
         secretName: jenkins-release-gpg
+    - emptyDir: {}
+      name: workspace-volume
     - downwardAPI:
         items:
         - fieldRef:

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -1066,7 +1066,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				}
 			}
 
-			pipeline, tasks, structure, err := parsed.GenerateCRDs("somepipeline", "somebuild", "jx", nil, nil)
+			pipeline, tasks, structure, err := parsed.GenerateCRDs("somepipeline", "somebuild", "jx", nil, nil, "workspace")
 
 			if err != nil {
 				if tt.expectedErrorMsg != "" {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This creates some small differences in the resulting CRDs for build
packs - namely, reordering environment variables and volumes a bit,
changing the task name, and adding output resources to the task. The
last is not ideal, but it's a more general issue where we're copying
the workspace as output for all tasks, but shouldn't for "final" tasks
- we'll tackle that in the next two weeks separately.

#### Special notes for the reviewer(s)

/assign @jstrachan 
/assign @warrenbailey 
/assign @dwnusbaum 
cc @joseblas @kshultzCB 

#### Which issue this PR fixes

n/a