### PR TITLE
feat: switch to a self uploading covered binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,25 +52,6 @@ endif
 # set dev version unless VERSION is explicitly set via environment
 VERSION ?= $(shell echo "$$(git describe --abbrev=0 --tags 2>/dev/null)-dev+$(REV)" | sed 's/^v//')
 
-BUILDFLAGS :=  -ldflags \
-  " -X $(ROOT_PACKAGE)/pkg/version.Version=$(VERSION)\
-		-X $(ROOT_PACKAGE)/pkg/version.Revision='$(REV)'\
-		-X $(ROOT_PACKAGE)/pkg/version.Branch='$(BRANCH)'\
-		-X $(ROOT_PACKAGE)/pkg/version.BuildDate='$(BUILD_DATE)'\
-		-X $(ROOT_PACKAGE)/pkg/version.GoVersion='$(GO_VERSION)'"
-
-ifdef DEBUG
-BUILDFLAGS := -gcflags "all=-N -l" $(BUILDFLAGS)
-endif
-
-ifdef PARALLEL_BUILDS
-BUILDFLAGS += -p $(PARALLEL_BUILDS)
-GOTEST += -p $(PARALLEL_BUILDS)
-else
-# -p 4 seems to work well for people
-GOTEST += -p 4
-endif
-
 # Various codecov.io variables that are set from the CI envrionment if present, otherwise from locally computed values
 
 CODECOV_NAME ?= integration
@@ -110,10 +91,39 @@ CODECOV_BRANCH := $(PULL_BASE_REF)
 endif
 
 ifeq ($(JOB_TYPE),postsubmit)
-CODECOV_ARGS += -T v$(VERSION)
+CODECOV_TAG := v$(VERSION)
+CODECOV_ARGS += -T $(CODECOV_TAG)
 endif
 
 #End Codecov
+
+BUILDFLAGS :=  -ldflags \
+  " -X $(ROOT_PACKAGE)/pkg/version.Version=$(VERSION)\
+		-X $(ROOT_PACKAGE)/pkg/version.Revision='$(REV)'\
+		-X $(ROOT_PACKAGE)/pkg/version.Branch='$(BRANCH)'\
+		-X $(ROOT_PACKAGE)/pkg/version.BuildDate='$(BUILD_DATE)'\
+		-X $(ROOT_PACKAGE)/pkg/version.GoVersion='$(GO_VERSION)'\
+		-X $(ROOT_PACKAGE)/cmd/jx/codecov.Flag=$(CODECOV_NAME)\
+		-X $(ROOT_PACKAGE)/cmd/jx/codecov.Slug=$(CODECOV_SLUG)\
+		-X $(ROOT_PACKAGE)/cmd/jx/codecov.Branch=$(CODECOV_BRANCH)\
+		-X $(ROOT_PACKAGE)/cmd/jx/codecov.Sha=$(CODECOV_SHA)\
+		-X $(ROOT_PACKAGE)/cmd/jx/codecov.BuildNumber=$(BUILD_NUMBER)\
+		-X $(ROOT_PACKAGE)/cmd/jx/codecov.PullRequestNumber=$(PULL_NUMBER)\
+		-X $(ROOT_PACKAGE)/cmd/jx/codecov.Tag=$(CODECOV_TAG)"
+
+ifdef DEBUG
+BUILDFLAGS := -gcflags "all=-N -l" $(BUILDFLAGS)
+endif
+
+ifdef PARALLEL_BUILDS
+BUILDFLAGS += -p $(PARALLEL_BUILDS)
+GOTEST += -p $(PARALLEL_BUILDS)
+else
+# -p 4 seems to work well for people
+GOTEST += -p 4
+endif
+
+
 
 # support for building a covered jx binary (one with the coverage instrumentation compiled in). The `build-covered`
 # target also builds the covered binary explicitly
@@ -124,6 +134,7 @@ ifdef COVERED_BINARY
 BUILDFLAGS += $(COVERAGE_BUILDFLAGS)
 BUILD_TARGET = $(COVERAGE_BUILD_TARGET)
 MAIN_SRC_FILE = $(COVERED_MAIN_SRC_FILE)
+
 endif
 
 # Build the Jenkins X distribution

