### PR TITLE
Equaled the PR and Batch CRDs expiration times so they get garbage collected together

### DIFF
--- a/pkg/jx/cmd/gc_activities_test.go
+++ b/pkg/jx/cmd/gc_activities_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/clients/fake"
+	"github.com/jenkins-x/jx/pkg/jx/cmd/cmd_test_helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jenkins-x/jx/pkg/jx/cmd/opts"
+	"testing"
+)
+
+func TestGCPipelineActivitiesWithBatchAndPRBuilds(t *testing.T) {
+	t.Parallel()
+
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	options := &commonOpts
+	cmd_test_helpers.ConfigureTestOptions(options, options.Git(), options.Helm())
+
+	o := &GCActivitiesOptions{
+		CommonOptions:           options,
+		PullRequestAgeLimit:     time.Hour * 24 * 30,
+		ReleaseAgeLimit:         time.Hour * 48,
+		ReleaseHistoryLimit:     5,
+		PullRequestHistoryLimit: 2,
+	}
+
+	jxClient, ns, err := options.JXClientAndDevNamespace()
+	assert.NoError(t, err)
+	err = options.ModifyDevEnvironment(func(env *v1.Environment) error {
+		env.Spec.TeamSettings.PromotionEngine = jenkinsv1.PromotionEngineProw
+		return nil
+	})
+	assert.NoError(t, err)
+
+	nowMinusThreeDays := time.Now().AddDate(0, 0, -3)
+	_, err = jxClient.JenkinsV1().PipelineActivities(ns).Create(&v1.PipelineActivity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "1",
+			Labels: map[string]string{
+				v1.LabelBranch: "PR-1",
+			},
+		},
+		Spec: v1.PipelineActivitySpec{
+			Pipeline:           "org/project/PR-1",
+			CompletedTimestamp: &metav1.Time{Time: nowMinusThreeDays},
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = jxClient.JenkinsV1().PipelineActivities(ns).Create(&v1.PipelineActivity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "2",
+			Labels: map[string]string{
+				v1.LabelBranch: "batch",
+			},
+		},
+		Spec: v1.PipelineActivitySpec{
+			Pipeline:           "org/project/batch",
+			CompletedTimestamp: &metav1.Time{Time: nowMinusThreeDays},
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = jxClient.JenkinsV1().PipelineActivities(ns).Create(&v1.PipelineActivity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "3",
+			Labels: map[string]string{
+				v1.LabelBranch: "master",
+			},
+		},
+		Spec: v1.PipelineActivitySpec{
+			Pipeline:           "org/project/master",
+			CompletedTimestamp: &metav1.Time{Time: nowMinusThreeDays},
+		},
+	})
+	assert.NoError(t, err)
+
+	err = o.Run()
+	assert.NoError(t, err)
+
+	activities, err := jxClient.JenkinsV1().PipelineActivities(ns).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+
+	assert.Len(t, activities.Items, 2, "One of the activities should've been garbage collected")
+
+	var verifier []bool
+	for _, v := range activities.Items {
+		if v.BranchName() == "batch" || v.BranchName() == "PR-1" {
+			verifier = append(verifier, true)
+		}
+	}
+	assert.Len(t, verifier, 2, "Both PR and Batch builds should've been verified")
+
+}


### PR DESCRIPTION
Equaled the PR and Batch CRDs expiration times so they get garbage collected together

Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
In an effort to link PRs and Batch builds together in the UI, the expiration time needs to be the same  for both resources so one doesn't get collected before the other and leave broken links in the UI.

#### Which issue this PR fixes

fixes #4091

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
