### PR TITLE
fix: lets let `jx step create values` work with vault + local files

### DIFF
--- a/pkg/apps/install.go
+++ b/pkg/apps/install.go
@@ -55,7 +55,6 @@ type InstallOptions struct {
 	Err             io.Writer
 	GitOps          bool
 	TeamName        string
-	BasePath        string
 	VaultClient     vault.Client
 	AutoMerge       bool
 	SecretsScheme   string
@@ -574,7 +573,7 @@ func (o *InstallOptions) createInterrogateChartFn(version string, chartName stri
 				gitOpsURL = o.DevEnv.Spec.Source.URL
 			}
 			if schema != nil {
-				valuesFileName, cleanup, err := ProcessValues(schema, chartName, gitOpsURL, o.TeamName, o.BasePath, o.BatchMode, askExisting, o.VaultClient, existing, o.SecretsScheme, o.In, o.Out, o.Err, o.Verbose)
+				valuesFileName, cleanup, err := ProcessValues(schema, chartName, gitOpsURL, o.TeamName, o.BatchMode, askExisting, o.VaultClient, existing, o.SecretsScheme, o.In, o.Out, o.Err, o.Verbose)
 				chartDetails.Cleanup = cleanup
 				if err != nil {
 					return &chartDetails, errors.WithStack(err)

--- a/pkg/apps/install.go
+++ b/pkg/apps/install.go
@@ -55,6 +55,7 @@ type InstallOptions struct {
 	Err             io.Writer
 	GitOps          bool
 	TeamName        string
+	BasePath        string
 	VaultClient     vault.Client
 	AutoMerge       bool
 	SecretsScheme   string
@@ -573,7 +574,7 @@ func (o *InstallOptions) createInterrogateChartFn(version string, chartName stri
 				gitOpsURL = o.DevEnv.Spec.Source.URL
 			}
 			if schema != nil {
-				valuesFileName, cleanup, err := ProcessValues(schema, chartName, gitOpsURL, o.TeamName, o.BatchMode, askExisting, o.VaultClient, existing, o.SecretsScheme, o.In, o.Out, o.Err, o.Verbose)
+				valuesFileName, cleanup, err := ProcessValues(schema, chartName, gitOpsURL, o.TeamName, o.BasePath, o.BatchMode, askExisting, o.VaultClient, existing, o.SecretsScheme, o.In, o.Out, o.Err, o.Verbose)
 				chartDetails.Cleanup = cleanup
 				if err != nil {
 					return &chartDetails, errors.WithStack(err)

--- a/pkg/apps/values.go
+++ b/pkg/apps/values.go
@@ -156,6 +156,7 @@ func ProcessValues(
 	name string,
 	gitOpsURL string,
 	teamName string,
+	basepath string,
 	batchMode bool,
 	askExisting bool,
 	secretURLClient secreturl.Client,
@@ -166,16 +167,17 @@ func ProcessValues(
 	outErr io.Writer,
 	verbose bool) (string, func(), error) {
 	var values []byte
-	var basepath string
 	var err error
-	if gitOpsURL != "" {
-		gitInfo, err := gits.ParseGitURL(gitOpsURL)
-		if err != nil {
-			return "", func() {}, err
+	if basepath == "" {
+		if gitOpsURL != "" {
+			gitInfo, err := gits.ParseGitURL(gitOpsURL)
+			if err != nil {
+				return "", func() {}, err
+			}
+			basepath = strings.Join([]string{"gitOps", gitInfo.Organisation, gitInfo.Name}, "/")
+		} else {
+			basepath = strings.Join([]string{"teams", teamName}, "/")
 		}
-		basepath = strings.Join([]string{"gitOps", gitInfo.Organisation, gitInfo.Name}, "/")
-	} else {
-		basepath = strings.Join([]string{"teams", teamName}, "/")
 	}
 	values, err = GenerateQuestions(schema, batchMode, askExisting, basepath, secretURLClient, existing, vaultScheme, in, out, outErr)
 	if err != nil {

--- a/pkg/apps/values.go
+++ b/pkg/apps/values.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/secreturl"
 
 	"io"
 	"io/ioutil"
@@ -17,10 +18,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 
-	"github.com/jenkins-x/jx/pkg/surveyutils"
-	"github.com/jenkins-x/jx/pkg/vault"
-
 	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/surveyutils"
 
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
@@ -108,10 +107,10 @@ func AddValuesToChart(name string, values []byte, verbose bool) (string, func(),
 }
 
 //GenerateQuestions asks questions based on the schema
-func GenerateQuestions(schema []byte, batchMode bool, askExisting bool, basePath string, vaultClient vault.Client,
+func GenerateQuestions(schema []byte, batchMode bool, askExisting bool, basePath string, secretURLClient secreturl.Client,
 	existing map[string]interface{}, vaultScheme string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) ([]byte, error) {
 	schemaOptions := surveyutils.JSONSchemaOptions{
-		VaultClient:         vaultClient,
+		VaultClient:         secretURLClient,
 		VaultScheme:         vaultScheme,
 		VaultBasePath:       basePath,
 		Out:                 out,
@@ -159,7 +158,7 @@ func ProcessValues(
 	teamName string,
 	batchMode bool,
 	askExisting bool,
-	vaultClient vault.Client,
+	secretURLClient secreturl.Client,
 	existing map[string]interface{},
 	vaultScheme string,
 	in terminal.FileReader,
@@ -178,7 +177,7 @@ func ProcessValues(
 	} else {
 		basepath = strings.Join([]string{"teams", teamName}, "/")
 	}
-	values, err = GenerateQuestions(schema, batchMode, askExisting, basepath, vaultClient, existing, vaultScheme, in, out, outErr)
+	values, err = GenerateQuestions(schema, batchMode, askExisting, basepath, secretURLClient, existing, vaultScheme, in, out, outErr)
 	if err != nil {
 		return "", func() {}, errors.Wrapf(err, "asking questions for schema")
 	}

--- a/pkg/cmd/add/add_app_test.go
+++ b/pkg/cmd/add/add_app_test.go
@@ -656,13 +656,13 @@ func TestAddAppForGitOpsWithSecrets(t *testing.T) {
 		assert.NoError(r, err)
 		data, err := ioutil.ReadFile(valuesFromPrPath)
 		assert.NoError(r, err)
-		assert.Equal(r, fmt.Sprintf(`tokenValue: vault:gitOps/%s/%s/tokenValue:token
+		assert.Equal(r, fmt.Sprintf(`tokenValue: vault:gitOps/%s/%s:tokenValue
 `, testOptions.DevEnvRepo.Owner, testOptions.DevEnvRepo.GitRepo.Name), string(data))
 		// Validate that vault has had the secret added
-		path := strings.Join([]string{"gitOps", testOptions.OrgName, testOptions.DevEnvRepoInfo.Name, "tokenValue"},
+		path := strings.Join([]string{"gitOps", testOptions.OrgName, testOptions.DevEnvRepoInfo.Name},
 			"/")
 		value := map[string]interface{}{
-			"token": "abc",
+			"tokenValue": "abc",
 		}
 		testOptions.MockVaultClient.VerifyWasCalledOnce().Write(path, value)
 	})
@@ -1286,7 +1286,7 @@ func TestAddAppIncludingConditionalQuestionsForGitOps(t *testing.T) {
 		data, err := ioutil.ReadFile(valuesFromPrPath)
 		assert.NoError(r, err)
 		assert.Equal(r, fmt.Sprintf(`databaseConnectionUrl: abc
-databasePassword: vault:gitOps/%s/%s/databasePassword:password
+databasePassword: vault:gitOps/%s/%s:databasePassword
 databaseUsername: wensleydale
 enablePersistentStorage: true
 `, testOptions.DevEnvRepo.Owner, testOptions.DevEnvRepo.GitRepo.Name), string(data))
@@ -1295,7 +1295,7 @@ enablePersistentStorage: true
 		path := strings.Join([]string{"gitOps", testOptions.OrgName, testOptions.DevEnvRepoInfo.Name},
 			"/")
 		value := map[string]interface{}{
-			"password": "cranberries",
+			"databasePassword": "cranberries",
 		}
 		testOptions.MockVaultClient.VerifyWasCalledOnce().Write(path, value)
 	})

--- a/pkg/cmd/add/add_app_test.go
+++ b/pkg/cmd/add/add_app_test.go
@@ -1292,7 +1292,7 @@ enablePersistentStorage: true
 `, testOptions.DevEnvRepo.Owner, testOptions.DevEnvRepo.GitRepo.Name), string(data))
 
 		// Validate that vault has had the secret added
-		path := strings.Join([]string{"gitOps", testOptions.OrgName, testOptions.DevEnvRepoInfo.Name, "databasePassword"},
+		path := strings.Join([]string{"gitOps", testOptions.OrgName, testOptions.DevEnvRepoInfo.Name},
 			"/")
 		value := map[string]interface{}{
 			"password": "cranberries",

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jenkins-x/jx/pkg/kube/cluster"
 	"github.com/jenkins-x/jx/pkg/secreturl"
 	"github.com/jenkins-x/jx/pkg/secreturl/localvault"
 	"github.com/pborman/uuid"
@@ -422,15 +421,7 @@ func (o *CommonOptions) GetSecretURLClient() (secreturl.Client, error) {
 	if vaultClient != nil {
 		return vaultClient, nil
 	}
-	clusterName, err := cluster.Name(o.Kube())
-	if err != nil || clusterName == "" {
-		// we could be bootstrapping the cluster
-		clusterName = os.Getenv("JX_CLUSTER_NAME")
-		if clusterName == "" {
-			clusterName = "default-cluster"
-		}
-	}
-	dir, err := util.LocalFileSystemSecretsDir(clusterName)
+	dir, err := util.LocalFileSystemSecretsDir()
 	return localvault.NewFileSystemClient(dir), nil
 }
 

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -37,8 +37,8 @@ import (
 
 const (
 	kanikoSecretMount = "/kaniko-secret/secret.json"
-	kanikoSecretName  = "kaniko-secret"
-	kanikoSecretKey   = "kaniko-secret"
+	kanikoSecretName  = kube.SecretKaniko
+	kanikoSecretKey   = kube.SecretKaniko
 )
 
 var (

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -2,12 +2,13 @@ package create
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/cmd/step/git"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/cmd/step/git"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/prow"
@@ -732,11 +733,20 @@ func (o *StepCreateTaskOptions) modifyEnvVars(container *corev1.Container, globa
 			})
 		}
 	}
-	if kube.GetSliceEnvVar(envVars, "JX_BATCH_MODE") == nil {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  "JX_BATCH_MODE",
-			Value: "true",
-		})
+	if o.InterpretMode {
+		if kube.GetSliceEnvVar(envVars, "JX_INTERPRET_PIPELINE") == nil {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "JX_INTERPRET_PIPELINE",
+				Value: "true",
+			})
+		}
+	} else {
+		if kube.GetSliceEnvVar(envVars, "JX_BATCH_MODE") == nil {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "JX_BATCH_MODE",
+				Value: "true",
+			})
+		}
 	}
 
 	for _, param := range o.pipelineParams {
@@ -1248,6 +1258,7 @@ func (o *StepCreateTaskOptions) interpretStep(ns string, task *pipelineapi.Task,
 		Dir:  dir,
 		Out:  os.Stdout,
 		Err:  os.Stdout,
+		In:   os.Stdin,
 		Env:  envMap,
 	}
 	_, err := cmd.RunWithoutRetry()

--- a/pkg/cmd/step/create/step_create_values.go
+++ b/pkg/cmd/step/create/step_create_values.go
@@ -140,7 +140,7 @@ func (o *StepCreateValuesOptions) CreateValuesFile() error {
 		return err
 	}
 	existing := make(map[string]interface{})
-	valuesFileName, cleanup, err := apps.ProcessValues(schema, o.Name, gitOpsURL, teamName, o.BatchMode, false, secretURLClient, existing, o.SecretsScheme, o.In, o.Out, o.Err, o.Verbose)
+	valuesFileName, cleanup, err := apps.ProcessValues(schema, o.Name, gitOpsURL, teamName, o.BasePath, o.BatchMode, false, secretURLClient, existing, o.SecretsScheme, o.In, o.Out, o.Err, o.Verbose)
 	defer cleanup()
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/cmd/step/create/step_create_values.go
+++ b/pkg/cmd/step/create/step_create_values.go
@@ -140,7 +140,7 @@ func (o *StepCreateValuesOptions) CreateValuesFile() error {
 		return err
 	}
 	existing := make(map[string]interface{})
-	valuesFileName, cleanup, err := apps.ProcessValues(schema, o.Name, gitOpsURL, teamName, o.BasePath, o.BatchMode, false, secretURLClient, existing, o.SecretsScheme, o.In, o.Out, o.Err, o.Verbose)
+	valuesFileName, cleanup, err := apps.ProcessValues(schema, o.Name, gitOpsURL, teamName, o.BatchMode, false, secretURLClient, existing, o.SecretsScheme, o.In, o.Out, o.Err, o.Verbose)
 	defer cleanup()
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/cmd/step/create/test_data/step_create_values/install/values.schema.json
+++ b/pkg/cmd/step/create/test_data/step_create_values/install/values.schema.json
@@ -142,7 +142,7 @@
                     "title": "Pipeline User username",
                     "description": "The Pipeline User is the user used to perform git operations inside a pipeline. This is normally a bot."
                   },
-                  "password": {
+                  "token": {
                     "type": "string",
                     "format": "token",
                     "title": "Pipeline User password",

--- a/pkg/cmd/step/create/test_data/step_create_values/install/values.yaml.golden
+++ b/pkg/cmd/step/create/test_data/step_create_values/install/values.yaml.golden
@@ -14,4 +14,4 @@ pipelineUser:
     token: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/pipelineUser-github:token
     username: james
 prow:
-  hmacToken: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/prow-hmacToken:token
+  hmacToken: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/prow-hmacToken

--- a/pkg/cmd/step/create/test_data/step_create_values/install/values.yaml.golden
+++ b/pkg/cmd/step/create/test_data/step_create_values/install/values.yaml.golden
@@ -11,7 +11,7 @@ gitProvider: github
 pipelineUser:
   github:
     host: github.com
-    password: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/pipelineUser-github:token
+    token: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/pipelineUser-github:token
     username: james
 prow:
   hmacToken: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/prow-hmacToken:token

--- a/pkg/cmd/step/create/test_data/step_create_values/install/values.yaml.golden
+++ b/pkg/cmd/step/create/test_data/step_create_values/install/values.yaml.golden
@@ -14,4 +14,4 @@ pipelineUser:
     token: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/pipelineUser-github:token
     username: james
 prow:
-  hmacToken: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/prow-hmacToken
+  hmacToken: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/prow:hmacToken

--- a/pkg/cmd/step/create/test_data/step_create_values/install/values.yaml.golden
+++ b/pkg/cmd/step/create/test_data/step_create_values/install/values.yaml.golden
@@ -1,8 +1,8 @@
 adminUser:
-  password: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/adminUser-password:password
+  password: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/adminUser:password
   username: admin
 docker:
-  password: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/docker-password:password
+  password: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/docker:password
   url: https://index.docker.io/v1/
   username: james
 enableDocker: true
@@ -11,7 +11,7 @@ gitProvider: github
 pipelineUser:
   github:
     host: github.com
-    password: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/pipelineUser-github-password:token
+    password: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/pipelineUser-github:token
     username: james
 prow:
   hmacToken: vault:gitOps/{{ .org }}/environment-{{ .org }}-{{ .repo }}-dev/prow-hmacToken:token

--- a/pkg/kube/constants.go
+++ b/pkg/kube/constants.go
@@ -74,6 +74,9 @@ const (
 	DefaultExternalDNSReleaseName = "external-dns"
 	DefaultExternalDNSTag         = "1.5.2"
 
+	// SecretKaniko the name of the secret containing the kaniko service account
+	SecretKaniko = "kaniko-secret"
+
 	// ServiceJenkins is the name of the Jenkins Service
 	ServiceJenkins = "jenkins"
 

--- a/pkg/secreturl/client.go
+++ b/pkg/secreturl/client.go
@@ -11,6 +11,9 @@ type Client interface {
 	// The secret _must_ be serializable to JSON.
 	ReadObject(secretName string, secret interface{}) error
 
+	// Write writes a named secret to the vault
+	Write(secretName string, data map[string]interface{}) (map[string]interface{}, error)
+
 	// WriteObject writes a generic named object to the vault.
 	// The secret _must_ be serializable to JSON.
 	WriteObject(secretName string, secret interface{}) (map[string]interface{}, error)

--- a/pkg/secreturl/mocks/secreturl_client.go
+++ b/pkg/secreturl/mocks/secreturl_client.go
@@ -77,6 +77,25 @@ func (mock *MockClient) ReplaceURIs(_param0 string) (string, error) {
 	return ret0, ret1
 }
 
+func (mock *MockClient) Write(_param0 string, _param1 map[string]interface{}) (map[string]interface{}, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockClient().")
+	}
+	params := []pegomock.Param{_param0, _param1}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("Write", params, []reflect.Type{reflect.TypeOf((*map[string]interface{})(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 map[string]interface{}
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(map[string]interface{})
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockClient) WriteObject(_param0 string, _param1 interface{}) (map[string]interface{}, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockClient().")
@@ -213,6 +232,37 @@ func (c *MockClient_ReplaceURIs_OngoingVerification) GetAllCapturedArguments() (
 		_param0 = make([]string, len(params[0]))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockClient) Write(_param0 string, _param1 map[string]interface{}) *MockClient_Write_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Write", params, verifier.timeout)
+	return &MockClient_Write_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockClient_Write_OngoingVerification struct {
+	mock              *MockClient
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockClient_Write_OngoingVerification) GetCapturedArguments() (string, map[string]interface{}) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+}
+
+func (c *MockClient_Write_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []map[string]interface{}) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(params[0]))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]map[string]interface{}, len(params[1]))
+		for u, param := range params[1] {
+			_param1[u] = param.(map[string]interface{})
 		}
 	}
 	return

--- a/pkg/surveyutils/jsonschema.go
+++ b/pkg/surveyutils/jsonschema.go
@@ -771,7 +771,9 @@ func (o *JSONSchemaOptions) handleBasicProperty(name string, prefixes []string, 
 		}
 		if o.VaultClient != nil {
 			dereferencedFormat := util.DereferenceString(t.Format)
-			path := strings.Join([]string{o.VaultBasePath, strings.Join(prefixes, "-")}, "/")
+			// lets ignore the last prefix as we use it as a key in the data value
+			pathPrefixes := prefixes[0 : len(prefixes)-1]
+			path := strings.Join([]string{o.VaultBasePath, strings.Join(pathPrefixes, "-")}, "/")
 			secretReference := secreturl.ToURI(path, dereferencedFormat, o.VaultScheme)
 			output.Set(name, secretReference)
 			o.VaultClient.Write(path, map[string]interface{}{

--- a/pkg/surveyutils/jsonschema.go
+++ b/pkg/surveyutils/jsonschema.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/iancoleman/orderedmap"
 
-	survey "gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1"
 
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )

--- a/pkg/surveyutils/jsonschema.go
+++ b/pkg/surveyutils/jsonschema.go
@@ -159,7 +159,7 @@ func (t *Items) UnmarshalJSON(b []byte) error {
 
 // JSONSchemaOptions are options for generating values from a schema
 type JSONSchemaOptions struct {
-	VaultClient         vault.Client
+	VaultClient         secreturl.Client
 	VaultBasePath       string
 	VaultScheme         string
 	AskExisting         bool

--- a/pkg/surveyutils/jsonschema.go
+++ b/pkg/surveyutils/jsonschema.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/jenkins-x/jx/pkg/vault"
-
 	"github.com/jenkins-x/jx/pkg/util"
 
 	"github.com/iancoleman/orderedmap"

--- a/pkg/surveyutils/jsonschema_test.go
+++ b/pkg/surveyutils/jsonschema_test.go
@@ -764,12 +764,11 @@ func TestPassword(t *testing.T) {
 				console.SendLine("abc")
 				console.ExpectEOF()
 			})
-		path := strings.Join([]string{vaultBasePath, "passwordValue"}, "/")
-		assert.Equal(r, fmt.Sprintf(`passwordValue: vault:%s:password
-`, path), values)
-		secrets, err := vaultClient.Read(path)
+		assert.Equal(r, fmt.Sprintf(`passwordValue: vault:%s:passwordValue
+`, vaultBasePath), values)
+		secrets, err := vaultClient.Read(vaultBasePath)
 		assert.NoError(t, err)
-		assert.Equal(r, "abc", secrets["password"])
+		assert.Equal(r, "abc", secrets["passwordValue"])
 		assert.NoError(r, err)
 	})
 }
@@ -787,12 +786,11 @@ func TestToken(t *testing.T) {
 				console.SendLine("abc")
 				console.ExpectEOF()
 			})
-		path := strings.Join([]string{vaultBasePath, "tokenValue"}, "/")
-		assert.Equal(r, fmt.Sprintf(`tokenValue: vault:%s:token
-`, path), values)
-		secrets, err := vaultClient.Read(path)
+		assert.Equal(r, fmt.Sprintf(`tokenValue: vault:%s:tokenValue
+`, vaultBasePath), values)
+		secrets, err := vaultClient.Read(vaultBasePath)
 		assert.NoError(t, err)
-		assert.Equal(r, "abc", secrets["token"])
+		assert.Equal(r, "abc", secrets["tokenValue"])
 		assert.NoError(r, err)
 	})
 }
@@ -810,13 +808,12 @@ func TestGeneratedToken(t *testing.T) {
 				console.SendLine("")
 				console.ExpectEOF()
 			})
-		path := strings.Join([]string{vaultBasePath, "tokenValue"}, "/")
-		assert.Equal(r, fmt.Sprintf(`tokenValue: vault:%s:token
-`, path), values)
+		assert.Equal(r, fmt.Sprintf(`tokenValue: vault:%s:tokenValue
+`, vaultBasePath), values)
 
-		secrets, err := vaultClient.Read(path)
+		secrets, err := vaultClient.Read(vaultBasePath)
 		assert.NoError(t, err)
-		assert.Len(t, secrets["token"], 20)
+		assert.Len(t, secrets["tokenValue"], 20)
 		assert.NoError(r, err)
 	})
 }

--- a/pkg/surveyutils/jsonschema_test.go
+++ b/pkg/surveyutils/jsonschema_test.go
@@ -606,7 +606,7 @@ func TestAllOf(t *testing.T) {
 		assert.NoError(r, err)
 		assert.Equal(r, fmt.Sprintf(`cheeseType: Stilton
 databaseConnectionUrl: abc
-databasePassword: vault:%s:password
+databasePassword: vault:%s:databasePassword
 databaseUsername: wensleydale
 enableCheese: true
 enablePersistentStorage: true

--- a/pkg/surveyutils/jsonschema_test.go
+++ b/pkg/surveyutils/jsonschema_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +13,7 @@ import (
 
 	"gopkg.in/AlecAivazis/survey.v1/core"
 
-	expect "github.com/Netflix/go-expect"
+	"github.com/Netflix/go-expect"
 	"github.com/ghodss/yaml"
 
 	"github.com/jenkins-x/jx/pkg/tests"

--- a/pkg/surveyutils/jsonschema_test.go
+++ b/pkg/surveyutils/jsonschema_test.go
@@ -516,12 +516,11 @@ func TestIfThen(t *testing.T) {
 				console.ExpectEOF()
 			})
 		assert.NoError(r, err)
-		path := strings.Join([]string{vaultBasePath, "databasePassword"}, "/")
 		assert.Equal(r, fmt.Sprintf(`databaseConnectionUrl: abc
-databasePassword: vault:%s:password
+databasePassword: vault:%s:databasePassword
 databaseUsername: wensleydale
 enablePersistentStorage: true
-`, path), values)
+`, vaultBasePath), values)
 	})
 }
 
@@ -639,14 +638,13 @@ func TestAllOfThen(t *testing.T) {
 				console.ExpectEOF()
 			})
 		assert.NoError(r, err)
-		path := strings.Join([]string{vaultBasePath, "databasePassword"}, "/")
 		assert.Equal(r, fmt.Sprintf(`databaseConnectionUrl: abc
-databasePassword: vault:%s:password
+databasePassword: vault:%s:databasePassword
 databaseUsername: wensleydale
 enableCheese: false
 enablePersistentStorage: true
 iDontLikeCheese: true
-`, path), values)
+`, vaultBasePath), values)
 	})
 }
 

--- a/pkg/surveyutils/jsonschema_test.go
+++ b/pkg/surveyutils/jsonschema_test.go
@@ -605,14 +605,13 @@ func TestAllOf(t *testing.T) {
 				console.ExpectEOF()
 			})
 		assert.NoError(r, err)
-		path := strings.Join([]string{vaultBasePath, "databasePassword"}, "/")
 		assert.Equal(r, fmt.Sprintf(`cheeseType: Stilton
 databaseConnectionUrl: abc
 databasePassword: vault:%s:password
 databaseUsername: wensleydale
 enableCheese: true
 enablePersistentStorage: true
-`, path), values)
+`, vaultBasePath), values)
 	})
 }
 

