### PR TITLE
fix for error during `jx create addon gloo` #4178

### DIFF
--- a/pkg/jx/cmd/opts/install.go
+++ b/pkg/jx/cmd/opts/install.go
@@ -428,7 +428,7 @@ func (o *CommonOptions) InstallGlooctl() error {
 	if runtime.GOOS == "windows" {
 		suffix += ".exe"
 	}
-	clientURL := fmt.Sprintf("https://github.com/solo-io/gloo/releases/download/v%v/glooctl-%s-%s", latestVersion, latestVersion, suffix)
+	clientURL := fmt.Sprintf("https://github.com/solo-io/gloo/releases/download/v%v/glooctl-%s-%s", latestVersion, runtime.GOOS, suffix)
 	fullPath := filepath.Join(binDir, fileName)
 	tmpFile := fullPath + ".tmp"
 	err = packages.DownloadFile(clientURL, tmpFile)


### PR DESCRIPTION
fix(jx create addon gloo): HTTP 404 during downloading glooctl

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Changed the 2 parameter used to generate the download url to GOOS.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #4178