--- a/cmd/jx/codecov/info.go
+++ b/cmd/jx/codecov/info.go
@@ -1,0 +1,19 @@
+package codecov
+
+// Variables in this file are set by the build and used by the instrumented binary for upload to codecov
+var (
+	// Flag is the flag to be passed to codecov
+	Flag string
+	// Slug is the slug to be passed to codecov
+	Slug string
+	// Branch is the branch on which the changeset is built to be passed to codecov
+	Branch string
+	// Sha is the sha of the last commit of the changeset to be passed to codecov
+	Sha string
+	// BuildNumber is the number of the build of the changeset to be passed to codecov
+	BuildNumber string
+	// PullRequestNumber is the number of the pull request for the changeset (or empty) to be passed to codecov
+	PullRequestNumber string
+	// Tag is the tag name of the changeset (or empty) to be passed to codecov
+	Tag string
+)

--- a/cmd/jx/jx_test.go
+++ b/cmd/jx/jx_test.go
@@ -2,18 +2,51 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/jenkins-x/jx/cmd/jx/codecov"
+
+	"github.com/jenkins-x/jx/pkg/log"
+
+	"github.com/pborman/uuid"
+
+	"github.com/jenkins-x/jx/pkg/util"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/jenkins-x/jx/cmd/jx/app"
 )
 
