### PR TITLE
fix: Use pipelineConfig.Env again, don't merge for later stages

### DIFF
--- a/pkg/jx/cmd/step_create_task.go
+++ b/pkg/jx/cmd/step_create_task.go
@@ -851,7 +851,10 @@ func (o *StepCreateTaskOptions) combineLabels(labels map[string]string) error {
 
 func (o *StepCreateTaskOptions) combineEnvVars(projectConfig *jenkinsfile.PipelineConfig) error {
 	// add any custom env vars
-	var envVars []corev1.EnvVar
+	envMap := make(map[string]corev1.EnvVar)
+	for _, e := range projectConfig.Env {
+		envMap[e.Name] = e
+	}
 	for _, customEnvVar := range o.CustomEnvs {
 		parts := strings.Split(customEnvVar, "=")
 		if len(parts) != 2 {
@@ -861,9 +864,9 @@ func (o *StepCreateTaskOptions) combineEnvVars(projectConfig *jenkinsfile.Pipeli
 			Name:  parts[0],
 			Value: parts[1],
 		}
-		envVars = append(envVars, e)
+		envMap[e.Name] = e
 	}
-	projectConfig.Env = envVars
+	projectConfig.Env = syntax.EnvMapToSlice(envMap)
 	return nil
 }
 

--- a/pkg/jx/cmd/test_data/step_create_task/from_yaml/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/from_yaml/tasks.yml
@@ -44,6 +44,8 @@ items:
         value: really-long
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: rawlingsj/builder-jx:wip34
       name: git-merge
       volumeMounts:
@@ -92,6 +94,8 @@ items:
         value: really-long
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-nodejs:0.1.235
       name: step2
       resources:
@@ -152,6 +156,8 @@ items:
         value: really-long
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-nodejs:0.1.235
       name: step3
       resources:
@@ -207,38 +213,6 @@ items:
         type: git
     steps:
     - args:
-      - step
-      - git
-      - merge
-      - --verbose
-      command:
-      - jx
-      env:
-      - name: DOCKER_REGISTRY
-      - name: BUILD_NUMBER
-        value: "1"
-      - name: PIPELINE_KIND
-        value: release
-      - name: REPO_OWNER
-        value: abayer
-      - name: REPO_NAME
-        value: js-test-repo
-      - name: JOB_NAME
-        value: abayer/js-test-repo/really-long
-      - name: APP_NAME
-        value: js-test-repo
-      - name: BRANCH_NAME
-        value: really-long
-      - name: JX_BATCH_MODE
-        value: "true"
-      image: rawlingsj/builder-jx:wip34
-      name: git-merge
-      volumeMounts:
-      - mountPath: /etc/podinfo
-        name: podinfo
-        readOnly: true
-      workingDir: /workspace/source
-    - args:
       - echo hi ${FRUIT}
       command:
       - /bin/sh
@@ -279,6 +253,8 @@ items:
         value: really-long
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-nodejs:0.1.235
       name: step2
       resources:

--- a/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/maven_build_pack/tasks.yml
@@ -46,6 +46,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       volumeMounts:
       - mountPath: /etc/podinfo
         name: podinfo
@@ -96,6 +98,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: setup-jx-git-credentials
       resources:
@@ -164,6 +168,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: setversion-next-version
       resources:
@@ -232,6 +238,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: setversion-set-version
       resources:
@@ -300,6 +308,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: setversion-tag-version
       resources:
@@ -368,6 +378,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: build-mvn-deploy
       resources:
@@ -436,6 +448,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: build-skaffold-version
       resources:
@@ -504,6 +518,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: build-container-build
       resources:
@@ -572,6 +588,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: build-post-build
       resources:
@@ -640,6 +658,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: promote-changelog
       resources:
@@ -708,6 +728,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: promote-helm-release
       resources:
@@ -776,6 +798,8 @@ items:
         value: master
       - name: JX_BATCH_MODE
         value: "true"
+      - name: FRUIT
+        value: BANANA
       image: jenkinsxio/builder-maven-java11:0.1.235
       name: promote-jx-promote
       resources:

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -616,6 +616,7 @@ func validateWorkspace(w string) *apis.FieldError {
 	return nil
 }
 
+// EnvMapToSlice transforms a map of environment variables into a slice that can be used in container configuration
 func EnvMapToSlice(envMap map[string]corev1.EnvVar) []corev1.EnvVar {
 	env := make([]corev1.EnvVar, 0, len(envMap))
 

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -104,7 +104,6 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("echo again"), workingDir("/workspace/source")),
 				)),
 			},
@@ -148,7 +147,6 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("echo again"), workingDir("/workspace/source")),
 				)),
 			},
@@ -210,21 +208,18 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 						tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-						tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 						tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("echo hello world"), workingDir("/workspace/source")),
 					)),
 				tb.Task("somepipeline-another-stage-1", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("echo again"), workingDir("/workspace/source")),
 				)),
 				tb.Task("somepipeline-last-stage-1", "jx", TaskStageLabel("Last Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("echo last"), workingDir("/workspace/source")),
 				)),
 			},
@@ -304,28 +299,24 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 						tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-						tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 						tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("echo hello world"), workingDir("/workspace/source")),
 					)),
 				tb.Task("somepipeline-another-stage-1", "jx", TaskStageLabel("Another stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("echo again"), workingDir("/workspace/source")),
 				)),
 				tb.Task("somepipeline-some-other-stage-1", "jx", TaskStageLabel("Some other stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("echo otherwise"), workingDir("/workspace/source")),
 				)),
 				tb.Task("somepipeline-last-stage-1", "jx", TaskStageLabel("Last Stage"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("echo last"), workingDir("/workspace/source")),
 				)),
 			},
@@ -413,21 +404,18 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("ls"), workingDir("/workspace/source")),
 				)),
 				tb.Task("somepipeline-stage3-1", "jx", TaskStageLabel("stage3"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("ls"), workingDir("/workspace/source")),
 				)),
 				tb.Task("somepipeline-stage4-1", "jx", TaskStageLabel("stage4"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("ls"), workingDir("/workspace/source")),
 				)),
 			},
@@ -495,21 +483,18 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("ls"), workingDir("/workspace/source")),
 				)),
 				tb.Task("somepipeline-stage4-1", "jx", TaskStageLabel("stage4"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("ls"), workingDir("/workspace/source")),
 				)),
 				tb.Task("somepipeline-stage5-1", "jx", TaskStageLabel("stage5"), tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-					tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 					tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("ls"), workingDir("/workspace/source")),
 				)),
 			},
@@ -692,7 +677,6 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.TaskInputs(
 							tb.InputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
 						tb.TaskOutputs(tb.OutputsResource("workspace", tektonv1alpha1.PipelineResourceTypeGit)),
-						tb.Step("git-merge", syntax.GitMergeImage, tb.Command("jx"), tb.Args("step", "git", "merge", "--verbose"), workingDir("/workspace/source")),
 						tb.Step("step2", "some-image", tb.Command("/bin/sh", "-c"), tb.Args("ls"), workingDir("/workspace/source")),
 					)),
 			},


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

#3585 nuked the usage of `PipelineConfig.Env` variables - this puts that back. We're still ignoring `ProjectConfig.Env`, since that was already being ignored by build packs using Knative Build, though. We also stop running `git merge` for stages after the one that actually needs to do the checkout, since we're reusing the workspace from the initial stage anyway.

#### Special notes for the reviewer(s)

/assign @rawlingsj 
/assign @jstrachan 
/assign @dwnusbaum 

#### Which issue this PR fixes

n/a