### PR TITLE
fix: Use Gitlab namespaces API to create repo under the user/org name…

### DIFF
--- a/pkg/gits/gitlab.go
+++ b/pkg/gits/gitlab.go
@@ -85,7 +85,7 @@ func getRepositories(g *gitlab.Client, username string, org string) ([]*gitlab.P
 }
 
 func GetOwnerNamespaceId(g *gitlab.Client, owner string) (int, error) {
-	n := &gitlab.ListNamespacesOptions {
+	n := &gitlab.ListNamespacesOptions{
 		Search: &owner,
 	}
 
@@ -93,13 +93,13 @@ func GetOwnerNamespaceId(g *gitlab.Client, owner string) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	
+
 	for _, v := range namespaces {
-	    if v.FullPath == owner {
-		    return v.ID, nil
+		if v.FullPath == owner {
+			return v.ID, nil
 		}
 	}
-	
+
 	return -1, fmt.Errorf("no namespace found for owner %s", owner)
 }
 
@@ -125,8 +125,8 @@ func (g *GitlabProvider) CreateRepository(org string, name string, private bool)
 	}
 
 	p := &gitlab.CreateProjectOptions{
-		Name:       &name,
-		Visibility: &visibility,
+		Name:        &name,
+		Visibility:  &visibility,
 		NamespaceID: &namespaceId,
 	}
 

--- a/pkg/gits/gitlab.go
+++ b/pkg/gits/gitlab.go
@@ -84,7 +84,7 @@ func getRepositories(g *gitlab.Client, username string, org string) ([]*gitlab.P
 	return g.Projects.ListUserProjects(username, &gitlab.ListProjectsOptions{Owned: gitlab.Bool(true)})
 }
 
-func GetOwnerNamespaceId(g *gitlab.Client, owner string) (int, error) {
+func GetOwnerNamespaceID(g *gitlab.Client, owner string) (int, error) {
 	n := &gitlab.ListNamespacesOptions{
 		Search: &owner,
 	}
@@ -119,7 +119,7 @@ func (g *GitlabProvider) CreateRepository(org string, name string, private bool)
 		visibility = gitlab.PrivateVisibility
 	}
 
-	namespaceId, err := GetOwnerNamespaceId(g.Client, owner(org, g.Username))
+	namespaceID, err := GetOwnerNamespaceID(g.Client, owner(org, g.Username))
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (g *GitlabProvider) CreateRepository(org string, name string, private bool)
 	p := &gitlab.CreateProjectOptions{
 		Name:        &name,
 		Visibility:  &visibility,
-		NamespaceID: &namespaceId,
+		NamespaceID: &namespaceID,
 	}
 
 	project, _, err := g.Client.Projects.CreateProject(p)


### PR DESCRIPTION
…space

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Use Gitlab namespaces API to create repo under the selected user/org name, as the current behaviour is to always create it under the user.

#### Special notes for the reviewer(s)
Tested successfully with `jx import` command both with an organisation name and a user name in the `--org=` argument.

#### Which issue this PR fixes

fixes #3143

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
