### PR TITLE
fix: propagate error from PatchUpdate

### DIFF
--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/app_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/app_expansion.go
@@ -25,7 +25,13 @@ func (c *apps) PatchUpdate(app *v1.App) (*v1.App, error) {
 	}
 
 	patch, err := util.CreatePatch(orig, app)
+	if err != nil {
+		return nil, err
+	}
 	patchedApp, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patchedApp, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/app_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/app_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testApp = &v1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.AppSpec{},
+	}
+)
+
+func TestPatchUpdateAppNoModification(t *testing.T) {
+	appJSON, err := json.Marshal(testApp)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(appJSON)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(appJSON)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	apps := apps{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updatedApp, err := apps.PatchUpdate(testApp)
+	assert.NoError(t, err)
+	assert.Equal(t, testApp, updatedApp)
+}
+
+func TestPatchUpdateAppWithChange(t *testing.T) {
+	services := []string{"foo", "bar"}
+	clonedApp := testApp.DeepCopy()
+	clonedApp.Spec.ExposedServices = services
+
+	get := func(*http.Request) (*http.Response, error) {
+		appJSON, err := json.Marshal(testApp)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(appJSON)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		appJSON, err := json.Marshal(clonedApp)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(appJSON)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	apps := apps{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updatedApp, err := apps.PatchUpdate(testApp)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testApp, updatedApp)
+	assert.Equal(t, services, updatedApp.Spec.ExposedServices)
+}
+
+func TestPatchUpdateAppWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	apps := apps{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updatedApp, err := apps.PatchUpdate(testApp)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updatedApp)
+}
+
+func TestPatchUpdateAppWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		appJSON, err := json.Marshal(testApp)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(appJSON)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	apps := apps{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updatedApp, err := apps.PatchUpdate(testApp)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updatedApp)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/buildpack_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/buildpack_expansion.go
@@ -25,7 +25,13 @@ func (c *buildPacks) PatchUpdate(buildPack *v1.BuildPack) (*v1.BuildPack, error)
 	}
 
 	patch, err := util.CreatePatch(orig, buildPack)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/buildpack_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/buildpack_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testBuildPack = &v1.BuildPack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.BuildPackSpec{},
