### PR TITLE
fix: remove the "jx console" command from import message

### DIFF
--- a/pkg/jx/cmd/opts/import.go
+++ b/pkg/jx/cmd/opts/import.go
@@ -211,7 +211,6 @@ func (o *CommonOptions) LogImportedProject(isEnvironment bool, gitInfo *gits.Git
 	if !isEnvironment {
 		log.Infof("Watch pipeline activity via:    %s\n", util.ColorInfo(fmt.Sprintf("jx get activity -f %s -w", gitInfo.Name)))
 		log.Infof("Browse the pipeline log via:    %s\n", util.ColorInfo(fmt.Sprintf("jx get build logs %s", gitInfo.PipelinePath())))
-		log.Infof("Open the Jenkins console via    %s\n", util.ColorInfo("jx console"))
 		log.Infof("You can list the pipelines via: %s\n", util.ColorInfo("jx get pipelines"))
 		log.Infof("When the pipeline is complete:  %s\n", util.ColorInfo("jx get applications"))
 		log.Blank()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

I think is fine to remove the `jx console` command from import message. We can add maybe later a link to the UI.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #3831

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->