### PR TITLE
add support for updating webhooks in user account

### DIFF
--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -124,6 +124,47 @@ func (p *GitHubProvider) IsUserInOrganisation(user string, org string) (bool, er
 	return false, nil
 }
 
+func (p *GitHubProvider) ListRepositoriesForUser(user string) ([]*GitRepository, error) {
+	owner := user
+	answer := []*GitRepository{}
+	options := &github.RepositoryListOptions{
+		ListOptions: github.ListOptions{
+			Page:    0,
+			PerPage: pageSize,
+		},
+	}
+
+	for {
+		repos, _, err := p.Client.Repositories.List(p.Context, owner, options)
+		if err != nil {
+			options := &github.RepositoryListOptions{
+				ListOptions: github.ListOptions{
+					Page:    0,
+					PerPage: pageSize,
+				},
+			}
+			repos, _, err = p.Client.Repositories.List(p.Context, owner, options)
+			if err != nil {
+				return answer, err
+			}
+
+		}
+		for _, repo := range repos {
+			answer = append(answer, toGitHubRepo(asText(repo.Name), repo))
+		}
+		if len(repos) < pageSize || len(repos) == 0 {
+			break
+		}
+		options.ListOptions.Page += 1
+	}
+	return answer, nil
+}
+
+// IsOwnerGitHubUser checks to see if the owner is the GitHub User
+func IsOwnerGitHubUser(owner string, gitHubUser string) bool {
+	return owner == gitHubUser && gitHubUser != ""
+}
+
 func (p *GitHubProvider) ListRepositories(org string) ([]*GitRepository, error) {
 	owner := org
 	answer := []*GitRepository{}
@@ -133,6 +174,11 @@ func (p *GitHubProvider) ListRepositories(org string) ([]*GitRepository, error) 
 			PerPage: pageSize,
 		},
 	}