+	}
+)
+
+func TestPatchUpdateBuildPackNoModification(t *testing.T) {
+	json, err := json.Marshal(testBuildPack)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	buildPacks := buildPacks{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := buildPacks.PatchUpdate(testBuildPack)
+	assert.NoError(t, err)
+	assert.Equal(t, testBuildPack, updated)
+}
+
+func TestPatchUpdateBuildPackWithChange(t *testing.T) {
+	url := "git@github.com:jenkins-x/jx.git"
+	clonedBuildPack := testBuildPack.DeepCopy()
+	clonedBuildPack.Spec.GitURL = url
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testBuildPack)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedBuildPack)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	buildPacks := buildPacks{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := buildPacks.PatchUpdate(testBuildPack)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testBuildPack, updated)
+	assert.Equal(t, url, updated.Spec.GitURL)
+}
+
+func TestPatchUpdateBuildPackWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	buildPacks := buildPacks{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := buildPacks.PatchUpdate(testBuildPack)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateBuildPackWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testBuildPack)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	buildPacks := buildPacks{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := buildPacks.PatchUpdate(testBuildPack)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/commitstatus_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/commitstatus_expansion.go
@@ -25,7 +25,13 @@ func (c *commitStatuses) PatchUpdate(commitStatus *v1.CommitStatus) (*v1.CommitS
 	}
 
 	patch, err := util.CreatePatch(orig, commitStatus)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/commitstatus_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/commitstatus_expansion_test.go
@@ -1,0 +1,129 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testCommitStatus = &v1.CommitStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.CommitStatusSpec{},
+	}
+)
+
+func TestPatchUpdateCommitStatusNoModification(t *testing.T) {
+	json, err := json.Marshal(testCommitStatus)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	commitStatuses := commitStatuses{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := commitStatuses.PatchUpdate(testCommitStatus)
+	assert.NoError(t, err)
+	assert.Equal(t, testCommitStatus, updated)
+}
+
+func TestPatchUpdateCommitStatusWithChange(t *testing.T) {
+	context := "foo"
+	clonedCommitStatus := testCommitStatus.DeepCopy()
+	clonedCommitStatus.Spec.Items = []v1.CommitStatusDetails{
+		{
+			Context: context,
+		},
+	}
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testCommitStatus)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedCommitStatus)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	commitStatuses := commitStatuses{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := commitStatuses.PatchUpdate(testCommitStatus)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testCommitStatus, updated)
+	assert.Equal(t, context, updated.Spec.Items[0].Context)
+}
+
+func TestPatchUpdateCommitStatusWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	commitStatuses := commitStatuses{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := commitStatuses.PatchUpdate(testCommitStatus)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateCommitStatusWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testCommitStatus)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	commitStatuses := commitStatuses{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := commitStatuses.PatchUpdate(testCommitStatus)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/environment_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/environment_expansion.go
@@ -25,7 +25,13 @@ func (c *environments) PatchUpdate(environment *v1.Environment) (*v1.Environment
 	}
 
 	patch, err := util.CreatePatch(orig, environment)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/environment_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/environment_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testEnvironment = &v1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.EnvironmentSpec{},
+	}
+)
+
+func TestPatchUpdateEnvironmentNoModification(t *testing.T) {
+	json, err := json.Marshal(testEnvironment)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	environments := environments{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := environments.PatchUpdate(testEnvironment)
+	assert.NoError(t, err)
+	assert.Equal(t, testEnvironment, updated)
+}
+
+func TestPatchUpdateEnvironmentWithChange(t *testing.T) {
+	namespace := "jx"
+	clonedEnvironment := testEnvironment.DeepCopy()
+	clonedEnvironment.Spec.Namespace = namespace
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testEnvironment)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedEnvironment)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	environments := environments{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := environments.PatchUpdate(testEnvironment)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testEnvironment, updated)
+	assert.Equal(t, namespace, updated.Spec.Namespace)
+}
+
+func TestPatchUpdateEnvironmentWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	environments := environments{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := environments.PatchUpdate(testEnvironment)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateEnvironmentWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testEnvironment)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	environments := environments{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := environments.PatchUpdate(testEnvironment)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/environmentrolebinding_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/environmentrolebinding_expansion.go
@@ -25,7 +25,13 @@ func (c *environmentRoleBindings) PatchUpdate(environmentRoleBinding *v1.Environ
 	}
 
 	patch, err := util.CreatePatch(orig, environmentRoleBinding)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/environmentrolebinding_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/environmentrolebinding_expansion_test.go
@@ -1,0 +1,130 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testEnvironmentRoleBinding = &v1.EnvironmentRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.EnvironmentRoleBindingSpec{},
+	}
+)
+
+func TestPatchUpdateEnvironmentRoleBindingNoModification(t *testing.T) {
+	json, err := json.Marshal(testEnvironmentRoleBinding)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	environmentRoleBindings := environmentRoleBindings{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := environmentRoleBindings.PatchUpdate(testEnvironmentRoleBinding)
+	assert.NoError(t, err)
+	assert.Equal(t, testEnvironmentRoleBinding, updated)
+}
+
+func TestPatchUpdateEnvironmentRoleBindingWithChange(t *testing.T) {
+	subject := "snafu"
+	clonedEnvironmentRoleBinding := testEnvironmentRoleBinding.DeepCopy()
+	clonedEnvironmentRoleBinding.Spec.Subjects = []rbacv1.Subject{
+		{
+			Name: subject,
+		},
+	}
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testEnvironmentRoleBinding)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedEnvironmentRoleBinding)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	environmentRoleBindings := environmentRoleBindings{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := environmentRoleBindings.PatchUpdate(testEnvironmentRoleBinding)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testEnvironmentRoleBinding, updated)
+	assert.Equal(t, subject, updated.Spec.Subjects[0].Name)
+}
+
+func TestPatchUpdateEnvironmentRoleBindingWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	environmentRoleBindings := environmentRoleBindings{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := environmentRoleBindings.PatchUpdate(testEnvironmentRoleBinding)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateEnvironmentRoleBindingWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testEnvironmentRoleBinding)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	environmentRoleBindings := environmentRoleBindings{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := environmentRoleBindings.PatchUpdate(testEnvironmentRoleBinding)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/extension_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/extension_expansion.go
@@ -25,7 +25,13 @@ func (c *extensions) PatchUpdate(extension *v1.Extension) (*v1.Extension, error)
 	}
 
 	patch, err := util.CreatePatch(orig, extension)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/extension_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/extension_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testExtension = &v1.Extension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.ExtensionSpec{},
