### PR TITLE
chore: Initial work on unification of build pack and jenkins-x.yml syntax

### DIFF
--- a/pkg/builds/jenkinsfiles.go
+++ b/pkg/builds/jenkinsfiles.go
@@ -81,7 +81,7 @@ func (j *JenkinsConverter) ToJenkinsfile() (string, error) {
 				j.startBlock("step")
 				j.startContainer()
 				for _, step := range build.Steps {
-					cmd := step.Command
+					cmd := step.GetFullCommand()
 					j.println(fmt.Sprintf(`sh "%s"`, cmd))
 				}
 				j.endContainer()

--- a/pkg/builds/jenkinsfiles_test.go
+++ b/pkg/builds/jenkinsfiles_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/jenkinsfile"
+	"github.com/jenkins-x/jx/pkg/tekton/syntax"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,7 @@ func TestJenkinsfileGenerator(t *testing.T) {
 			Pipelines: jenkinsfile.Pipelines{
 				PullRequest: &jenkinsfile.PipelineLifecycles{
 					Build: &jenkinsfile.PipelineLifecycle{
-						Steps: []*jenkinsfile.PipelineStep{
+						Steps: []*syntax.Step{
 							{
 								Command: "mvn test",
 							},
@@ -37,7 +38,7 @@ func TestJenkinsfileGenerator(t *testing.T) {
 				},
 				Release: &jenkinsfile.PipelineLifecycles{
 					Build: &jenkinsfile.PipelineLifecycle{
-						Steps: []*jenkinsfile.PipelineStep{
+						Steps: []*syntax.Step{
 							{
 								Command: "mvn test",
 							},

--- a/pkg/config/project_config_test.go
+++ b/pkg/config/project_config_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/jenkinsfile"
 	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/tekton/syntax"
 	"github.com/jenkins-x/jx/pkg/tests"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
@@ -31,7 +32,7 @@ func TestProjectConfigMarshal(t *testing.T) {
 			Pipelines: jenkinsfile.Pipelines{
 				PullRequest: &jenkinsfile.PipelineLifecycles{
 					Build: &jenkinsfile.PipelineLifecycle{
-						Steps: []*jenkinsfile.PipelineStep{
+						Steps: []*syntax.Step{
 							{
 								Command: "mvn test",
 							},
@@ -40,7 +41,7 @@ func TestProjectConfigMarshal(t *testing.T) {
 				},
 				Release: &jenkinsfile.PipelineLifecycles{
 					Build: &jenkinsfile.PipelineLifecycle{
-						Steps: []*jenkinsfile.PipelineStep{
+						Steps: []*syntax.Step{
 							{
 								Command: "mvn test",
 							},

--- a/pkg/jx/cmd/create_step.go
+++ b/pkg/jx/cmd/create_step.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/tekton/syntax"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
 	survey "gopkg.in/AlecAivazis/survey.v1"
@@ -41,7 +42,7 @@ type NewStepDetails struct {
 	Pipeline  string
 	Lifecycle string
 	Mode      string
-	Step      jenkinsfile.PipelineStep
+	Step      syntax.Step
 }
 
 // AddToPipeline adds the step to the given pipeline configuration
@@ -148,8 +149,8 @@ func (o *CreateStepOptions) configureNewStepDetails(stepDetails *NewStepDetails)
 		if s.Mode == "" {
 			s.Mode = defaultMode
 		}
-		if s.Step.Command == "" {
-			return util.MissingOption("sh")
+		if s.Step.GetCommand() == "" {
+			return util.MissingOption("command")
 		}
 		return nil
 	}
@@ -173,7 +174,7 @@ func (o *CreateStepOptions) configureNewStepDetails(stepDetails *NewStepDetails)
 			return err
 		}
 	}
-	if s.Step.Command == "" {
+	if s.Step.GetCommand() == "" {
 		prompt := &survey.Input{
 			Message: "Command for the new step: ",
 			Help:    "The shell command executed inside the container to implement this step",

--- a/pkg/jx/cmd/create_variable.go
+++ b/pkg/jx/cmd/create_variable.go
@@ -211,7 +211,7 @@ func (o *CreateVariableOptions) loadEnvVars(projectConfig *config.ProjectConfig)
 	if err != nil {
 		return answer, err
 	}
-	containerName := pipelineConfig.Agent.Container
+	containerName := pipelineConfig.Agent.GetImage()
 	if containerName != "" && podTemplates != nil && podTemplates[containerName] != nil {
 		podTemplate := podTemplates[containerName]
 		if len(podTemplate.Spec.Containers) > 0 {

--- a/pkg/jx/cmd/step_buildpack_apply_test.go
+++ b/pkg/jx/cmd/step_buildpack_apply_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/jenkins-x/jx/pkg/jenkinsfile"
+	"github.com/jenkins-x/jx/pkg/tekton/syntax"
 	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/stretchr/testify/require"
 
@@ -89,16 +90,16 @@ func TestSavePipelineConfig(t *testing.T) {
 	file := filepath.Join(tempDir, "pipeline.yaml")
 
 	config := &jenkinsfile.PipelineConfig{
-		Agent: jenkinsfile.PipelineAgent{
+		Agent: syntax.Agent{
 			Label: "jenkins-maven",
 		},
 		Pipelines: jenkinsfile.Pipelines{
 			Release: &jenkinsfile.PipelineLifecycles{
 				Setup: &jenkinsfile.PipelineLifecycle{
-					Steps: []*jenkinsfile.PipelineStep{
+					Steps: []*syntax.Step{
 						{
-							Container: "maven",
-							Steps: []*jenkinsfile.PipelineStep{
+							Image: "maven",
+							Steps: []*syntax.Step{
 								{
 									Command: "mvn deploy",
 								},

--- a/pkg/jx/cmd/test_data/step_create_task/from_yaml/jenkins-x.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/from_yaml/jenkins-x.yml
@@ -5,7 +5,7 @@ pipelineConfig:
   pipelines:
     release:
       pipeline:
-        environment:
+        env:
           - name: GIT_AUTHOR_NAME
             value: somebodyelse
         options:

--- a/pkg/jx/cmd/test_data/step_create_task/packs/apps/pipeline.yaml
+++ b/pkg/jx/cmd/test_data/step_create_task/packs/apps/pipeline.yaml
@@ -18,7 +18,7 @@ pipelines:
       steps:
         - sh: make build
           name: build
-          container: gcr.io/jenkinsxio/builder-go:0.0.0-SNAPSHOT-PR-380-56
+          image: gcr.io/jenkinsxio/builder-go:0.0.0-SNAPSHOT-PR-380-56
         - dir: charts/REPLACE_ME_APP_NAME
           name: dir-block
           steps:

--- a/pkg/jx/cmd/test_data/step_create_task/packs/maven/pipeline.yaml
+++ b/pkg/jx/cmd/test_data/step_create_task/packs/maven/pipeline.yaml
@@ -8,7 +8,9 @@ pipelines:
   pullRequest:
     build:
       steps:
-      - sh: skaffold version
+      - command: skaffold
+        args:
+          - version
         name: skaffold-version
       - sh: export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml
         name: container-build
@@ -28,7 +30,9 @@ pipelines:
   release:
     build:
       steps:
-      - sh: skaffold version
+      - command: skaffold
+        args:
+          - version
         name: skaffold-version
       - sh: export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml
         name: container-build

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -372,6 +372,9 @@ func (s *Step) GetImage() string {
 	if s.Image != "" {
 		return s.Image
 	}
+	if !equality.Semantic.DeepEqual(s.Agent, Agent{}) && s.Agent.Image != "" {
+		return s.Agent.Image
+	}
 
 	return s.Container
 }
@@ -1289,10 +1292,8 @@ func generateSteps(step Step, inheritedAgent string, env []corev1.EnvVar, parent
 	var steps []corev1.Container
 
 	stepImage := inheritedAgent
-	if step.Image != "" {
-		stepImage = step.Image
-	} else if step.Agent.Image != "" {
-		stepImage = step.Agent.Image
+	if step.GetImage() != "" {
+		stepImage = step.GetImage()
 	}
 
 	workingDir := step.Dir

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -1737,7 +1737,7 @@ func PipelineOptionsRetry(count int8) PipelineOptionsOp {
 // PipelineEnvVar add an environment variable, with specified name and value, to the pipeline.
 func PipelineEnvVar(name, value string) PipelineOp {
 	return func(parsed *syntax.ParsedPipeline) {
-		parsed.Environment = append(parsed.Environment, syntax.EnvVar{
+		parsed.Env = append(parsed.GetEnv(), syntax.EnvVar{
 			Name:  name,
 			Value: value,
 		})
@@ -1842,7 +1842,7 @@ func StageOptionsUnstash(name, dir string) StageOptionsOp {
 // StageEnvVar add an environment variable, with specified name and value, to the stage.
 func StageEnvVar(name, value string) StageOp {
 	return func(stage *syntax.Stage) {
-		stage.Environment = append(stage.Environment, syntax.EnvVar{
+		stage.Env = append(stage.GetEnv(), syntax.EnvVar{
 			Name:  name,
 			Value: value,
 		})
@@ -2077,7 +2077,7 @@ func TestParsedPipelineHelpers(t *testing.T) {
 				Unit: syntax.TimeoutUnitSeconds,
 			},
 		},
-		Environment: []syntax.EnvVar{
+		Env: []syntax.EnvVar{
 			{
 				Name:  "ANIMAL",
 				Value: "MONKEY",
@@ -2150,7 +2150,7 @@ func TestParsedPipelineHelpers(t *testing.T) {
 								Image: "some-other-image",
 							},
 						}},
-						Environment: []syntax.EnvVar{
+						Env: []syntax.EnvVar{
 							{
 								Name:  "STAGE_VAR_ONE",
 								Value: "some value",

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -1378,6 +1378,63 @@ func TestFailedValidation(t *testing.T) {
 			name:          "unknown_field",
 			expectedError: errors.New("Validation failures in YAML file test_data/validation_failures/unknown_field/jenkins-x.yml:\npipelineConfig: Additional property banana is not allowed"),
 		},
+		{
+			name: "comment_field",
+			expectedError: (&apis.FieldError{
+				Message: "the comment field is only valid in legacy build packs, not in jenkins-x.yml. Please remove it.",
+				Paths:   []string{"comment"},
+			}).ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "groovy_field",
+			expectedError: (&apis.FieldError{
+				Message: "the groovy field is only valid in legacy build packs, not in jenkins-x.yml. Please remove it.",
+				Paths:   []string{"groovy"},
+			}).ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "when_field",
+			expectedError: (&apis.FieldError{
+				Message: "the when field is only valid in legacy build packs, not in jenkins-x.yml. Please remove it.",
+				Paths:   []string{"when"},
+			}).ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "sh_field",
+			expectedError: (&apis.FieldError{
+				Message: "the sh field is deprecated - please use command instead",
+				Paths:   []string{"sh"},
+			}).ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "container_field",
+			expectedError: (&apis.FieldError{
+				Message: "the container field is deprecated - please use image instead",
+				Paths:   []string{"container"},
+			}).ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "legacy_steps_field",
+			expectedError: (&apis.FieldError{
+				Message: "the steps field is only valid in legacy build packs, not in jenkins-x.yml. Please remove it and list the nested stages sequentially instead.",
+				Paths:   []string{"steps"},
+			}).ViaFieldIndex("steps", 0).ViaFieldIndex("stages", 0),
+		},
+		{
+			name: "agent_dir_field",
+			expectedError: (&apis.FieldError{
+				Message: "the dir field is only valid in legacy build packs, not in jenkins-x.yml. Please remove it.",
+				Paths:   []string{"dir"},
+			}).ViaField("agent"),
+		},
+		{
+			name: "agent_container_field",
+			expectedError: (&apis.FieldError{
+				Message: "the container field is deprecated - please use image instead",
+				Paths:   []string{"container"},
+			}).ViaField("agent"),
+>>>>>>> chore: Initial work on unification of build pack and jenkins-x.yml syntax
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -1433,7 +1433,6 @@ func TestFailedValidation(t *testing.T) {
 				Message: "the container field is deprecated - please use image instead",
 				Paths:   []string{"container"},
 			}).ViaField("agent"),
->>>>>>> chore: Initial work on unification of build pack and jenkins-x.yml syntax
 		},
 	}
 

--- a/pkg/tekton/syntax/test_data/container_options_env_merge/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/container_options_env_merge/jenkins-x.yml
@@ -11,7 +11,7 @@ pipelineConfig:
                 value: Original value
               - name: OVERRIDE_STAGE_ENV
                 value: Original value
-        environment:
+        env:
           - name: SOME_OTHER_VAR
             value: A value for the other env var
           - name: OVERRIDE_ENV
@@ -25,7 +25,7 @@ pipelineConfig:
                 env:
                   - name: ANOTHER_OVERRIDE_STAGE_ENV
                     value: Original value
-            environment:
+            env:
               - name: OVERRIDE_STAGE_ENV
                 value: New value
               - name: ANOTHER_OVERRIDE_STAGE_ENV

--- a/pkg/tekton/syntax/test_data/environment_at_top_and_in_stage/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/environment_at_top_and_in_stage/jenkins-x.yml
@@ -4,12 +4,12 @@ pipelineConfig:
       pipeline:
         agent:
           image: some-image
-        environment:
+        env:
           - name: SOME_VAR
             value: A value for the env var
         stages:
           - name: A stage with environment
-            environment:
+            env:
                 - name: SOME_OTHER_VAR
                   value: A value for the other env var
             steps:

--- a/pkg/tekton/syntax/test_data/loop_step/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/loop_step/jenkins-x.yml
@@ -2,14 +2,14 @@ pipelineConfig:
   pipelines:
     release:
       pipeline:
-        environment:
+        env:
           - name: LANGUAGE
             value: rust
         agent:
           image: some-image
         stages:
           - name: A Working Stage
-            environment:
+            env:
               - name: DISTRO
                 value: gentoo
             steps:

--- a/pkg/tekton/syntax/test_data/validation_failures/agent_container_field/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/agent_container_field/jenkins-x.yml
@@ -1,0 +1,14 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          container: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such

--- a/pkg/tekton/syntax/test_data/validation_failures/agent_dir_field/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/agent_dir_field/jenkins-x.yml
@@ -1,0 +1,15 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+          dir: somewhere
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such

--- a/pkg/tekton/syntax/test_data/validation_failures/comment_field/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/comment_field/jenkins-x.yml
@@ -1,0 +1,15 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such
+                comment: this will blow up

--- a/pkg/tekton/syntax/test_data/validation_failures/container_field/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/container_field/jenkins-x.yml
@@ -1,0 +1,15 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such
+                container: some-other-image

--- a/pkg/tekton/syntax/test_data/validation_failures/groovy_field/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/groovy_field/jenkins-x.yml
@@ -1,0 +1,15 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such
+                groovy: this will blow up

--- a/pkg/tekton/syntax/test_data/validation_failures/legacy_steps_field/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/legacy_steps_field/jenkins-x.yml
@@ -1,0 +1,16 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such
+                steps:
+                  - command: echo hi there

--- a/pkg/tekton/syntax/test_data/validation_failures/sh_field/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/sh_field/jenkins-x.yml
@@ -1,0 +1,14 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - sh: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such

--- a/pkg/tekton/syntax/test_data/validation_failures/when_field/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/when_field/jenkins-x.yml
@@ -1,0 +1,15 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such
+                when: this will blow up

--- a/pkg/util/jenkinsfile_writer.go
+++ b/pkg/util/jenkinsfile_writer.go
@@ -1,10 +1,8 @@
-package jenkinsfile
+package util
 
 import (
 	"bytes"
 	"strings"
-
-	"github.com/jenkins-x/jx/pkg/util"
 )
 
 var (
@@ -39,7 +37,7 @@ func (s *Statement) Text() string {
 // the same context as that statement
 func (s *Statement) ContextEquals(that *Statement) bool {
 	if s.Function == that.Function && contextFunctions[s.Function] {
-		return util.StringArraysEqual(s.Arguments, that.Arguments)
+		return StringArraysEqual(s.Arguments, that.Arguments)
 	}
 	return false
 }

--- a/pkg/util/jenkinsfile_writer_test.go
+++ b/pkg/util/jenkinsfile_writer_test.go
@@ -1,7 +1,7 @@
-package jenkinsfile_test
+package util_test
 
 import (
-	"github.com/jenkins-x/jx/pkg/jenkinsfile"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -14,17 +14,17 @@ func TestJenkinsfileWriter(t *testing.T) {
   }
 }
 `
-	writer := jenkinsfile.NewWriter(0)
+	writer := util.NewWriter(0)
 
-	statements := []*jenkinsfile.Statement{
+	statements := []*util.Statement{
 		{
 			Function:  "container",
 			Arguments: []string{"maven"},
-			Children: []*jenkinsfile.Statement{
+			Children: []*util.Statement{
 				{
 					Function:  "dir",
 					Arguments: []string{"/foo/bar"},
-					Children: []*jenkinsfile.Statement{
+					Children: []*util.Statement{
 						{
 							Statement: "sh \"ls -al\"",
 						},
@@ -35,11 +35,11 @@ func TestJenkinsfileWriter(t *testing.T) {
 		{
 			Function:  "container",
 			Arguments: []string{"maven"},
-			Children: []*jenkinsfile.Statement{
+			Children: []*util.Statement{
 				{
 					Function:  "dir",
 					Arguments: []string{"/foo/bar"},
-					Children: []*jenkinsfile.Statement{
+					Children: []*util.Statement{
 						{
 							Statement: "sh \"mvn deploy\"",
 						},


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Here specifically, we're getting rid of `PipelineAgent` and
`PipelineStep`, so that you can use the `jenkins-x.yml` syntax for
agents and steps within a build pack or for overriding/adding to a
build pack in `jenkins-x.yml`. The existing syntax still works in
build pack context, but can't be used when defining the whole pipeline
- you'll get validation errors telling you what you should do
instead.

More is likely to come - but since this is functional as is with no
backwards compatibility concerns that I can find, hey, might as well
toss it up.

#### Special notes for the reviewer(s)

cc @sharepointoscar 
/assign @jstrachan 
/assign @pmuir 
/assign @rawlingsj 
/assign @dwnusbaum 

#### Which issue this PR fixes

n/a