### PR TITLE
Make sure the command `jx upgrade app` finds the correct latest version when not providing one

### DIFF
--- a/pkg/apps/gitops.go
+++ b/pkg/apps/gitops.go
@@ -55,10 +55,11 @@ func (o *GitOpsOptions) UpgradeApp(app string, version string, repository string
 
 	if app != "" {
 		all = false
-		if version == "" {
-			version = "latest"
+		versionBranchName := version
+		if versionBranchName == "" {
+			versionBranchName = "latest"
 		}
-		details.BranchName = fmt.Sprintf("upgrade-app-%s-%s", app, version)
+		details.BranchName = fmt.Sprintf("upgrade-app-%s-%s", app, versionBranchName)
 	} else {
 		details.BranchName = fmt.Sprintf("upgrade-all-apps")
 		details.Title = fmt.Sprintf("Upgrade all apps")


### PR DESCRIPTION
…a version but the version itself is empty when calling helm

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description

While using GitOps: 

When calling `jx upgrade app jx-app-datadog` without providing a version, it couldn't find the actual latest version because a version named `latest` was being passed to Helm. 

In order to find the latest version, Helm needs the `--version` flag to be empty.

The branch will still be named `<PREFIX>-latest`. 

#### Which issue this PR fixes

fixes #3674

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
