### PR TITLE
feat: add support for `jx step git fork-and-clone`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ docs/apidocs/build
 docs/apidocs/includes
 docs/apidocs/site
 
+# generated clients
+clients/
+
 # ignore these files 1 by 1 so we can not ignore the stylesheet override
 docs/apidocs/static/FontAwesome.otf
 docs/apidocs/static/bootstrap-3.3.7.min.js

--- a/jx/scripts/update-clients.sh
+++ b/jx/scripts/update-clients.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+ORG_REPOS=("jenkins-x/jx-ts-client")
+for org_repo in "${ORG_REPOS[@]}"; do
+  OUTDIR="$(jx step git fork-and-clone -b --print-out-dir https://github.com/$org_repo)"
+  echo "Forked repo to $OUTDIR"
+  VERSION="$(cat VERSION)"
+  pushd $OUTDIR
+  make all
+  git add -N .
+  git diff --exit-code
+  if [ $? -ne 0 ]; then
+    jx create pullrequest -b --push=true --body="upgrade $org_repo client to jx $VERSION" --title="upgrade to jx $VERSION" --label="updatebot"
+  fi
+  popd
+done

--- a/pkg/apps/gitops.go
+++ b/pkg/apps/gitops.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/jenkins-x/jx/pkg/gits"
+
 	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/util"
 	"k8s.io/helm/pkg/proto/hapi/chart"
