### PR TITLE
Istio addon fails to install when using --no-tiller

### DIFF
--- a/pkg/helm/helm_template.go
+++ b/pkg/helm/helm_template.go
@@ -346,9 +346,18 @@ func (h *HelmTemplate) UpgradeChart(chart string, releaseName string, ns string,
 	}
 	outputDir, _, chartsDir, err := h.getDirectories(releaseName)
 
-	chartDir, err := h.fetchChart(chart, version, chartsDir, repo, username, password)
+	// check if we are installing a chart from the filesystem
+	chartDir := filepath.Join(h.CWD, chart)
+	exists, err := util.FileExists(chartDir)
 	if err != nil {
 		return err
+	}
+	if !exists {
+		log.Debugf("Fetching chart: %s\n", chart)
+		chartDir, err = h.fetchChart(chart, version, chartsDir, repo, username, password)
+		if err != nil {
+			return err
+		}
 	}
 	err = h.Client.Template(chartDir, releaseName, ns, outputDir, false, values, valueFiles)
 	if err != nil {

--- a/pkg/jx/cmd/create_addon_istio.go
+++ b/pkg/jx/cmd/create_addon_istio.go
@@ -138,6 +138,12 @@ func (o *CreateAddonIstioOptions) Run() error {
 	}
 	setValues := strings.Split(o.SetValues, ",")
 	values = append(values, setValues...)
+	log.Infof("installing istio-init\n")
+	err = o.InstallChartAt(o.Dir, o.ReleaseName, o.Chart+"-init", o.Version, o.Namespace, true, values, nil, "")
+	if err != nil {
+		return fmt.Errorf("istio-init deployment failed: %v", err)
+	}
+	log.Infof("installing istio\n")
 	err = o.InstallChartAt(o.Dir, o.ReleaseName, o.Chart, o.Version, o.Namespace, true, values, nil, "")
 	if err != nil {
 		return fmt.Errorf("istio deployment failed: %v", err)


### PR DESCRIPTION
fix: Istio addon needs to install istio-init chart (#3724)

   fix: Istio addon fails to install when using --no-tiller (#3724)

   The helm template installation fails when the chart is installed from the
   filesystem Only when using no-tiller (the default now)


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #3724

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->