### PR TITLE
chore(tekton): Make Pipeline/Tasks owned by PipelineActivity

### DIFF
--- a/pkg/jx/cmd/step_create_task.go
+++ b/pkg/jx/cmd/step_create_task.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io"
 	"github.com/jenkins-x/jx/pkg/prow"
 
 	"github.com/ghodss/yaml"
@@ -1011,6 +1012,27 @@ func (o *StepCreateTaskOptions) applyPipeline(pipeline *pipelineapi.Pipeline, ta
 
 	info := util.ColorInfo
 
+	var activityOwnerReference *metav1.OwnerReference
+
+	if activityKey != nil {
+
+		jxClient, _, jxErr := o.JXClientAndDevNamespace()
+		if jxErr != nil {
+			return jxErr
+		}
+		activity, _, err := activityKey.GetOrCreate(jxClient, pipeline.Namespace)
+		if err != nil {
+			return err
+		}
+
+		activityOwnerReference = &metav1.OwnerReference{
+			APIVersion: jenkinsio.GroupAndVersion,
+			Kind:       "PipelineActivity",
+			Name:       activity.Name,
+			UID:        activity.UID,
+		}
+	}
+
 	for _, resource := range resources {
 		_, err := tekton.CreateOrUpdateSourceResource(tektonClient, ns, resource)
 		if err != nil {
@@ -1025,11 +1047,18 @@ func (o *StepCreateTaskOptions) applyPipeline(pipeline *pipelineapi.Pipeline, ta
 	}
 
 	for _, task := range tasks {
+		if activityOwnerReference != nil {
+			task.OwnerReferences = []metav1.OwnerReference{*activityOwnerReference}
+		}
 		_, err = tekton.CreateOrUpdateTask(tektonClient, ns, task)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create/update the task %s in namespace %s", task.Name, ns)
 		}
 		log.Infof("upserted Task %s\n", info(task.Name))
+	}
+
+	if activityOwnerReference != nil {
+		pipeline.OwnerReferences = []metav1.OwnerReference{*activityOwnerReference}
 	}
 
 	pipeline, err = tekton.CreateOrUpdatePipeline(tektonClient, ns, pipeline)
@@ -1074,18 +1103,6 @@ func (o *StepCreateTaskOptions) applyPipeline(pipeline *pipelineapi.Pipeline, ta
 			return errors.Wrapf(structErr, "failed to create the PipelineStructure in namespace %s", ns)
 		}
 		log.Infof("created PipelineStructure %s\n", info(structure.Name))
-	}
-
-	if activityKey != nil {
-
-		jxClient, _, jxErr := o.JXClientAndDevNamespace()
-		if jxErr != nil {
-			return jxErr
-		}
-		_, _, err := activityKey.GetOrCreate(jxClient, pipeline.Namespace)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This will mean that when the `PipelineActivity` is GCed, the
`Pipeline`, `Task`s, and all other CRDs owned by those (i.e., `PipelineRun`, `TaskRun`s,
`PipelineStructure`) will get GCed as well.

`PipelineResource` is *not* owned by `PipelineActivity`, since that's
per-branch, not per-build.

#### Special notes for the reviewer(s)

/assign @jstrachan 

#### Which issue this PR fixes

n/a