+	}
+)
+
+func TestPatchUpdateExtensionNoModification(t *testing.T) {
+	json, err := json.Marshal(testExtension)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	extensions := extensions{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := extensions.PatchUpdate(testExtension)
+	assert.NoError(t, err)
+	assert.Equal(t, testExtension, updated)
+}
+
+func TestPatchUpdateExtensionWithChange(t *testing.T) {
+	name := "fubu"
+	clonedExtension := testExtension.DeepCopy()
+	clonedExtension.Spec.Name = name
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testExtension)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedExtension)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	extensions := extensions{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := extensions.PatchUpdate(testExtension)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testExtension, updated)
+	assert.Equal(t, name, updated.Spec.Name)
+}
+
+func TestPatchUpdateExtensionWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	extensions := extensions{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := extensions.PatchUpdate(testExtension)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateExtensionWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testExtension)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	extensions := extensions{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := extensions.PatchUpdate(testExtension)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/fact_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/fact_expansion.go
@@ -25,7 +25,13 @@ func (c *facts) PatchUpdate(fact *v1.Fact) (*v1.Fact, error) {
 	}
 
 	patch, err := util.CreatePatch(orig, fact)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/fact_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/fact_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testFact = &v1.Fact{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.FactSpec{},
+	}
+)
+
+func TestPatchUpdateFactNoModification(t *testing.T) {
+	json, err := json.Marshal(testFact)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	facts := facts{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := facts.PatchUpdate(testFact)
+	assert.NoError(t, err)
+	assert.Equal(t, testFact, updated)
+}
+
+func TestPatchUpdateFactWithChange(t *testing.T) {
+	name := "susfu"
+	clonedFact := testFact.DeepCopy()
+	clonedFact.Spec.Name = name
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testFact)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedFact)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	facts := facts{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := facts.PatchUpdate(testFact)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testFact, updated)
+	assert.Equal(t, name, updated.Spec.Name)
+}
+
+func TestPatchUpdateFactWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	facts := facts{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := facts.PatchUpdate(testFact)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateFactWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testFact)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	facts := facts{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := facts.PatchUpdate(testFact)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/gitservice_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/gitservice_expansion.go
@@ -25,7 +25,13 @@ func (c *gitServices) PatchUpdate(gitService *v1.GitService) (*v1.GitService, er
 	}
 
 	patch, err := util.CreatePatch(orig, gitService)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/gitservice_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/gitservice_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testGitService = &v1.GitService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.GitServiceSpec{},
+	}
+)
+
+func TestPatchUpdateGitServiceNoModification(t *testing.T) {
+	json, err := json.Marshal(testGitService)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	gitServices := gitServices{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := gitServices.PatchUpdate(testGitService)
+	assert.NoError(t, err)
+	assert.Equal(t, testGitService, updated)
+}
+
+func TestPatchUpdateGitServiceWithChange(t *testing.T) {
+	name := "susfu"
+	clonedGitService := testGitService.DeepCopy()
+	clonedGitService.Spec.Name = name
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testGitService)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedGitService)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	gitServices := gitServices{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := gitServices.PatchUpdate(testGitService)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testGitService, updated)
+	assert.Equal(t, name, updated.Spec.Name)
+}
+
+func TestPatchUpdateGitServiceWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	gitServices := gitServices{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := gitServices.PatchUpdate(testGitService)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateGitServiceWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testGitService)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	gitServices := gitServices{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := gitServices.PatchUpdate(testGitService)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelineactivity_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelineactivity_expansion.go
@@ -25,7 +25,13 @@ func (c *pipelineActivities) PatchUpdate(pipelineActivity *v1.PipelineActivity) 
 	}
 
 	patch, err := util.CreatePatch(orig, pipelineActivity)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelineactivity_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelineactivity_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testPipelineActivity = &v1.PipelineActivity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.PipelineActivitySpec{},
