### PR TITLE
feat: adding ability to create namespace via 'jx ns --create <name>

### DIFF
--- a/pkg/jx/cmd/namespace.go
+++ b/pkg/jx/cmd/namespace.go
@@ -2,14 +2,15 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/jenkins-x/jx/pkg/kube"
-	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -18,10 +19,15 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"gopkg.in/AlecAivazis/survey.v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	core_v1 "k8s.io/api/core/v1"
 )
 
 type NamespaceOptions struct {
 	*opts.CommonOptions
+
+	Create bool
 }
 
 var (
@@ -29,17 +35,20 @@ var (
 )
 
 var (
-	namespace_long = templates.LongDesc(`
+	namespaceLong = templates.LongDesc(`
 		Displays or changes the current namespace.`)
-	namespace_example = templates.Examples(`
+	namespaceExample = templates.Examples(`
 		# view the current namespace
-		jx ns -b
+		jx --batch-mode ns
 
-		# to select the namespace to switch to
+		# interactively select the namespace to switch to
 		jx ns
 
-		# Change the current namespace to 'cheese'
-		jx ns cheese`)
+		# change the current namespace to 'cheese'
+		jx ns cheese
+
+		# change the current namespace to 'brie' creating it if necessary
+		jx ns --create brie`)
 )
 
 func NewCmdNamespace(commonOpts *opts.CommonOptions) *cobra.Command {
@@ -50,8 +59,8 @@ func NewCmdNamespace(commonOpts *opts.CommonOptions) *cobra.Command {
 		Use:     "namespace",
 		Aliases: []string{"ns"},
 		Short:   "View or change the current namespace context in the current Kubernetes cluster",
-		Long:    namespace_long,
-		Example: namespace_example,
+		Long:    namespaceLong,
+		Example: namespaceExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Cmd = cmd
 			options.Args = args
@@ -59,72 +68,127 @@ func NewCmdNamespace(commonOpts *opts.CommonOptions) *cobra.Command {
 			CheckErr(err)
 		},
 	}
+
+	cmd.Flags().BoolVarP(&options.Create, "create", "c", false, "Creates the specified namespace if it does not exist")
 	return cmd
 }
 
 func (o *NamespaceOptions) Run() error {
-	config, po, err := o.Kube().LoadConfig()
+	config, pathOptions, err := o.Kube().LoadConfig()
 	if err != nil {
 		return errors.Wrap(err, "loading Kubernetes configuration")
-	}
-	ns := ""
-	args := o.Args
-	if len(args) > 0 {
-		ns = args[0]
 	}
 	client, err := o.KubeClient()
 	if err != nil {
 		return errors.Wrap(err, "creating kubernetes client")
 	}
-	names, err := GetNamespaceNames(client)
-	if err != nil {
-		return errors.Wrap(err, "retrieving the names of the namespaces")
-	}
 	currentNS := kube.CurrentNamespace(config)
 
+	ns := namespace(o)
+
 	if ns == "" && !o.BatchMode {
-		defaultNamespace := ""
-		ctx := kube.CurrentContext(config)
-		if ctx != nil {
-			defaultNamespace = currentNS
-		}
-		pick, err := o.PickNamespace(names, defaultNamespace)
+		ns, err = pickNamespace(o, client, currentNS)
 		if err != nil {
-			return errors.Wrap(err, "picking the namespace")
+			return err
 		}
-		ns = pick
 	}
+
 	info := util.ColorInfo
 	if ns != "" && ns != currentNS {
-		_, err = client.CoreV1().Namespaces().Get(ns, meta_v1.GetOptions{})
+		ctx, err := changeNamespace(client, config, pathOptions, ns, o.Create)
 		if err != nil {
-			return errors.Wrapf(err, "getting namespace %q", ns)
+			return err
 		}
-		newConfig := *config
-		ctx := kube.CurrentContext(config)
-		if ctx == nil {
-			return errNoContextDefined
-		}
-		if ctx.Namespace == ns {
-			return nil
-		}
-		ctx.Namespace = ns
-		err = clientcmd.ModifyConfig(po, newConfig, false)
-		if err != nil {
-			return fmt.Errorf("failed to update the kube config %s", err)
-		}
-		fmt.Fprintf(o.Out, "Now using namespace '%s' on server '%s'.\n", info(ctx.Namespace), info(kube.Server(config, ctx)))
+		_, _ = fmt.Fprintf(o.Out, "Now using namespace '%s' on server '%s'.\n", info(ctx.Namespace), info(kube.Server(config, ctx)))
+
 	} else {
 		ns := kube.CurrentNamespace(config)
 		server := kube.CurrentServer(config)
-		fmt.Fprintf(o.Out, "Using namespace '%s' from context named '%s' on server '%s'.\n", info(ns), info(config.CurrentContext), info(server))
+		_, _ = fmt.Fprintf(o.Out, "Using namespace '%s' from context named '%s' on server '%s'.\n", info(ns), info(config.CurrentContext), info(server))
 	}
 	return nil
 }
 
-// GetNamespaceNames returns the sorted list of environment names
-func GetNamespaceNames(client kubernetes.Interface) ([]string, error) {
-	names := []string{}
+func namespace(o *NamespaceOptions) string {
+	ns := ""
+	args := o.Args
+	if len(args) > 0 {
+		ns = args[0]
+	}
+	return ns
+}
+
+func changeNamespace(client kubernetes.Interface, config *api.Config, pathOptions *clientcmd.PathOptions, ns string, create bool) (*api.Context, error) {
+	_, err := client.CoreV1().Namespaces().Get(ns, meta_v1.GetOptions{})
+	if err != nil {
+		switch err.(type) {
+		case *api_errors.StatusError:
+			err = handleStatusError(err, client, ns, create)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, errors.Wrapf(err, "getting namespace %q", ns)
+		}
+	}
+	newConfig := *config
+	ctx := kube.CurrentContext(config)
+	if ctx == nil {
+		return nil, errNoContextDefined
+	}
+	if ctx.Namespace == ns {
+		return ctx, nil
+	}
+	ctx.Namespace = ns
+	err = clientcmd.ModifyConfig(pathOptions, newConfig, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update the kube config %s", err)
+	}
+	return ctx, nil
+}
+
+func handleStatusError(err error, client kubernetes.Interface, ns string, create bool) error {
+	statusErr, _ := err.(*api_errors.StatusError)
+	if statusErr.Status().Reason == meta_v1.StatusReasonNotFound && create {
+		err = createNamespace(client, ns)
+		if err != nil {
+			return err
+		}
+	} else {
+		return err
+	}
+	return nil
+}
+
+func createNamespace(client kubernetes.Interface, ns string) error {
+	namespace := core_v1.Namespace{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: ns,
+		},
+	}
+	_, err := client.CoreV1().Namespaces().Create(&namespace)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create namespace %s", ns)
+	}
+	return nil
+}
+
+func pickNamespace(o *NamespaceOptions, client kubernetes.Interface, defaultNamespace string) (string, error) {
+	names, err := getNamespaceNames(client)
+	if err != nil {
+		return "", errors.Wrap(err, "retrieving namespace the names of the namespaces")
+	}
+
+	selectedNamespace, err := pick(o, names, defaultNamespace)
+	if err != nil {
+		return "", errors.Wrap(err, "picking the namespace")
+	}
+	return selectedNamespace, nil
+}
+
+// getNamespaceNames returns the sorted list of environment names
+func getNamespaceNames(client kubernetes.Interface) ([]string, error) {
+	var names []string
 	list, err := client.CoreV1().Namespaces().List(meta_v1.ListOptions{})
 	if err != nil {
 		return names, fmt.Errorf("loading namespaces %s", err)
@@ -136,7 +200,7 @@ func GetNamespaceNames(client kubernetes.Interface) ([]string, error) {
 	return names, nil
 }
 
-func (o *NamespaceOptions) PickNamespace(names []string, defaultNamespace string) (string, error) {
+func pick(o *NamespaceOptions, names []string, defaultNamespace string) (string, error) {
 	if len(names) == 0 {
 		return "", nil
 	}

--- a/pkg/jx/cmd/namespace_test.go
+++ b/pkg/jx/cmd/namespace_test.go
@@ -1,24 +1,195 @@
 package cmd_test
 
 import (
+	"fmt"
+	"github.com/jenkins-x/jx/pkg/jx/cmd"
+	mocks "github.com/jenkins-x/jx/pkg/jx/cmd/clients/mocks"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
+	kuber_mocks "github.com/jenkins-x/jx/pkg/kube/mocks"
+	. "github.com/petergtz/pegomock"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"os"
+	"regexp"
 	"testing"
 )
 
-func TestNamespace(t *testing.T) {
-	//	options := &cmd.NamespaceOptions{
-	//		CommonOptions: cmd.CommonOptions{
-	//			Factory: f,
-	//			In:      in,
-	//			Out:     out,
-	//			Err:     errOut,
-	//		},
-	//	}
-	//
-	//	buf := new(bytes.Buffer)
-	//	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf))
-	//	require.Nil(t, err)
-	//	defer c.Close()
-	//	term := Stdio(c)
-	//	opts := survey.WithStdio(term.In, term.Out, term.Err)
+func Test_display_current_namespace(t *testing.T) {
+	commonOpts, _, stdOutFileName, stdErrFileName, kubeConfig := setUp(t)
+	defer func() {
+		_ = os.Remove(stdOutFileName)
+		_ = os.Remove(stdErrFileName)
+		_ = os.Remove(kubeConfig)
+	}()
 
+	namespace := &cmd.NamespaceOptions{
+		CommonOptions: commonOpts,
+	}
+
+	err := namespace.Run()
+	assert.NoError(t, err, "should not error")
+
+	expected := "Using namespace 'snafu' from context named 'foo-context' on server 'https://fubar.com'.\n"
+	actual := sanitizedContent(t, stdOutFileName)
+	assert.Equal(t, expected, actual, "wrong message returned")
+
+	assert.Empty(t, sanitizedContent(t, stdErrFileName))
+}
+
+func Test_change_current_namespace(t *testing.T) {
+	commonOpts, kubeClient, stdOutFileName, stdErrFileName, kubeConfig := setUp(t)
+	defer func() {
+		_ = os.Remove(stdOutFileName)
+		_ = os.Remove(stdErrFileName)
+		_ = os.Remove(kubeConfig)
+	}()
+
+	ns := core_v1.Namespace{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "acme",
+		},
+	}
+	_, err := kubeClient.CoreV1().Namespaces().Create(&ns)
+
+	namespace := &cmd.NamespaceOptions{
+		CommonOptions: commonOpts,
+	}
+
+	commonOpts.Args = []string{"acme"}
+
+	err = namespace.Run()
+	assert.NoError(t, err, "should not error")
+
+	expected := "Now using namespace 'acme' on server 'https://fubar.com'.\n"
+	actual := sanitizedContent(t, stdOutFileName)
+	assert.Equal(t, expected, actual, "wrong message returned")
+
+	assert.Empty(t, sanitizedContent(t, stdErrFileName))
+}
+
+func Test_change_to_new_namespace_with_create(t *testing.T) {
+	commonOpts, kubeClient, stdOutFileName, stdErrFileName, kubeConfig := setUp(t)
+	defer func() {
+		_ = os.Remove(stdOutFileName)
+		_ = os.Remove(stdErrFileName)
+		_ = os.Remove(kubeConfig)
+	}()
+
+	namespace := &cmd.NamespaceOptions{
+		CommonOptions: commonOpts,
+		Create:        true,
+	}
+
+	testNamespaceName := "test-ns"
+	commonOpts.Args = []string{testNamespaceName}
+
+	err := namespace.Run()
+	assert.NoError(t, err, "should not error")
+
+	expected := fmt.Sprintf("Now using namespace '%s' on server 'https://fubar.com'.\n", testNamespaceName)
+	actual := sanitizedContent(t, stdOutFileName)
+	assert.Equal(t, expected, actual, "wrong message returned")
+
+	assert.Empty(t, sanitizedContent(t, stdErrFileName))
+
+	_, err = kubeClient.CoreV1().Namespaces().Get(testNamespaceName, meta_v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("The namespace '%s' should have been created", testNamespaceName)
+	}
+}
+
+func Test_change_to_unknown_namespace_creates_error(t *testing.T) {
+	commonOpts, _, stdOutFileName, stdErrFileName, kubeConfig := setUp(t)
+	defer func() {
+		_ = os.Remove(stdOutFileName)
+		_ = os.Remove(stdErrFileName)
+		_ = os.Remove(kubeConfig)
+	}()
+
+	namespace := &cmd.NamespaceOptions{
+		CommonOptions: commonOpts,
+	}
+
+	commonOpts.Args = []string{"unknown"}
+
+	err := namespace.Run()
+	assert.Error(t, err, "should return error since namespace is unknown")
+	assert.Equal(t, "namespaces \"unknown\" not found", err.Error())
+	assert.Empty(t, sanitizedContent(t, stdOutFileName))
+}
+
+func sanitizedContent(t *testing.T, fileName string) string {
+	raw, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	content := string(raw)
+	// remove potential ANSI escape sequences
+	re := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	content = re.ReplaceAllString(content, "")
+
+	return content
+}
+
+func setUp(t *testing.T) (*opts.CommonOptions, *fake.Clientset, string, string, string) {
+	// mock factory
+	factory := mocks.NewMockFactory()
+	// mock Kubernetes interface
+	kubeInterface := fake.NewSimpleClientset()
+
+	// Override CreateKubeClient to return mock Kubernetes interface
+	When(factory.CreateKubeClient()).ThenReturn(kubeInterface, "jx-testing", nil)
+
+	kubeMock := kuber_mocks.NewMockKuber()
+	fakeKubeConfig := api.NewConfig()
+	fakeKubeConfig.CurrentContext = "foo-context"
+	fakeKubeConfig.Clusters = map[string]*api.Cluster{
+		"foo-cluster": {
+			Server: "https://fubar.com",
+		},
+	}
+	fakeKubeConfig.Contexts = map[string]*api.Context{
+		"foo-context": {
+			Cluster:   "foo-cluster",
+			Namespace: "snafu",
+		},
+		"acme-context": {
+			Cluster:   "foo-cluster",
+			Namespace: "acme",
+		},
+	}
+	pathOptions := clientcmd.NewDefaultPathOptions()
+	When(kubeMock.LoadConfig()).ThenReturn(fakeKubeConfig, pathOptions, nil)
+
+	tmpKubeConfig, err := ioutil.TempFile("", "jx-test-namespace")
+	err = os.Setenv("KUBECONFIG", tmpKubeConfig.Name())
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	// Setup options
+	tmpFileStdOut, err := ioutil.TempFile("", "jx-test-namespace")
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	tmpFileStdErr, err := ioutil.TempFile("", "jx-test-namespace")
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	commonOpts := opts.NewCommonOptionsWithFactory(factory)
+	commonOpts.Out = tmpFileStdOut
+	commonOpts.Err = tmpFileStdErr
+	// all tests in batch mode, non interactive
+	commonOpts.BatchMode = true
+
+	commonOpts.SetKube(kubeMock)
+
+	return &commonOpts, kubeInterface, tmpFileStdOut.Name(), tmpFileStdErr.Name(), tmpKubeConfig.Name()
 }

--- a/pkg/jx/cmd/opts/common.go
+++ b/pkg/jx/cmd/opts/common.go
@@ -139,18 +139,6 @@ func (o *CommonOptions) CreateTable() table.Table {
 	return o.factory.CreateTable(o.Out)
 }
 
-// NewCommonOptions a helper method to create a new CommonOptions instance
-// pre configured in a specific devNamespace
-func NewCommonOptions(devNamespace string, factory clients.Factory) CommonOptions {
-	return CommonOptions{
-		factory:          factory,
-		Out:              os.Stdout,
-		Err:              os.Stderr,
-		currentNamespace: devNamespace,
-		devNamespace:     devNamespace,
-	}
-}
-
 // NewCommonOptionsWithTerm creates a new CommonOptions instance with given terminal input, output and error
 func NewCommonOptionsWithTerm(factory clients.Factory, in terminal.FileReader, out terminal.FileWriter, err io.Writer) *CommonOptions {
 	return &CommonOptions{
@@ -191,19 +179,19 @@ func (o *CommonOptions) Debugf(format string, a ...interface{}) {
 }
 
 // addCommonFlags adds the common flags to the given command
-func (options *CommonOptions) AddCommonFlags(cmd *cobra.Command) {
+func (o *CommonOptions) AddCommonFlags(cmd *cobra.Command) {
 	defaultBatchMode := false
 	if os.Getenv("JX_BATCH_MODE") == "true" {
 		defaultBatchMode = true
 	}
-	cmd.PersistentFlags().BoolVarP(&options.BatchMode, OptionBatchMode, "b", defaultBatchMode, "Runs in batch mode without prompting for user input")
-	cmd.PersistentFlags().BoolVarP(&options.Verbose, OptionVerbose, "", false, "Enables verbose output")
-	cmd.PersistentFlags().StringVarP(&options.LogLevel, OptionLogLevel, "", logrus.InfoLevel.String(), "Sets the logging level (panic, fatal, error, warning, info, debug)")
-	cmd.PersistentFlags().BoolVarP(&options.NoBrew, OptionNoBrew, "", false, "Disables brew package manager on MacOS when installing binary dependencies")
-	cmd.PersistentFlags().BoolVarP(&options.InstallDependencies, OptionInstallDeps, "", false, "Enables automatic dependencies installation when required")
-	cmd.PersistentFlags().BoolVarP(&options.SkipAuthSecretsMerge, OptionSkipAuthSecMerge, "", false, "Skips merging the secrets from local files with the secrets from Kubernetes cluster")
+	cmd.PersistentFlags().BoolVarP(&o.BatchMode, OptionBatchMode, "b", defaultBatchMode, "Runs in batch mode without prompting for user input")
+	cmd.PersistentFlags().BoolVarP(&o.Verbose, OptionVerbose, "", false, "Enables verbose output")
+	cmd.PersistentFlags().StringVarP(&o.LogLevel, OptionLogLevel, "", logrus.InfoLevel.String(), "Sets the logging level (panic, fatal, error, warning, info, debug)")
+	cmd.PersistentFlags().BoolVarP(&o.NoBrew, OptionNoBrew, "", false, "Disables brew package manager on MacOS when installing binary dependencies")
+	cmd.PersistentFlags().BoolVarP(&o.InstallDependencies, OptionInstallDeps, "", false, "Enables automatic dependencies installation when required")
+	cmd.PersistentFlags().BoolVarP(&o.SkipAuthSecretsMerge, OptionSkipAuthSecMerge, "", false, "Skips merging the secrets from local files with the secrets from Kubernetes cluster")
 
-	options.Cmd = cmd
+	o.Cmd = cmd
 }
 
 // ApiExtensionsClient return or creates the api extension client

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -117,8 +117,8 @@ func (k *KubeConfig) UpdateConfig(namespace string, server string, caData string
 
 // AddUserToConfig adds the given user to the config
 func AddUserToConfig(user string, token string, config *api.Config) (*api.Config, error) {
-	currentCluserName, currentCluster := CurrentCluster(config)
-	if currentCluster == nil || currentCluserName == "" {
+	currentClusterName, currentCluster := CurrentCluster(config)
+	if currentCluster == nil || currentClusterName == "" {
 		return config, errors.New("no cluster found in config")
 	}
 	currentCtx := CurrentContext(config)
@@ -128,7 +128,7 @@ func AddUserToConfig(user string, token string, config *api.Config) (*api.Config
 	}
 
 	ctx := &api.Context{
-		Cluster:   currentCluserName,
+		Cluster:   currentClusterName,
 		AuthInfo:  user,
 		Namespace: currentNamespace,
 	}
@@ -138,7 +138,7 @@ func AddUserToConfig(user string, token string, config *api.Config) (*api.Config
 	}
 
 	config.AuthInfos[user] = authInfo
-	ctxName := fmt.Sprintf("jx-%s-%s-ctx", currentCluserName, user)
+	ctxName := fmt.Sprintf("jx-%s-%s-ctx", currentClusterName, user)
 	config.Contexts[ctxName] = ctx
 	config.CurrentContext = ctxName
 


### PR DESCRIPTION
fixes issue #3846

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Adds a `--create` option to `jx ns <name>` and adds some tests around the namespace command.