### PR TITLE
fix: removed the hack to set the verbose flag

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -502,9 +502,6 @@ func (options *InstallOptions) Run() error {
 
 	configStore := configio.NewFileStore()
 
-	// Default to verbose mode to get more information during the install
-	options.Verbose = true
-
 	ns, originalNs, err := options.setupNamespace()
 	if err != nil {
 		return errors.Wrap(err, "setting up current namespace")


### PR DESCRIPTION
setting this flag in this way will no longer make any difference to the output
displayed when installing JX.