### PR TITLE
NotExecuted is not a failure

### DIFF
--- a/pkg/kube/activity.go
+++ b/pkg/kube/activity.go
@@ -192,8 +192,8 @@ func (k *PipelineActivityKey) GetOrCreate(jxClient versioned.Interface, ns strin
 	activitiesClient := jxClient.JenkinsV1().PipelineActivities(ns)
 
 	if activitiesClient == nil {
-		log.Warn("Warning: no PipelineActivities client available!")
-		return defaultActivity, create, nil
+		log.Errorf("No PipelineActivities client available")
+		return defaultActivity, create, fmt.Errorf("no PipelineActivities client available")
 	}
 	a, err := activitiesClient.Get(name, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Another crack at #3175 as the logic I fixed in https://github.com/jenkins-x/jx/pull/3394 was duplicated elsewhere.

#### Special notes for the reviewer(s)

Also tidied up a few code paths where we appeared to be trying to blithely continue when we failed to retrieve a `PipelineActivity` even though a subsequent update was then doomed anyway.

#### Which issue this PR fixes

fixes #3175

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
