### PR TITLE
Added --url-only argument to get preview

### DIFF
--- a/.stignore
+++ b/.stignore
@@ -1,0 +1,8 @@
+.git
+.idea
+.settings
+.vscode
+bin
+build
+target
+node_modules

--- a/pkg/jx/cmd/create_step.go
+++ b/pkg/jx/cmd/create_step.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1"
+	survey "gopkg.in/AlecAivazis/survey.v1"
 )
 
 const (

--- a/pkg/jx/cmd/get_preview.go
+++ b/pkg/jx/cmd/get_preview.go
@@ -97,6 +97,9 @@ func (o *GetPreviewOptions) CurrentPreviewUrl() error {
 		if env.Spec.Kind == v1.EnvironmentKindTypePreview && env.Name == name {
 			if o.URLOutput != "" {
 				err = ioutil.WriteFile(o.URLOutput, []byte(env.Spec.PreviewGitSpec.ApplicationURL), 0644)
+				if err != nil {
+					return err
+				}
 			}
 			if o.URLOnly {
 				fmt.Sprintf("%s", env.Spec.PreviewGitSpec.ApplicationURL)

--- a/pkg/jx/cmd/get_preview.go
+++ b/pkg/jx/cmd/get_preview.go
@@ -58,6 +58,7 @@ func NewCmdGetPreview(commonOpts *opts.CommonOptions) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&options.Current, "current", "c", false, "Output the URL of the current Preview application the current pipeline just deployed")
+	cmd.Flags().BoolVarP(&options.URLOnly, "url-only", "u", false, "Output only the URL")
 
 	options.addGetFlags(cmd)
 	return cmd
@@ -90,7 +91,11 @@ func (o *GetPreviewOptions) CurrentPreviewUrl() error {
 	}
 	for _, env := range envList.Items {
 		if env.Spec.Kind == v1.EnvironmentKindTypePreview && env.Name == name {
-			log.Info(env.Spec.PreviewGitSpec.ApplicationURL)
+			if o.URLOnly {
+				fmt.Sprintf("%s", env.Spec.PreviewGitSpec.ApplicationURL)
+			} else {
+				log.Info(env.Spec.PreviewGitSpec.ApplicationURL)
+			}
 			return nil
 		}
 	}

--- a/pkg/jx/cmd/get_preview.go
+++ b/pkg/jx/cmd/get_preview.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
@@ -16,8 +17,9 @@ import (
 type GetPreviewOptions struct {
 	GetEnvOptions
 
-	Current bool
-	URLOnly bool
+	Current   bool
+	URLOnly   bool
+	URLOutput string
 }
 
 var (
@@ -60,6 +62,7 @@ func NewCmdGetPreview(commonOpts *opts.CommonOptions) *cobra.Command {
 
 	cmd.Flags().BoolVarP(&options.Current, "current", "c", false, "Output the URL of the current Preview application the current pipeline just deployed")
 	cmd.Flags().BoolVarP(&options.URLOnly, "url-only", "u", false, "Output only the URL")
+	cmd.Flags().StringVarP(&options.URLOutput, "url-output", "f", "", "The path to the file when the URL of the preview will be stored.")
 
 	options.addGetFlags(cmd)
 	return cmd
@@ -92,6 +95,9 @@ func (o *GetPreviewOptions) CurrentPreviewUrl() error {
 	}
 	for _, env := range envList.Items {
 		if env.Spec.Kind == v1.EnvironmentKindTypePreview && env.Name == name {
+			if o.URLOutput != "" {
+				err = ioutil.WriteFile(o.URLOutput, []byte(env.Spec.PreviewGitSpec.ApplicationURL), 0644)
+			}
 			if o.URLOnly {
 				fmt.Sprintf("%s", env.Spec.PreviewGitSpec.ApplicationURL)
 			} else {

--- a/pkg/jx/cmd/get_preview.go
+++ b/pkg/jx/cmd/get_preview.go
@@ -17,6 +17,7 @@ type GetPreviewOptions struct {
 	GetEnvOptions
 
 	Current bool
+	URLOnly bool
 }
 
 var (


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Often, tests need to know the address of the application under test. `jx get preview --current` outputs it, but it does not react to `-o` argument so the output is a log entry. Since it outputs only the URL, it should probably not make sense to add the support for `-o`. Instead, a simple plain-text output of the address should suffice.

I recommend we add an argument `--url-only` that would output only the URL instead of a log entry that would be hard to parse.

The end goal is to be able to do something like the following steps in pipelines (similar to how we use `VERSION`):

```yaml
        - sh: echo \$(jx preview --app $APP_NAME --dir ../..) > ADDRESS
          name: jx-preview
        - sh: ADDRESS=$(cat ADDRESS) make functional-tests
          name: test
```

#### Special notes for the reviewer(s)

Yet another argument.

#### Which issue this PR fixes

fixes #3713
