### PR TITLE
Default to configured zone/region on GKE interactive install

### DIFF
--- a/pkg/jx/cmd/opts/gcp.go
+++ b/pkg/jx/cmd/opts/gcp.go
@@ -80,12 +80,20 @@ func (o *CommonOptions) GetGoogleProjectId() (string, error) {
 
 // GetGoogleZone returns the GCP zone
 func (o *CommonOptions) GetGoogleZone(projectId string) (string, error) {
-	return o.GetGoogleZoneWithDefault(projectId, "")
+	configuredZone, err := o.GetCommandOutput("", "gcloud", "config", "get-value", "compute/zone")
+	if err != nil {
+		return "", err
+	}
+	return o.GetGoogleZoneWithDefault(projectId, configuredZone)
 }
 
 // GetGoogleRegion returns the GCP region
 func (o *CommonOptions) GetGoogleRegion(projectId string) (string, error) {
-	return o.GetGoogleRegionWithDefault(projectId, "")
+	configuredRegion, err := o.GetCommandOutput("", "gcloud", "config", "get-value", "compute/region")
+	if err != nil {
+		return "", err
+	}
+	return o.GetGoogleRegionWithDefault(projectId, configuredRegion)
 }
 
 // GetGoogleZoneWithDefault returns the GCP zone, if not zone is found returns the default zone

--- a/pkg/jx/cmd/opts/gcp.go
+++ b/pkg/jx/cmd/opts/gcp.go
@@ -82,7 +82,7 @@ func (o *CommonOptions) GetGoogleProjectId() (string, error) {
 func (o *CommonOptions) GetGoogleZone(projectId string) (string, error) {
 	configuredZone, err := o.GetCommandOutput("", "gcloud", "config", "get-value", "compute/zone")
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "getting google zone")
 	}
 	return o.GetGoogleZoneWithDefault(projectId, configuredZone)
 }
@@ -91,7 +91,7 @@ func (o *CommonOptions) GetGoogleZone(projectId string) (string, error) {
 func (o *CommonOptions) GetGoogleRegion(projectId string) (string, error) {
 	configuredRegion, err := o.GetCommandOutput("", "gcloud", "config", "get-value", "compute/region")
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "getting google region")
 	}
 	return o.GetGoogleRegionWithDefault(projectId, configuredRegion)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Use the user configured zone/region (if it's set) as the default option when executing `jx create cluster gke` in interactive mode

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
