### PR TITLE
fix: changed a variable that was needed to do a shallow clone on step…

### DIFF
--- a/pkg/jx/cmd/step_create_task.go
+++ b/pkg/jx/cmd/step_create_task.go
@@ -1107,7 +1107,7 @@ func (o *StepCreateTaskOptions) cloneGitRepositoryToTempDir(gitURL string, branc
 		if o.Verbose {
 			log.Infof("ran git init in %s", tmpDir)
 		}
-		err = o.Git().AddRemote(tmpDir, "origin", tmpDir)
+		err = o.Git().AddRemote(tmpDir, "origin", gitURL)
 		if err != nil {
 			return errors.Wrapf(err, "failed to add remote origin with url %s in directory %s", gitURL, tmpDir)
 		}


### PR DESCRIPTION
…_create_task

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
There's a bug in `step_create_task` when attempting a shallow clone, it's setting the remote to the git temp folder so it fails to do a shallow clone later.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #4071 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
