### PR TITLE
Two typos in environment controller related commands are fixed

### DIFF
--- a/pkg/jx/cmd/controller_enviornmentcontroller.go
+++ b/pkg/jx/cmd/controller_enviornmentcontroller.go
@@ -95,7 +95,7 @@ func NewCmdControllerEnvironment(commonOpts *opts.CommonOptions) *cobra.Command 
 		"The path to listen on for requests to trigger a pipeline run.")
 	cmd.Flags().BoolVarP(&options.NoGitCredeentialsInit, "no-git-init", "", false, "Disables checking we have setup git credentials on startup")
 	cmd.Flags().BoolVarP(&options.RequireHeaders, "require-headers", "", true, "If enabled we reject webhooks which do not have the github headers: 'X-GitHub-Event' and 'X-GitHub-Delivery'")
-	cmd.Flags().BoolVarP(&options.NoGitCredeentialsInit, "no-register-webhook", "", false, "Disables checking to register the webhook on startup")
+	cmd.Flags().BoolVarP(&options.NoRegisterWebHook, "no-register-webhook", "", false, "Disables checking to register the webhook on startup")
 	cmd.Flags().StringVarP(&options.SourceURL, "source-url", "s", "", "The source URL of the environment git repository")
 	cmd.Flags().StringVarP(&options.GitServerURL, "git-server-url", "", "", "The git server URL. If not specified defaults to $GIT_SERVER_URL")
 	cmd.Flags().StringVarP(&options.GitKind, "git-kind", "", "", "The kind of git repository. Should be one of: "+strings.Join(gits.KindGits, ", ")+". If not specified defaults to $GIT_KIND")

--- a/pkg/jx/cmd/create_addon_environment_controller.go
+++ b/pkg/jx/cmd/create_addon_environment_controller.go
@@ -236,7 +236,7 @@ func (o *CreateAddonEnvironmentControllerOptions) Run() error {
 	}
 	setValues = append(setValues, "source.owner="+gitInfo.Organisation)
 	setValues = append(setValues, "source.repo="+gitInfo.Name)
-	setValues = append(setValues, "source.serverURL="+serverURL)
+	setValues = append(setValues, "source.serverUrl="+serverURL)
 	setValues = append(setValues, "source.gitKind="+o.GitKind)
 	setValues = append(setValues, "source.user="+o.GitUser)
 	setValues = append(setValues, "source.token="+o.GitToken)


### PR DESCRIPTION
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

* `create addon envctl` used to path `source.serverURL` when chart was
  expecting the `source.serverUrl`
* `controller environment` had `no-register-webhook` pointing to the
  wrong struct field (`NoGitCredeentialsInit` instead of `NoRegisterWebHook`)


