### PR TITLE
feat: store helm repo creds in Vault

### DIFF
--- a/pkg/apps/helmops.go
+++ b/pkg/apps/helmops.go
@@ -36,7 +36,7 @@ func (o *HelmOpsOptions) AddApp(app string, chart string, name string, version s
 		Repository:  repository,
 		Username:    username,
 		Password:    password,
-	}, o.Helmer, o.KubeClient, o.InstallTimeout)
+	}, o.Helmer, o.KubeClient, o.InstallTimeout, o.VaultClient)
 	if err != nil {
 		return errors.Wrapf(err, "failed to install app %s", app)
 	}

--- a/pkg/apps/install.go
+++ b/pkg/apps/install.go
@@ -47,7 +47,7 @@ type InstallOptions struct {
 	Err             io.Writer
 	GitOps          bool
 	TeamName        string
-	VaultClient     *vault.Client
+	VaultClient     vault.Client
 
 	valuesFiles *environments.ValuesFiles // internal variable used to track, most be passed in
 }
@@ -330,7 +330,7 @@ func (o *InstallOptions) handleSecrets(dir string, app string, generatedSecrets 
 		} else {
 			vaultBasepath = strings.Join([]string{"teams", o.TeamName}, "/")
 		}
-		f, err := AddSecretsToVault(generatedSecrets, *o.VaultClient, vaultBasepath)
+		f, err := AddSecretsToVault(generatedSecrets, o.VaultClient, vaultBasepath)
 		if err != nil {
 			return func() {}, errors.Wrapf(err, "adding secrets to vault with basepath %s for %s", vaultBasepath,
 				app)

--- a/pkg/expose/exposecontroller.go
+++ b/pkg/expose/exposecontroller.go
@@ -118,7 +118,7 @@ func RunExposecontroller(devNamespace, targetNamespace string, ic kube.IngressCo
 		HelmUpdate:  true,
 		VersionsDir: versionsDir,
 		SetValues:   exValues,
-	}, helmer, kubeClient, installTimeout)
+	}, helmer, kubeClient, installTimeout, nil)
 	if err != nil {
 		return fmt.Errorf("exposecontroller deployment failed: %v", err)
 	}

--- a/pkg/jx/cmd/add_app.go
+++ b/pkg/jx/cmd/add_app.go
@@ -215,7 +215,7 @@ func (o *AddAppOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		installOpts.VaultClient = &client
+		installOpts.VaultClient = client
 	}
 
 	args := o.Args

--- a/pkg/jx/cmd/opts/helm.go
+++ b/pkg/jx/cmd/opts/helm.go
@@ -22,8 +22,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	version2 "github.com/jenkins-x/jx/pkg/version"
 	"github.com/pkg/errors"
-	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/src-d/go-git.v4"
+	survey "gopkg.in/AlecAivazis/survey.v1"
+	git "gopkg.in/src-d/go-git.v4"
 	gitconfig "gopkg.in/src-d/go-git.v4/config"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -396,7 +396,11 @@ func (o *CommonOptions) InstallChartWithOptions(options helm.InstallChartOptions
 	if options.VersionsDir == "" {
 		options.VersionsDir, err = o.CloneJXVersionsRepo("")
 	}
-	return helm.InstallFromChartOptions(options, o.Helm(), client, DefaultInstallTimeout)
+	vaultClient, err := o.SystemVaultClient("")
+	if err != nil {
+		return err
+	}
+	return helm.InstallFromChartOptions(options, o.Helm(), client, DefaultInstallTimeout, vaultClient)
 }
 
 // CloneJXVersionsRepo clones the jenkins-x versions repo to a local working dir

--- a/pkg/jx/cmd/upgrade_apps.go
+++ b/pkg/jx/cmd/upgrade_apps.go
@@ -180,7 +180,8 @@ func (o *UpgradeAppsOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		installOpts.VaultClient = &client
+
+		installOpts.VaultClient = client
 	}
 
 	app := ""


### PR DESCRIPTION
If Vault is available automatically store repo creds in it, and use them the next time the repo is accessed. If new creds are provided, they will replace the old creds.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
