### PR TITLE
Fix: remove '*' from possible characters for secrets because Jenkins …

### DIFF
--- a/pkg/config/admin_secrets.go
+++ b/pkg/config/admin_secrets.go
@@ -64,7 +64,7 @@ const defaultMavenSettings = `<settings>
   </settings>
 `
 
-const allowedSymbols = "~!#%^*_+-=?,."
+const allowedSymbols = "~!#%^_+-=?,."
 
 type ChartMuseum struct {
 	ChartMuseumEnv ChartMuseumEnv `json:"env"`


### PR DESCRIPTION
#### Submitter checklist
- [X ] Change is code complete and matches issue description.
- [ X] Change is covered by existing or new tests.

#### Description
After installing Jenkins-X today on our cluster the generated password for Jenkins wasn't accepted by Jenkins. It contained an *.

#### Special notes for the reviewer(s)
Requested by @garethjevans to submit this PR.

#### Which issue this PR fixes
Didn't create an issue for this PR.
