### PR TITLE
fix: Don't barf on pods without container statuses

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -241,7 +241,7 @@ func GetContainersWithStatusAndIsInit(pod *v1.Pod) ([]v1.Container, []v1.Contain
 	statuses := pod.Status.InitContainerStatuses
 	containers := pod.Spec.Containers
 
-	if len(containers) > 1 && containers[len(containers)-1].Name == "nop" {
+	if len(containers) > 1 && len(pod.Status.ContainerStatuses) == len(containers) && containers[len(containers)-1].Name == "nop" {
 		isInit = false
 		// Add the non-init containers, and trim off the no-op container at the end of the list.
 		allContainers = append(allContainers, containers[:len(containers)-1]...)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Stumbled across this when running `jx get build logs` while, as it
turns out, there was a pod that failed to provision due to
insufficient resources:

```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/jenkins-x/jx/pkg/kube.GetContainersWithStatusAndIsInit(...)
	/Users/abayer/go/src/github.com/jenkins-x/jx/pkg/kube/pod.go:248
```

So let's fix that by not trying to pull in any pod that doesn't have
as many container statuses as it does containers.

#### Special notes for the reviewer(s)

/assign @jstrachan 
/assign @dwnusbaum 

#### Which issue this PR fixes

n/a