### PR TITLE
fix: defaulting LTS to false if provide not GKE as not supported by other providers

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -2352,8 +2352,13 @@ func (options *InstallOptions) configureLongTermStorageBucket() error {
 				return errors.Wrap(err, "asking to enable Long Term Storage")
 			}
 		} else {
-			options.Flags.LongTermStorage = true
-			log.Logger().Infof(util.QuestionAnswer("Default enabling long term logs storage", util.YesNo(options.Flags.LongTermStorage)))
+			if options.Flags.Provider == cloud.GKE {
+				options.Flags.LongTermStorage = true
+				log.Logger().Infof(util.QuestionAnswer("Default enabling long term logs storage", util.YesNo(options.Flags.LongTermStorage)))
+			} else {
+				options.Flags.LongTermStorage = false
+				log.Logger().Debugf("Long Term Storage not supported by this provider, disabling this option")
+			}
 		}
 	}
 


### PR DESCRIPTION


#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
When running in non-batch mode without the --advanced-mode flag LTS is set to true which then later creates an error if the provider is not GKE. This change defaults LTS to false if provider is not GKE.

If change is good - I'll write tests to cover since current tests run only in batch mode and I'll need to figure that out. 


