### PR TITLE
user commonoptions username field instead

### DIFF
--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -177,6 +177,7 @@ func (p *GitHubProvider) ListRepositories(org string) ([]*GitRepository, error) 
 	}
 
 	if IsOwnerGitHubUser(owner, p.Username) {
+		log.Infof("Owner of repo is same as username, using GitHub API for Users")
 		return p.ListRepositoriesForUser(p.Username)
 	}
 

--- a/pkg/jx/cmd/update_webhooks.go
+++ b/pkg/jx/cmd/update_webhooks.go
@@ -120,9 +120,17 @@ func (options *UpdateWebhooksOptions) Run() error {
 	}
 	owner := GetOrgOrUserFromOptions(options)
 
+	if options.Verbose {
+		log.Infof("Updating webhooks for Owner %v and Repo %v\n", owner, options.Repo)
+	}
+
 	if options.Repo != "" {
 		options.updateRepoHook(git, options.Repo, webhookURL, isProwEnabled, hmacToken)
 	} else {
+		if owner == "" {
+			return errors.Wrap(err, "unable to list repositories - no repo owner")
+		}
+
 		repositories, err := git.ListRepositories(owner)
 		if err != nil {
 			return errors.Wrap(err, "unable to list repositories")
@@ -143,8 +151,8 @@ func (options *UpdateWebhooksOptions) Run() error {
 // or "" if neither is set
 func GetOrgOrUserFromOptions(options *UpdateWebhooksOptions) string {
 	owner := options.Org
-	if owner == "" && options.User != "" {
-		owner = options.User
+	if owner == "" && options.Username != "" {
+		owner = options.Username
 	}
 	return owner
 }

--- a/pkg/jx/cmd/update_webhooks_test.go
+++ b/pkg/jx/cmd/update_webhooks_test.go
@@ -1,15 +1,17 @@
 package cmd
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetOrgOrUserFromOptions_orgIsSet(t *testing.T) {
 	t.Parallel()
 	options := &UpdateWebhooksOptions{
-		Org:  "MyOrg",
-		User: "MyUser",
+		Org:           "MyOrg",
+		CommonOptions: &opts.CommonOptions{Username: "MyUser"},
 	}
 	owner := GetOrgOrUserFromOptions(options)
 	assert.Equal(t, options.Org, owner, "The Owner should be the Org name")
@@ -18,18 +20,18 @@ func TestGetOrgOrUserFromOptions_orgIsSet(t *testing.T) {
 func TestGetOrgOrUserFromOptions_orgNotSetUserIsSet(t *testing.T) {
 	t.Parallel()
 	options := &UpdateWebhooksOptions{
-		Org:  "",
-		User: "MyUser",
+		Org:           "",
+		CommonOptions: &opts.CommonOptions{Username: "MyUser"},
 	}
 	owner := GetOrgOrUserFromOptions(options)
-	assert.Equal(t, options.User, owner, "The Owner should be the Username")
+	assert.Equal(t, options.Username, owner, "The Owner should be the Username")
 }
 
 func TestGetOrgOrUserFromOptions_orgNotSetUserNotSet(t *testing.T) {
 	t.Parallel()
 	options := &UpdateWebhooksOptions{
-		Org:  "",
-		User: "",
+		Org:           "",
+		CommonOptions: &opts.CommonOptions{Username: ""},
 	}
 	owner := GetOrgOrUserFromOptions(options)
 	assert.Equal(t, "", owner, "The Owner should be empty")

--- a/pkg/jx/cmd/upgrade_ingress.go
+++ b/pkg/jx/cmd/upgrade_ingress.go
@@ -661,6 +661,10 @@ func (o *UpgradeIngressOptions) updateWebHooks(oldHookEndpoint string, newHookEn
 		return errors.Wrap(err, "unable to determine git provider")
 	}
 
+	if o.CommonOptions.Verbose {
+		log.Infof("Updating all webHooks for org %s and/or username %s\n", organisation, updateWebHook.Username)
+	}
+
 	updateWebHook.PreviousHookUrl = oldHookEndpoint
 	updateWebHook.Org = organisation
 	updateWebHook.DryRun = false


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description

Using `CommonOptions` should be preferred, as it will aid code flows using other commands, such as `upgrade ingress`.

Also included some verbose logging and throwing an error when there's no `owner` set, to avoid hanging on retrieving repositories forever.

#### Special notes for the reviewer(s)

Related to PR 3527

#### Which issue this PR fixes

fixes #3810, fixes #3115 (already closed, but affected)

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
