### PR TITLE
Fixes the upgrade app command so it doesn't ask for already answered configuration questions

### DIFF
--- a/pkg/apps/gitops.go
+++ b/pkg/apps/gitops.go
@@ -35,7 +35,7 @@ func (o *GitOpsOptions) AddApp(app string, dir string, version string, repositor
 		GitProvider: o.GitProvider,
 	}
 
-	info, err := options.Create(o.DevEnv, o.EnvironmentsDir, &details, nil)
+	info, err := options.Create(o.DevEnv, o.EnvironmentsDir, &details, nil, "")
 
 	if err != nil {
 		return errors.Wrapf(err, "creating pr for %s", app)
@@ -88,7 +88,7 @@ func (o *GitOpsOptions) UpgradeApp(app string, version string, repository string
 			o.Helmer, inspectChartFunc, o.Verbose, o.valuesFiles),
 		GitProvider: o.GitProvider,
 	}
-	_, err := options.Create(o.DevEnv, o.EnvironmentsDir, &details, nil)
+	_, err := options.Create(o.DevEnv, o.EnvironmentsDir, &details, nil, app)
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func (o *GitOpsOptions) DeleteApp(app string, alias string) error {
 		GitProvider:   o.GitProvider,
 	}
 
-	info, err := options.Create(o.DevEnv, o.EnvironmentsDir, &details, nil)
+	info, err := options.Create(o.DevEnv, o.EnvironmentsDir, &details, nil, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/helm/helm_helpers.go
+++ b/pkg/helm/helm_helpers.go
@@ -51,7 +51,8 @@ const (
 	// FakeChartmusuem is the url for the fake chart museum used in tests
 	FakeChartmusuem = "http://fake.chartmuseum"
 
-	defaultEnvironmentChartDir = "env"
+	// DefaultEnvironmentChartDir is the default environment path where charts are stored
+	DefaultEnvironmentChartDir = "env"
 
 	//RepoVaultPath is the path to the repo credentials in Vault
 	RepoVaultPath = "helm/repos"
@@ -158,6 +159,13 @@ func FindValuesFileName(dir string) (string, error) {
 	return findFileName(dir, ValuesFileName)
 }
 
+// FindValuesFileNameForChart returns the values.yaml file name for a given chart within the environment or the default if the chart name is empty
+func FindValuesFileNameForChart(dir string, chartName string) (string, error) {
+	//Chart name and file name are joined here to avoid hard coding the environment
+	//The chart name is ignored in the path if it's empty
+	return findFileName(dir, filepath.Join(chartName, ValuesFileName))
+}
+
 // FindTemplatesDirName returns the default templates/ dir name
 func FindTemplatesDirName(dir string) (string, error) {
 	return findFileName(dir, TemplatesDirName)
@@ -165,7 +173,7 @@ func FindTemplatesDirName(dir string) (string, error) {
 
 func findFileName(dir string, fileName string) (string, error) {
 	names := []string{
-		filepath.Join(dir, defaultEnvironmentChartDir, fileName),
+		filepath.Join(dir, DefaultEnvironmentChartDir, fileName),
 		filepath.Join(dir, fileName),
 	}
 	for _, name := range names {
@@ -194,7 +202,7 @@ func findFileName(dir string, fileName string) (string, error) {
 		}
 	}
 	dirs := []string{
-		filepath.Join(dir, defaultEnvironmentChartDir),
+		filepath.Join(dir, DefaultEnvironmentChartDir),
 		dir,
 	}
 	for _, d := range dirs {

--- a/pkg/jx/cmd/delete_application.go
+++ b/pkg/jx/cmd/delete_application.go
@@ -327,7 +327,7 @@ func (o *DeleteApplicationOptions) deleteApplicationFromEnvironment(env *v1.Envi
 		ModifyChartFn: modifyChartFn,
 		GitProvider:   gitProvider,
 	}
-	info, err := options.Create(env, environmentsDir, &details, nil)
+	info, err := options.Create(env, environmentsDir, &details, nil, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/opts/helm.go
+++ b/pkg/jx/cmd/opts/helm.go
@@ -367,7 +367,7 @@ func (o *CommonOptions) InstallChartOrGitOps(isGitOps bool, gitOpsDir string, gi
 	}
 
 	// if we are part of an initial installation we won't have done a git push yet so lets just write to the gitOpsEnvDir where the dev env chart is
-	return environments.ModifyChartFiles(gitOpsEnvDir, nil, modifyFn)
+	return environments.ModifyChartFiles(gitOpsEnvDir, nil, modifyFn, "")
 }
 
 // InstallChartAt installs the given chart

--- a/pkg/jx/cmd/promote.go
+++ b/pkg/jx/cmd/promote.go
@@ -488,7 +488,7 @@ func (o *PromoteOptions) PromoteViaPullRequest(env *v1.Environment, releaseInfo 
 		ModifyChartFn: modifyChartFn,
 		GitProvider:   gitProvider,
 	}
-	info, err := options.Create(env, environmentsDir, &details, releaseInfo.PullRequestInfo)
+	info, err := options.Create(env, environmentsDir, &details, releaseInfo.PullRequestInfo, "")
 	releaseInfo.PullRequestInfo = info
 	return err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Fixes the behavior that happened after upgrading an app that had configuration questions. 
The questions were being asked again because the CLI wasn't able to find the distribution's `values.yaml` file containing all already provided answers and was only finding the main chart's yaml file.

It will now look into the dependencies in the `requirements.yaml` file and attempt to find a valid `values.yaml` in the composed path. It will warn the user if it's unable to find a values.file.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #3673

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
