### PR TITLE
Fix: make `jx step changelog` less verbose

### DIFF
--- a/pkg/jx/cmd/step_changelog.go
+++ b/pkg/jx/cmd/step_changelog.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/jx/cmd/helper"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/helper"
 
 	"github.com/pkg/errors"
 
@@ -528,14 +529,20 @@ func (o *StepChangelogOptions) addCommit(spec *v1.ReleaseSpec, commit *object.Co
 	url := ""
 	branch := "master"
 
+	var author, committer *v1.User
+	var err error
 	sha := commit.Hash.String()
-	author, err := resolver.GitSignatureAsUser(&commit.Author)
-	if err != nil {
-		log.Warnf("Failed to enrich commits with issues: %v\n", err)
+	if commit.Author.Email != "" && commit.Author.Name == "" {
+		author, err = resolver.GitSignatureAsUser(&commit.Author)
+		if err != nil {
+			log.Warnf("Failed to enrich commit %s with issues: %v\n", sha, err)
+		}
 	}
-	committer, err := resolver.GitSignatureAsUser(&commit.Committer)
-	if err != nil {
-		log.Warnf("Failed to enrich commits with issues: %v\n", err)
+	if commit.Committer.Email != "" && commit.Committer.Name == "" {
+		committer, err = resolver.GitSignatureAsUser(&commit.Committer)
+		if err != nil {
+			log.Warnf("Failed to enrich commit %s with issues: %v\n", sha, err)
+		}
 	}
 	var authorDetails, committerDetails v1.UserDetails
 	if author != nil {
@@ -553,11 +560,11 @@ func (o *StepChangelogOptions) addCommit(spec *v1.ReleaseSpec, commit *object.Co
 		Committer: &committerDetails,
 	}
 	err = o.addIssuesAndPullRequests(spec, &commitSummary, commit)
-
-	spec.Commits = append(spec.Commits, commitSummary)
 	if err != nil {
-		log.Warnf("Failed to enrich commits with issues: %s\n", err)
+		log.Warnf("Failed to enrich commit %s with issues: %s\n", sha, err)
 	}
+	spec.Commits = append(spec.Commits, commitSummary)
+
 }
 
 func (o *StepChangelogOptions) addIssuesAndPullRequests(spec *v1.ReleaseSpec, commit *v1.CommitSummary, rawCommit *object.Commit) error {


### PR DESCRIPTION
Right now it spews out errors about not being to find users with no details, which isn’t helpful

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
