### PR TITLE
feat(tekton): Allow specifying default working dir on pipeline and stage

### DIFF
--- a/pkg/tekton/syntax/test_data/dir_on_pipeline_and_stage/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/dir_on_pipeline_and_stage/jenkins-x.yml
@@ -1,0 +1,22 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        dir: a-relative-dir
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+          - name: Another stage
+            dir: /an/absolute/dir
+            steps:
+              - command: echo
+                args: ['again']
+              - command: echo
+                args: ['in another dir']
+                dir: another-relative-dir/with/a/subdir


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Syntax is:

```
pipeline:
  dir: some-dir
  ...
  stages:
    - name: some-stage
      dir: /an/absolute/dir
      ...
```

Relative directories are appended to the base working directory (i.e.,
`/workspace/source`), and absolute directories are used directly.

Pipeline `dir` is overridden by stage `dir` and/or step `dir`, and
stage `dir` is overridden by either nested stages' `dir`s or step `dir`.

#### Special notes for the reviewer(s)

/assign @warrenbailey 
/assign @rawlingsj 
/assign @pmuir 
/assign @dwnusbaum 
/assign @joseblas 

#### Which issue this PR fixes

fixes #3838
