### PR TITLE
fix(gke): GetCurrentProject can be multi-line causing error(s)

### DIFF
--- a/pkg/cloud/gke/helper.go
+++ b/pkg/cloud/gke/helper.go
@@ -103,6 +103,12 @@ func GetCurrentProject() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	index := strings.LastIndex(out, "\n")
+	if index >= 0 {
+		return out[index+1:], nil
+	}
+
 	return out, nil
 }
 


### PR DESCRIPTION
#### Description
`gcloud config get-value project` returns a multi-line value which includes the current configuration and then the project ID.  GetCurrentProject() is not handling this.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes
None reported yet
