### PR TITLE
Fix: There was an incompatibility problem between gcloud and go-cloud so we are going to create buckets with gsutil

### DIFF
--- a/pkg/cloud/gke/storage/long_term_storage.go
+++ b/pkg/cloud/gke/storage/long_term_storage.go
@@ -5,40 +5,58 @@ import (
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/satori/go.uuid"
 )
 
-func EnableLongTermStorage(installValues map[string]string, providedBucketName string,
-	createBucketFN func(bucketName string, bucketKind string) (string, error)) (string, error) {
-	var bucketName string
+// EnableLongTermStorage will take the cluster install values and a provided bucket name and use it / create a new one for gs
+func EnableLongTermStorage(installValues map[string]string, providedBucketName string) (string, error) {
 	if providedBucketName != "" {
-		exists, err := gke.BucketExists(installValues[kube.ProjectID], providedBucketName)
-		if err != nil {
-			return "", errors.Wrap(err, "checking if the provided bucket exists")
-		}
-		if exists {
-			bucketName = providedBucketName
-			return fmt.Sprintf("gs://%s", bucketName), nil
-		}
-
-		bucketURL, err := createBucketFN(providedBucketName, "gs")
-		if err == nil {
-			return bucketURL, nil
-		}
-		log.Warnf("Attempted to create the bucket %s in the project %s but failed, will now create a "+
-			"random bucket", providedBucketName, installValues[kube.ProjectID])
-	}
-
-	if providedBucketName == "" {
+		return ensureProvidedBucketExists(installValues, providedBucketName)
+	} else {
 		log.Info("No bucket name provided for long term storage, creating a new one")
+		return createBucket(createUniqueBucketName(installValues))
+	}
+}
+
+func ensureProvidedBucketExists(installValues map[string]string, providedBucketName string) (string, error) {
+	exists, err := gke.BucketExists(installValues[kube.ProjectID], providedBucketName)
+	if err != nil {
+		return "", errors.Wrap(err, "checking if the provided bucket exists")
+	}
+	if exists {
+		return fmt.Sprintf("gs://%s", providedBucketName), nil
 	}
 
+	bucketURL, err := createBucket(providedBucketName, installValues)
+	if err == nil {
+		return bucketURL, nil
+	}
+	log.Warnf("Attempted to create the bucket %s in the project %s but failed, will now create a "+
+		"random bucket", providedBucketName, installValues[kube.ProjectID])
+
+	return createBucket(createUniqueBucketName(installValues))
+}
+
+func createUniqueBucketName(installValues map[string]string) (string, map[string]string) {
 	uuid4, _ := uuid.NewV4()
-	bucketName = fmt.Sprintf("%s-lts-%s", installValues[kube.ClusterName], uuid4.String())
+	bucketName := fmt.Sprintf("%s-lts-%s", installValues[kube.ClusterName], uuid4.String())
 	if len(bucketName) > 60 {
 		bucketName = bucketName[:60]
 	}
+	return bucketName, installValues
+}
 
-	return createBucketFN(bucketName, "gs")
+func createBucket(bucketName string, installValues map[string]string) (string, error) {
+	bucketURL := fmt.Sprintf("gs://%s", bucketName)
+	infoBucketURL := util.ColorInfo(bucketURL)
+	log.Infof("The bucket %s does not exist so lets create it", infoBucketURL)
+	region := gke.GetRegionFromZone(installValues[kube.Zone])
+	err := gke.CreateBucket(installValues[kube.ProjectID], bucketName, region)
+	if err != nil {
+		return "", errors.Wrapf(err, "there was a problem creating the bucket %s in the GKE Project %s",
+			bucketName, installValues[kube.ProjectID])
+	}
+	return bucketURL, err
 }

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -2314,7 +2314,7 @@ func (options *InstallOptions) configureLongTermStorageBucket() error {
 				return errors.Wrap(err, "filling install values with cluster information")
 			}
 			bucketURL, err = gkeStorage.EnableLongTermStorage(options.installValues,
-				options.Flags.LongTermStorageBucketName, options.doCreateBucket)
+				options.Flags.LongTermStorageBucketName)
 			if err != nil {
 				return errors.Wrap(err, "enabling long term storage on GKE")
 			}
@@ -2388,29 +2388,6 @@ func (options *InstallOptions) ensureGKEInstallValuesAreFilled() error {
 	}
 
 	return nil
-}
-
-// this method should work for any bucket kind even if the properties are called GKE*
-func (options *InstallOptions) doCreateBucket(bucketName string, bucketKind string) (string, error) {
-	cbv := &opts.CreateBucketValues{
-		Bucket:       bucketName,
-		BucketKind:   bucketKind,
-		GKEProjectID: options.installValues[kube.ProjectID],
-		GKEZone:      options.installValues[kube.Zone],
-	}
-
-	teamSettings, err := options.TeamSettings()
-	if err != nil {
-		return "", errors.Wrap(err, "there was a problem obtaining the default team settings")
-	}
-
-	bucketURL, err := options.CreateBucket(cbv, teamSettings)
-	if err != nil {
-		return "", errors.Wrapf(err, "there was a problem creating the bucket %s in the GKE Project %s",
-			cbv.Bucket, cbv.GKEProjectID)
-	}
-
-	return bucketURL, err
 }
 
 func (options *InstallOptions) saveIngressConfig() (*kube.IngressConfig, error) {


### PR DESCRIPTION
…, so we are going to create the buckets with gsutil

Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
A bug surfaced yesterday which didn't allow people with a newer version of gcloud to create buckets for long term storage.

After further investigation, an incompatibility between gcloud and `go-cloud`, the library we were using to abstract the cloud provider. 

The method to create buckets has changed to use gsutil instead.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
