### PR TITLE
fix(cmd): GetJenkinsURL ignores the ns argument

### DIFF
--- a/pkg/jx/cmd/clients/factory.go
+++ b/pkg/jx/cmd/clients/factory.go
@@ -125,9 +125,12 @@ func (f *factory) CreateCustomJenkinsClient(kubeClient kubernetes.Interface, ns 
 // GetJenkinsURL gets the Jenkins URL for the given namespace
 func (f *factory) GetJenkinsURL(kubeClient kubernetes.Interface, ns string) (string, error) {
 	// lets find the Kubernetes service
-	client, ns, err := f.CreateKubeClient()
+	client, curNS, err := f.CreateKubeClient()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create the kube client")
+	}
+	if ns == "" {
+		ns = curNS
 	}
 	url, err := services.FindServiceURL(client, ns, kube.ServiceJenkins)
 	if err != nil {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] (**GUESSING IT IS**) Change is covered by existing or new tests.

#### Description

The `ns` argument to `GetJenkinsURL` gets immediately overwritten with the current namespace stored in kube config.  Very likely they are always the same, but in places like running JX in the cluster, they are not.

Just giving some more details as to how I ran into this problem: it was from doing a JX install from within the cluster.  On install, it builds the `CreateJenkinsUserOptions` command and specifies the Namespace it should run in in order to generate the Jenkins API token.  Then in `CreateJenkinsUserOptions.Run` it calls `CustomJenkinsURL`, passing in the namespace.  Once you make it to `GetJenkinsURL`, the namespace argument is ignored and it reads the namespace from the kube config or pod namespace.

#### Special notes for the reviewer(s)

I'm hoping the BDD tests cover this change.

#### Which issue this PR fixes

None.