### PR TITLE
Defaulting workload type

### DIFF
--- a/pkg/jx/cmd/edit_buildpack.go
+++ b/pkg/jx/cmd/edit_buildpack.go
@@ -148,7 +148,7 @@ func (o *EditBuildPackOptions) Run() error {
 				}
 			} else {
 				label = defaultValue
-				log.Logger().Infof(("Defaulting workload build pack: %s", util.ColorPrompt(defaultValue))
+				log.Logger().Infof("Defaulting workload build pack: %s", util.ColorPrompt(defaultValue))
 			}
 			buildPack := m[label]
 			if buildPack == nil {

--- a/pkg/jx/cmd/edit_buildpack.go
+++ b/pkg/jx/cmd/edit_buildpack.go
@@ -140,9 +140,15 @@ func (o *EditBuildPackOptions) Run() error {
 					}
 				}
 			}
-			label, err := util.PickNameWithDefault(labels, "Pick default workload build pack: ", defaultValue, "Build packs are used to automate your CI/CD pipelines when you create or import projects", o.In, o.Out, o.Err)
-			if err != nil {
-				return err
+			var label string
+			if o.AdvancedMode {
+				label, err = util.PickNameWithDefault(labels, "Pick default workload build pack: ", defaultValue, "Build packs are used to automate your CI/CD pipelines when you create or import projects", o.In, o.Out, o.Err)
+				if err != nil {
+					return err
+				}
+			} else {
+				label = defaultValue
+				log.Logger().Infof(("Defaulting workload build pack: %s", util.ColorPrompt(defaultValue))
 			}
 			buildPack := m[label]
 			if buildPack == nil {


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Default work loads buildpack to `Kubernetes Workloads: Automated CI+CD with GitOps Promotion` when using `--advanced` mode