### PR TITLE
(fix) git version for jx step bdd versions repository

### DIFF
--- a/pkg/jx/cmd/step_bdd.go
+++ b/pkg/jx/cmd/step_bdd.go
@@ -57,6 +57,7 @@ type StepBDDFlags struct {
 	TestGitPrNumber     string
 	JxBinary            string
 	TestCases           []string
+	VersionsRepoPr      bool
 }
 
 var (
@@ -115,6 +116,7 @@ func NewCmdStepBDD(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.Flags.IgnoreTestFailure, "ignore-fail", "i", false, "Ignores test failures so that a BDD test run can capture the output and report on the test passes/failures")
 	cmd.Flags().BoolVarP(&options.Flags.IgnoreTestFailure, "parallel", "", false, "Should we process each cluster configuration in parallel")
 	cmd.Flags().BoolVarP(&options.Flags.UseRevision, "use-revision", "", true, "Use the git revision from the current git clone instead of the Pull Request branch")
+	cmd.Flags().BoolVarP(&options.Flags.VersionsRepoPr, "version-repo-pr", "", false, "For use with jenkins-x-versions PR. Indicates the git revision of the PR should be used to clone the jenkins-x-versions")
 
 	cmd.Flags().StringVarP(&installOptions.Flags.Provider, "provider", "", "", "Cloud service providing the Kubernetes cluster.  Supported providers: "+KubernetesProviderOptions())
 
@@ -522,12 +524,14 @@ func (o *StepBDDOptions) createCluster(cluster *bdd.CreateCluster) error {
 	}
 	log.Infof("found git revision %s: branch %s\n", revision, branch)
 
-	if o.InstallOptions.Flags.VersionsGitRef == "" {
+	if o.Flags.VersionsRepoPr && o.InstallOptions.Flags.VersionsGitRef == "" {
 		if revision != "" && (branch == "" || o.Flags.UseRevision) {
 			o.InstallOptions.Flags.VersionsGitRef = revision
 		} else {
 			o.InstallOptions.Flags.VersionsGitRef = branch
 		}
+	} else {
+		o.InstallOptions.Flags.VersionsGitRef = "master"
 	}
 
 	log.Infof("using versions git repo %s and ref %s\n", o.InstallOptions.Flags.VersionsRepository, o.InstallOptions.Flags.VersionsGitRef)


### PR DESCRIPTION
Adding a flag to indicate if the PR is a versions repository PR. If it's not
then use the master branch and head revision for the jenkins-x-versions repositories

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
