### PR TITLE
fix: Handle shortening cluster names for clusters named by their FQDN.

### DIFF
--- a/pkg/kube/cluster/cluster.go
+++ b/pkg/kube/cluster/cluster.go
@@ -3,9 +3,10 @@ package cluster
 import (
 	"strings"
 
-	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/jenkins-x/jx/pkg/kube"
 )
 
 // Name gets the cluster name from the current context
@@ -43,24 +44,7 @@ func ShortName(kuber kube.Kuber) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "retrieving the cluster name")
 	}
-	return ShortClusterName(clusterName), nil
-}
-
-// ShortClusterName shrinks the cluster name
-func ShortClusterName(clusterName string) string {
-	return ShortNameN(clusterName, 16)
-}
-
-// ShortNameN shrinks the name to a max length
-func ShortNameN(clusterName string, maxLen int) string {
-	shortClusterName := clusterName
-	if len(clusterName) > maxLen {
-		shortClusterName = clusterName[0:maxLen]
-	}
-	if strings.HasSuffix(shortClusterName, "_") || strings.HasSuffix(shortClusterName, "-") {
-		shortClusterName = shortClusterName[0 : len(shortClusterName)-1]
-	}
-	return shortClusterName
+	return kube.ToValidNameTruncated(clusterName, 16), nil
 }
 
 // SimplifiedClusterName get the simplified cluster name from the long-winded context cluster name that gets generated

--- a/pkg/kube/cluster/cluster_test.go
+++ b/pkg/kube/cluster/cluster_test.go
@@ -1,14 +1,15 @@
 package cluster_test
 
 import (
-	"github.com/jenkins-x/jx/pkg/kube/vault"
 	"testing"
 
-	"github.com/jenkins-x/jx/pkg/kube/cluster"
-	kube_test "github.com/jenkins-x/jx/pkg/kube/mocks"
 	. "github.com/petergtz/pegomock"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/jenkins-x/jx/pkg/kube/cluster"
+	kube_test "github.com/jenkins-x/jx/pkg/kube/mocks"
+	"github.com/jenkins-x/jx/pkg/kube/vault"
 )
 
 func TestGetSimplifiedClusterName(t *testing.T) {
@@ -41,6 +42,9 @@ func TestShortClusterName(t *testing.T) {
 		},
 	}
 	When(kuber.LoadConfig()).ThenReturn(&config, nil, nil)
+
+	clusterName, err = cluster.ShortName(kuber)
+
 	assert.NoError(t, err)
 	assert.Equal(t, "short-cluster-na", clusterName)
 
@@ -51,6 +55,9 @@ func TestShortClusterName(t *testing.T) {
 		},
 	}
 	When(kuber.LoadConfig()).ThenReturn(&config, nil, nil)
+
+	clusterName, err = cluster.ShortName(kuber)
+
 	assert.NoError(t, err)
 	assert.Equal(t, "short-cluster-na", clusterName)
 }

--- a/pkg/kube/vault/vault.go
+++ b/pkg/kube/vault/vault.go
@@ -5,15 +5,16 @@ import (
 
 	"github.com/banzaicloud/bank-vaults/operator/pkg/apis/vault/v1alpha1"
 	"github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/kube/cluster"
 	"github.com/jenkins-x/jx/pkg/kube/serviceaccount"
 	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/jenkins-x/jx/pkg/vault"
-	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -137,9 +138,9 @@ func SystemVaultName(kuber kube.Kuber) (string, error) {
 
 // SystemVaultNameForCluster returns the system vault name from a given cluster name
 func SystemVaultNameForCluster(clusterName string) string {
-	shortClusterName := cluster.ShortClusterName(clusterName)
+	shortClusterName := kube.ToValidNameTruncated(clusterName, 16)
 	fullName := fmt.Sprintf("%s-%s", vault.SystemVaultNamePrefix, shortClusterName)
-	return cluster.ShortNameN(fullName, 22)
+	return kube.ToValidNameTruncated(fullName, 22)
 }
 
 // CreateGKEVault creates a new vault backed by GCP KMS and storage


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
Fixes the case that the cluster name is a FQDN which then ends up with a short name ending in a dot which forms an invalid name used for creating the vault service account

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #3755

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
