### PR TITLE
Chore: refactor usage of fork when creating a pull request

### DIFF
--- a/pkg/apps/gitops.go
+++ b/pkg/apps/gitops.go
@@ -171,7 +171,7 @@ func (o *GitOpsOptions) GetApps(appNames map[string]bool, expandFn func([]string
 		ModifyChartFn: nil,
 		GitProvider:   o.GitProvider,
 	}
-	dir, _, _, _, err := gits.ForkAndPullPullRepo(o.DevEnv.Spec.Source.URL, o.EnvironmentsDir, o.DevEnv.Spec.Source.Ref, "master", o.GitProvider, o.Gitter, options.ConfigGitFn)
+	dir, _, _, err := gits.ForkAndPullPullRepo(o.DevEnv.Spec.Source.URL, o.EnvironmentsDir, o.DevEnv.Spec.Source.Ref, "master", o.GitProvider, o.Gitter, options.ConfigGitFn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "couldn't pull the environment repository from %s", o.DevEnv.Name)
 	}

--- a/pkg/environments/gitops.go
+++ b/pkg/environments/gitops.go
@@ -57,7 +57,7 @@ type EnvironmentPullRequestOptions struct {
 // changes into.
 func (o *EnvironmentPullRequestOptions) Create(env *jenkinsv1.Environment, environmentsDir string,
 	pullRequestDetails *gits.PullRequestDetails, pullRequestInfo *gits.PullRequestInfo, chartName string, autoMerge bool) (*gits.PullRequestInfo, error) {
-	dir, base, gitInfo, fork, err := gits.ForkAndPullPullRepo(env.Spec.Source.URL, environmentsDir, env.Spec.Source.Ref, pullRequestDetails.BranchName, o.GitProvider, o.Gitter, o.ConfigGitFn)
+	dir, base, gitInfo, err := gits.ForkAndPullPullRepo(env.Spec.Source.URL, environmentsDir, env.Spec.Source.Ref, pullRequestDetails.BranchName, o.GitProvider, o.Gitter, o.ConfigGitFn)
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "pulling environment repo %s into %s", env.Spec.Source.URL,
@@ -68,7 +68,7 @@ func (o *EnvironmentPullRequestOptions) Create(env *jenkinsv1.Environment, envir
 	if err != nil {
 		return nil, err
 	}
-	return gits.PushRepoAndCreatePullRequest(dir, gitInfo, base, pullRequestDetails, pullRequestInfo, fork, true, true, autoMerge, o.GitProvider, o.Gitter)
+	return gits.PushRepoAndCreatePullRequest(dir, gitInfo, base, pullRequestDetails, pullRequestInfo, true, true, autoMerge, o.GitProvider, o.Gitter)
 }
 
 // ModifyChartFiles modifies the chart files in the given directory using the given modify function

--- a/pkg/jx/cmd/create_pullrequest.go
+++ b/pkg/jx/cmd/create_pullrequest.go
@@ -108,7 +108,7 @@ func (o *CreatePullRequestOptions) Run() error {
 		return errors.WithStack(err)
 	}
 
-	o.Results, err = gits.PushRepoAndCreatePullRequest(o.Dir, gitInfo, o.Base, details, nil, true, o.Push, o.Push, false, provider, o.Git())
+	o.Results, err = gits.PushRepoAndCreatePullRequest(o.Dir, gitInfo, o.Base, details, nil, o.Push, o.Push, false, provider, o.Git())
 	if err != nil {
 		return errors.Wrapf(err, "failed to create PR for base %s and head branch %s", o.Base, details.BranchName)
 	}

--- a/pkg/jx/cmd/step_git_fork_and_clone.go
+++ b/pkg/jx/cmd/step_git_fork_and_clone.go
@@ -84,7 +84,7 @@ func (o *StepGitForkAndCloneOptions) Run() error {
 	if err != nil {
 		return errors.Wrapf(err, "getting git provider for %s", gitURL)
 	}
-	dir, baseRef, _, fork, err := gits.ForkAndPullPullRepo(gitURL, o.Dir, o.BaseRef, "", provider, o.Git(), nil)
+	dir, baseRef, gitInfo, err := gits.ForkAndPullPullRepo(gitURL, o.Dir, o.BaseRef, "", provider, o.Git(), nil)
 	if err != nil {
 		return errors.Wrapf(err, "forking and pulling %s", gitURL)
 	}
@@ -93,7 +93,7 @@ func (o *StepGitForkAndCloneOptions) Run() error {
 		// Output the directory so it can be used in a script
 		fmt.Print(dir)
 	}
-	if fork {
+	if gitInfo.Fork {
 		log.Infof("Forked %s and pulled it into %s checking out %s", gitURL, dir, baseRef)
 	} else {
 		log.Infof("Pulled %s (%s) into %s", gitURL, baseRef, dir)


### PR DESCRIPTION
Fixes below error where a pull request on a fork is missing a prefix. Refactored to better encapsulate the fork parameter.

`error: adding Prow config to environment repo: creating pr for prow config: POST https://api.github.com/repos/cb-kubecd/environment-shriekviolet-dev/pulls: 422 Validation Failed [{Resource:PullRequest Field:head Code:invalid Message:}]`