### PR TITLE
feat(tekton): Add support for per-step environment variables

### DIFF
--- a/pkg/jx/cmd/test_data/step_create_task/from_yaml/jenkins-x.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/from_yaml/jenkins-x.yml
@@ -25,6 +25,9 @@ pipelineConfig:
               - command: ls
                 args:
                   - -la
+                env:
+                  - name: ANOTHER_VAR
+                    value: Another value
           - name: Second
             steps:
               - command: echo

--- a/pkg/jx/cmd/test_data/step_create_task/from_yaml/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/from_yaml/tasks.yml
@@ -123,6 +123,8 @@ items:
       - /bin/sh
       - -c
       env:
+      - name: ANOTHER_VAR
+        value: Another value
       - name: DOCKER_CONFIG
         value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY

--- a/pkg/jx/cmd/test_data/step_create_task/kaniko_entrypoint/jenkins-x.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/kaniko_entrypoint/jenkins-x.yml
@@ -23,11 +23,6 @@ pipelineConfig:
               image: docker.io/golang:1.11.5
               command: make
               args: ['linux']
-              env:
-                - name: GOPATH
-                  value: /workspace/go
-                - name: GOPROXY
-                  value: http://jx-app-athens-athens-proxy
               resources:
                 limits:
                   cpu: 4
@@ -40,9 +35,6 @@ pipelineConfig:
               image: docker.io/golang:1.11.5
               command: "./build/linux/jx"
               args: ['--help']
-              env:
-                - name: GOPATH
-                  value: /workspace/go
 
             - name: build-and-push-image
               image: rawlingsj/executor:dev40
@@ -64,15 +56,6 @@ pipelineConfig:
             - name: preview
               image: gcr.io/jenkinsxio/builder-go:0.1.332
               command: ./jx/scripts/ci.sh
-              env:
-                - name: HOME
-                  value: /workspace
-                - name: GOPATH
-                  value: /workspace/go
-                - name: PATH
-                  value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin/google-cloud-sdk/bin:/opt/google/chrome:/usr/local/go/bin:/usr/local/glide:/usr/local/dep:/usr/local/:/home/jenkins/go/bin:/workspace/go/bin"
-                - name: GOPROXY
-                  value: http://jx-app-athens-athens-proxy
               resources:
                 limits:
                   cpu: 4

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -157,6 +157,9 @@ type Step struct {
 
 	// Image alows the docker image for a step to be specified
 	Image string `json:"image,omitempty"`
+
+	// env allows defining per-step environment variables
+	Env []EnvVar `json:"env,omitempty"`
 }
 
 // Loop is a special step that defines a variable, a list of possible values for that variable, and a set of steps to
@@ -1101,7 +1104,7 @@ func generateSteps(step Step, inheritedAgent string, env []corev1.EnvVar, parent
 
 		c.Stdin = false
 		c.TTY = false
-		c.Env = scopedEnv(env, c.Env)
+		c.Env = scopedEnv(toContainerEnvVars(step.Env), scopedEnv(env, c.Env))
 
 		steps = append(steps, *c)
 	} else if !equality.Semantic.DeepEqual(step.Loop, Loop{}) {

--- a/pkg/tekton/syntax/test_data/environment_at_top_and_in_stage/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/environment_at_top_and_in_stage/jenkins-x.yml
@@ -15,3 +15,10 @@ pipelineConfig:
             steps:
               - command: echo
                 args: ['hello', '${SOME_OTHER_VAR}']
+              - command: echo
+                args: ['goodbye', '${SOME_VAR} and ${ANOTHER_VAR}']
+                env:
+                  - name: SOME_VAR
+                    value: An overriding value
+                  - name: ANOTHER_VAR
+                    value: Yet another variable


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Allow specifying environment variables for individual steps.

Note that we're using `env` for per-step env vars - in #3841, we allow `env` for stage and pipeline env vars as well.

#### Special notes for the reviewer(s)

/assign @warrenbailey 
/assign @jstrachan 
/assign @joseblas 
/assign @dwnusbaum 

#### Which issue this PR fixes

n/a
