### PR TITLE
fix: Get fork status from repo

### DIFF
--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -245,7 +245,7 @@ func PushRepoAndCreatePullRequest(dir string, gitInfo *GitRepository, base strin
 	if username == "" {
 		return nil, fmt.Errorf("no git user name found")
 	}
-	if gitInfo.Organisation != username && fork {
+	if gitInfo.Organisation != username && gitInfo.Fork {
 		headPrefix = username + ":"
 	}
 

--- a/pkg/jx/cmd/create_mlquickstart.go
+++ b/pkg/jx/cmd/create_mlquickstart.go
@@ -92,7 +92,7 @@ func NewCmdCreateMLQuickstart(commonOpts *opts.CommonOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "mlquickstart",
-		Short:   "Create a new app from a mlquickstart and import the generated code into Git and Jenkins for CI/CD",
+		Short:   "Create a new machine learning app from a set of quickstarts and import the generated code into Git and Jenkins for CI/CD",
 		Long:    createMLQuickstartLong,
 		Example: createMLQuickstartExample,
 		Aliases: []string{"arch"},
@@ -119,6 +119,13 @@ func NewCmdCreateMLQuickstart(commonOpts *opts.CommonOptions) *cobra.Command {
 // Run implements the generic Create command
 func (o *CreateMLQuickstartOptions) Run() error {
 	o.Debugf("Running CreateMLQuickstart...\n")
+
+	interactive := true
+	if o.BatchMode {
+		interactive = false
+		o.Debugf("In batch mode.\n")
+	}
+
 	authConfigSvc, err := o.CreateGitAuthConfigService()
 	if err != nil {
 		return err
@@ -248,7 +255,8 @@ func (o *CreateMLQuickstartOptions) Run() error {
 		stub := o.Filter.ProjectName
 		for _, project := range ps {
 			w.ImportOptions = o.ImportOptions // Reset the options each time as they are modified by Import (DraftPack)
-			if !o.BatchMode {
+			if interactive {
+				o.Debugf("Setting Quickstart from surveys.\n")
 				w.ImportOptions.Organisation = details.Organisation
 				w.GitRepositoryOptions = o.GitRepositoryOptions
 				w.GitRepositoryOptions.ServerURL = details.GitServer.URL


### PR DESCRIPTION
Signed-off-by: Terry Cox <terry@bootstrap.je>

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Uses the fork status from the repo details rather than the input parameter.

#### Special notes for the reviewer(s)
It's not clear why `fork` was being passed explicitly as an input so this change may break something in the GitOps functionality in gitops.go which is the only other consumer of this method. I have therefore just changed the source of the fork status but not removed this from the API. If all the tests still work for GitOps, then we need to clean this up by removing the `fork` parameter from the function.

#### Which issue this PR fixes

fixes #3994

