### PR TITLE
fix: the logic for determining tag history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ release: clean build test-slow-integration linux darwin win arm ## Release the b
 	GITHUB_ACCESS_TOKEN=$(GITHUB_ACCESS_TOKEN) gh-release create $(RELEASE_ORG_REPO) $(VERSION) master $(VERSION)
 
 	@if [[ -z "${DISTRO}" ]]; then \
-		./build/linux/jx step changelog  --header-file docs/dev/changelog-header.md --version $(VERSION); \
+		./build/linux/jx step changelog  --verbose --header-file docs/dev/changelog-header.md --version $(VERSION) --rev $(PULL_BASE_SHA); \
 	fi
 
 .PHONY: release-distro

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -657,16 +657,21 @@ func (g *GitCLI) RemoteBranchNames(dir string, prefix string) ([]string, error) 
 
 // GetPreviousGitTagSHA returns the previous git tag from the repository at the given directory
 func (g *GitCLI) GetPreviousGitTagSHA(dir string) (string, error) {
-	latestTag, err := g.gitCmdWithOutput(dir, "describe", "--abbrev=0", "--tags", "--always")
+	latestTag, err := g.gitCmdWithOutput(dir, "describe", "--tags", "--always")
 	if err != nil {
 		return "", fmt.Errorf("failed to find latest tag for project in %s : %s", dir, err)
 	}
 
-	previousTag, err := g.gitCmdWithOutput(dir, "describe", "--abbrev=0", "--tags", "--always", latestTag+"^")
+	previousTag, err := g.gitCmdWithOutput(dir, "describe", "--tags", "--always", latestTag+"^")
 	if err != nil {
 		return "", fmt.Errorf("failed to find previous tag for project in %s : %s", dir, err)
 	}
-	return previousTag, err
+
+	previousTagSha, err := g.gitCmdWithOutput(dir, "rev-list", "-n", "1", previousTag)
+	if err != nil {
+		return "", errors.Wrapf(err, "running for git rev-list -n 1 %s", previousTag)
+	}
+	return previousTagSha, nil
 }
 
 // GetRevisionBeforeDate returns the revision before the given date

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -970,9 +970,10 @@ func (p *GitHubProvider) UpdateRelease(owner string, repo string, tag string, re
 	if release.TagName == nil && releaseInfo.TagName != "" {
 		release.TagName = &releaseInfo.TagName
 	}
-	if release.Body == nil && releaseInfo.Body != "" {
+	if (release.Body == nil || *release.Body == "") && releaseInfo.Body != "" {
 		release.Body = &releaseInfo.Body
 	}
+
 	if r != nil && r.StatusCode == 404 {
 		log.Logger().Warnf("No release found for %s/%s and tag %s so creating a new release\n", owner, repo, tag)
 		_, _, err = p.Client.Repositories.CreateRelease(p.Context, owner, repo, release)


### PR DESCRIPTION
This should fix jx step changelog

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
