### PR TITLE
fix(tekton): Non-schema-errors weren't showing up in validation

### DIFF
--- a/pkg/jx/cmd/step_syntax_validate_pipeline.go
+++ b/pkg/jx/cmd/step_syntax_validate_pipeline.go
@@ -14,7 +14,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 var (


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

We had the wrong yaml library in `step_syntax_validate_pipeline`. Sigh.

#### Special notes for the reviewer(s)

/assign @dwnusbaum 

#### Which issue this PR fixes

fixes #3944 