+	}
+)
+
+func TestPatchUpdatePipelineActivityNoModification(t *testing.T) {
+	json, err := json.Marshal(testPipelineActivity)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	pipelineActivities := pipelineActivities{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := pipelineActivities.PatchUpdate(testPipelineActivity)
+	assert.NoError(t, err)
+	assert.Equal(t, testPipelineActivity, updated)
+}
+
+func TestPatchUpdatePipelineActivityWithChange(t *testing.T) {
+	name := "test"
+	clonedPipelineActivity := testPipelineActivity.DeepCopy()
+	clonedPipelineActivity.Spec.Pipeline = name
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testPipelineActivity)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedPipelineActivity)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	pipelineActivities := pipelineActivities{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := pipelineActivities.PatchUpdate(testPipelineActivity)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testPipelineActivity, updated)
+	assert.Equal(t, name, updated.Spec.Pipeline)
+}
+
+func TestPatchUpdatePipelineActivityWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	pipelineActivities := pipelineActivities{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := pipelineActivities.PatchUpdate(testPipelineActivity)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdatePipelineActivityWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testPipelineActivity)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	pipelineActivities := pipelineActivities{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := pipelineActivities.PatchUpdate(testPipelineActivity)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelinestructure_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelinestructure_expansion.go
@@ -25,7 +25,13 @@ func (c *pipelineStructures) PatchUpdate(pipelineStructure *v1.PipelineStructure
 	}
 
 	patch, err := util.CreatePatch(orig, pipelineStructure)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelinestructure_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelinestructure_expansion_test.go
@@ -1,0 +1,124 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testPipelineStructure = &v1.PipelineStructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+)
+
+func TestPatchUpdatePipelineStructureNoModification(t *testing.T) {
+	json, err := json.Marshal(testPipelineStructure)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	pipelineStructures := pipelineStructures{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := pipelineStructures.PatchUpdate(testPipelineStructure)
+	assert.NoError(t, err)
+	assert.Equal(t, testPipelineStructure, updated)
+}
+
+func TestPatchUpdatePipelineStructureWithChange(t *testing.T) {
+	ref := "susfu"
+	clonedPipelineStructure := testPipelineStructure.DeepCopy()
+	clonedPipelineStructure.PipelineRef = &ref
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testPipelineStructure)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedPipelineStructure)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	pipelineStructures := pipelineStructures{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := pipelineStructures.PatchUpdate(testPipelineStructure)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testPipelineStructure, updated)
+	assert.Equal(t, &ref, updated.PipelineRef)
+}
+
+func TestPatchUpdatePipelineStructureWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	pipelineStructures := pipelineStructures{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := pipelineStructures.PatchUpdate(testPipelineStructure)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdatePipelineStructureWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testPipelineStructure)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	pipelineStructures := pipelineStructures{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := pipelineStructures.PatchUpdate(testPipelineStructure)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/plugin_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/plugin_expansion.go
@@ -25,7 +25,13 @@ func (c *plugins) PatchUpdate(plugin *v1.Plugin) (*v1.Plugin, error) {
 	}
 
 	patch, err := util.CreatePatch(orig, plugin)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/plugin_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/plugin_expansion_test.go
@@ -1,0 +1,124 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testPlugin = &v1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.PluginSpec{},
+	}
+)
+
+func TestPatchUpdatePluginNoModification(t *testing.T) {
+	json, err := json.Marshal(testPlugin)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	plugins := plugins{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := plugins.PatchUpdate(testPlugin)
+	assert.NoError(t, err)
+	assert.Equal(t, testPlugin, updated)
+}
+
+func TestPatchUpdatePluginWithChange(t *testing.T) {
+	name := "susfu"
+	clonedPlugin := testPlugin.DeepCopy()
+	clonedPlugin.Spec.Name = name
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testPlugin)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedPlugin)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	plugins := plugins{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := plugins.PatchUpdate(testPlugin)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testPlugin, updated)
+	assert.Equal(t, name, updated.Spec.Name)
+}
+
+func TestPatchUpdatePluginWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	plugins := plugins{
+		client: fakeClient,
+		ns:     "default",
+	}
+	updated, err := plugins.PatchUpdate(testPlugin)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdatePluginWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testPlugin)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	plugins := plugins{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := plugins.PatchUpdate(testPlugin)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/release_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/release_expansion.go
@@ -25,7 +25,13 @@ func (c *releases) PatchUpdate(release *v1.Release) (*v1.Release, error) {
 	}
 
 	patch, err := util.CreatePatch(orig, release)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/release_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/release_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testRelease = &v1.Release{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.ReleaseSpec{},
+	}
+)
+
+func TestPatchUpdateReleaseNoModification(t *testing.T) {
+	json, err := json.Marshal(testRelease)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	releases := releases{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := releases.PatchUpdate(testRelease)
+	assert.NoError(t, err)
+	assert.Equal(t, testRelease, updated)
+}
+
+func TestPatchUpdateReleaseWithChange(t *testing.T) {
+	name := "susfu"
+	clonedRelease := testRelease.DeepCopy()
+	clonedRelease.Spec.Name = name
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testRelease)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedRelease)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	releases := releases{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := releases.PatchUpdate(testRelease)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testRelease, updated)
+	assert.Equal(t, name, updated.Spec.Name)
+}
+
+func TestPatchUpdateReleaseWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	releases := releases{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := releases.PatchUpdate(testRelease)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateReleaseWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testRelease)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	releases := releases{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := releases.PatchUpdate(testRelease)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/sourcerepository_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/sourcerepository_expansion.go
@@ -25,7 +25,13 @@ func (c *sourceRepositories) PatchUpdate(sourceRepository *v1.SourceRepository) 
 	}
 
 	patch, err := util.CreatePatch(orig, sourceRepository)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/sourcerepository_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/sourcerepository_expansion_test.go
