### PR TITLE
fix: remove the 'jx-' prefix from application name

### DIFF
--- a/pkg/kube/version.go
+++ b/pkg/kube/version.go
@@ -133,6 +133,12 @@ func GetAppName(name string, namespaces ...string) string {
 				}
 			}
 		}
+		// The applications seems to be prefixed with jx regardless of the namespace
+		// where they are deployed. Let's remove this prefix.
+		prefix := "jx-"
+		if strings.HasPrefix(name, prefix) {
+			name = strings.TrimPrefix(name, prefix)
+		}
 	}
 	return name
 }


### PR DESCRIPTION
It seems that the applications are prefixed with `jx-` regardless of the namesapce
where they are installed. This can create confusion when for instance users are trying to
promote an application. They are often use the application with the jx prefix which
leads to an error, because the chart is published without the prefix.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->