--- a/pkg/util/dirs.go
+++ b/pkg/util/dirs.go
@@ -46,12 +46,12 @@ func ConfigDir() (string, error) {
 }
 
 // LocalFileSystemSecretsDir returns the default local file system secrets location for the file system alternative to vault
-func LocalFileSystemSecretsDir(clusterName string) (string, error) {
+func LocalFileSystemSecretsDir() (string, error) {
 	home, err := ConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, "localSecrets", clusterName), nil
+	return filepath.Join(home, "localSecrets"), nil
 }
 
 // KubeConfigFile gets the .kube/config file

--- a/pkg/vault/fake/client.go
+++ b/pkg/vault/fake/client.go
@@ -32,6 +32,7 @@ func NewFakeVaultClient() FakeVaultClient {
 
 // Write a secret to vault
 func (f *FakeVaultClient) Write(secretName string, data map[string]interface{}) (map[string]interface{}, error) {
+	fmt.Printf("======= storing key at %s data: %#v\n", secretName, data)
 	f.Data[secretName] = data
 	return data, nil
 }
@@ -68,7 +69,7 @@ func (f *FakeVaultClient) List(path string) ([]string, error) {
 // Read a secret from vault
 func (f *FakeVaultClient) Read(secretName string) (map[string]interface{}, error) {
 	if answer, ok := f.Data[secretName]; !ok {
-		return nil, errors.Errorf("secret does not exist")
+		return nil, errors.Errorf("secret does not exist at key %s", secretName)
 	} else {
 		return answer, nil
 	}

--- a/pkg/vault/fake/client.go
+++ b/pkg/vault/fake/client.go
@@ -32,7 +32,7 @@ func NewFakeVaultClient() FakeVaultClient {
 
 // Write a secret to vault
 func (f *FakeVaultClient) Write(secretName string, data map[string]interface{}) (map[string]interface{}, error) {
-	fmt.Printf("======= storing key at %s data: %#v\n", secretName, data)
+	fmt.Printf("fakeClient: storing key at %s data: %#v\n", secretName, data)
 	f.Data[secretName] = data
 	return data, nil
 }


### PR DESCRIPTION
also lets polish a little the directory structure + file names to be more concise
also lets allow the secret base path to be configured; when bootstrapping a new cluster we may not be able to find the name yet; so providing a consistent path to secrets helps avoid things moving during the bootstrap proces

Signed-off-by: James Strachan <james.strachan@gmail.com>