### PR TITLE
fix: the generated apps weren't getting the real app.yml file from it…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/google/go-containerregistry v0.0.0-20190317040536-ebbba8469d06 // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/uuid v1.1.0
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/hcl v1.0.0

--- a/pkg/jx/cmd/add_app_test.go
+++ b/pkg/jx/cmd/add_app_test.go
@@ -105,7 +105,7 @@ func TestAddAppForGitOps(t *testing.T) {
 	assert.Len(t, found, 1)
 	assert.Equal(t, version, found[0].Version)
 	app := &jenkinsv1.App{}
-	appBytes, err := ioutil.ReadFile(filepath.Join(devEnvDir, name, "templates", name+"-app.yaml"))
+	appBytes, err := ioutil.ReadFile(filepath.Join(devEnvDir, name, "templates", "app.yaml"))
 	_ = yaml.Unmarshal(appBytes, app)
 	assert.Equal(t, name, app.Labels[helm.LabelAppName])
 	assert.Equal(t, version, app.Labels[helm.LabelAppVersion])
@@ -188,7 +188,7 @@ func TestAddAppForGitOpsWithShortName(t *testing.T) {
 	assert.Len(t, found, 1)
 	assert.Equal(t, version, found[0].Version)
 	app := &jenkinsv1.App{}
-	appBytes, err := ioutil.ReadFile(filepath.Join(devEnvDir, name, "templates", name+"-app.yaml"))
+	appBytes, err := ioutil.ReadFile(filepath.Join(devEnvDir, name, "templates", "app.yaml"))
 	_ = yaml.Unmarshal(appBytes, app)
 	assert.Equal(t, name, app.Labels[helm.LabelAppName])
 	assert.Equal(t, version, app.Labels[helm.LabelAppVersion])

--- a/pkg/jx/cmd/get_apps_test.go
+++ b/pkg/jx/cmd/get_apps_test.go
@@ -50,7 +50,7 @@ func TestGetAppsGitops(t *testing.T) {
 		},
 		Namespace: namespace,
 	}
-	appResourceLocation := filepath.Join(devEnvDir, name1, "templates", name1+"-app.yaml")
+	appResourceLocation := filepath.Join(devEnvDir, name1, "templates", "app.yaml")
 	app := &v1.App{}
 	appBytes, err := ioutil.ReadFile(appResourceLocation)
 	err = yaml.Unmarshal(appBytes, app)

--- a/pkg/jx/cmd/opts/helm.go
+++ b/pkg/jx/cmd/opts/helm.go
@@ -3,6 +3,7 @@ package opts
 import (
 	"context"
 	"fmt"
+	"github.com/pborman/uuid"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -22,8 +23,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	version2 "github.com/jenkins-x/jx/pkg/version"
 	"github.com/pkg/errors"
-	survey "gopkg.in/AlecAivazis/survey.v1"
-	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/src-d/go-git.v4"
 	gitconfig "gopkg.in/src-d/go-git.v4/config"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -351,7 +352,15 @@ func (o *CommonOptions) InstallChartOrGitOps(isGitOps bool, gitOpsDir string, gi
 		valuesFiles.Items = append(valuesFiles.Items, fileName.Name())
 	}
 
-	modifyFn := environments.CreateAddRequirementFn(chart, alias, version, repo, valuesFiles, gitOpsEnvDir, o.Verbose, o.Helm())
+	//Needed for generated Apps - Otherwise the main repo's Chart.yml is used and the Apps metadata is left empty
+	chartUntarDir, _ := ioutil.TempDir("", chart+uuid.NewUUID().String())
+	err := o.Helm().FetchChart(chart, version, true, chartUntarDir, repo, "", "")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Maybe modify the gitOpsEnvDir to after a fetch
+	modifyFn := environments.CreateAddRequirementFn(chart, alias, version, repo, valuesFiles, filepath.Join(chartUntarDir, chart), o.Verbose, o.Helm())
 
 	if len(setSecrets) > 0 {
 		secretsFile := filepath.Join(gitOpsEnvDir, helm.SecretsFileName)


### PR DESCRIPTION
…s base chart, also added a way to modifiy the base app yaml files of charts

Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Performs a helm fetch for generated apps so we can extract data from their Chart.yml files and add them to our Apps CRD labels.
Also added a way to override default app.yml files for actual apps with enriched data.

#### Special notes for the reviewer(s)
The test for `step_helm_apply.go` is in another PR, there are many test changes that are needed for that and this is just a subset of that PR so it doesn't get too out of hand.

#### Which issue this PR fixes

fixes #3917

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
