### PR TITLE
Fix to the get, upgrade and delete app commands after the side effects of the add apps changes

### DIFF
--- a/pkg/apps/install.go
+++ b/pkg/apps/install.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
@@ -173,6 +173,10 @@ func (o *InstallOptions) UpgradeApp(app string, version string, repository strin
 		Items: make([]string, 0),
 	}
 
+	if releaseName == "" {
+		releaseName = fmt.Sprintf("%s-%s", o.Namespace, app)
+	}
+
 	username, password, err := helm.DecorateWithCredentials(repository, username, password, o.VaultClient)
 	if err != nil {
 		return errors.Wrapf(err, "locating credentials for %s", repository)
@@ -200,9 +204,6 @@ func (o *InstallOptions) UpgradeApp(app string, version string, repository strin
 		}
 	} else {
 		upgradeAppFunc := func(dir string) error {
-			if releaseName == "" {
-				releaseName = app
-			}
 			// Try to load existing answers from the apps CRD
 			appCrdName := fmt.Sprintf("%s-%s", releaseName, app)
 			appResource, err := o.JxClient.JenkinsV1().Apps(o.Namespace).Get(appCrdName, v1.GetOptions{})
@@ -241,7 +242,7 @@ func (o *InstallOptions) UpgradeApp(app string, version string, repository strin
 			return nil
 		}
 		// Do the actual work
-		err := helm.InspectChart(app, version, repository, username, password, o.Helmer, upgradeAppFunc)
+		err = helm.InspectChart(app, version, repository, username, password, o.Helmer, upgradeAppFunc)
 		if err != nil {
 			return err
 		}

--- a/pkg/apps/values.go
+++ b/pkg/apps/values.go
@@ -47,7 +47,7 @@ type: Opaque
 
 // StashValues takes the values used to configure an app and annotates the APP CRD with them allowing them to be used
 // at a later date e.g. when the app is upgraded
-func StashValues(values []byte, name string, jxClient versioned.Interface, ns string, chartDir string, repository string) error {
+func StashValues(values []byte, name string, jxClient versioned.Interface, ns string, chartDir string, repository string) (bool, *jenkinsv1.App, error) {
 	// locate the app CRD
 	create := false
 	app, err := jxClient.JenkinsV1().Apps(ns).Get(name, metav1.GetOptions{})
@@ -55,7 +55,8 @@ func StashValues(values []byte, name string, jxClient versioned.Interface, ns st
 		create = true
 		app = &jenkinsv1.App{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
+				Name:      name,
+				Namespace: ns,
 			},
 			Spec: jenkinsv1.AppSpec{},
 		}
@@ -69,18 +70,7 @@ func StashValues(values []byte, name string, jxClient versioned.Interface, ns st
 
 	environments.AddAppMetaData(chartDir, app, repository)
 
-	if create {
-		_, err := jxClient.JenkinsV1().Apps(ns).Create(app)
-		if err != nil {
-			return errors.Wrapf(err, "creating App %s to annotate with values.yaml", name)
-		}
-	} else {
-		_, err = jxClient.JenkinsV1().Apps(ns).PatchUpdate(app)
-		if err != nil {
-			return errors.Wrapf(err, "updating App %s to annotate with values.yaml", name)
-		}
-	}
-	return nil
+	return create, app, nil
 }
 
 // AddSecretsToVault adds the generatedSecrets into the vault using client at basepath
@@ -218,4 +208,19 @@ func GenerateQuestions(schema []byte, batchMode bool, askExisting bool, basePath
 		return nil, nil, errors.WithStack(err)
 	}
 	return values, secrets, nil
+}
+
+func addApp(create bool, jxClient versioned.Interface, app *jenkinsv1.App) error {
+	if create {
+		_, err := jxClient.JenkinsV1().Apps(app.Namespace).Create(app)
+		if err != nil {
+			return errors.Wrapf(err, "creating App %s to annotate with values.yaml", app.Name)
+		}
+	} else {
+		_, err := jxClient.JenkinsV1().Apps(app.Namespace).PatchUpdate(app)
+		if err != nil {
+			return errors.Wrapf(err, "updating App %s to annotate with values.yaml", app.Name)
+		}
+	}
+	return nil
 }

--- a/pkg/jx/cmd/add_app.go
+++ b/pkg/jx/cmd/add_app.go
@@ -102,9 +102,6 @@ func (o *AddAppOptions) addFlags(cmd *cobra.Command, defaultNamespace string) {
 		"The password for the repository")
 	cmd.Flags().StringVarP(&o.Alias, optionAlias, "", "",
 		"An alias to use for the app if you wish to install multiple instances of the same app")
-	cmd.Flags().StringVarP(&o.ReleaseName, optionRelease, "r", "",
-		"The chart release name (by default the name of the app, available when NOT using GitOps for your dev"+
-			" environment)")
 	cmd.Flags().BoolVarP(&o.HelmUpdate, optionHelmUpdate, "", true,
 		"Should we run helm update first to ensure we use the latest version (available when NOT using GitOps for your dev environment)")
 	cmd.Flags().StringVarP(&o.Namespace, optionNamespace, "n", "", "The Namespace to install into (available when NOT using GitOps for your dev environment)")
@@ -139,9 +136,6 @@ func (o *AddAppOptions) Run() error {
 
 	if o.GitOps {
 		msg := "unable to specify --%s when using GitOps for your dev environment"
-		if o.ReleaseName != "" {
-			return util.InvalidOptionf(optionRelease, o.ReleaseName, msg, optionRelease)
-		}
 		if !o.HelmUpdate {
 			return util.InvalidOptionf(optionHelmUpdate, o.HelmUpdate, msg, optionHelmUpdate)
 		}

--- a/pkg/jx/cmd/add_app_test.go
+++ b/pkg/jx/cmd/add_app_test.go
@@ -15,10 +15,10 @@ import (
 	"strings"
 	"testing"
 
-	expect "github.com/Netflix/go-expect"
+	"github.com/Netflix/go-expect"
 	"github.com/jenkins-x/jx/pkg/apps"
-	helm_test "github.com/jenkins-x/jx/pkg/helm/mocks"
-	uuid "github.com/satori/go.uuid"
+	"github.com/jenkins-x/jx/pkg/helm/mocks"
+	"github.com/satori/go.uuid"
 
 	"k8s.io/helm/pkg/chartutil"
 

--- a/pkg/jx/cmd/clients/mocks/factory.go
+++ b/pkg/jx/cmd/clients/mocks/factory.go
@@ -4,7 +4,7 @@
 package clients_test
 
 import (
-	versioned "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
+	versioned1 "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 	client "github.com/heptio/sonobuoy/pkg/client"
 	dynamic "github.com/heptio/sonobuoy/pkg/dynamic"
 	golang_jenkins "github.com/jenkins-x/golang-jenkins"
@@ -16,11 +16,11 @@ import (
 	clients "github.com/jenkins-x/jx/pkg/jx/cmd/clients"
 	table "github.com/jenkins-x/jx/pkg/table"
 	vault "github.com/jenkins-x/jx/pkg/vault"
-	versioned1 "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
-	versioned2 "github.com/knative/build/pkg/client/clientset/versioned"
-	versioned3 "github.com/knative/serving/pkg/client/clientset/versioned"
+	versioned2 "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	versioned3 "github.com/knative/build/pkg/client/clientset/versioned"
+	versioned4 "github.com/knative/serving/pkg/client/clientset/versioned"
 	pegomock "github.com/petergtz/pegomock"
-	versioned4 "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	terminal "gopkg.in/AlecAivazis/survey.v1/terminal"
 	io "io"
 	v1 "k8s.io/api/core/v1"
@@ -119,17 +119,17 @@ func (mock *MockFactory) CreateAuthConfigService(_param0 string, _param1 string)
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateCertManagerClient() (versioned1.Interface, error) {
+func (mock *MockFactory) CreateCertManagerClient() (versioned2.Interface, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateCertManagerClient", params, []reflect.Type{reflect.TypeOf((*versioned1.Interface)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned1.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateCertManagerClient", params, []reflect.Type{reflect.TypeOf((*versioned2.Interface)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned2.Interface
 	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned1.Interface)
+			ret0 = result[0].(versioned2.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(error)
@@ -351,18 +351,18 @@ func (mock *MockFactory) CreateJenkinsClient(_param0 kubernetes.Interface, _para
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateKnativeBuildClient() (versioned2.Interface, string, error) {
+func (mock *MockFactory) CreateKnativeBuildClient() (versioned3.Interface, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeBuildClient", params, []reflect.Type{reflect.TypeOf((*versioned2.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned2.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeBuildClient", params, []reflect.Type{reflect.TypeOf((*versioned3.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned3.Interface
 	var ret1 string
 	var ret2 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned2.Interface)
+			ret0 = result[0].(versioned3.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(string)
@@ -374,18 +374,18 @@ func (mock *MockFactory) CreateKnativeBuildClient() (versioned2.Interface, strin
 	return ret0, ret1, ret2
 }
 
-func (mock *MockFactory) CreateKnativeServeClient() (versioned3.Interface, string, error) {
+func (mock *MockFactory) CreateKnativeServeClient() (versioned4.Interface, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeServeClient", params, []reflect.Type{reflect.TypeOf((*versioned3.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned3.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateKnativeServeClient", params, []reflect.Type{reflect.TypeOf((*versioned4.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned4.Interface
 	var ret1 string
 	var ret2 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned3.Interface)
+			ret0 = result[0].(versioned4.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(string)
@@ -492,18 +492,18 @@ func (mock *MockFactory) CreateTable(_param0 io.Writer) table.Table {
 	return ret0
 }
 
-func (mock *MockFactory) CreateTektonClient() (versioned4.Interface, string, error) {
+func (mock *MockFactory) CreateTektonClient() (versioned.Interface, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateTektonClient", params, []reflect.Type{reflect.TypeOf((*versioned4.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned4.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateTektonClient", params, []reflect.Type{reflect.TypeOf((*versioned.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned.Interface
 	var ret1 string
 	var ret2 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned4.Interface)
+			ret0 = result[0].(versioned.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(string)
@@ -534,17 +534,17 @@ func (mock *MockFactory) CreateVaultClient(_param0 string, _param1 string) (vaul
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateVaultOperatorClient() (versioned.Interface, error) {
+func (mock *MockFactory) CreateVaultOperatorClient() (versioned1.Interface, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateVaultOperatorClient", params, []reflect.Type{reflect.TypeOf((*versioned.Interface)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 versioned.Interface
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateVaultOperatorClient", params, []reflect.Type{reflect.TypeOf((*versioned1.Interface)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned1.Interface
 	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(versioned.Interface)
+			ret0 = result[0].(versioned1.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(error)

--- a/pkg/jx/cmd/delete_app.go
+++ b/pkg/jx/cmd/delete_app.go
@@ -121,11 +121,19 @@ func (o *DeleteAppOptions) Run() error {
 		if err != nil {
 			return errors.Wrap(err, "failed to ensure that helm is present")
 		}
-
+		jxClient, ns, err := o.JXClientAndDevNamespace()
+		if err != nil {
+			return errors.Wrapf(err, "getting jx client")
+		}
 		if o.Alias != "" {
 			return util.InvalidOptionf(optionAlias, o.Alias,
 				"Unable to specify --%s when NOT using GitOps for your dev environment", optionAlias)
 		}
+		opts.JxClient = jxClient
+		if o.Namespace == "" {
+			o.Namespace = ns
+		}
+		opts.Namespace = o.Namespace
 	}
 
 	args := o.Args

--- a/pkg/jx/cmd/delete_app_test.go
+++ b/pkg/jx/cmd/delete_app_test.go
@@ -85,5 +85,5 @@ func TestDeleteApp(t *testing.T) {
 	assert.NoError(t, err)
 
 	testOptions.MockHelmer.VerifyWasCalledOnce().
-		DeleteRelease(pegomock.AnyString(), pegomock.EqString(name), pegomock.AnyBool())
+		DeleteRelease(pegomock.AnyString(), pegomock.EqString(fmt.Sprintf("%s-%s", namespace, name)), pegomock.AnyBool())
 }

--- a/pkg/jx/cmd/get_apps.go
+++ b/pkg/jx/cmd/get_apps.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/apps"
 	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
@@ -35,6 +35,7 @@ type appOutput struct {
 	Description     string `yaml:"description" json:"description"`
 	ChartRepository string `yaml:"chartRepository" json:"chartRepository"`
 	Status          string `yaml:"status" json:"status"`
+	Namespace       string `yaml:"namespace" json:"namespace"`
 }
 
 // HelmOutput is the representation of the Helm status command
@@ -159,7 +160,8 @@ func (o *GetAppsOptions) Run() error {
 }
 
 func (o *GetAppsOptions) generateAppStatusOutput(app *v1.App) error {
-	output, err := o.Helm().StatusReleaseWithOutput(o.Namespace, app.Labels[helm.LabelAppName], "json")
+	name := app.Labels[helm.LabelReleaseName]
+	output, err := o.Helm().StatusReleaseWithOutput(o.Namespace, name, "json")
 	if err != nil {
 		return err
 	}
@@ -178,14 +180,15 @@ func (o *GetAppsOptions) generateTableFormatted(apps *v1.AppList) appsResult {
 			if name != "" && app.Annotations != nil {
 				var status string
 				if releasesMap != nil {
-					status = releasesMap[name].Status
+					status = releasesMap[app.Labels[helm.LabelReleaseName]].Status
 				}
 				results.AppOutput = append(results.AppOutput, appOutput{
 					Name:            name,
 					Version:         app.Labels[helm.LabelAppVersion],
-					Description:     app.Annotations[helm.AnnotationAppDescription],
 					ChartRepository: app.Annotations[helm.AnnotationAppRepository],
+					Namespace:       app.Namespace,
 					Status:          status,
+					Description:     app.Annotations[helm.AnnotationAppDescription],
 				})
 			}
 		}
@@ -208,7 +211,7 @@ func (o *GetAppsOptions) generateTable(apps *v1.AppList, kubeClient kubernetes.I
 				repository := app.Annotations[helm.AnnotationAppRepository]
 				var status string
 				if releasesMap != nil {
-					status = releasesMap[name].Status
+					status = releasesMap[app.Labels[helm.LabelReleaseName]].Status
 				}
 				namespace := app.Namespace
 				row := []string{name, version, repository, namespace, status, description}

--- a/pkg/jx/cmd/get_apps_test.go
+++ b/pkg/jx/cmd/get_apps_test.go
@@ -3,6 +3,7 @@ package cmd_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/jenkins-x/jx/pkg/helm"
 	"io/ioutil"
 	"os"
@@ -59,6 +60,7 @@ func TestGetAppsGitops(t *testing.T) {
 	app := &v1.App{}
 	appBytes, err := ioutil.ReadFile(appResourceLocation)
 	err = yaml.Unmarshal(appBytes, app)
+	app.Labels[helm.LabelReleaseName] = fmt.Sprintf("%s-%s", namespace, name1)
 	app.Namespace = namespace
 	cmd.ConfigureTestOptionsWithResources(getAppOptions.CommonOptions,
 		[]runtime.Object{},
@@ -301,10 +303,10 @@ func TestGetAppsHasStatus(t *testing.T) {
 		},
 		Namespace: namespace,
 	}
-
+	formattedName := fmt.Sprintf("%s-%s", namespace, name1)
 	pegomock.When(getAppOptions.Helm().StatusReleases(pegomock.EqString(namespace))).
 		ThenReturn(map[string]helm.Release{
-			name1: {Status: "DEPLOYED"},
+			formattedName: {Status: "DEPLOYED"},
 		}, nil)
 
 	getAppOptions.Args = []string{name1}
@@ -347,10 +349,10 @@ func TestGetAppsAsJson(t *testing.T) {
 		},
 		Namespace: namespace,
 	}
-
+	formattedName := fmt.Sprintf("%s-%s", namespace, name1)
 	pegomock.When(getAppOptions.Helm().StatusReleases(pegomock.EqString(namespace))).
 		ThenReturn(map[string]helm.Release{
-			name1: {Status: "DEPLOYED"},
+			formattedName: {Status: "DEPLOYED"},
 		}, nil)
 
 	getAppOptions.Args = []string{name1}
@@ -398,10 +400,10 @@ func TestGetAppsAsYaml(t *testing.T) {
 		},
 		Namespace: namespace,
 	}
-
+	formattedName := fmt.Sprintf("%s-%s", namespace, name1)
 	pegomock.When(getAppOptions.Helm().StatusReleases(pegomock.EqString(namespace))).
 		ThenReturn(map[string]helm.Release{
-			name1: {Status: "DEPLOYED"},
+			formattedName: {Status: "DEPLOYED"},
 		}, nil)
 
 	getAppOptions.Args = []string{name1}
@@ -501,7 +503,6 @@ func TestGetAppsResourcesStatusJsonFormat(t *testing.T) {
 	pegomock.When(getAppOptions.Helm().StatusReleaseWithOutput(pegomock.EqString(namespace),
 		pegomock.AnyString(), pegomock.EqString("json"))).
 		ThenReturn(string(expectedJSON), nil)
-
 	getAppOptions.Args = []string{name1, name2}
 	console := tests.NewTerminal(t)
 	r, fakeStdout, _ := os.Pipe()
@@ -555,7 +556,6 @@ func TestGetAppsResourcesStatusYamlFormat(t *testing.T) {
 	pegomock.When(testOptions.MockHelmer.StatusReleaseWithOutput(pegomock.EqString(namespace),
 		pegomock.AnyString(), pegomock.EqString("json"))).
 		ThenReturn(string(expectedJSON), nil)
-
 	getAppOptions.Args = []string{name1, name2}
 	console := tests.NewTerminal(t)
 	r, fakeStdout, _ := os.Pipe()
@@ -608,7 +608,6 @@ func TestGetAppsResourcesStatusRawFormat(t *testing.T) {
 	pegomock.When(testOptions.MockHelmer.StatusReleaseWithOutput(pegomock.EqString(namespace),
 		pegomock.AnyString(), pegomock.EqString("json"))).
 		ThenReturn(string(expectedJSON), nil)
-
 	getAppOptions.Args = []string{name1, name2}
 	console := tests.NewTerminal(t)
 	r, fakeStdout, _ := os.Pipe()

--- a/pkg/jx/cmd/test_data/get_apps/get_apps_table_json.json
+++ b/pkg/jx/cmd/test_data/get_apps/get_apps_table_json.json
@@ -5,7 +5,8 @@
       "version": "0.0.1",
       "description": "My test chart description",
       "chartRepository": "http://chartmuseum.jenkins-x.io",
-      "status": "DEPLOYED"
+      "status": "DEPLOYED",
+      "namespace": "jx-testing"
     }
   ]
 }

--- a/pkg/jx/cmd/test_data/get_apps/get_apps_table_yaml.yaml
+++ b/pkg/jx/cmd/test_data/get_apps/get_apps_table_yaml.yaml
@@ -2,5 +2,6 @@ items:
 - appName: <NAME_PLACEHOLDER>
   chartRepository: http://chartmuseum.jenkins-x.io
   description: My test chart description
+  namespace: jx-testing
   status: DEPLOYED
   version: 0.0.1


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Modifies the add app command to include the `ReleaseName` Helm label to the Apps CRD object and refactor to separate the responsibilities of `StashValues`and `addApp` functions.

Modified the get apps command to show the release name as the app name and use the CRD List API to list Apps by the `ReleaseName` label.

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
fixes #3658 
