### PR TITLE
Template for naming service accounts

### DIFF
--- a/pkg/cloud/gke/externaldns/external_dns.go
+++ b/pkg/cloud/gke/externaldns/external_dns.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	serviceAccountSecretKey = "credentials.json"
-	DefaultExternalDNSAbbreviation = "dn"
+	serviceAccountSecretKey        = "credentials.json"
+	defaultExternalDNSAbbreviation = "dn"
 )
 
 var (
@@ -21,7 +21,7 @@ var (
 // CreateExternalDNSGCPServiceAccount creates a service account in GCP for ExternalDNS
 func CreateExternalDNSGCPServiceAccount(kubeClient kubernetes.Interface, externalDNSName, namespace, clusterName, projectID string) (string, error) {
 
-	gcpServiceAccountSecretName, err := gke.CreateGCPServiceAccount(kubeClient, externalDNSName, DefaultExternalDNSAbbreviation, namespace, clusterName, projectID, serviceAccountRoles, serviceAccountSecretKey)
+	gcpServiceAccountSecretName, err := gke.CreateGCPServiceAccount(kubeClient, externalDNSName, defaultExternalDNSAbbreviation, namespace, clusterName, projectID, serviceAccountRoles, serviceAccountSecretKey)
 	if err != nil {
 		return "", errors.Wrap(err, "creating the ExternalDNS GCP Service Account")
 	}

--- a/pkg/cloud/gke/externaldns/external_dns.go
+++ b/pkg/cloud/gke/externaldns/external_dns.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	serviceAccountSecretKey = "credentials.json"
+	DefaultExternalDNSAbbreviation = "dn"
 )
 
 var (
@@ -20,9 +21,9 @@ var (
 // CreateExternalDNSGCPServiceAccount creates a service account in GCP for ExternalDNS
 func CreateExternalDNSGCPServiceAccount(kubeClient kubernetes.Interface, externalDNSName, namespace, clusterName, projectID string) (string, error) {
 
-	gcpServiceAccountSecretName, error := gke.CreateGCPServiceAccount(kubeClient, externalDNSName, namespace, clusterName, projectID, serviceAccountRoles, serviceAccountSecretKey)
-	if error != nil {
-		return "", errors.Wrap(error, "creating the ExternalDNS GCP Service Account")
+	gcpServiceAccountSecretName, err := gke.CreateGCPServiceAccount(kubeClient, externalDNSName, DefaultExternalDNSAbbreviation, namespace, clusterName, projectID, serviceAccountRoles, serviceAccountSecretKey)
+	if err != nil {
+		return "", errors.Wrap(err, "creating the ExternalDNS GCP Service Account")
 	}
 	return gcpServiceAccountSecretName, nil
 }

--- a/pkg/cloud/gke/helper.go
+++ b/pkg/cloud/gke/helper.go
@@ -148,17 +148,15 @@ func GetGoogleMachineTypes() []string {
 }
 
 // CreateGCPServiceAccount creates a service account in GCP for a service using the account roles specified
-func CreateGCPServiceAccount(kubeClient kubernetes.Interface, serviceName, namespace, clusterName, projectID string, serviceAccountRoles []string, serviceAccountSecretKey string) (string, error) {
+func CreateGCPServiceAccount(kubeClient kubernetes.Interface, serviceName, serviceAbbreviation, namespace, clusterName, projectID string, serviceAccountRoles []string, serviceAccountSecretKey string) (string, error) {
 	serviceAccountDir, err := ioutil.TempDir("", "gke")
 	if err != nil {
 		return "", errors.Wrap(err, "creating a temporary folder where the service account will be stored")
 	}
 	defer os.RemoveAll(serviceAccountDir)
 
-	serviceAccountName := ServiceAccountName(serviceName)
-	if err != nil {
-		return "", err
-	}
+	serviceAccountName := ServiceAccountName(clusterName, serviceAbbreviation)
+
 	serviceAccountPath, err := GetOrCreateServiceAccount(serviceAccountName, projectID, serviceAccountDir, serviceAccountRoles)
 	if err != nil {
 		return "", errors.Wrap(err, "creating the service account")

--- a/pkg/cloud/gke/naming.go
+++ b/pkg/cloud/gke/naming.go
@@ -8,8 +8,8 @@ func BucketName(serviceName string) string {
 }
 
 // ServiceAccountName creates a service account name for a given service and cluster name
-func ServiceAccountName(serviceName string) string {
-	return generateName(serviceName, "sa")
+func ServiceAccountName(clusterName, serviceAbbreviation string) string {
+	return generateName(clusterName, serviceAbbreviation)
 }
 
 // KeyringName creates a keyring name for a given service and cluster name

--- a/pkg/cloud/gke/vault/vault_backend.go
+++ b/pkg/cloud/gke/vault/vault_backend.go
@@ -16,7 +16,7 @@ import (
 const (
 	gkeServiceAccountSecretKey = "service-account.json"
 	//DefaultVaultAbbreviation is vault service accounts suffix
-	DefaultVaultAbbreviation   = "vt"
+	DefaultVaultAbbreviation = "vt"
 )
 
 var (

--- a/pkg/cloud/gke/vault/vault_backend.go
+++ b/pkg/cloud/gke/vault/vault_backend.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	gkeServiceAccountSecretKey = "service-account.json"
+	//vault service account suffix
 	DefaultVaultAbbreviation   = "vt"
 )
 

--- a/pkg/cloud/gke/vault/vault_backend.go
+++ b/pkg/cloud/gke/vault/vault_backend.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	gkeServiceAccountSecretKey = "service-account.json"
-	//vault service account suffix
+	//DefaultVaultAbbreviation is vault service accounts suffix
 	DefaultVaultAbbreviation   = "vt"
 )
 

--- a/pkg/cloud/gke/vault/vault_backend.go
+++ b/pkg/cloud/gke/vault/vault_backend.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	gkeServiceAccountSecretKey = "service-account.json"
+	DefaultVaultAbbreviation   = "vt"
 )
 
 var (
@@ -59,7 +60,7 @@ func CreateKmsConfig(vaultName, clusterName, projectId string) (*KmsConfig, erro
 // CreateGCPServiceAccount creates a service account in GCP for the vault service
 func CreateVaultGCPServiceAccount(kubeClient kubernetes.Interface, vaultName, namespace, clusterName, projectID string) (string, error) {
 
-	gcpServiceAccountSecretName, error := gke.CreateGCPServiceAccount(kubeClient, vaultName, namespace, clusterName, projectID, ServiceAccountRoles, gkeServiceAccountSecretKey)
+	gcpServiceAccountSecretName, error := gke.CreateGCPServiceAccount(kubeClient, vaultName, DefaultVaultAbbreviation, namespace, clusterName, projectID, ServiceAccountRoles, gkeServiceAccountSecretKey)
 
 	if error != nil {
 		return "", errors.Wrap(error, "creating the Vault GCP Service Account")

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -2168,9 +2168,9 @@ func (options *InstallOptions) configureKaniko() error {
 			}
 		}
 
-		serviceAccountName := kube.ToValidNameTruncated(fmt.Sprintf("jxkaniko-%s", clusterName), 30)
-
+		serviceAccountName := kube.ToValidNameTruncated(fmt.Sprintf("%s-ko", clusterName), 30)
 		log.Logger().Infof("Configuring Kaniko service account %s for project %s", util.ColorInfo(serviceAccountName), util.ColorInfo(projectID))
+
 		serviceAccountPath, err := gke.GetOrCreateServiceAccount(serviceAccountName, projectID, serviceAccountDir, gke.KanikoServiceAccountRoles)
 		if err != nil {
 			return errors.Wrap(err, "creating the service account")

--- a/pkg/cmd/deletecmd/delete_vault.go
+++ b/pkg/cmd/deletecmd/delete_vault.go
@@ -174,7 +174,7 @@ func (o *DeleteVaultOptions) removeGCPResources(vaultName string) error {
 		o.GKEZone = zone
 	}
 
-	sa := gke.ServiceAccountName(vaultName)
+	sa := gke.ServiceAccountName(vaultName, gkevault.DefaultVaultAbbreviation)
 	err = gke.DeleteServiceAccount(sa, o.GKEProjectID, gkevault.ServiceAccountRoles)
 	if err != nil {
 		return errors.Wrapf(err, "deleting the GCP service account '%s'", sa)


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Follow the template for `${cluster_name}-ko`generated service accounts names. Ensuring cluster name doesn't exceed the limited 30 characters. Done for kaniko, external dns and vault service accounts.


#4210