### PR TITLE
Avoid having a null reference as a list element in the requirements.yaml file when deleting an app in GitOps mode

### DIFF
--- a/pkg/apps/gitops.go
+++ b/pkg/apps/gitops.go
@@ -105,7 +105,7 @@ func (o *GitOpsOptions) DeleteApp(app string, alias string) error {
 		for i, d := range requirements.Dependencies {
 			if d.Name == app && d.Alias == alias {
 				found = true
-				requirements.Dependencies[i] = nil
+				requirements.Dependencies = append(requirements.Dependencies[:i], requirements.Dependencies[i+1:]...)
 			}
 		}
 		// If app not found, add it

--- a/pkg/jx/cmd/delete_app_test.go
+++ b/pkg/jx/cmd/delete_app_test.go
@@ -55,8 +55,7 @@ func TestDeleteAppForGitOps(t *testing.T) {
 	// Validate the updated Requirements.yaml
 	requirements, err := helm.LoadRequirementsFile(filepath.Join(devEnvDir, helm.RequirementsFileName))
 	assert.NoError(t, err)
-	assert.Len(t, requirements.Dependencies, 1)
-	assert.Nil(t, requirements.Dependencies[0])
+	assert.Len(t, requirements.Dependencies, 0)
 }
 
 func TestDeleteApp(t *testing.T) {


### PR DESCRIPTION
…nts.yaml file as it causes the apps upgrade to panic

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
When deleting an app in GitOps mode, a null reference was added to the `requirements.yaml` in the place of the deleted app. This causes the `jx app upgrade` command to panic when going through the requirements file.

With this fix, the app is just removed from the slice.

#### Which issue this PR fixes

fixes #3699

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
