### PR TITLE
fix: store the dev environment next to other environments in the .jx folder

### DIFF
--- a/jenkins-x-integration.yml
+++ b/jenkins-x-integration.yml
@@ -20,6 +20,8 @@ pipelineConfig:
                 value: /workspace/source
               - name: GOPROXY
                 value: http://jenkins-x-athens-proxy:80
+              - name: JX_HOME
+                value: /tmp
             options:
               containerOptions:
                 resources:

--- a/jenkins-x-integration.yml
+++ b/jenkins-x-integration.yml
@@ -20,8 +20,6 @@ pipelineConfig:
                 value: /workspace/source
               - name: GOPROXY
                 value: http://jenkins-x-athens-proxy:80
-              - name: JX_HOME
-                value: /tmp
             options:
               containerOptions:
                 resources:

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/base64"
 	"fmt"
+
 	"github.com/jenkins-x/jx/pkg/jx/cmd/step/env"
 
 	"github.com/jenkins-x/jx/pkg/jx/cmd/helper"
@@ -1694,8 +1695,8 @@ func (options *InstallOptions) generateGitOpsDevEnvironmentConfig(gitOpsDir stri
 				}
 			}
 			dir = filepath.Join(dir, repo.Name)
-			if err := os.Rename(gitOpsDir, dir); err != nil {
-				return "", errors.Wrap(err, "renaming dev environment")
+			if err := util.RenameDir(gitOpsDir, dir, true); err != nil {
+				return "", errors.Wrap(err, "renaming dev environment dir")
 			}
 			return filepath.Join(dir, "env"), nil
 		}

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -1687,9 +1687,14 @@ func (options *InstallOptions) generateGitOpsDevEnvironmentConfig(gitOpsDir stri
 			}
 			log.Infof("Pushed Git repository to %s\n\n", util.ColorInfo(repo.HTMLURL))
 
-			dir = filepath.Join(envDir, gitRepoOptions.Owner, repo.Name)
-			err = os.Rename(gitOpsDir, dir)
-			if err != nil {
+			dir = filepath.Join(envDir, gitRepoOptions.Owner)
+			if _, err := os.Stat(dir); os.IsNotExist(err) {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					return "", errors.Wrapf(err, "creating directory %q", dir)
+				}
+			}
+			dir = filepath.Join(dir, repo.Name)
+			if err := os.Rename(gitOpsDir, dir); err != nil {
 				return "", errors.Wrap(err, "renaming dev environment")
 			}
 			return filepath.Join(dir, "env"), nil

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -432,6 +432,12 @@ func (options *InstallOptions) checkFlags() error {
 		flags.ExposeControllerURLTemplate = "{{.Service}}-{{.Namespace}}.{{.Domain}}"
 	}
 
+	// Make sure that the default environment prefix is configured. Typically it is the cluster
+	// name when the install command is called from create cluster.
+	if options.Flags.DefaultEnvironmentPrefix == "" {
+		options.Flags.DefaultEnvironmentPrefix = strings.ToLower(randomdata.SillyName())
+	}
+
 	return nil
 }
 
@@ -1548,9 +1554,6 @@ func (options *InstallOptions) configureGitOpsMode(configStore configio.ConfigSt
 			}
 		}
 
-		if options.Flags.DefaultEnvironmentPrefix == "" {
-			options.Flags.DefaultEnvironmentPrefix = strings.ToLower(randomdata.SillyName())
-		}
 		envName := fmt.Sprintf("environment-%s-dev", options.Flags.DefaultEnvironmentPrefix)
 		gitOpsDir = filepath.Join(options.Flags.Dir, envName)
 		gitOpsEnvDir = filepath.Join(gitOpsDir, "env")
@@ -2539,10 +2542,6 @@ func (options *InstallOptions) installAddons() error {
 }
 
 func (options *InstallOptions) createEnvironments(namespace string) error {
-	if options.Flags.DefaultEnvironmentPrefix == "" {
-		options.Flags.DefaultEnvironmentPrefix = strings.ToLower(randomdata.SillyName())
-	}
-
 	if !options.Flags.NoDefaultEnvironments {
 		createEnvironments := true
 		if options.Flags.GitOpsMode {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Store and name the dev environment folder consistently with other environments.

```
.jx
├── environments
│   └── ccojocar
│       ├── environment-cosmin-devenv12345-dev
│       ├── environment-cosmin-devenv12345-production
│       └── environment-cosmin-devenv12345-staging
```

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #3741 #3695 #3694 #3684 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->