### PR TITLE
feat(tekton): Add a potentially multiline script field for steps

### DIFF
--- a/pkg/jx/cmd/step_create_task.go
+++ b/pkg/jx/cmd/step_create_task.go
@@ -1642,7 +1642,7 @@ func (o *StepCreateTaskOptions) invokeSteps(steps []*syntax.Step) error {
 func (o *StepCreateTaskOptions) modifyStep(projectConfig *config.ProjectConfig, parsedStep syntax.Step, gitInfo *gits.GitRepository, pipelineConfig *jenkinsfile.PipelineConfig, templateKind string, step *syntax.Step, containerName string, dir string) syntax.Step {
 
 	if !o.NoKaniko {
-		if strings.HasPrefix(parsedStep.Command, "skaffold build") ||
+		if strings.HasPrefix(parsedStep.GetCommand(), "skaffold build") ||
 			(len(parsedStep.Arguments) > 0 && strings.HasPrefix(strings.Join(parsedStep.Arguments[1:], " "), "skaffold build")) {
 			sourceDir := o.getWorkspaceDir()
 			dockerfile := filepath.Join(sourceDir, "Dockerfile")

--- a/pkg/jx/cmd/step_create_task_test.go
+++ b/pkg/jx/cmd/step_create_task_test.go
@@ -242,6 +242,21 @@ func TestGenerateTektonCRDs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:         "script-step",
+			language:     "none",
+			repoName:     "js-test-repo",
+			organization: "abayer",
+			branch:       "really-long",
+			kind:         "release",
+			expectedActivityKey: &kube.PromoteStepActivityKey{
+				PipelineActivityKey: kube.PipelineActivityKey{
+					Name:     "abayer-js-test-repo-really-long-1",
+					Pipeline: "abayer/js-test-repo/really-long",
+					Build:    "1",
+				},
+			},
+		},
 	}
 
 	k8sObjects := []runtime.Object{

--- a/pkg/jx/cmd/test_data/step_create_task/script-step/jenkins-x.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/script-step/jenkins-x.yml
@@ -1,0 +1,38 @@
+pipelineConfig:
+  env:
+    - name: FRUIT
+      value: BANANA
+  pipelines:
+    release:
+      pipeline:
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: somebodyelse
+        options:
+          containerOptions:
+            resources:
+              requests:
+                cpu: 0.1
+                memory: 64Mi
+        agent:
+          image: nodejs
+        stages:
+          - name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+            steps:
+              - script: |
+                  echo hello world
+                  ls -la
+                env:
+                  - name: ANOTHER_VAR
+                    value: Another value
+          - name: Second
+            steps:
+              - command: echo
+                args:
+                  - hi ${FRUIT}
+            options:
+              containerOptions:
+                resources:
+                  limits:
+                    cpu: 0.4
+                    memory: 256Mi

--- a/pkg/jx/cmd/test_data/step_create_task/script-step/pipeline.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/script-step/pipeline.yml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  creationTimestamp: null
+  name: abayer-js-test-repo-really-long-1
+  namespace: jx
+spec:
+  params: []
+  resources:
+  - name: abayer-js-test-repo-really-long
+    type: git
+  tasks:
+  - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+    resources:
+      inputs:
+      - name: workspace
+        resource: abayer-js-test-repo-really-long
+      outputs:
+      - name: workspace
+        resource: abayer-js-test-repo-really-long
+    taskRef:
+      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  - name: second
+    resources:
+      inputs:
+      - from:
+        - build-a-really-long-stage-name-please-but-not-too-long-thanks
+        name: workspace
+        resource: abayer-js-test-repo-really-long
+    runAfter:
+      - build-a-really-long-stage-name-please-but-not-too-long-thanks
+    taskRef:
+      name: abayer-js-test-repo-really-long-second-1
+status: {}

--- a/pkg/jx/cmd/test_data/step_create_task/script-step/pipelineresources.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/script-step/pipelineresources.yml
@@ -1,0 +1,15 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    creationTimestamp: null
+    name: abayer-js-test-repo-really-long
+  spec:
+    params:
+    - name: revision
+      value: ""
+    - name: url
+      value: https://github.com/abayer/js-test-repo
+    type: git
+  status: {}
+metadata: {}

--- a/pkg/jx/cmd/test_data/step_create_task/script-step/pipelinerun.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/script-step/pipelinerun.yml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
+  name: abayer-js-test-repo-really-long-1
+spec:
+  Status: ""
+  params: null
+  pipelineRef:
+    apiVersion: tekton.dev/v1alpha1
+    name: abayer-js-test-repo-really-long-1
+  resources:
+  - name: abayer-js-test-repo-really-long
+    resourceRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: abayer-js-test-repo-really-long
+  serviceAccount: tekton-bot
+  trigger:
+    type: manual
+status:
+  conditions: null

--- a/pkg/jx/cmd/test_data/step_create_task/script-step/structure.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/script-step/structure.yml
@@ -1,0 +1,13 @@
+metadata:
+  creationTimestamp: null
+  name: abayer-js-test-repo-really-long-1
+pipelineRef: null
+pipelineRunRef: null
+stages:
+- depth: 0
+  name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+- depth: 0
+  name: Second
+  previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+  taskRef: abayer-js-test-repo-really-long-second-1

--- a/pkg/jx/cmd/test_data/step_create_task/script-step/tasks.yml
+++ b/pkg/jx/cmd/test_data/step_create_task/script-step/tasks.yml
@@ -1,0 +1,234 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: null
+    labels:
+      jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    namespace: jx
+  spec:
+    inputs:
+      resources:
+      - name: workspace
+        targetPath: source
+        type: git
+    outputs:
+      resources:
+      - name: workspace
+        targetPath: ""
+        type: git
+    steps:
+    - args:
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - jx
+      env:
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: DOCKER_REGISTRY
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: rawlingsj/builder-jx:wip34
+      name: git-merge
+      volumeMounts:
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - |
+        echo hello world
+        ls -la
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: ANOTHER_VAR
+        value: Another value
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step2
+      resources:
+        requests:
+          cpu: 0.1
+          memory: 64Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: null
+    labels:
+      jenkins.io/task-stage-name: second
+    name: abayer-js-test-repo-really-long-second-1
+    namespace: jx
+  spec:
+    inputs:
+      resources:
+      - name: workspace
+        targetPath: source
+        type: git
+    steps:
+    - args:
+      - echo hi ${FRUIT}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step2
+      resources:
+        requests:
+          cpu: 0.1
+          memory: 64Mi
+        limits:
+          cpu: 0.4
+          memory: 256Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+metadata: {}

--- a/pkg/tekton/syntax/test_data/script_step/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/script_step/jenkins-x.yml
@@ -1,0 +1,13 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - script: |
+                  echo hello world
+                  echo goodbye world
+                name: A Step With A Script


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This allows doing things like:
```
steps:
  - name: A script step
    script: |
      ls -la
      echo tada
      for d in 1 2 3 4; do
        echo "d is ${d}";
      done
  - name: A command step
    command: echo
    args: ['a normal step']
```

#### Special notes for the reviewer(s)

/assign @hferentschik 
/assign @jstrachan 
/assign @warrenbailey 
/assign @rawlingsj 
/assign @dwnusbaum 
cc @sharepointoscar @vfarcic 

#### Which issue this PR fixes

fixes #3767 
