### PR TITLE
Extend use of jx create cluster advanced flag

### DIFF
--- a/pkg/auth/auth_config.go
+++ b/pkg/auth/auth_config.go
@@ -351,7 +351,7 @@ func (c *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defaultUse
 	var err error
 
 	if editUser || auth.Username == "" {
-		auth.Username, err = util.PickValue(serverLabel+" user name:", auth.Username, true, "", in, out, outErr)
+		auth.Username, err = util.PickValue(serverLabel+" username:", auth.Username, true, "", in, out, outErr)
 		if err != nil {
 			return err
 		}

--- a/pkg/gits/provider_test.go
+++ b/pkg/gits/provider_test.go
@@ -245,7 +245,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			false,
 			false,
 		},
-		{"create GitHub provider in barch mode ",
+		{"create GitHub provider in batch mode ",
 			nil,
 			nil,
 			"GitHub",
@@ -269,7 +269,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
-					c.ExpectString("github.com user name:")
+					c.ExpectString("github.com username:")
 					c.SendLine("test")
 					c.ExpectString("API Token:")
 					c.SendLine("test")
@@ -358,7 +358,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			false,
 			false,
 		},
-		{"create Gitlab provider in barch mode ",
+		{"create Gitlab provider in batch mode ",
 			nil,
 			nil,
 			"Gitlab",
@@ -382,7 +382,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
-					c.ExpectString("gitlab.com user name:")
+					c.ExpectString("gitlab.com username:")
 					c.SendLine("test")
 					c.ExpectString("API Token:")
 					c.SendLine("test")
@@ -471,7 +471,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			false,
 			false,
 		},
-		{"create Gitea provider in barch mode ",
+		{"create Gitea provider in batch mode ",
 			nil,
 			nil,
 			"Gitea",
@@ -495,7 +495,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
-					c.ExpectString("gitea.com user name:")
+					c.ExpectString("gitea.com username:")
 					c.SendLine("test")
 					c.ExpectString("API Token:")
 					c.SendLine("test")
@@ -584,7 +584,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			false,
 			false,
 		},
-		{"create BitbucketServer provider in barch mode ",
+		{"create BitbucketServer provider in batch mode ",
 			nil,
 			nil,
 			"BitbucketServer",
@@ -608,7 +608,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
-					c.ExpectString("bitbucket-server.com user name:")
+					c.ExpectString("bitbucket-server.com username:")
 					c.SendLine("test")
 					c.ExpectString("API Token:")
 					c.SendLine("test")
@@ -697,7 +697,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 			false,
 			false,
 		},
-		{"create BitbucketCloud provider in barch mode ",
+		{"create BitbucketCloud provider in batch mode ",
 			nil,
 			nil,
 			"BitbucketCloud",
@@ -721,7 +721,7 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 				donech := make(chan struct{})
 				go func() {
 					defer close(donech)
-					c.ExpectString("bitbucket.org user name:")
+					c.ExpectString("bitbucket.org username:")
 					c.SendLine("test")
 					c.ExpectString("API Token:")
 					c.SendLine("test")

--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -224,7 +224,7 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 
 			if o.InstallOptions.Flags.NextGeneration {
 				log.Infof(util.ColorWarning("Defaulting to zonal cluster type as --ng is selected.\n"))
-			} else {
+			} else if advanced {
 				prompts := &survey.Select{
 					Message: "What type of cluster would you like to create",
 					Options: []string{"Regional", "Zonal"},
@@ -236,6 +236,8 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 				if err != nil {
 					return err
 				}
+			} else {
+				log.Infof("Defaulting to cluster type: %s", util.ColorPrompt(clusterType))
 			}
 
 			if "Regional" == clusterType {
@@ -326,14 +328,19 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 
 	if !o.BatchMode {
 		if !o.IsFlagExplicitlySet(preemptibleFlagName) {
-			prompt := &survey.Confirm{
-				Message: "Would you like use preemptible VMs?",
-				Default: false,
-				Help:    "Preemptible VMs can significantly lower the cost of a cluster",
-			}
-			err = survey.AskOne(prompt, &o.Flags.Preemptible, nil, surveyOpts)
-			if err != nil {
-				return err
+			if advanced {
+				prompt := &survey.Confirm{
+					Message: "Would you like to use preemptible VMs?",
+					Default: false,
+					Help:    "Preemptible VMs can significantly lower the cost of a cluster",
+				}
+				err = survey.AskOne(prompt, &o.Flags.Preemptible, nil, surveyOpts)
+				if err != nil {
+					return err
+				}
+			} else {
+				o.Flags.Preemptible = false
+				log.Infof("Defaulting use of preemptible VMs: %v", util.ColorPrompt(util.YesNo(o.Flags.Preemptible)))
 			}
 		}
 	}
@@ -347,14 +354,19 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 	if !o.BatchMode {
 		// if scopes is empty &
 		if len(o.Flags.Scopes) == 0 && !o.IsFlagExplicitlySet(enhancedScopesFlagName) {
-			prompt := &survey.Confirm{
-				Message: "Would you like to access Google Cloud Storage / Google Container Registry?",
-				Default: o.InstallOptions.Flags.DockerRegistry == "",
-				Help:    "Enables enhanced oauth scopes to allow access to storage based services",
-			}
-			err = survey.AskOne(prompt, &o.Flags.EnhancedScopes, nil, surveyOpts)
-			if err != nil {
-				return err
+			if advanced {
+				prompt := &survey.Confirm{
+					Message: "Would you like to access Google Cloud Storage / Google Container Registry?",
+					Default: o.InstallOptions.Flags.DockerRegistry == "",
+					Help:    "Enables enhanced oauth scopes to allow access to storage based services",
+				}
+				err = survey.AskOne(prompt, &o.Flags.EnhancedScopes, nil, surveyOpts)
+				if err != nil {
+					return err
+				}
+			} else {
+				o.Flags.EnhancedScopes = true
+				log.Infof("Defaulting access to Google Cloud Storage / Google Container Registry: %v", util.ColorPrompt(util.YesNo(o.Flags.EnhancedScopes)))
 			}
 		}
 	}
@@ -373,14 +385,19 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 		// only provide the option if enhanced scopes are enabled
 		if o.Flags.EnhancedScopes {
 			if !o.IsFlagExplicitlySet(enhancedAPIFlagName) {
-				prompt := &survey.Confirm{
-					Message: "Would you like to enable Cloud Build, Container Registry & Container Analysis APIs?",
-					Default: o.Flags.EnhancedScopes,
-					Help:    "Enables extra APIs on the GCP project",
-				}
-				err = survey.AskOne(prompt, &o.Flags.EnhancedApis, nil, surveyOpts)
-				if err != nil {
-					return err
+				if advanced {
+					prompt := &survey.Confirm{
+						Message: "Would you like to enable Cloud Build, Container Registry & Container Analysis APIs?",
+						Default: o.Flags.EnhancedScopes,
+						Help:    "Enables extra APIs on the GCP project",
+					}
+					err = survey.AskOne(prompt, &o.Flags.EnhancedApis, nil, surveyOpts)
+					if err != nil {
+						return err
+					}
+				} else {
+					o.Flags.EnhancedApis = true
+					log.Infof("Defaulting enabling Cloud Build, Container Registry & Container Analysis API's: %v", util.ColorPrompt(util.YesNo(o.Flags.EnhancedApis)))
 				}
 			}
 		}
@@ -398,14 +415,19 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 	if !o.BatchMode {
 		// only provide the option if enhanced scopes are enabled
 		if o.Flags.EnhancedScopes && !o.InstallOptions.Flags.Kaniko {
-			prompt := &survey.Confirm{
-				Message: "Would you like to enable Kaniko for building container images",
-				Default: o.Flags.EnhancedScopes,
-				Help:    "Use Kaniko for docker images",
-			}
-			err = survey.AskOne(prompt, &o.InstallOptions.Flags.Kaniko, nil, surveyOpts)
-			if err != nil {
-				return err
+			if advanced {
+				prompt := &survey.Confirm{
+					Message: "Would you like to enable Kaniko for building container images",
+					Default: o.Flags.EnhancedScopes,
+					Help:    "Use Kaniko for docker images",
+				}
+				err = survey.AskOne(prompt, &o.InstallOptions.Flags.Kaniko, nil, surveyOpts)
+				if err != nil {
+					return err
+				}
+			} else {
+				o.InstallOptions.Flags.Kaniko = false
+				log.Infof("Defaulting enabling Kaniko for building container images: %v", util.ColorPrompt(util.YesNo(o.InstallOptions.Flags.Kaniko)))
 			}
 		}
 	}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -210,3 +210,11 @@ func RemoveStringFromSlice(strings []string, toRemove string) []string {
 	}
 	return strings
 }
+
+// YesNo returns a Yes/No conversion for a boolean parameter
+func YesNo(t bool) string {
+	if t {
+		return "Yes"
+	}
+	return "No"
+}

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -81,3 +81,8 @@ func assertDiffSlice(t *testing.T, originalSlice, newSlice, removed, added []str
 	assert.Equal(t, toDelete, removed, fmt.Sprintf("removal incorrect - original [%s] new [%s]", strings.Join(originalSlice, ", "), strings.Join(newSlice, ", ")))
 	assert.Equal(t, toInsert, added, fmt.Sprintf("insert incorrect - original [%s] new [%s]", strings.Join(originalSlice, ", "), strings.Join(newSlice, ", ")))
 }
+
+func TestYesNo(t *testing.T) {
+	assert.Equal(t, "Yes", util.YesNo(true), "Yes boolean conversion")
+	assert.Equal(t, "No", util.YesNo(false), "No boolean conversion")
+}


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Further extends the usage of the --advanced flag for jx create cluster gke. This reduces the questions asked, simplifying the UX of the CLI.

#3915