@@ -21,7 +23,7 @@ type GitOpsOptions struct {
 
 // AddApp adds the app with version rooted in dir from the repository. An alias can be specified.
 func (o *GitOpsOptions) AddApp(app string, dir string, version string, repository string, alias string) error {
-	details := environments.PullRequestDetails{
+	details := gits.PullRequestDetails{
 		BranchName: "add-app-" + app + "-" + version,
 		Title:      fmt.Sprintf("Add %s %s", app, version),
 		Message:    fmt.Sprintf("Add app %s %s", app, version),
@@ -51,7 +53,7 @@ func (o *GitOpsOptions) UpgradeApp(app string, version string, repository string
 	alias string, interrogateChartFunc func(dir string, existing map[string]interface{}) (*ChartDetails,
 		error)) error {
 	all := true
-	details := environments.PullRequestDetails{}
+	details := gits.PullRequestDetails{}
 
 	// use a random string in the branch name to ensure we use a unique git branch and fail to push
 	rand, err := util.RandStringBytesMaskImprSrc(5)
@@ -105,7 +107,7 @@ func (o *GitOpsOptions) UpgradeApp(app string, version string, repository string
 func (o *GitOpsOptions) DeleteApp(app string, alias string) error {
 
 	modifyChartFn := func(requirements *helm.Requirements, metadata *chart.Metadata, values map[string]interface{},
-		templates map[string]string, dir string, details *environments.PullRequestDetails) error {
+		templates map[string]string, dir string, details *gits.PullRequestDetails) error {
 		// See if the app already exists in requirements
 		found := false
 		for i, d := range requirements.Dependencies {
@@ -134,7 +136,7 @@ func (o *GitOpsOptions) DeleteApp(app string, alias string) error {
 		}
 		return nil
 	}
-	details := environments.PullRequestDetails{
+	details := gits.PullRequestDetails{
 		BranchName: "delete-app-" + app,
 		Title:      fmt.Sprintf("Delete %s", app),
 		Message:    fmt.Sprintf("Delete app %s", app),

--- a/pkg/apps/install.go
+++ b/pkg/apps/install.go
@@ -46,7 +46,7 @@ type InstallOptions struct {
 	Namespace       string
 	EnvironmentsDir string
 	GitProvider     gits.GitProvider
-	ConfigureGitFn  environments.ConfigureGitFn
+	ConfigureGitFn  gits.ConfigureGitFn
 	Gitter          gits.Gitter
 	Verbose         bool
 	DevEnv          *jenkinsv1.Environment

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -242,3 +242,13 @@ type Gitter interface {
 	GetRevisionBeforeDateText(dir string, dateText string) (string, error)
 	DeleteRemoteBranch(dir string, remoteName string, branch string) error
 }
+
+// ConfigureGitFn callback to optionally configure git before its used for creating commits and PRs
+type ConfigureGitFn func(dir string, gitInfo *GitRepository, gitAdapter Gitter) error
+
+// PullRequestDetails is the details for creating a pull request
+type PullRequestDetails struct {
+	Message    string
+	BranchName string
+	Title      string
+}

--- a/pkg/jx/cmd/add_app.go
+++ b/pkg/jx/cmd/add_app.go
@@ -3,12 +3,12 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/jenkins-x/jx/pkg/gits"
+
 	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
 
 	"github.com/jenkins-x/jx/pkg/apps"
-
-	"github.com/jenkins-x/jx/pkg/environments"
 
 	"github.com/jenkins-x/jx/pkg/io/secrets"
 
@@ -35,7 +35,7 @@ type AddAppOptions struct {
 	Prefixes []string
 
 	// allow git to be configured externally before a PR is created
-	ConfigureGitCallback environments.ConfigureGitFn
+	ConfigureGitCallback gits.ConfigureGitFn
 
 	Namespace   string
 	Version     string

--- a/pkg/jx/cmd/cmd_test_helpers/app_test_helpers.go
+++ b/pkg/jx/cmd/cmd_test_helpers/app_test_helpers.go
@@ -13,8 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
-	"github.com/jenkins-x/jx/pkg/environments"
-
 	resources_test "github.com/jenkins-x/jx/pkg/kube/resources/mocks"
 
 	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
@@ -37,7 +35,7 @@ import (
 
 // AppTestOptions contains all useful data from the test environment initialized by `prepareInitialPromotionEnv`
 type AppTestOptions struct {
-	ConfigureGitFn  environments.ConfigureGitFn
+	ConfigureGitFn  gits.ConfigureGitFn
 	CommonOptions   *opts.CommonOptions
 	FakeGitProvider *gits.FakeProvider
 	DevRepo         *gits.FakeRepository

--- a/pkg/jx/cmd/controller_workflow.go
+++ b/pkg/jx/cmd/controller_workflow.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jenkins-x/jx/pkg/environments"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
@@ -46,7 +45,7 @@ type ControllerWorkflowOptions struct {
 	pipelineMap             map[string]*v1.PipelineActivity
 
 	// Allow Git to be configured
-	ConfigureGitFn environments.ConfigureGitFn
+	ConfigureGitFn gits.ConfigureGitFn
 }
 
 // NewCmdControllerWorkflow creates a command object for the generic "get" action, which

--- a/pkg/jx/cmd/create_pullrequest.go
+++ b/pkg/jx/cmd/create_pullrequest.go
@@ -19,7 +19,9 @@ import (
 
 var (
 	createPullRequestLong = templates.LongDesc(`
-		Creates a Pull Request in a the git project of the current directory
+		Creates a Pull Request in a the git project of the current directory. 
+
+		If --push is specified the contents of the directory will be committed, pushed and used to create the pull request  
 `)
 
 	createPullRequestExample = templates.Examples(`
@@ -47,14 +49,10 @@ type CreatePullRequestOptions struct {
 	Body   string
 	Labels []string
 	Base   string
+	Push   bool
+	Fork   bool
 
-	Results CreatePullRequestResults
-}
-
-type CreatePullRequestResults struct {
-	GitInfo     *gits.GitRepository
-	GitProvider gits.GitProvider
-	PullRequest *gits.GitPullRequest
+	Results *gits.PullRequestInfo
 }
 
 // NewCmdCreatePullRequest creates a command object for the "create" command
@@ -84,6 +82,7 @@ func NewCmdCreatePullRequest(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Body, "body", "", "", "The body of the pullrequest")
 	cmd.Flags().StringVarP(&options.Base, "base", "", "master", "The base branch to create the pull request into")
 	cmd.Flags().StringArrayVarP(&options.Labels, "label", "l", []string{}, "The labels to add to the pullrequest")
+	cmd.Flags().BoolVarP(&options.Push, "push", "", false, "If true the contents of the source directory will be committed, pushed, and used to create the pull request")
 
 	return cmd
 }
@@ -94,50 +93,32 @@ func (o *CreatePullRequestOptions) Run() error {
 	if o.Dir == "" {
 		dir, err := os.Getwd()
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "getting working directory")
 		}
 		o.Dir = dir
 	}
 	gitInfo, provider, _, err := o.CreateGitProvider(o.Dir)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "creating git provider for directory %s", o.Dir)
 	}
 
-	o.Results.GitInfo = gitInfo
-	o.Results.GitProvider = provider
-
-	branchName, err := o.Git().Branch(o.Dir)
+	details, err := o.createPullRequestDetails(gitInfo)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
-	base := o.Base
-	arguments := &gits.GitPullRequestArguments{
-		Base: base,
-		Head: branchName,
-	}
-	err = o.PopulatePullRequest(arguments, gitInfo)
+	o.Results, err = gits.PushRepoAndCreatePullRequest(o.Dir, gitInfo, o.Base, details, nil, true, o.Push, o.Push, provider, o.Git())
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to create PR for base %s and head branch %s", o.Base, details.BranchName)
 	}
-
-	pr, err := provider.CreatePullRequest(arguments)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create PR for base %s and head branch %s", base, branchName)
-	}
-
-	o.Results.PullRequest = pr
-
-	log.Infof("\nCreated PullRequest %s at %s\n", util.ColorInfo(pr.NumberString()), util.ColorInfo(pr.URL))
-
 	return nil
 }
 
-func (o *CreatePullRequestOptions) PopulatePullRequest(pullRequest *gits.GitPullRequestArguments, gitInfo *gits.GitRepository) error {
+func (o *CreatePullRequestOptions) createPullRequestDetails(gitInfo *gits.GitRepository) (*gits.PullRequestDetails, error) {
 	title := o.Title
 	if title == "" {
 		if o.BatchMode {
-			return util.MissingOption(optionTitle)
+			return nil, util.MissingOption(optionTitle)
 		}
 		defaultValue, body, err := o.findLastCommitTitle()
 		if err != nil {
@@ -148,18 +129,22 @@ func (o *CreatePullRequestOptions) PopulatePullRequest(pullRequest *gits.GitPull
 		}
 		title, err = util.PickValue("PullRequest title:", defaultValue, true, "", o.In, o.Out, o.Err)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-	body := o.Body
-	pullRequest.Title = title
-	pullRequest.Body = body
-	pullRequest.GitRepository = gitInfo
-
 	if title == "" {
-		return fmt.Errorf("No title specified!")
+		return nil, fmt.Errorf("no title specified!")
 	}
-	return nil
+	branchName, err := o.Git().Branch(o.Dir)
+	if err != nil {
+		return nil, err
+	}
+	return &gits.PullRequestDetails{
+		Title:      title,
+		Message:    o.Body,
+		BranchName: branchName,
+	}, nil
+
 }
 
 func (o *CreatePullRequestOptions) findLastCommitTitle() (string, string, error) {

--- a/pkg/jx/cmd/delete_app.go
+++ b/pkg/jx/cmd/delete_app.go
@@ -2,8 +2,7 @@ package cmd
 
 import (
 	"github.com/jenkins-x/jx/pkg/apps"
-
-	"github.com/jenkins-x/jx/pkg/environments"
+	"github.com/jenkins-x/jx/pkg/gits"
 
 	"github.com/pkg/errors"
 
@@ -47,7 +46,7 @@ type DeleteAppOptions struct {
 	Alias       string
 
 	// allow git to be configured externally before a PR is created
-	ConfigureGitCallback environments.ConfigureGitFn
+	ConfigureGitCallback gits.ConfigureGitFn
 }
 
 // NewCmdDeleteApp creates a command object for this command

--- a/pkg/jx/cmd/delete_application.go
+++ b/pkg/jx/cmd/delete_application.go
@@ -67,7 +67,7 @@ type DeleteApplicationOptions struct {
 	PullRequestPollDuration *time.Duration
 
 	// allow git to be configured externally before a PR is created
-	ConfigureGitCallback environments.ConfigureGitFn
+	ConfigureGitCallback gits.ConfigureGitFn
 }
 
 // NewCmdDeleteApplication creates a command object for this command
@@ -359,7 +359,7 @@ func (o *DeleteApplicationOptions) deleteApplicationFromEnvironment(env *v1.Envi
 	log.Infof("Removing application %s from environment %s\n", applicationName, env.Spec.Label)
 
 	modifyChartFn := func(requirements *helm.Requirements, metadata *chart.Metadata, values map[string]interface{},
-		templates map[string]string, dir string, info *environments.PullRequestDetails) error {
+		templates map[string]string, dir string, info *gits.PullRequestDetails) error {
 		requirements.RemoveApplication(applicationName)
 		return nil
 	}
@@ -372,7 +372,7 @@ func (o *DeleteApplicationOptions) deleteApplicationFromEnvironment(env *v1.Envi
 		return errors.Wrapf(err, "getting environments dir")
 	}
 
-	details := environments.PullRequestDetails{
+	details := gits.PullRequestDetails{
 		BranchName: "delete-" + applicationName,
 		Title:      "Delete application " + applicationName + " from this environment",
 		Message:    "The command `jx delete application` was run by " + username + " and it generated this Pull Request",

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"github.com/Pallinder/go-randomdata"
+	randomdata "github.com/Pallinder/go-randomdata"
 	"github.com/jenkins-x/jx/pkg/io/secrets"
 	kubevault "github.com/jenkins-x/jx/pkg/kube/vault"
 	"github.com/jenkins-x/jx/pkg/vault"
@@ -43,8 +43,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/src-d/go-git.v4"
+	survey "gopkg.in/AlecAivazis/survey.v1"
+	git "gopkg.in/src-d/go-git.v4"
 	core_v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1698,7 +1698,7 @@ func (options *InstallOptions) applyGitOpsDevEnvironmentConfig(gitOpsEnvDir stri
 
 			err := envApplyOptions.Run()
 			if err != nil {
-				return errors.Wrap(err, "appyting the dev environment configuration")
+				return errors.Wrap(err, "applying the dev environment configuration")
 			}
 		}
 	}

--- a/pkg/jx/cmd/promote.go
+++ b/pkg/jx/cmd/promote.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	survey "gopkg.in/AlecAivazis/survey.v1"
 
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/environments"
 
 	"k8s.io/helm/pkg/proto/hapi/chart"
@@ -17,7 +19,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube/services"
 
 	"github.com/blang/semver"
-	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	typev1 "github.com/jenkins-x/jx/pkg/client/clientset/versioned/typed/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/helm"
@@ -27,7 +28,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
-	survey "gopkg.in/AlecAivazis/survey.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -67,7 +67,7 @@ type PromoteOptions struct {
 	Alias                   string
 
 	// allow git to be configured externally before a PR is created
-	ConfigureGitCallback environments.ConfigureGitFn
+	ConfigureGitCallback gits.ConfigureGitFn
 
 	// calculated fields
 	TimeoutDuration         *time.Duration
@@ -455,14 +455,14 @@ func (o *PromoteOptions) PromoteViaPullRequest(env *v1.Environment, releaseInfo 
 	}
 	app := o.Application
 
-	details := environments.PullRequestDetails{
+	details := gits.PullRequestDetails{
 		BranchName: "promote-" + app + "-" + versionName,
 		Title:      app + " to " + versionName,
 		Message:    fmt.Sprintf("Promote %s to version %s", app, versionName),
 	}
 
 	modifyChartFn := func(requirements *helm.Requirements, metadata *chart.Metadata, values map[string]interface{},
-		templates map[string]string, dir string, details *environments.PullRequestDetails) error {
+		templates map[string]string, dir string, details *gits.PullRequestDetails) error {
 		var err error
 		if version == "" {
 			version, err = o.findLatestVersion(app)

--- a/pkg/jx/cmd/promote_test.go
+++ b/pkg/jx/cmd/promote_test.go
@@ -11,10 +11,7 @@ import (
 
 	"k8s.io/helm/pkg/proto/hapi/chart"
 
-	"github.com/jenkins-x/jx/pkg/environments"
-
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
-
 	"github.com/jenkins-x/jx/pkg/gits"
 	helm_test "github.com/jenkins-x/jx/pkg/helm/mocks"
 	"github.com/jenkins-x/jx/pkg/jx/cmd"
@@ -235,7 +232,7 @@ type TestEnv struct {
 	DevRepo              *gits.FakeRepository
 	StagingRepo          *gits.FakeRepository
 	ProdRepo             *gits.FakeRepository
-	ConfigureGitFolderFn environments.ConfigureGitFn
+	ConfigureGitFolderFn gits.ConfigureGitFn
 }
 
 // Prepares an initial configuration with a typical environment setup.

--- a/pkg/jx/cmd/step_git.go
+++ b/pkg/jx/cmd/step_git.go
@@ -39,6 +39,7 @@ func NewCmdStepGit(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.AddCommand(NewCmdStepGitCredentials(commonOpts))
 	cmd.AddCommand(NewCmdStepGitEnvs(commonOpts))
 	cmd.AddCommand(NewCmdStepGitMerge(commonOpts))
+	cmd.AddCommand(NewCmdStepGitForkAndClone(commonOpts))
 	return cmd
 }
 

--- a/pkg/jx/cmd/step_git_fork_and_clone.go
+++ b/pkg/jx/cmd/step_git_fork_and_clone.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jenkins-x/jx/pkg/log"
+
+	errors "github.com/pkg/errors"
+
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/templates"
+	"github.com/spf13/cobra"
+)
+
+// StepGitForkAndCloneOptions contains the command line flags
+type StepGitForkAndCloneOptions struct {
+	StepOptions
+	Dir         string
+	BaseRef     string
+	PrintOutDir bool
+
+	OutputDir string
+}
+
+var (
+	// StepGitForkAndCloneLong command long description
+	StepGitForkAndCloneLong = templates.LongDesc(`
+		This pipeline step will clone a git repo, creating a fork if required. The fork is created if the owner of the 
+		repo is not the current git user (and that forking the git repo is allowed).
+
+`)
+	// StepGitForkAndCloneExample command example
+	StepGitForkAndCloneExample = templates.Examples(`
+		# Fork and clone the jx repo
+		jx step git fork-and-clone https://github.com/jenkins-x/jx.git
+
+`)
+)
+
+// NewCmdStepGitForkAndClone create the 'step git envs' command
+func NewCmdStepGitForkAndClone(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := StepGitForkAndCloneOptions{
+		StepOptions: StepOptions{
+			CommonOptions: commonOpts,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:     "fork-and-clone",
+		Short:   "Forks and clones a git repo",
+		Long:    StepGitForkAndCloneLong,
+		Example: StepGitForkAndCloneExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			CheckErr(err)
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.Dir, "dir", "", "", "The directory in which the git repo is checked out, by default the working directory")
+	cmd.Flags().StringVarP(&options.BaseRef, "base", "", "master", "The base ref to start from")
+	cmd.Flags().BoolVarP(&options.BatchMode, opts.OptionBatchMode, "b", false, "Enable batch mode")
+	cmd.Flags().BoolVarP(&options.PrintOutDir, "print-out-dir", "", false, "prints the directory the fork has been cloned to on stdout")
+	return cmd
+}
+
+// Run implements the command
+func (o *StepGitForkAndCloneOptions) Run() error {
+	if len(o.Args) != 1 {
+		return errors.Errorf("Must specify exactly one git url but was %v", o.Args)
+	}
+	if o.Dir == "" {
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		o.Dir = dir
+	}
+	gitURL := o.Args[0]
+	provider, err := o.GitProviderForURL(gitURL, "git username")
+	if err != nil {
+		return errors.Wrapf(err, "getting git provider for %s", gitURL)
+	}
+	dir, baseRef, _, fork, err := gits.ForkAndPullPullRepo(gitURL, o.Dir, o.BaseRef, "", provider, o.Git(), nil)
+	if err != nil {
+		return errors.Wrapf(err, "forking and pulling %s", gitURL)
+	}
+	o.OutDir = dir
+	if o.PrintOutDir {
+		// Output the directory so it can be used in a script
+		fmt.Print(dir)
+	}
+	if fork {
+		log.Infof("Forked %s and pulled it into %s checking out %s", gitURL, dir, baseRef)
+	} else {
+		log.Infof("Pulled %s (%s) into %s", gitURL, baseRef, dir)
+	}
+
+	return nil
+}

--- a/pkg/jx/cmd/upgrade_apps.go
+++ b/pkg/jx/cmd/upgrade_apps.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/jenkins-x/jx/pkg/gits"
+
 	"github.com/jenkins-x/jx/pkg/apps"
 	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"github.com/pkg/errors"
-
-	"github.com/jenkins-x/jx/pkg/environments"
 
 	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
@@ -53,7 +53,7 @@ type UpgradeAppsOptions struct {
 	Set       []string
 
 	// allow git to be configured externally before a PR is created
-	ConfigureGitCallback environments.ConfigureGitFn
+	ConfigureGitCallback gits.ConfigureGitFn
 }
 
 // NewCmdUpgradeApps defines the command


### PR DESCRIPTION
This command will fork and then clone locally a git repo.
It will fork if the git repo is in a different org (or user)
than the current git user.

Also adds support to `jx create pull request` to commit and push the
code in the current directory. Together these two commands allow you
to clone a git repo, run something (e.g. a `Makefile`) and then create
a pull request with the changes.   Also adds `hack/generate-clients.sh` that will use these commands to
clone and create PRs for the various clients for Jenkins X.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