@@ -1,0 +1,124 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testSourceRepository = &v1.SourceRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.SourceRepositorySpec{},
+	}
+)
+
+func TestPatchUpdateSourceRepositoryNoModification(t *testing.T) {
+	json, err := json.Marshal(testSourceRepository)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	sourceRepositories := sourceRepositories{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := sourceRepositories.PatchUpdate(testSourceRepository)
+	assert.NoError(t, err)
+	assert.Equal(t, testSourceRepository, updated)
+}
+
+func TestPatchUpdateSourceRepositoryWithChange(t *testing.T) {
+	description := "my repo"
+	clonedSourceRepository := testSourceRepository.DeepCopy()
+	clonedSourceRepository.Spec.Description = description
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testSourceRepository)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedSourceRepository)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	sourceRepositories := sourceRepositories{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := sourceRepositories.PatchUpdate(testSourceRepository)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testSourceRepository, updated)
+	assert.Equal(t, description, updated.Spec.Description)
+}
+
+func TestPatchUpdateSourceRepositoryWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	sourceRepositories := sourceRepositories{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := sourceRepositories.PatchUpdate(testSourceRepository)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateSourceRepositoryWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testSourceRepository)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	sourceRepositories := sourceRepositories{
+		client: fakeClient,
+		ns:     "default",
+	}
+	updated, err := sourceRepositories.PatchUpdate(testSourceRepository)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/team_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/team_expansion.go
@@ -25,7 +25,13 @@ func (c *teams) PatchUpdate(team *v1.Team) (*v1.Team, error) {
 	}
 
 	patch, err := util.CreatePatch(orig, team)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/team_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/team_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testTeam = &v1.Team{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.TeamSpec{},
+	}
+)
+
+func TestPatchUpdateTeamNoModification(t *testing.T) {
+	json, err := json.Marshal(testTeam)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	teams := teams{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := teams.PatchUpdate(testTeam)
+	assert.NoError(t, err)
+	assert.Equal(t, testTeam, updated)
+}
+
+func TestPatchUpdateTeamWithChange(t *testing.T) {
+	label := "Black Team"
+	clonedTeam := testTeam.DeepCopy()
+	clonedTeam.Spec.Label = label
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testTeam)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedTeam)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	teams := teams{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := teams.PatchUpdate(testTeam)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testTeam, updated)
+	assert.Equal(t, label, updated.Spec.Label)
+}
+
+func TestPatchUpdateTeamWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	teams := teams{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := teams.PatchUpdate(testTeam)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateTeamWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testTeam)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	teams := teams{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := teams.PatchUpdate(testTeam)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/testutil.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/testutil.go
@@ -1,0 +1,73 @@
+package v1
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/client/clientset/versioned/scheme"
+	"io"
+	"io/ioutil"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	fakerest "k8s.io/client-go/rest/fake"
+	"net/http"
+)
+
+var (
+	codecs = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+)
+
+type fakeGetPatchRequest struct {
+	get   func(*http.Request) (*http.Response, error)
+	patch func(*http.Request) (*http.Response, error)
+}
+
+func newClientForTest(get func(*http.Request) (*http.Response, error), patch func(*http.Request) (*http.Response, error)) *fakerest.RESTClient {
+	faker := newGetPatchRequest(get, patch)
+
+	fakeClient := &fakerest.RESTClient{
+		Client:               fakerest.CreateHTTPClient(faker.GetHandler()),
+		NegotiatedSerializer: codecs,
+		GroupVersion:         v1.SchemeGroupVersion,
+		VersionedAPIPath:     "/not/a/real/path",
+	}
+	return fakeClient
+}
+
+func newGetPatchRequest(get func(*http.Request) (*http.Response, error), patch func(*http.Request) (*http.Response, error)) *fakeGetPatchRequest {
+	return &fakeGetPatchRequest{
+		get:   get,
+		patch: patch,
+	}
+}
+
+func (f *fakeGetPatchRequest) GetHandler() func(*http.Request) (*http.Response, error) {
+	return f.fakeReqHandler
+}
+
+func (f *fakeGetPatchRequest) fakeReqHandler(req *http.Request) (*http.Response, error) {
+	switch req.Method {
+	case "GET":
+		if f.get == nil {
+			return nil, fmt.Errorf("unexpected request for URL %q with method %q", req.URL.String(), req.Method)
+		}
+		return f.get(req)
+	case "PATCH":
+		if f.patch == nil {
+			return nil, fmt.Errorf("unexpected request for URL %q with method %q", req.URL.String(), req.Method)
+		}
+		return f.patch(req)
+	default:
+		return nil, fmt.Errorf("unexpected request for URL %q with method %q", req.URL.String(), req.Method)
+	}
+}
+
+func bytesBody(bodyBytes []byte) io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader(bodyBytes))
+}
+
+func defaultHeaders() http.Header {
+	header := http.Header{}
+	header.Set("Content-Type", runtime.ContentTypeJSON)
+	return header
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/user_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/user_expansion.go
@@ -25,7 +25,13 @@ func (c *users) PatchUpdate(user *v1.User) (*v1.User, error) {
 	}
 
 	patch, err := util.CreatePatch(orig, user)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/user_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/user_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testUser = &v1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.UserDetails{},
+	}
+)
+
+func TestPatchUpdateUserNoModification(t *testing.T) {
+	json, err := json.Marshal(testUser)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	users := users{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := users.PatchUpdate(testUser)
+	assert.NoError(t, err)
+	assert.Equal(t, testUser, updated)
+}
+
+func TestPatchUpdateUserWithChange(t *testing.T) {
+	name := "susfu"
+	clonedUser := testUser.DeepCopy()
+	clonedUser.Spec.Name = name
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testUser)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedUser)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	users := users{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := users.PatchUpdate(testUser)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testUser, updated)
+	assert.Equal(t, name, updated.Spec.Name)
+}
+
+func TestPatchUpdateUserWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	users := users{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := users.PatchUpdate(testUser)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateUserWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testUser)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	users := users{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := users.PatchUpdate(testUser)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/workflow_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/workflow_expansion.go
@@ -25,7 +25,13 @@ func (c *workflows) PatchUpdate(workflow *v1.Workflow) (*v1.Workflow, error) {
 	}
 
 	patch, err := util.CreatePatch(orig, workflow)
+	if err != nil {
+		return nil, err
+	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
+	if err != nil {
+		return nil, err
+	}
 
 	return patched, nil
 }

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/workflow_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/workflow_expansion_test.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+var (
+	testWorkflow = &v1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.WorkflowSpec{},
+	}
+)
+
+func TestPatchUpdateWorkflowNoModification(t *testing.T) {
+	json, err := json.Marshal(testWorkflow)
+	if err != nil {
+		assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+	}
+	get := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	workflows := workflows{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := workflows.PatchUpdate(testWorkflow)
+	assert.NoError(t, err)
+	assert.Equal(t, testWorkflow, updated)
+}
+
+func TestPatchUpdateWorkflowWithChange(t *testing.T) {
+	pipelineName := "dummy-pipeline"
+	clonedWorkflow := testWorkflow.DeepCopy()
+	clonedWorkflow.Spec.PipelineName = pipelineName
+
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testWorkflow)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(clonedWorkflow)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	workflows := workflows{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := workflows.PatchUpdate(testWorkflow)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testWorkflow, updated)
+	assert.Equal(t, pipelineName, updated.Spec.PipelineName)
+}
+
+func TestPatchUpdateWorkflowWithErrorInGet(t *testing.T) {
+	errorMessage := "error during GET"
+	get := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, nil)
+
+	workflows := workflows{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := workflows.PatchUpdate(testWorkflow)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}
+
+func TestPatchUpdateWorkflowWithErrorInPatch(t *testing.T) {
+	errorMessage := "error during PATCH"
+	get := func(*http.Request) (*http.Response, error) {
+		json, err := json.Marshal(testWorkflow)
+		if err != nil {
+			assert.Failf(t, "unable to marshal test instance: %s", err.Error())
+		}
+		return &http.Response{StatusCode: 200, Header: defaultHeaders(), Body: bytesBody(json)}, nil
+	}
+
+	patch := func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(errorMessage)
+	}
+
+	fakeClient := newClientForTest(get, patch)
+
+	workflows := workflows{
+		client: fakeClient,
+		ns:     "default",
+	}
+
+	updated, err := workflows.PatchUpdate(testWorkflow)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), errorMessage)
+	assert.Nil(t, updated)
+}


### PR DESCRIPTION
fixes issue #3505

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Propagates error from PatchUpdate for custom CRDs

