### PR TITLE
Solved helm namespace issue for IBM block storage

### DIFF
--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1829,7 +1829,6 @@ func (options *InstallOptions) configureCloudProivderPostInit(client kubernetes.
 		helmOptions := helm.InstallChartOptions{
 			Chart:       "ibm/ibmcloud-block-storage-plugin",
 			ReleaseName: "ibmcloud-block-storage-plugin",
-			Ns:          "default",
 			NoForce:     true,
 		}
 		err = options.InstallChartWithOptions(helmOptions)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Solved the helm namespace issue when installing the IBM block storage chart.
This chart is installed for the `iks` provider is.
The installation overrides the namespace to `default` which fails to resolve resource resolution.


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #3391

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->