### PR TITLE
Skip ECR docker repository creation if a project doesn't need a docker image/file

### DIFF
--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -900,9 +900,16 @@ func (options *ImportOptions) doImport() error {
 		jenkinsfile = defaultJenkinsfileName
 	}
 
-	err = options.ensureDockerRepositoryExists()
+	dockerfileExists, err := util.FileExists("Dockerfile")
 	if err != nil {
 		return err
+	}
+
+	if dockerfileExists {
+		err = options.ensureDockerRepositoryExists()
+		if err != nil {
+			return err
+		}
 	}
 
 	isProw, err := options.IsProw()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
This PR fixes this issue:
- When importing a project, if there's no Dockerfile and the project doesn't require one, the code still goes and creates an ecr repository for the project, this PR skips that step in that case.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
