### PR TITLE
fix: pass helm values files to tekton chart installation

### DIFF
--- a/pkg/jx/cmd/opts/install.go
+++ b/pkg/jx/cmd/opts/install.go
@@ -1665,7 +1665,7 @@ func (o *CommonOptions) InstallProw(useTekton bool, useExternalDNS bool, isGitOp
 
 		err = o.Retry(2, time.Second, func() (err error) {
 			return o.InstallChartOrGitOps(isGitOps, gitOpsDir, gitOpsEnvDir, kube.DefaultTektonReleaseName,
-				kube.ChartTekton, "tekton", "", devNamespace, true, setValues, ksecretValues, nil, "")
+				kube.ChartTekton, "tekton", "", devNamespace, true, setValues, ksecretValues, valuesFiles, "")
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to install Tekton")


### PR DESCRIPTION
Signed-off-by: Carlos Sanchez <carlos@apache.org>

/hold this does not work because tekton is installed individually and not part of the platform.

It would need to have the tekton values in the top level

```yaml
pvc:
  size: 20Gi
```

https://github.com/jenkins-x/cloud-environments/pull/5
