### PR TITLE
WIP: Remove platform update from updatebot config

### DIFF
--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -4,7 +4,6 @@ github:
     repositories:
     - name: homebrew-jx
     - name: jx-docs
-    - name: jenkins-x-platform
     - name: jenkins-x-builders
     - name: jenkins-x-serverless
     - name: jx-tutorial


### PR DESCRIPTION
Signed-off-by: Cai Cooper <caicooper82@gmail.com>

Since we update jenkins-x-platform jx versions via jenkins-x-builders and update jenkins-x-builders jx versions via jx, it seems counter-intuitive to update jenkins-x-platform jx versions straight from jx.