### PR TITLE
Flag for static jenkins master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -180,7 +180,7 @@ require (
 	k8s.io/helm v2.7.2+incompatible
 	k8s.io/klog v0.2.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20180719232738-d8ea2fe547a4
-	k8s.io/kubernetes v1.11.3 // indirect
+	k8s.io/kubernetes v1.11.3
 	k8s.io/metrics v0.0.0-20180620010437-b11cf31b380b
 	k8s.io/test-infra v0.0.0-20190131093439-a22cef183a8f
 	sigs.k8s.io/yaml v1.1.0

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -115,6 +115,7 @@ type InstallFlags struct {
 	NoGitOpsEnvSetup            bool
 	NoGitOpsVault               bool
 	NextGeneration              bool
+	StaticJenkins               bool
 }
 
 // Secrets struct for secrets
@@ -341,7 +342,7 @@ func (options *InstallOptions) addInstallFlags(cmd *cobra.Command, includesInit 
 	cmd.Flags().StringVarP(&flags.Version, "version", "", "", "The specific platform version to install")
 	cmd.Flags().BoolVarP(&flags.Prow, "prow", "", false, "Enable Prow to implement Serverless Jenkins and support ChatOps on Pull Requests")
 	cmd.Flags().BoolVarP(&flags.Tekton, "tekton", "", false, "Enables the Tekton pipeline engine (which used to be called knative build pipeline) along with Prow to provide Serverless Jenkins. Otherwise we default to use Knative Build if you enable Prow")
-	cmd.Flags().BoolVarP(&flags.KnativeBuild, "knative-build", "", false, "Note this option is deprecated now in favour of tekton. If specified this will keep using the old knative build with Prow instead of the stratgegic tekton")
+	cmd.Flags().BoolVarP(&flags.KnativeBuild, "knative-build", "", false, "Note this option is deprecated now in favour of tekton. If specified this will keep using the old knative build with Prow instead of the strategic tekton")
 	cmd.Flags().BoolVarP(&flags.ExternalDNS, "external-dns", "", false, "Installs external-dns into the cluster. ExternalDNS manages service DNS records for your cluster, providing you've setup your domain record")
 	cmd.Flags().BoolVarP(&flags.GitOpsMode, "gitops", "", false, "Creates a git repository for the Dev environment to manage the installation, configuration, upgrade and addition of Apps in Jenkins X all via GitOps")
 	cmd.Flags().BoolVarP(&flags.NoGitOpsEnvApply, "no-gitops-env-apply", "", false, "When using GitOps to create the source code for the development environment and installation, don't run 'jx step env apply' to perform the install")
@@ -353,6 +354,7 @@ func (options *InstallOptions) addInstallFlags(cmd *cobra.Command, includesInit 
 	cmd.Flags().StringVarP(&flags.BuildPackName, "buildpack", "", "", "The name of the build pack to use for the Team")
 	cmd.Flags().BoolVarP(&flags.Kaniko, "kaniko", "", false, "Use Kaniko for building docker images")
 	cmd.Flags().BoolVarP(&flags.NextGeneration, "ng", "", false, "Use the Next Generation Jenkins X features like Prow, Tekton, No Tiller, Vault, Dev GitOps")
+	cmd.Flags().BoolVarP(&flags.StaticJenkins, "static-jenkins", "", false, "Install a static Jenkins master to use as the pipeline engine. Note this functionality is deprecated in favour of running serverless Tekton builds")
 
 	opts.AddGitRepoOptionsArguments(cmd, &options.GitRepositoryOptions)
 	options.HelmValuesConfig.AddExposeControllerValues(cmd, true)
@@ -370,8 +372,20 @@ func (flags *InstallFlags) addCloudEnvOptions(cmd *cobra.Command) {
 func (options *InstallOptions) checkFlags() error {
 	flags := &options.Flags
 
+	if flags.NextGeneration && flags.StaticJenkins {
+		return fmt.Errorf("Incompatible options '--ng' and '--static-jenkins'. Please pick only one of them. We recommend --ng as --static-jenkins is deprecated")
+	}
+
+	if flags.Tekton && flags.StaticJenkins {
+		return fmt.Errorf("Incompatible options '--tekton' and '--static-jenkins'. Please pick only one of them. We recommend --tekton as --static-jenkins is deprecated")
+	}
+
 	if flags.KnativeBuild && flags.Tekton {
 		return fmt.Errorf("Incompatible options '--knative-build' and '--tekton'. Please pick only one of them. We recommend --tekton as --knative-build is deprecated")
+	}
+
+	if flags.Prow {
+		flags.StaticJenkins = false
 	}
 	if flags.Prow && !flags.KnativeBuild {
 		flags.Tekton = true
@@ -384,6 +398,7 @@ func (options *InstallOptions) checkFlags() error {
 		}
 	}
 	if flags.NextGeneration {
+		flags.StaticJenkins = false
 		flags.KnativeBuild = false
 		flags.GitOpsMode = true
 		flags.Vault = true
@@ -1041,19 +1056,21 @@ func (options *InstallOptions) configureHelmRepo() error {
 }
 
 func (options *InstallOptions) selectJenkinsInstallation() error {
-	if !options.BatchMode && !options.Flags.Prow {
-		jenkinsInstallOptions := []string{
-			ServerlessJenkins,
-			StaticMasterJenkins,
-		}
-		jenkinsInstallOption, err := util.PickNameWithDefault(jenkinsInstallOptions, "Select Jenkins installation type:", ServerlessJenkins, "", options.In, options.Out, options.Err)
-		if err != nil {
-			return errors.Wrap(err, "picking Jenkins installation type")
-		}
-		if jenkinsInstallOption == ServerlessJenkins {
-			options.Flags.Prow = true
-			if !options.Flags.KnativeBuild {
-				options.Flags.Tekton = true
+	if !options.BatchMode {
+		if !options.Flags.Prow && !options.Flags.StaticJenkins {
+			jenkinsInstallOptions := []string{
+				ServerlessJenkins,
+				StaticMasterJenkins,
+			}
+			jenkinsInstallOption, err := util.PickNameWithDefault(jenkinsInstallOptions, "Select Jenkins installation type:", ServerlessJenkins, "", options.In, options.Out, options.Err)
+			if err != nil {
+				return errors.Wrap(err, "picking Jenkins installation type")
+			}
+			if jenkinsInstallOption == ServerlessJenkins {
+				options.Flags.Prow = true
+				if !options.Flags.KnativeBuild {
+					options.Flags.Tekton = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Adding a flag to specifically enable a static jenkins master instead of it being the default option if
prow, tekton or ng is selected.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