+type TestSystemWriter struct {
+	wrapped io.Writer
+}
+
+var coverageOutputRegex = regexp.MustCompile(`(?m:^coverage: ([\d\.]*%) of statements in [\w\.\/]*$)`)
+var passOutputRegex = regexp.MustCompile(`(?m:^PASS$)`)
+
+func (t TestSystemWriter) Write(p []byte) (n int, err error) {
+	s := string(p)
+	s = coverageOutputRegex.ReplaceAllString(s, "")
+	s = passOutputRegex.ReplaceAllString(s, "")
+	_, err = t.wrapped.Write([]byte(s))
+	return len(p), err
+}
+
 func TestSystem(t *testing.T) {
-	enableCoverage := os.Getenv("COVER_JX_BINARY") == "true"
-	if enableCoverage {
+	disableCoverage := os.Getenv("COVER_JX_BINARY") == "false"
+	if !disableCoverage {
+		disableSelfUpload := os.Getenv("COVER_SELF_UPLOAD") == "false"
+		alreadyWrapped := os.Getenv("COVER_WRAPPED") == "true"
+		coverprofileArgFound := false
 		args := make([]string, 0)
 		strippedArgs := make([]string, 0)
 		for i, arg := range os.Args {
@@ -25,14 +58,149 @@ func TestSystem(t *testing.T) {
 			} else {
 				strippedArgs = append(strippedArgs, arg)
 			}
+			if strings.HasPrefix(arg, "-test.coverprofile") {
+				coverprofileArgFound = true
+			}
 		}
-		fmt.Printf("This is a covered JX binary. Run with -test.coverprofile=mycover.out to generate coverage\n")
-		fmt.Printf("Removed arguments %s\n", strings.Join(strippedArgs, ", "))
-		fmt.Printf("Arguments passed to `jx` are %s\n\n", strings.Join(args, ", "))
-		// Purposefully ignore errors from app.Run as we are checking coverage
-		err := app.Run(args)
-		assert.NoError(t, err, "error executing jx")
+		if !alreadyWrapped && (!disableSelfUpload || !coverprofileArgFound) {
+			// We need to wrap our own execution
+			var outFile string
+			var id string
+			if !coverprofileArgFound {
+				reportsDir := os.Getenv("REPORTS_DIR")
+				if reportsDir == "" {
+					reportsDir = filepath.Join("build", "reports")
+				}
+				err := os.MkdirAll(reportsDir, 0700)
+				if err != nil {
+					log.Errorf("Error making reports directory %s %v", reportsDir, err)
+				}
+				id = "jx"
+				for _, arg := range args[1:] {
+					if strings.HasPrefix(arg, "-") {
+						break
+					}
+					id = fmt.Sprintf("%s_%s", id, arg)
+				}
+				args = append(args, "" /* use the zero value of the element type */)
+				copy(args[2:], args[1:])
+				outFile = filepath.Join(reportsDir, fmt.Sprintf("%s.%s.out", id, uuid.New()))
+				args[1] = fmt.Sprintf("-test.coverprofile=%s", outFile)
+			} else if !disableSelfUpload {
+				// TODO support this
+				log.Errorf("Self upload is not supported if -test.coverprofile is specified. Disabling it.")
+				disableSelfUpload = true
+			}
+			cmd := util.Command{
+				Env: map[string]string{
+					"COVER_WRAPPED": "true",
+				},
+				Args: args[1:],
+				Name: os.Args[0],
+				Out: TestSystemWriter{
+					wrapped: os.Stdout,
+				},
+				In:  os.Stdin,
+				Err: os.Stderr,
+			}
+			_, err := cmd.RunWithoutRetry()
+			if !disableSelfUpload {
+				if os.Getenv("CODECOV_TOKEN") == "" {
+					log.Errorf("cannot upload to codecov because CODECOV_TOKEN environment variable is not set")
+				} else {
+					err := uploadToCodecov(outFile, id)
+					if err != nil {
+						log.Errorf("cannot upload to codecov because %v", err)
+					}
+				}
+
+			}
+			if err != nil {
+				log.Error(err.Error())
+				os.Exit(1)
+			}
+			os.Exit(0)
+		} else {
+			// Purposefully ignore errors from app.Run as we are checking coverage
+			err := app.Run(args)
+			// the assert.NoError defers the error reporting until after the coverage is written out
+			assert.NoError(t, err, "error executing jx")
+		}
 	} else {
 		main()
 	}
+}
+
+func uploadToCodecov(outFile string, name string) error {
+	script, err := downloadCodecovUploader()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	err = os.Chmod(script, 0700)
+	if err != nil {
+		return errors.Wrapf(err, "making %s executable", script)
+	}
+	args := []string{
+		"-Z",
+		"-f",
+		outFile,
+		"-n",
+		name,
+	}
+	if codecov.Flag != "" {
+		args = append(args, "-F", codecov.Flag)
+	}
+	if codecov.BuildNumber != "" {
+		args = append(args, "-b", codecov.BuildNumber)
+	}
+	if codecov.PullRequestNumber != "" {
+		args = append(args, "-P", codecov.PullRequestNumber)
+	}
+	if codecov.Tag != "" {
+		args = append(args, "-T", codecov.Tag)
+	}
+	cmd := util.Command{
+		Name: script,
+		Env: map[string]string{
+			"DOCKER_REPO":   codecov.Slug,
+			"SOURCE_COMMIT": codecov.Sha,
+			"SOURCE_BRANCH": codecov.Branch,
+		},
+		Args: args,
+	}
+	out, err := cmd.RunWithoutRetry()
+	if err != nil {
+		log.Errorf("Running %s", cmd.String())
+		log.Errorf(out)
+		return errors.Wrapf(err, "error uploading coverage to codecov.io")
+
+	}
+	return nil
+}
+
+func downloadCodecovUploader() (string, error) {
+	script, err := ioutil.TempFile("", "codecov")
+	defer script.Close()
+	if err != nil {
+		return "", errors.Wrapf(err, "creating tempfile")
+	}
+	err = downloadFile(script, "https://codecov.io/bash")
+	if err != nil {
+		return "", errors.Wrapf(err, "downloading codecov uploader")
+	}
+	return script.Name(), nil
+}
+
+func downloadFile(out *os.File, url string) error {
+
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/nlopes/slack v0.0.0-20180721202243-347a74b1ea30
 	github.com/nwaples/rardecode v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -512,6 +512,8 @@ github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnG
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936 h1:kw1v0NlnN+GZcU8Ma8CLF2Zzgjfx95gs3/GN3vYAPpo=
+github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e/go.mod h1:waEya8ee1Ro/lgxpVhkJI4BVASzkm3UZqkx/cFJiYHM=
 github.com/mitchellh/mapstructure v0.0.0-20180511142126-bb74f1db0675/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/jenkins-x-bdd.yml
+++ b/jenkins-x-bdd.yml
@@ -25,9 +25,6 @@ pipelineConfig:
                 # Build a binary that can emit coverage
               - name: COVERED_BINARY
                 value: "true"
-                # Enable coverage reporting during BDD test run
-              - name: ENABLE_COVERAGE
-                value: "true"
               - name: CODECOV_NAME
                 value: e2e
             options:
@@ -56,6 +53,10 @@ pipelineConfig:
                 image: docker.io/golang:1.11.5
                 command: "./build/linux/jx"
                 args: ['help']
+                # Supported when we upgrade
+                #env:
+                #- name: COVER_JX_BINARY
+                #  value: false
 
               - name: build-and-push-image
                 image: rawlingsj/executor:dev40
@@ -80,8 +81,3 @@ pipelineConfig:
               - name: preview
                 image: gcr.io/jenkinsxio/builder-go:0.1.332
                 command: ./jx/scripts/ci.sh
-
-              - name: codecov-upload
-                image: gcr.io/jenkinsxio/builder-go:0.1.332
-                command: make
-                args: ['codecov-upload']

--- a/jx/scripts/ci.sh
+++ b/jx/scripts/ci.sh
@@ -2,14 +2,14 @@
 set -e
 
 echo "verifying Pull Request"
-
+JX=./build/linux/jx
 export ORG="jenkinsxio"
 export APP_NAME="jx"
 export TEAM="$(echo ${BRANCH_NAME}-$BUILD_ID  | tr '[:upper:]' '[:lower:]')"
 
-export GHE_CREDS_PSW="$(jx step credential -s jx-pipeline-git-github-ghe)"
-export JENKINS_CREDS_PSW="$(jx step credential -s  test-jenkins-user)"
-export GKE_SA="$(jx step credential -s gke-sa)"
+export GHE_CREDS_PSW="$(${JX} step credential -s jx-pipeline-git-github-ghe)"
+export JENKINS_CREDS_PSW="$(${JX} step credential -s  test-jenkins-user)"
+export GKE_SA="$(${JX} step credential -s gke-sa)"
 
 export REPORTS_DIR="${BASE_WORKSPACE}/build/reports"
 
@@ -33,24 +33,25 @@ export GIT_COMMITTER_NAME="dev1"
 
 mkdir -p $JX_HOME
 
-jx --version
-jx step git credentials
+# Disable coverage for jx version as we don't validate the output at all
+COVER_JX_BINARY=false ${JX} version
+${JX} step git credentials
 
 # lets create a team for this PR and run the BDD tests
 gcloud auth activate-service-account --key-file $GKE_SA
 gcloud container clusters get-credentials jx-bdd-tests --zone europe-west1-c --project jenkins-x-infra
 
-sed s/\$VERSION/${VERSION}/g myvalues.yaml.template > myvalues.yaml
+sed -e s/\$VERSION/${VERSION}/g -e s/\$CODECOV_TOKEN/${CODECOV_TOKEN}/g myvalues.yaml.template > myvalues.yaml
 
-echo the myvalues.yaml file is:
-cat myvalues.yaml
+#echo the myvalues.yaml file is:
+#cat myvalues.yaml
 
 echo "creating team: $TEAM"
 
 git config --global --add user.name JenkinsXBot
 git config --global --add user.email jenkins-x@googlegroups.com
 
-cp ./build/linux/jx /usr/bin
+cp ${JX} /usr/bin
 
 # lets trigger the BDD tests in a new team and git provider
-./build/linux/jx step bdd -b --provider=gke --git-provider=ghe --git-provider-url=https://github.beescloud.com --git-username dev1 --git-api-token $GHE_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+${JX} step bdd -b --provider=gke --git-provider=ghe --git-provider-url=https://github.beescloud.com --git-username dev1 --git-api-token $GHE_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring

--- a/myvalues.yaml.template
+++ b/myvalues.yaml.template
@@ -6,15 +6,20 @@ jenkins:
         Containers:
           Maven:
             Image: jenkinsxio/builder-maven:$VERSION
+        EnvVars:
+          CODECOV_TOKEN: $CODECOV_TOKEN
       Nodejs:
         Containers:
           Nodejs:
             Image: jenkinsxio/builder-nodejs:$VERSION
+        EnvVars:
+          CODECOV_TOKEN: $CODECOV_TOKEN
       Go:
         Containers:
           Go:
             Image: jenkinsxio/builder-go:$VERSION
-
+        EnvVars:
+          CODECOV_TOKEN: $CODECOV_TOKEN
 # disable stuff
 pipelinecontroller:
   enabled: false

--- a/pkg/util/commands.go
+++ b/pkg/util/commands.go
@@ -22,6 +22,7 @@ type Command struct {
 	Timeout            time.Duration
 	Out                io.Writer
 	Err                io.Writer
+	In                 io.Reader
 	Env                map[string]string
 }
 
@@ -218,6 +219,10 @@ func (c *Command) run() (string, error) {
 
 	if c.Err != nil {
 		e.Stderr = c.Err
+	}
+
+	if c.In != nil {
+		e.Stdin = c.In
 	}
 
 	var text string


### PR DESCRIPTION
If called when compiled into coverage mode, this binary will call itself, adding the `test.coverprofile` argument, and, after the subprocess exits, upload the coverage to codecov. It also fixes the output to remove the coverage lines generated by go. This allows us to use it transparently in tests, only setting the `CODECOV_TOKEN` into the environment.