### PR TITLE
EKS BDD Fixes

### DIFF
--- a/pkg/cloud/amazon/routes.go
+++ b/pkg/cloud/amazon/routes.go
@@ -2,6 +2,7 @@ package amazon
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -24,8 +25,10 @@ func RegisterAwsCustomDomain(customDomain string, elbAddress string) error {
 	listZonesInput := &route53.ListHostedZonesInput{}
 	err = svc.ListHostedZonesPages(listZonesInput, func(page *route53.ListHostedZonesOutput, hasNext bool) bool {
 		if page != nil {
+			customDomainParts := strings.Split(customDomain, ".")
 			for _, r := range page.HostedZones {
-				if r != nil && r.Name != nil && (*r.Name == customDomain || *r.Name == customDomain+".") {
+				strings.Split(customDomain, ".")
+				if r != nil && r.Name != nil && (*r.Name == customDomain || *r.Name == customDomain+"." || *r.Name == strings.Join(customDomainParts[1:], ".")+".") {
 					hostedZoneId = r.Id
 					return false
 				}

--- a/pkg/jx/cmd/create_cluster_eks.go
+++ b/pkg/jx/cmd/create_cluster_eks.go
@@ -109,7 +109,7 @@ func (o *CreateClusterEKSOptions) Run() error {
 	if d != "" {
 		deps = append(deps, d)
 	}
-	d = opts.BinaryShouldBeInstalled("heptio-authenticator-aws")
+	d = opts.BinaryShouldBeInstalled("aws-iam-authenticator")
 
 	if d != "" {
 		deps = append(deps, d)

--- a/pkg/jx/cmd/delete_eks.go
+++ b/pkg/jx/cmd/delete_eks.go
@@ -68,7 +68,7 @@ func (o *deleteEksOptions) Run() error {
 	if d != "" {
 		deps = append(deps, d)
 	}
-	d = opts.BinaryShouldBeInstalled("heptio-authenticator-aws")
+	d = opts.BinaryShouldBeInstalled("aws-iam-authenticator")
 	if d != "" {
 		deps = append(deps, d)
 	}

--- a/pkg/jx/cmd/get_eks.go
+++ b/pkg/jx/cmd/get_eks.go
@@ -73,7 +73,7 @@ func (o *GetEksOptions) Run() error {
 		if d != "" {
 			deps = append(deps, d)
 		}
-		d = opts.BinaryShouldBeInstalled("heptio-authenticator-aws")
+		d = opts.BinaryShouldBeInstalled("aws-iam-authenticator")
 		if d != "" {
 			deps = append(deps, d)
 		}

--- a/pkg/jx/cmd/import.go
+++ b/pkg/jx/cmd/import.go
@@ -874,7 +874,13 @@ func (options *ImportOptions) doImport() error {
 		jenkinsfile = defaultJenkinsfileName
 	}
 
-	dockerfileExists, err := util.FileExists("Dockerfile")
+	dockerfileLocation := ""
+	if options.Dir != "" {
+		dockerfileLocation = filepath.Join(options.Dir, "Dockerfile")
+	} else {
+		dockerfileLocation = "Dockerfile"
+	}
+	dockerfileExists, err := util.FileExists(dockerfileLocation)
 	if err != nil {
 		return err
 	}

--- a/pkg/jx/cmd/install_dependencies.go
+++ b/pkg/jx/cmd/install_dependencies.go
@@ -54,7 +54,7 @@ var (
 		"oci",
 		"aws",
 		"eksctl",
-		"heptio-authenticator-aws",
+		"aws-iam-authenticator",
 		"kustomize",
 	}
 )

--- a/pkg/jx/cmd/opts/domain.go
+++ b/pkg/jx/cmd/opts/domain.go
@@ -65,9 +65,14 @@ func (o *CommonOptions) GetDomain(client kubernetes.Interface, domain string, pr
 			err := amazon.RegisterAwsCustomDomain(domain, address)
 			return domain, err
 		}
+
 		log.Infof("\nOn AWS we recommend using a custom DNS name to access services in your Kubernetes cluster to ensure you can use all of your Availability Zones\n")
 		log.Infof("If you do not have a custom DNS name you can use yet, then you can register a new one here: %s\n\n",
 			util.ColorInfo("https://console.aws.amazon.com/route53/home?#DomainRegistration:"))
+
+		if o.BatchMode {
+			return "", fmt.Errorf("Please specify a custom DNS name via --domain when installing on AWS in batch mode")
+		}
 
 		for {
 			if util.Confirm("Would you like to register a wildcard DNS ALIAS to point at this ELB address? ", true,

--- a/pkg/jx/cmd/opts/install.go
+++ b/pkg/jx/cmd/opts/install.go
@@ -144,8 +144,8 @@ func (o *CommonOptions) DoInstallMissingDependencies(install []string) error {
 			err = o.InstallAws()
 		case "eksctl":
 			err = o.InstallEksCtl(false)
-		case "heptio-authenticator-aws":
-			err = o.InstallHeptioAuthenticatorAws(false)
+		case "aws-iam-authenticator":
+			err = o.InstallAwsIamAuthenticator(false)
 		case "kustomize":
 			err = o.InstallKustomize()
 		default:
@@ -1329,17 +1329,17 @@ func (o *CommonOptions) InstallEksCtlWithVersion(version string, skipPathScan bo
 	})
 }
 
-// InstallHeptioAuthenticatorAws install heptio authenticator for AWS
-func (o *CommonOptions) InstallHeptioAuthenticatorAws(skipPathScan bool) error {
-	return o.InstallHeptioAuthenticatorAwsWithVersion(packages.HeptioAuthenticatorAwsVersion, skipPathScan)
+// InstallAwsIamAuthenticator install iam authenticator for AWS
+func (o *CommonOptions) InstallAwsIamAuthenticator(skipPathScan bool) error {
+	return o.InstallAwsIamAuthenticatorWithVersion(packages.IamAuthenticatorAwsVersion, skipPathScan)
 }
 
-// InstallHeptioAuthenticatorAwsWithVersion install a specific version of heptio authenticator for AWS
-func (o *CommonOptions) InstallHeptioAuthenticatorAwsWithVersion(version string, skipPathScan bool) error {
+// InstallAwsIamAuthenticatorWithVersion install a specific version of iam authenticator for AWS
+func (o *CommonOptions) InstallAwsIamAuthenticatorWithVersion(version string, skipPathScan bool) error {
 	return o.InstallOrUpdateBinary(InstallOrUpdateBinaryOptions{
-		Binary:              "heptio-authenticator-aws",
+		Binary:              "aws-iam-authenticator",
 		GitHubOrganization:  "",
-		DownloadUrlTemplate: "https://amazon-eks.s3-us-west-2.amazonaws.com/{{.version}}/2018-06-05/bin/{{.os}}/{{.arch}}/heptio-authenticator-aws",
+		DownloadUrlTemplate: "https://amazon-eks.s3-us-west-2.amazonaws.com/{{.version}}/2019-03-27/bin/{{.os}}/{{.arch}}/aws-iam-authenticator",
 		Version:             version,
 		SkipPathScan:        skipPathScan,
 		VersionExtractor:    nil,
@@ -1450,7 +1450,7 @@ func (o *CommonOptions) InstallRequirements(cloudProvider string, extraDependenc
 		deps = o.AddRequiredBinary("kops", deps)
 	case cloud.EKS:
 		deps = o.AddRequiredBinary("eksctl", deps)
-		deps = o.AddRequiredBinary("heptio-authenticator-aws", deps)
+		deps = o.AddRequiredBinary("aws-iam-authenticator", deps)
 	case cloud.AKS:
 		deps = o.AddRequiredBinary("az", deps)
 	case cloud.GKE:

--- a/pkg/jx/cmd/upgrade_binaries.go
+++ b/pkg/jx/cmd/upgrade_binaries.go
@@ -63,8 +63,8 @@ func (o *UpgradeBinariesOptions) Run() error {
 			if err != nil {
 				return err
 			}
-		} else if binary.Name() == "heptio-authenticator-aws" {
-			err = o.InstallHeptioAuthenticatorAws(true)
+		} else if binary.Name() == "aws-iam-authenticator" {
+			err = o.InstallAwsIamAuthenticator(true)
 			if err != nil {
 				return err
 			}

--- a/pkg/kube/services/services.go
+++ b/pkg/kube/services/services.go
@@ -175,6 +175,9 @@ func GetServiceURL(svc *v1.Service) string {
 				if ing.IP != "" {
 					return scheme + "://" + ing.IP + "/"
 				}
+				if ing.Hostname != "" {
+					return scheme + "://" + ing.Hostname + "/"
+				}
 			}
 		}
 	}

--- a/pkg/packages/packages.go
+++ b/pkg/packages/packages.go
@@ -15,8 +15,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+// IBMCloudVersion ibm cloud binary version
 const IBMCloudVersion = "0.10.1"
-const HeptioAuthenticatorAwsVersion = "1.10.3"
+
+// IamAuthenticatorAwsVersion authenticator binary version to use
+const IamAuthenticatorAwsVersion = "1.12.7"
+
+// KubectlVersion binary version to use
 const KubectlVersion = "1.13.2"
 
 func BinaryWithExtension(binary string) string {


### PR DESCRIPTION
Fixes #3826 - iam binary name
Fixes: #3801 - batch mode prompts for questions
Fixes: #3816 - BDD tests for EKS

Also contains:
- Environment controller can use ingress hostname created by EKS services of type LoadBalancer
- Improvements around registering wildcard domain in Route 53