### PR TITLE
fix(controller_team): copy team settings for git

### DIFF
--- a/pkg/jx/cmd/controller_team.go
+++ b/pkg/jx/cmd/controller_team.go
@@ -232,6 +232,9 @@ func (o *ControllerTeamOptions) onTeamChange(obj interface{}, kubeClient kuberne
 		provider := ""
 		if adminTeamSettings != nil {
 			provider = adminTeamSettings.KubeProvider
+			io.GitRepositoryOptions.Private = adminTeamSettings.GitPrivate
+			io.GitRepositoryOptions.ServerURL = adminTeamSettings.GitServer
+			io.GitRepositoryOptions.Username = adminTeamSettings.PipelineUsername
 		}
 		if provider == "" {
 			log.Warnf("No kube provider specified on admin team settings %s\n. Defaulting to gke", adminNs)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The `jx create team` does not copy the admin team settings for git.

#### Special notes for the reviewer(s)

I couldn't figure out how to actually run this.

#### Which issue this PR fixes

None.