### PR TITLE
Fixed the status for listed installed apps when not in gitops mode

### DIFF
--- a/pkg/jx/cmd/get_apps.go
+++ b/pkg/jx/cmd/get_apps.go
@@ -288,8 +288,8 @@ func (o *GetAppsOptions) getAppsStatus(gitOps bool, namespace string, apps *v1.A
 	if err != nil {
 		return nil, errors.Wrap(err, "there was a problem getting the status of the apps")
 	}
-	for k, v := range statusReleases {
-		appsStatus[k] = v.Status
+	for _, v := range statusReleases {
+		appsStatus[v.Chart] = v.Status
 	}
 	return appsStatus, nil
 }

--- a/pkg/jx/cmd/get_apps_test.go
+++ b/pkg/jx/cmd/get_apps_test.go
@@ -287,7 +287,7 @@ func TestGetAppsHasStatus(t *testing.T) {
 
 	pegomock.When(getAppOptions.Helm().ListReleases(pegomock.EqString(namespace))).
 		ThenReturn(map[string]helm.ReleaseSummary{
-			name1: {Status: "DEPLOYED"},
+			name1: {Status: "DEPLOYED", Chart: name1},
 		}, nil, nil)
 
 	getAppOptions.Args = []string{name1}
@@ -329,7 +329,7 @@ func TestGetAppsAsJson(t *testing.T) {
 
 	pegomock.When(getAppOptions.Helm().ListReleases(pegomock.EqString(namespace))).
 		ThenReturn(map[string]helm.ReleaseSummary{
-			name1: {Status: "DEPLOYED"},
+			name1: {Status: "DEPLOYED", Chart: name1},
 		}, nil, nil)
 
 	getAppOptions.Args = []string{name1}
@@ -376,7 +376,7 @@ func TestGetAppsAsYaml(t *testing.T) {
 
 	pegomock.When(getAppOptions.Helm().ListReleases(pegomock.EqString(namespace))).
 		ThenReturn(map[string]helm.ReleaseSummary{
-			name1: {Status: "DEPLOYED"},
+			name1: {Status: "DEPLOYED", Chart: name1},
 		}, nil, nil)
 
 	getAppOptions.Args = []string{name1}


### PR DESCRIPTION
Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
There was an issue with the status of installed apps after it moved to no tiller clusters

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
