### PR TITLE
Set URLTemplate when external-dns flag is set

### DIFF
--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -429,6 +429,11 @@ func (options *InstallOptions) checkFlags() error {
 		}
 	}
 
+	// If we're using external-dns then remove the namespace subdomain from the URLTemplate
+	if flags.ExternalDNS {
+		flags.ExposeControllerURLTemplate = "{{.Service}}-{{.Namespace}}.{{.Domain}}"
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When using external-dns it's easier if all services operate on the domain rather than the subdomain (namespace)