### PR TITLE
Restrict cluster name length

### DIFF
--- a/pkg/jx/cmd/create_cluster_gke.go
+++ b/pkg/jx/cmd/create_cluster_gke.go
@@ -61,6 +61,7 @@ const (
 	preemptibleFlagName    = "preemptible"
 	enhancedAPIFlagName    = "enhanced-apis"
 	enhancedScopesFlagName = "enhanced-scopes"
+	maxClusterNameLength   = 27
 )
 
 var (
@@ -195,6 +196,9 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 	clusterName := o.Flags.ClusterName
 	if clusterName == "" {
 		defaultClusterName := strings.ToLower(randomdata.SillyName())
+		if len(defaultClusterName) > maxClusterNameLength {
+			defaultClusterName = strings.ToLower(randomdata.SillyName())
+		}
 		if advancedMode {
 			prompt := &survey.Input{
 				Message: "What cluster name would you like to use",

--- a/pkg/jx/cmd/create_cluster_gke_test.go
+++ b/pkg/jx/cmd/create_cluster_gke_test.go
@@ -26,7 +26,7 @@ func Test_sanitizeLabel(t *testing.T) {
 }
 
 func Test_validateClusterName(t *testing.T) {
-	var bigLongName = string("this-name-is-too-long-to-be-used-by-2chars")
+	var bigLongName = string("this-name-is-too-long-by-one")
 	var capitalName = string("NameWithCapitalLetters")
 	var gibberishName = string("l337n@me")
 	var goodName = string("good-name-for-cluster")

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -3193,7 +3193,7 @@ func (options *InstallOptions) setValuesFileValue(fileName string, key string, v
 func validateClusterName(clustername string) error {
 	// Check for length greater than 27.
 	if len(clustername) > maxGKEClusterNameLength {
-		err := fmt.Errorf("cluster name %v is greater than the maximum %s characters", clustername, maxGKEClusterNameLength)
+		err := fmt.Errorf("cluster name %s is greater than the maximum %d characters", clustername, maxGKEClusterNameLength)
 		return err
 	}
 	// Now we need only make sure that clustername is limited to

--- a/pkg/jx/cmd/install.go
+++ b/pkg/jx/cmd/install.go
@@ -3191,9 +3191,9 @@ func (options *InstallOptions) setValuesFileValue(fileName string, key string, v
 // validateClusterName checks for compliance of a user supplied
 // cluster name against GKE's rules for these names.
 func validateClusterName(clustername string) error {
-	// Check for length greater than 40.
-	if len(clustername) > 40 {
-		err := fmt.Errorf("cluster name %v is greater than the maximum 40 characters", clustername)
+	// Check for length greater than 27.
+	if len(clustername) > maxGKEClusterNameLength {
+		err := fmt.Errorf("cluster name %v is greater than the maximum %s characters", clustername, maxGKEClusterNameLength)
 		return err
 	}
 	// Now we need only make sure that clustername is limited to


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Restrict gke cluster name length to 27 as it is used as a prefix to service account names e.g. `${cluster_name}-ko` which are limited to 30 chars

#4210