### PR TITLE
Do not try to create the environments if they already exist

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -568,6 +568,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+v
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/petergtz/pegomock v2.2.0+incompatible h1:UjfRYEyjM8X8lNPuZs8FKakZI1pD7FqMRYc6KfLFNJU=
 github.com/petergtz/pegomock v2.2.0+incompatible/go.mod h1:nuBLWZpVyv/fLo56qTwt/AUau7jgouO1h7bEvZCq82o=
+github.com/petergtz/pegomock v2.3.0+incompatible h1:kcZy3H5eNyitPhWxrUQOuEoEcKqH/D5SiytA7x9snVI=
 github.com/pierrec/lz4 v0.0.0-20181005164709-635575b42742/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/pkg/jx/cmd/create_env.go
+++ b/pkg/jx/cmd/create_env.go
@@ -67,6 +67,7 @@ type CreateEnvOptions struct {
 	BranchPattern          string
 	Vault                  bool
 	PullSecrets            string
+	Update                 bool
 }
 
 // NewCmdCreateEnv creates a command object for the "create" command
@@ -97,6 +98,7 @@ func NewCmdCreateEnv(commonOpts *opts.CommonOptions) *cobra.Command {
 
 	cmd.Flags().StringVarP(&options.Options.Name, kube.OptionName, "n", "", "The Environment resource name. Must follow the Kubernetes name conventions like Services, Namespaces")
 	cmd.Flags().StringVarP(&options.Options.Spec.Label, "label", "l", "", "The Environment label which is a descriptive string like 'Production' or 'Staging'")
+	cmd.Flags().BoolVarP(&options.Update, "update", "u", false, "Update environment if already exists")
 
 	cmd.Flags().StringVarP(&options.Options.Spec.Namespace, kube.OptionNamespace, "s", "", "The Kubernetes namespace for the Environment")
 	cmd.Flags().StringVarP(&options.Options.Spec.Cluster, "cluster", "c", "", "The Kubernetes cluster for the Environment. If blank and a namespace is specified assumes the current cluster")
@@ -185,7 +187,7 @@ func (o *CreateEnvOptions) Run() error {
 
 	env := v1.Environment{}
 	o.Options.Spec.PromotionStrategy = v1.PromotionStrategyType(o.PromotionStrategy)
-	gitProvider, err := kube.CreateEnvironmentSurvey(o.BatchMode, authConfigSvc, devEnv, &env, &o.Options, o.ForkEnvironmentGitRepo, ns,
+	gitProvider, err := kube.CreateEnvironmentSurvey(o.BatchMode, authConfigSvc, devEnv, &env, &o.Options, o.Update, o.ForkEnvironmentGitRepo, ns,
 		jxClient, kubeClient, envDir, &o.GitRepositoryOptions, o.HelmValuesConfig, o.Prefix, o.Git(), o.ResolveChartMuseumURL, o.In, o.Out, o.Err)
 	if err != nil {
 		return err

--- a/pkg/jx/cmd/edit_env.go
+++ b/pkg/jx/cmd/edit_env.go
@@ -151,7 +151,7 @@ func (o *EditEnvOptions) Run() error {
 		return err
 	}
 	o.Options.Spec.PromotionStrategy = v1.PromotionStrategyType(o.PromotionStrategy)
-	gitProvider, err := kube.CreateEnvironmentSurvey(o.BatchMode, authConfigSvc, devEnv, env, &o.Options, o.ForkEnvironmentGitRepo,
+	gitProvider, err := kube.CreateEnvironmentSurvey(o.BatchMode, authConfigSvc, devEnv, env, &o.Options, true, o.ForkEnvironmentGitRepo,
 		ns, jxClient, kubeClient, envDir, &o.GitRepositoryOptions, o.HelmValuesConfig, o.Prefix, o.Git(), o.ResolveChartMuseumURL, o.In, o.Out, o.Err)
 	if err != nil {
 		return err

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -2568,21 +2568,8 @@ func (options *InstallOptions) createEnvironments(namespace string) error {
 			options.CreateEnvOptions.GitOpsMode = true
 			options.CreateEnvOptions.ModifyDevEnvironmentFn = options.ModifyDevEnvironmentFn
 			options.CreateEnvOptions.ModifyEnvironmentFn = options.ModifyEnvironmentFn
-		} else {
-			createEnvironments = false
-
-			jxClient, _, err := options.JXClient()
-			if err != nil {
-				return errors.Wrap(err, "failed to create the jx client")
-			}
-
-			// lets only recreate the environments if its the first time we run this
-			_, envNames, err := kube.GetEnvironments(jxClient, namespace)
-			if err != nil || len(envNames) <= 1 {
-				createEnvironments = true
-			}
-
 		}
+
 		if createEnvironments {
 			log.Info("Creating default staging and production environments\n")
 			_, devNamespace, err := options.KubeClientAndDevNamespace()
@@ -2594,6 +2581,8 @@ func (options *InstallOptions) createEnvironments(namespace string) error {
 				return errors.Wrap(err, "building the Git repository options for environments")
 			}
 			options.CreateEnvOptions.GitRepositoryOptions = *gitRepoOptions
+			// lets not fail if environments already exist
+			options.CreateEnvOptions.Update = true
 
 			options.CreateEnvOptions.Prefix = options.Flags.DefaultEnvironmentPrefix
 			options.CreateEnvOptions.Prow = options.Flags.Prow

--- a/pkg/kube/env.go
+++ b/pkg/kube/env.go
@@ -37,7 +37,7 @@ type ResolveChartMuseumURLFn func() (string, error)
 // CreateEnvironmentSurvey creates a Survey on the given environment using the default options
 // from the CLI
 func CreateEnvironmentSurvey(batchMode bool, authConfigSvc auth.ConfigService, devEnv *v1.Environment, data *v1.Environment,
-	config *v1.Environment, forkEnvGitURL string, ns string, jxClient versioned.Interface, kubeClient kubernetes.Interface, envDir string,
+	config *v1.Environment, update bool, forkEnvGitURL string, ns string, jxClient versioned.Interface, kubeClient kubernetes.Interface, envDir string,
 	gitRepoOptions *gits.GitRepositoryOptions, helmValues config.HelmValuesConfig, prefix string, git gits.Gitter, chartMusemFn ResolveChartMuseumURLFn, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (gits.GitProvider, error) {
 	surveyOpts := survey.WithStdio(in, out, errOut)
 	name := data.Name
@@ -48,9 +48,11 @@ func CreateEnvironmentSurvey(batchMode bool, authConfigSvc auth.ConfigService, d
 			if err != nil {
 				return nil, err
 			}
-			err = ValidateEnvironmentDoesNotExist(jxClient, ns, config.Name)
-			if err != nil {
-				return nil, err
+			if !update {
+				err = ValidateEnvironmentDoesNotExist(jxClient, ns, config.Name)
+				if err != nil {
+					return nil, err
+				}
 			}
 			data.Name = config.Name
 		} else {

--- a/pkg/kube/env_test.go
+++ b/pkg/kube/env_test.go
@@ -220,6 +220,7 @@ func TestCreateEnvironmentSurvey(t *testing.T) {
 		&devEnv,
 		&data,
 		&conf,
+		true,
 		forkEnvGitURL,
 		ns,
 		versiondInterface,


### PR DESCRIPTION
in GitOps mode the behavior is different and re-installation fails

```
Creating default staging and production environments
Using xxx environment git owner in batch mode.
error: creating the environments: failed to create staging environment in namespace jx: Environment staging already exists!
```

Signed-off-by: Carlos Sanchez <carlos@apache.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
