### PR TITLE
Amended environment to return cluster name

### DIFF
--- a/pkg/jx/cmd/environment.go
+++ b/pkg/jx/cmd/environment.go
@@ -118,18 +118,18 @@ func (o *EnvironmentOptions) Run() error {
 		if err != nil {
 			return fmt.Errorf("Failed to update the kube config %s", err)
 		}
-		fmt.Fprintf(o.Out, "Now using environment '%s' in team '%s' on server '%s'.\n",
-			info(env), info(devNs), info(kube.Server(config, ctx)))
+		fmt.Fprintf(o.Out, "Now using environment '%s' in team '%s' on cluster '%s'.\n",
+			info(env), info(devNs), info(kube.Cluster(config)))
 	} else {
 		ns := kube.CurrentNamespace(config)
-		server := kube.CurrentServer(config)
+		cluster := kube.Cluster(config)
 		if env == "" {
 			env = currentEnv
 		}
 		if env == "" {
-			fmt.Fprintf(o.Out, "Using namespace '%s' from context named '%s' on server '%s'.\n", info(ns), info(config.CurrentContext), info(server))
+			fmt.Fprintf(o.Out, "Using namespace '%s' from context named '%s' on cluster '%s'.\n", info(ns), info(config.CurrentContext), info(cluster))
 		} else {
-			fmt.Fprintf(o.Out, "Using environment '%s' in team '%s' on server '%s'.\n", info(env), info(devNs), info(server))
+			fmt.Fprintf(o.Out, "Using environment '%s' in team '%s' on cluster '%s'.\n", info(env), info(devNs), info(cluster))
 		}
 	}
 	return nil

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -55,6 +55,17 @@ func CurrentCluster(config *api.Config) (string, *api.Cluster) {
 	return "", nil
 }
 
+// Cluster returns the cluster of the given config
+func Cluster(config *api.Config) string {
+	if config != nil {
+		context := CurrentContext(config)
+		if context != nil && config.Clusters != nil {
+			return context.Cluster
+		}
+	}
+	return ""
+}
+
 // CurrentServer returns the current context's server
 func CurrentServer(config *api.Config) string {
 	context := CurrentContext(config)


### PR DESCRIPTION
At present, the 'jx env' command returns information on the current environment which contains the server in which it's connected. I propose replacing the server value (as it doesn't provide a good reference to the cluster) with the cluster name. This is valuable when used within the status bar of a terminal or detecting specific environments.