+
+	if IsOwnerGitHubUser(owner, p.Username) {
+		return p.ListRepositoriesForUser(p.Username)
+	}
+
 	for {
 		repos, _, err := p.Client.Repositories.ListByOrg(p.Context, owner, options)
 		if err != nil {

--- a/pkg/gits/github_test.go
+++ b/pkg/gits/github_test.go
@@ -1,0 +1,18 @@
+package gits
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsOwnerGitHubUser_isOwner(t *testing.T) {
+	t.Parallel()
+	isOwnerGitHubUser := IsOwnerGitHubUser("owner", "owner")
+	assert.True(t, isOwnerGitHubUser, "The owner should be the same as the GitHubUser")
+}
+
+func TestIsOwnerGitHubUser_isNotOwner(t *testing.T) {
+	t.Parallel()
+	isOwnerGitHubUser := IsOwnerGitHubUser("owner", "notowner")
+	assert.False(t, isOwnerGitHubUser, "The owner must not be the same as the GitHubUser")
+}

--- a/pkg/jx/cmd/clients/mocks/factory.go
+++ b/pkg/jx/cmd/clients/mocks/factory.go
@@ -4,7 +4,7 @@
 package clients_test
 
 import (
-	versioned1 "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
+	versioned "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 	client "github.com/heptio/sonobuoy/pkg/client"
 	dynamic "github.com/heptio/sonobuoy/pkg/dynamic"
 	golang_jenkins "github.com/jenkins-x/golang-jenkins"
@@ -16,11 +16,11 @@ import (
 	clients "github.com/jenkins-x/jx/pkg/jx/cmd/clients"
 	table "github.com/jenkins-x/jx/pkg/table"
 	vault "github.com/jenkins-x/jx/pkg/vault"
-	versioned2 "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
-	versioned3 "github.com/knative/build/pkg/client/clientset/versioned"
-	versioned4 "github.com/knative/serving/pkg/client/clientset/versioned"
+	versioned1 "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	versioned2 "github.com/knative/build/pkg/client/clientset/versioned"
+	versioned3 "github.com/knative/serving/pkg/client/clientset/versioned"
 	pegomock "github.com/petergtz/pegomock"
-	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	versioned4 "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	terminal "gopkg.in/AlecAivazis/survey.v1/terminal"
 	io "io"
 	v1 "k8s.io/api/core/v1"
@@ -119,17 +119,17 @@ func (mock *MockFactory) CreateAuthConfigService(_param0 string, _param1 string)
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateCertManagerClient() (versioned2.Interface, error) {
+func (mock *MockFactory) CreateCertManagerClient() (versioned1.Interface, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateCertManagerClient", params, []reflect.Type{reflect.TypeOf((*versioned2.Interface)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned2.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateCertManagerClient", params, []reflect.Type{reflect.TypeOf((*versioned1.Interface)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned1.Interface
 	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned2.Interface)
+			ret0 = result[0].(versioned1.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(error)
@@ -351,18 +351,18 @@ func (mock *MockFactory) CreateJenkinsClient(_param0 kubernetes.Interface, _para
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateKnativeBuildClient() (versioned3.Interface, string, error) {
+func (mock *MockFactory) CreateKnativeBuildClient() (versioned2.Interface, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeBuildClient", params, []reflect.Type{reflect.TypeOf((*versioned3.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned3.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeBuildClient", params, []reflect.Type{reflect.TypeOf((*versioned2.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned2.Interface
 	var ret1 string
 	var ret2 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned3.Interface)
+			ret0 = result[0].(versioned2.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(string)
@@ -374,18 +374,18 @@ func (mock *MockFactory) CreateKnativeBuildClient() (versioned3.Interface, strin
 	return ret0, ret1, ret2
 }
 
-func (mock *MockFactory) CreateKnativeServeClient() (versioned4.Interface, string, error) {
+func (mock *MockFactory) CreateKnativeServeClient() (versioned3.Interface, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeServeClient", params, []reflect.Type{reflect.TypeOf((*versioned4.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned4.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeServeClient", params, []reflect.Type{reflect.TypeOf((*versioned3.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned3.Interface
 	var ret1 string
 	var ret2 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned4.Interface)
+			ret0 = result[0].(versioned3.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(string)
@@ -492,18 +492,18 @@ func (mock *MockFactory) CreateTable(_param0 io.Writer) table.Table {
 	return ret0
 }
 
-func (mock *MockFactory) CreateTektonClient() (versioned.Interface, string, error) {
+func (mock *MockFactory) CreateTektonClient() (versioned4.Interface, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateTektonClient", params, []reflect.Type{reflect.TypeOf((*versioned.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateTektonClient", params, []reflect.Type{reflect.TypeOf((*versioned4.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned4.Interface
 	var ret1 string
 	var ret2 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned.Interface)
+			ret0 = result[0].(versioned4.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(string)
@@ -534,17 +534,17 @@ func (mock *MockFactory) CreateVaultClient(_param0 string, _param1 string) (vaul
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateVaultOperatorClient() (versioned1.Interface, error) {
+func (mock *MockFactory) CreateVaultOperatorClient() (versioned.Interface, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateVaultOperatorClient", params, []reflect.Type{reflect.TypeOf((*versioned1.Interface)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned1.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateVaultOperatorClient", params, []reflect.Type{reflect.TypeOf((*versioned.Interface)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned.Interface
 	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned1.Interface)
+			ret0 = result[0].(versioned.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(error)

--- a/pkg/jx/cmd/update_webhooks_test.go
+++ b/pkg/jx/cmd/update_webhooks_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetOrgOrUserFromOptions_orgIsSet(t *testing.T) {
+	t.Parallel()
+	options := &UpdateWebhooksOptions{
+		Org:  "MyOrg",
+		User: "MyUser",
+	}
+	owner := GetOrgOrUserFromOptions(options)
+	assert.Equal(t, options.Org, owner, "The Owner should be the Org name")
+}
+
+func TestGetOrgOrUserFromOptions_orgNotSetUserIsSet(t *testing.T) {
+	t.Parallel()
+	options := &UpdateWebhooksOptions{
+		Org:  "",
+		User: "MyUser",
+	}
+	owner := GetOrgOrUserFromOptions(options)
+	assert.Equal(t, options.User, owner, "The Owner should be the Username")
+}
+
+func TestGetOrgOrUserFromOptions_orgNotSetUserNotSet(t *testing.T) {
+	t.Parallel()
+	options := &UpdateWebhooksOptions{
+		Org:  "",
+		User: "",
+	}
+	owner := GetOrgOrUserFromOptions(options)
+	assert.Equal(t, "", owner, "The Owner should be empty")
+}

--- a/pkg/jx/cmd/upgrade_ingress_test.go
+++ b/pkg/jx/cmd/upgrade_ingress_test.go
@@ -196,3 +196,23 @@ func TestRealJenkinsService(t *testing.T) {
 	assert.Equal(t, "kubernetes.io/ingress.class: nginx\nnginx.ingress.kubernetes.io/proxy-body-size: 500m\ncertmanager.k8s.io/issuer: letsencrypt-prod", ingressAnnotations)
 	assert.NoError(t, err)
 }
+
+func TestReturnUserNameIfPicked_notPicked(t *testing.T) {
+	t.Parallel()
+	organisation := "MyOrg"
+	username := "MyUser"
+
+	actual := cmd.ReturnUserNameIfPicked(organisation, username)
+	expected := ""
+	assert.Equal(t, expected, actual, "Username should be empty an organization was picked")
+}
+
+func TestReturnUserNameIfPicked_wasPicked(t *testing.T) {
+	t.Parallel()
+	organisation := ""
+	username := "MyUser"
+
+	actual := cmd.ReturnUserNameIfPicked(organisation, username)
+	expected := username
+	assert.Equal(t, expected, actual, "Username should be returned as no organization was picked")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This allows both the direct `update webhooks` and `upgrade ingress` commands to update webhooks belonging to either an organisation or to a user account.

In `upgrade ingress` it makes sure to also check for the current user as an option in the selection for where to look for updating webhooks.

In the GItHub implementation for the repo retrieval, it does a check to see if the org is the same as the user.  If it is the same, we should retrieve the list of repositories via the user-based API instead.

#### Special notes for the reviewer(s)

In summary, this allows people to update webhooks for a GitHub account rather than org.
This is sort-of "patched" in with a trick. Maybe it would be better to do a more thorough change for adding this kind of support. Or, add a warning this is not supported for accounts and people should use organisations instead - I might be the only sucker use Jenkins X like this.

#### Which issue this PR fixes

fixes #3115 

