### PR TITLE
fix(cmd): application environment was always the last environment

### DIFF
--- a/pkg/jx/cmd/get_applications.go
+++ b/pkg/jx/cmd/get_applications.go
@@ -201,7 +201,7 @@ func (o *GetApplicationsOptions) generateTable(apps []string, envApps []EnvApps,
 
 					appEnvInfo := &ApplicationEnvironmentInfo{
 						Deployment:  &d,
-						Environment: &ea.Environment,
+						Environment: ea.Environment.DeepCopy(),
 						Version:     version,
 						URL:         url,
 					}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

The JX Environment listed in `ApplicationEnvironmentInfo` here:

https://github.com/jenkins-x/jx/blob/443b821c5093b71eabbd1eca0d7334b6f89429af/pkg/jx/cmd/get_applications.go#L47

Is always set to the last environment that was iterated over.  I think this is caused by variable shadowing.  The fix was to clone the environment struct.

#### Special notes for the reviewer(s)

Manually built and tested the fix.

#### Which issue this PR fixes

None.