### PR TITLE
feat(tag): set the chart's appVersion when tagging

### DIFF
--- a/pkg/jx/cmd/step_tag.go
+++ b/pkg/jx/cmd/step_tag.go
@@ -177,6 +177,7 @@ func (o *StepTagOptions) updateChart(version string, chartsDir string) error {
 		return nil
 	}
 	chart.Version = version
+	chart.AppVersion = version
 	log.Infof("Updating chart version in %s to %s\n", chartFile, version)
 	err = chartutil.SaveChartfile(chartFile, chart)
 	if err != nil {

--- a/pkg/jx/cmd/step_tag_test.go
+++ b/pkg/jx/cmd/step_tag_test.go
@@ -53,6 +53,7 @@ func TestStepTagCharts(t *testing.T) {
 	assert.NoError(t, err, "failed to load file %s", chartFile)
 
 	assert.Equal(t, expectedVersion, chart.Version, "replaced chart version")
+	assert.Equal(t, expectedVersion, chart.AppVersion, "replaced chart appVersion")
 
 	data, err := ioutil.ReadFile(valuesFile)
 	assert.NoError(t, err, "failed to load file %s", valuesFile)

--- a/pkg/jx/cmd/test_data/step_tag_project/charts/mydemo/Chart.yaml
+++ b/pkg/jx/cmd/test_data/step_tag_project/charts/mydemo/Chart.yaml
@@ -3,3 +3,4 @@ description: A Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/images/java.png
 name: demo118
 version: 0.1.0-SNAPSHOT
+appVersion: 0.1.0-SNAPSHOT


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

When running `jx step tag`, we update the `version` field of the chart. This PR also update the `appVersion` field to the same value

#### Special notes for the reviewer(s)

Setting the `appVersion` field to the same value as the `version` field shouldn't be an issue, because in Jenkins X, it's assumed that the chart has the same lifecycle and versioning as the app.
Setting this field allows to easily see the version when running commands such as `helm list`, and to get a better integration with helm-based tools