### PR TITLE
chore(tekton): Speed up "jx get build logs" listing builds with filters

### DIFF
--- a/pkg/builds/build_info.go
+++ b/pkg/builds/build_info.go
@@ -193,6 +193,24 @@ func CreateBuildPodInfo(pod *corev1.Pod) *BuildPodInfo {
 	return answer
 }
 
+// LabelSelectorsForBuild returns a slice of label selectors corresponding to the filter
+func (o *BuildPodInfoFilter) LabelSelectorsForBuild() []string {
+	var labelSelectors []string
+	if o.Context != "" {
+		labelSelectors = append(labelSelectors, "context="+o.Context)
+	}
+	if o.Owner != "" {
+		labelSelectors = append(labelSelectors, "owner="+o.Owner)
+	}
+	if o.Repository != "" {
+		labelSelectors = append(labelSelectors, "repo="+o.Repository)
+	}
+	if o.Branch != "" {
+		labelSelectors = append(labelSelectors, "branch="+o.Branch)
+	}
+	return labelSelectors
+}
+
 // BuildMatches returns true if the build info matches the filter
 func (o *BuildPodInfoFilter) BuildMatches(info *BuildPodInfo) bool {
 	if o.Owner != "" && o.Owner != info.Organisation {

--- a/pkg/jx/cmd/step/create/step_create_task.go
+++ b/pkg/jx/cmd/step/create/step_create_task.go
@@ -551,7 +551,7 @@ func (o *StepCreateTaskOptions) GenerateTektonCRDs(packsDir string, projectConfi
 	}
 
 	pipelineResourceName := tekton.PipelineResourceName(o.GitInfo, o.Branch, o.Context)
-	pipeline, tasks, structure, err := parsed.GenerateCRDs(pipelineResourceName, o.BuildNumber, ns, o.PodTemplates, o.GetDefaultTaskInputs().Params, o.SourceName)
+	pipeline, tasks, structure, err := parsed.GenerateCRDs(pipelineResourceName, o.BuildNumber, ns, o.PodTemplates, o.GetDefaultTaskInputs().Params, o.SourceName, o.labels)
 	if err != nil {
 		return nil, errors.Wrapf(err, "generation failed for Pipeline")
 	}

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-golang-qs-test-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: golang-qs-test
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-golang-qs-test-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: golang-qs-test
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: golang-qs-test
       name: abayer-golang-qs-test-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
   namespace: jx
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
       namespace: jx
     spec:
@@ -219,6 +222,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: second
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-second-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: jx-demo-qs
       name: abayer-jx-demo-qs-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
   namespace: jx
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/command-as-multiline-script/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/command-as-multiline-script/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/command-as-multiline-script/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/command-as-multiline-script/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
       namespace: jx
     spec:
@@ -159,6 +162,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: second
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-second-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: jx-demo-qs
       name: abayer-jx-demo-qs-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
   namespace: jx
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
       namespace: jx
     spec:
@@ -219,6 +222,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: second
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-second-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-golang-qs-test-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: golang-qs-test
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-buildpack/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-buildpack/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-golang-qs-test-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: golang-qs-test
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-buildpack/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-buildpack/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: golang-qs-test
       name: abayer-golang-qs-test-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
   namespace: jx
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
       namespace: jx
     spec:
@@ -219,6 +222,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: second
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-second-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/from_yaml/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/from_yaml/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
   namespace: jx
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/from_yaml/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/from_yaml/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/from_yaml/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/from_yaml/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
       namespace: jx
     spec:
@@ -223,6 +226,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: second
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-second-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-build-pack-1
   namespace: jx
+  labels:
+    branch: build-pack
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/js_build_pack/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/js_build_pack/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-build-pack-1
+  labels:
+    branch: build-pack
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: build-pack
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-build-pack-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: jenkins-x-jx-fix-kaniko-special-1
   namespace: jx
+  labels:
+    branch: fix-kaniko-special-casing
+    owner: jenkins-x
+    repo: jx
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: jenkins-x-jx-fix-kaniko-special-1
+  labels:
+    branch: fix-kaniko-special-casing
+    owner: jenkins-x
+    repo: jx
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: ci
+        branch: fix-kaniko-special-casing
+        owner: jenkins-x
+        repo: jx
       name: jenkins-x-jx-fix-kaniko-special-ci-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: jx-demo-qs
       name: abayer-jx-demo-qs-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/maven_build_pack/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/maven_build_pack/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/maven_build_pack/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/maven_build_pack/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: jx-demo-qs
       name: abayer-jx-demo-qs-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-override-de-1
   namespace: jx
+  labels:
+    branch: override-default-agent
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-override-de-1
+  labels:
+    branch: override-default-agent
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: override-default-agent
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-override-de-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-golang-qs-test-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: golang-qs-test
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-golang-qs-test-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: golang-qs-test
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: golang-qs-test
       name: abayer-golang-qs-test-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
   namespace: jx
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
       namespace: jx
     spec:
@@ -219,6 +222,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: second
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-second-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-steps/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-steps/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-steps/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-steps/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: jx-demo-qs
       name: abayer-jx-demo-qs-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override_block_step/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override_block_step/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-golang-qs-test-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: golang-qs-test
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override_block_step/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override_block_step/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-golang-qs-test-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: golang-qs-test
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: golang-qs-test
       name: abayer-golang-qs-test-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-golang-qs-test-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: golang-qs-test
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-golang-qs-test-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: golang-qs-test
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: golang-qs-test
       name: abayer-golang-qs-test-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
   namespace: jx
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: jx-demo-qs
       name: abayer-jx-demo-qs-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
   namespace: jx
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-really-long-1
+  labels:
+    branch: really-long
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
       namespace: jx
     spec:
@@ -219,6 +222,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: second
+        branch: really-long
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-really-long-second-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
   namespace: jx
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-jx-demo-qs-master-1
+  labels:
+    branch: master
+    owner: abayer
+    repo: jx-demo-qs
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: master
+        owner: abayer
+        repo: jx-demo-qs
       name: abayer-jx-demo-qs-master-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipeline.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipeline.yml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-no-default-1
   namespace: jx
+  labels:
+    branch: no-default-agent
+    owner: abayer
+    repo: js-test-repo
 spec:
   params:
     - default: 0.0.1

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/structure.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/structure.yml
@@ -1,6 +1,10 @@
 metadata:
   creationTimestamp: null
   name: abayer-js-test-repo-no-default-1
+  labels:
+    branch: no-default-agent
+    owner: abayer
+    repo: js-test-repo
 pipelineRef: null
 pipelineRunRef: null
 stages:

--- a/pkg/jx/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
+++ b/pkg/jx/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
@@ -5,6 +5,9 @@ items:
       creationTimestamp: null
       labels:
         jenkins.io/task-stage-name: from-build-pack
+        branch: no-default-agent
+        owner: abayer
+        repo: js-test-repo
       name: abayer-js-test-repo-no-default-from-build-pack-1
       namespace: jx
     spec:

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -1140,7 +1140,7 @@ func (ts *transformedStage) computeWorkspace(parentWorkspace string) {
 	}
 }
 
-func stageToTask(s Stage, pipelineIdentifier string, buildIdentifier string, namespace string, sourceDir string, baseWorkingDir *string, parentEnv []corev1.EnvVar, parentAgent *Agent, parentWorkspace string, parentContainer *corev1.Container, depth int8, enclosingStage *transformedStage, previousSiblingStage *transformedStage, podTemplates map[string]*corev1.Pod) (*transformedStage, error) {
+func stageToTask(s Stage, pipelineIdentifier string, buildIdentifier string, namespace string, sourceDir string, baseWorkingDir *string, parentEnv []corev1.EnvVar, parentAgent *Agent, parentWorkspace string, parentContainer *corev1.Container, depth int8, enclosingStage *transformedStage, previousSiblingStage *transformedStage, podTemplates map[string]*corev1.Pod, labels map[string]string) (*transformedStage, error) {
 	if len(s.Post) != 0 {
 		return nil, errors.New("post on stages not yet supported")
 	}
@@ -1203,7 +1203,7 @@ func stageToTask(s Stage, pipelineIdentifier string, buildIdentifier string, nam
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      MangleToRfc1035Label(fmt.Sprintf("%s-%s", pipelineIdentifier, s.Name), buildIdentifier),
-				Labels:    util.MergeMaps(map[string]string{LabelStageName: s.stageLabelName()}),
+				Labels:    util.MergeMaps(labels, map[string]string{LabelStageName: s.stageLabelName()}),
 			},
 		}
 		// Only add the default git merge step if this is the first actual step stage - including if the stage is one of
@@ -1274,7 +1274,7 @@ func stageToTask(s Stage, pipelineIdentifier string, buildIdentifier string, nam
 			if i > 0 {
 				nestedPreviousSibling = tasks[i-1]
 			}
-			nestedTask, err := stageToTask(nested, pipelineIdentifier, buildIdentifier, namespace, sourceDir, baseWorkingDir, env, agent, *ts.Stage.Options.Workspace, stageContainer, depth+1, &ts, nestedPreviousSibling, podTemplates)
+			nestedTask, err := stageToTask(nested, pipelineIdentifier, buildIdentifier, namespace, sourceDir, baseWorkingDir, env, agent, *ts.Stage.Options.Workspace, stageContainer, depth+1, &ts, nestedPreviousSibling, podTemplates, labels)
 			if err != nil {
 				return nil, err
 			}
@@ -1291,7 +1291,7 @@ func stageToTask(s Stage, pipelineIdentifier string, buildIdentifier string, nam
 		ts.computeWorkspace(parentWorkspace)
 
 		for _, nested := range s.Parallel {
-			nestedTask, err := stageToTask(nested, pipelineIdentifier, buildIdentifier, namespace, sourceDir, baseWorkingDir, env, agent, *ts.Stage.Options.Workspace, stageContainer, depth+1, &ts, nil, podTemplates)
+			nestedTask, err := stageToTask(nested, pipelineIdentifier, buildIdentifier, namespace, sourceDir, baseWorkingDir, env, agent, *ts.Stage.Options.Workspace, stageContainer, depth+1, &ts, nil, podTemplates, labels)
 			if err != nil {
 				return nil, err
 			}
@@ -1476,7 +1476,7 @@ func PipelineRunName(pipelineIdentifier string, buildIdentifier string) string {
 }
 
 // GenerateCRDs translates the Pipeline structure into the corresponding Pipeline and Task CRDs
-func (j *ParsedPipeline) GenerateCRDs(pipelineIdentifier string, buildIdentifier string, namespace string, podTemplates map[string]*corev1.Pod, taskParams []tektonv1alpha1.TaskParam, sourceDir string) (*tektonv1alpha1.Pipeline, []*tektonv1alpha1.Task, *v1.PipelineStructure, error) {
+func (j *ParsedPipeline) GenerateCRDs(pipelineIdentifier string, buildIdentifier string, namespace string, podTemplates map[string]*corev1.Pod, taskParams []tektonv1alpha1.TaskParam, sourceDir string, labels map[string]string) (*tektonv1alpha1.Pipeline, []*tektonv1alpha1.Task, *v1.PipelineStructure, error) {
 	if len(j.Post) != 0 {
 		return nil, nil, nil, errors.New("Post at top level not yet supported")
 	}
@@ -1519,6 +1519,11 @@ func (j *ParsedPipeline) GenerateCRDs(pipelineIdentifier string, buildIdentifier
 		},
 	}
 
+	if len(labels) > 0 {
+		p.Labels = util.MergeMaps(labels)
+		structure.Labels = util.MergeMaps(labels)
+	}
+
 	var previousStage *transformedStage
 
 	var tasks []*tektonv1alpha1.Task
@@ -1528,7 +1533,7 @@ func (j *ParsedPipeline) GenerateCRDs(pipelineIdentifier string, buildIdentifier
 	for i, s := range j.Stages {
 		isLastStage := i == len(j.Stages)-1
 
-		stage, err := stageToTask(s, pipelineIdentifier, buildIdentifier, namespace, sourceDir, baseWorkingDir, baseEnv, j.Agent, "default", parentContainer, 0, nil, previousStage, podTemplates)
+		stage, err := stageToTask(s, pipelineIdentifier, buildIdentifier, namespace, sourceDir, baseWorkingDir, baseEnv, j.Agent, "default", parentContainer, 0, nil, previousStage, podTemplates, labels)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -1157,7 +1157,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				}
 			}
 
-			pipeline, tasks, structure, err := parsed.GenerateCRDs("somepipeline", "1", "jx", nil, nil, "source")
+			pipeline, tasks, structure, err := parsed.GenerateCRDs("somepipeline", "1", "jx", nil, nil, "source", nil)
 
 			if err != nil {
 				if tt.expectedErrorMsg != "" {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

To make this work best, we also add the same labels that get put on the `PipelineRun` to the `Pipeline`, `Task`s, and `PipelineStructure`. Which is something we should do anyway.

#### Special notes for the reviewer(s)

This isn't going to have very good coverage at this point - I've opened #4147 to tackle that later.

/assign @dgozalo 
/assign @ccojocar 
/assign @wbrefvem 
/assign @dwnusbaum 
/assign @joseblas 

#### Which issue this PR fixes

n/a