### PR TITLE
Created a step to handle JsonPatch syntax queries into Configmaps and a way to apply them into second level embedded resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/dsnet/compress v0.0.0-20171208185109-cc9eb1d7ad76 // indirect
 	github.com/elazarl/goproxy v0.0.0-20181111060418-2ce16c963a8a // indirect
 	github.com/emirpasic/gods v1.9.0 // indirect
+	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/fatih/color v1.7.0
 	github.com/fatih/structs v1.1.0
 	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect

--- a/pkg/cmd/cloudbees/cloudbees.go
+++ b/pkg/cmd/cloudbees/cloudbees.go
@@ -19,7 +19,8 @@ import (
 type CloudBeesOptions struct {
 	*opts.CommonOptions
 
-	OnlyViewURL bool
+	OnlyViewURL  bool
+	HideURLLabel bool
 }
 
 var (
@@ -56,7 +57,9 @@ func NewCmdCloudBees(commonOpts *opts.CommonOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(NewCmdCloudBeesPipeline(commonOpts))
-	cmd.Flags().BoolVarP(&options.OnlyViewURL, "url", "u", false, "Only displays and the URL and does not open the browser")
+	cmd.Flags().BoolVarP(&options.OnlyViewURL, "url", "u", false, "Only displays the label and the URL and does not open the browser")
+	cmd.Flags().BoolVarP(&options.HideURLLabel, "hide-label", "l", false, "Hides the URL label from display")
+
 	return cmd
 }
 
@@ -97,7 +100,11 @@ func (o *CloudBeesOptions) Open(name string, label string) error {
 
 func (o *CloudBeesOptions) OpenURL(url string, label string) error {
 	// TODO Logger
-	fmt.Fprintf(o.Out, "%s: %s\n", label, util.ColorInfo(url))
+	if o.HideURLLabel {
+		fmt.Fprintf(o.Out, "%s\n", util.ColorInfo(url))
+	} else {
+		fmt.Fprintf(o.Out, "%s: %s\n", label, util.ColorInfo(url))
+	}
 	if !o.OnlyViewURL {
 		browser.OpenURL(url)
 	}

--- a/pkg/cmd/config/patch_configmap.go
+++ b/pkg/cmd/config/patch_configmap.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/evanphx/json-patch"
+	"github.com/ghodss/yaml"
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/templates"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/api/core/v1"
+	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var (
+	stepModifyConfigMapLong = templates.LongDesc(`
+		This step will take a json patch and attempt to modify the given ConfigMap. This is supposed to be used by
+		Helm hooks to modify certain configuration values depending on the chart needs
+`)
+
+	stepModifyConfigMapExample = templates.Examples(`
+		# Update the plank property in the data section of a config map, which is an embedded yaml file as a string literal called config.yaml:
+		jx step patch-config -m config --first-level-property config.yaml -p '["op": "replace", "path": "/plank", "value": {"foo": "bar"}]'
+		
+		# Update a root level property of a config map using strategic merge:
+		jx step patch-config -m config -t strategic -p '{"metadata": {"initializers": {"result": {"status": "newstatus"}}}}'
+			`)
+)
+
+// StepModifyConfigMapOptions are the options for the step patch-config command
+type StepModifyConfigMapOptions struct {
+	opts.StepOptions
+	ConfigMapName      string
+	JSONPatch          string
+	FirstLevelProperty string
+	Type               string
+	OutputFormat       string
+}
+
+// NewCmdStepPatchConfigMap executes the patch-config step, which applies JSONPatches to ConfigMaps
+func NewCmdStepPatchConfigMap(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := &StepModifyConfigMapOptions{
+		StepOptions: opts.StepOptions{
+			CommonOptions: commonOpts,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "patch-config",
+		Short:   "Modifies a ConfigMap with the given json patch",
+		Long:    stepModifyConfigMapLong,
+		Example: stepModifyConfigMapExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.ConfigMapName, "config-map", "m", "", "The ConfigMap that will be modified")
+	cmd.Flags().StringVarP(&options.FirstLevelProperty, "first-level-property", "", "", "The first level property within \"Data:\" where the json patch will be applied. If left empty, the patch will be applied to the whole ConfigMap")
+	cmd.Flags().StringVarP(&options.JSONPatch, "patch", "p", "", "The Json patch that will be applied to the Data within the ConfigMap")
+	cmd.Flags().StringVarP(&options.Type, "type", "t", "", "The type of patch being provided; one of [json merge strategic] - If the \"first-level-property\" flag is provided, this has no effect")
+	cmd.Flags().StringVarP(&options.OutputFormat, "output", "o", "", "the output of the modified ConfigMap if dry-run was provided")
+
+	return cmd
+}
+
+// Run implements this command
+func (o *StepModifyConfigMapOptions) Run() error {
+
+	if o.JSONPatch == "" {
+		return fmt.Errorf("the json patch to apply can't be empty")
+	}
+
+	if o.ConfigMapName == "" {
+		return fmt.Errorf("the config map to apply the patch into can't be empty")
+	}
+
+	jsonPatch := []byte(o.JSONPatch)
+	var updatedConfig *v1.ConfigMap
+	var err error
+	if o.FirstLevelProperty != "" {
+		updatedConfig, err = o.applyPatchToFirstLevelProperty(jsonPatch)
+		if err != nil {
+			return err
+		}
+	} else {
+		updatedConfig, err = o.applyPatchToRoot(jsonPatch)
+		if err != nil {
+			return err
+		}
+	}
+
+	if o.OutputFormat != "" {
+		err := renderResult(updatedConfig, o.OutputFormat)
+		if err != nil {
+			return errors.Wrap(err, "there was a problem rendering the output")
+		}
+	}
+
+	return nil
+}
+
+func (o *StepModifyConfigMapOptions) applyPatchToRoot(jsonPatch []byte) (*v1.ConfigMap, error) {
+	kubeClient, ns, err := o.KubeClientAndNamespace()
+	var patch types.PatchType
+	switch o.Type {
+	case "json":
+		patch = types.JSONPatchType
+	case "merge":
+		patch = types.MergePatchType
+	case "strategic":
+		patch = types.StrategicMergePatchType
+	default:
+		return nil, errors.New("the provided type is not supported. Please use one of [json merge strategic]")
+	}
+	updatedConfig, err := kubeClient.CoreV1().ConfigMaps(ns).Patch(o.ConfigMapName, patch, jsonPatch)
+	if err != nil {
+		return nil, err
+	}
+	return updatedConfig, nil
+}
+
+func (o *StepModifyConfigMapOptions) applyPatchToFirstLevelProperty(jsonPatch []byte) (*v1.ConfigMap, error) {
+	kubeClient, ns, err := o.KubeClientAndNamespace()
+	if err != nil {
+		return nil, errors.Wrap(err, "there was a problem obtaining the Kubernetes client")
+	}
+	config, err := kubeClient.CoreV1().ConfigMaps(ns).Get(o.ConfigMapName, k8sv1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "there was a problem obtaining the %s ConfigMap", o.ConfigMapName)
+	}
+
+	data := config.Data[o.FirstLevelProperty]
+
+	orig := []byte(data)
+	orig, err = yaml.YAMLToJSON(orig)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println(o.JSONPatch)
+
+	patch, err := jsonpatch.DecodePatch(jsonPatch)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := patch.Apply(orig)
+	if err != nil {
+		return nil, err
+	}
+
+	yamlData, err := yaml.JSONToYAML(b)
+	if err != nil {
+		return nil, err
+	}
+
+	config.Data[o.FirstLevelProperty] = string(yamlData)
+
+	updatedConfig, err := kubeClient.CoreV1().ConfigMaps(ns).Update(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if o.OutputFormat != "" {
+		err = renderResult(updatedConfig, o.OutputFormat)
+		if err != nil {
+			return nil, errors.Wrap(err, "there was a problem rendering the output")
+		}
+	}
+
+	return updatedConfig, nil
+}
+
+func renderResult(value interface{}, format string) error {
+	switch format {
+	case "json":
+		data, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		_, e := fmt.Println(string(data))
+		return e
+	case "yaml":
+		data, err := yaml.Marshal(value)
+		if err != nil {
+			return err
+		}
+		_, e := fmt.Println(string(data))
+		return e
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}

--- a/pkg/cmd/config/patch_configmap_test.go
+++ b/pkg/cmd/config/patch_configmap_test.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"github.com/ghodss/yaml"
+	"github.com/jenkins-x/jx/pkg/cmd/clients/fake"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"k8s.io/api/core/v1"
+	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStepModifyConfigMapRootLevel(t *testing.T) {
+	t.Parallel()
+
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	options := &commonOpts
+	testhelpers.ConfigureTestOptions(options, options.Git(), options.Helm())
+
+	kubeClient, ns, err := options.KubeClientAndNamespace()
+	assert.NoError(t, err)
+
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	testDataPath := filepath.Join(wd, "..", "test_data", "step_config", "config_map1.txt")
+	bytes, err := ioutil.ReadFile(testDataPath)
+	assert.NoErrorf(t, err, "The test data in folder %s should be read", testDataPath)
+
+	configMap := &v1.ConfigMap{}
+	err = yaml.Unmarshal(bytes, configMap)
+	assert.NoErrorf(t, err, "The test data in folder %s should be unmarshaled", testDataPath)
+
+	_, err = kubeClient.CoreV1().ConfigMaps(ns).Create(configMap)
+	assert.NoError(t, err, "the test config map should be created")
+
+	o := &StepModifyConfigMapOptions{
+		StepOptions: opts.StepOptions{
+			CommonOptions: options,
+		},
+
+		JSONPatch:     `{"metadata": {"initializers": {"result": {"status": "newstatus"}}}}`,
+		ConfigMapName: "config",
+		// The fake client only supports strategic
+		Type: "strategic",
+	}
+
+	err = o.Run()
+	assert.NoError(t, err)
+
+	updatedConfig, err := kubeClient.CoreV1().ConfigMaps(ns).Get("config", k8sv1.GetOptions{})
+	assert.NoError(t, err, "there should be a config map called config")
+
+	assert.Equal(t, "newstatus", updatedConfig.Initializers.Result.Status)
+}
+
+func TestStepModifyConfigMapFirstLevelPropertySet(t *testing.T) {
+	t.Parallel()
+
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	options := &commonOpts
+	testhelpers.ConfigureTestOptions(options, options.Git(), options.Helm())
+
+	kubeClient, ns, err := options.KubeClientAndNamespace()
+	assert.NoError(t, err)
+
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	testDataPath := filepath.Join(wd, "..", "test_data", "step_config", "config_map1.txt")
+	bytes, err := ioutil.ReadFile(testDataPath)
+	assert.NoErrorf(t, err, "The test data in folder %s should be read", testDataPath)
+
+	configMap := &v1.ConfigMap{}
+	err = yaml.Unmarshal(bytes, configMap)
+	assert.NoErrorf(t, err, "The test data in folder %s should be Unmarshal", testDataPath)
+
+	_, err = kubeClient.CoreV1().ConfigMaps(ns).Create(configMap)
+	assert.NoError(t, err, "the test config map should be created")
+
+	o := &StepModifyConfigMapOptions{
+		StepOptions: opts.StepOptions{
+			CommonOptions: options,
+		},
+
+		JSONPatch:          `[{"op": "replace", "path": "/plank", "value" : {"url": "http:"}}]`,
+		ConfigMapName:      "config",
+		FirstLevelProperty: "config.yaml",
+	}
+
+	err = o.Run()
+	assert.NoError(t, err)
+
+	updatedConfig, err := kubeClient.CoreV1().ConfigMaps(ns).Get("config", k8sv1.GetOptions{})
+	assert.NoError(t, err, "there should be a config map called config")
+
+	prowConfig := updatedConfig.Data["config.yaml"]
+	k := make(map[string]interface{})
+	err = yaml.Unmarshal([]byte(prowConfig), &k)
+	assert.NoError(t, err)
+
+	k = k["plank"].(map[string]interface{})
+
+	assert.Equal(t, "http:", k["url"])
+}

--- a/pkg/cmd/step.go
+++ b/pkg/cmd/step.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/jenkins-x/jx/pkg/cmd/config"
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/step"
@@ -68,6 +69,7 @@ func NewCmdStep(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.AddCommand(step.NewCmdStepUnstash(commonOpts))
 	cmd.AddCommand(step.NewCmdStepValuesSchemaTemplate(commonOpts))
 	cmd.AddCommand(scheduler.NewCmdStepScheduler(commonOpts))
+	cmd.AddCommand(config.NewCmdStepPatchConfigMap(commonOpts))
 
 	return cmd
 }

--- a/pkg/cmd/test_data/step_config/config_map1.txt
+++ b/pkg/cmd/test_data/step_config/config_map1.txt
@@ -1,0 +1,133 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    branch-protection:
+      orgs:
+        testOrg:
+          repos:
+            environment-cluster-dev-cluster-production:
+              required_status_checks:
+                contexts:
+                - promotion-build
+            environment-cluster-dev-cluster-staging:
+              required_status_checks:
+                contexts:
+                - promotion-build
+            p22:
+              required_status_checks:
+                contexts:
+                - serverless-jenkins
+        jenkins-x:
+          repos:
+            dummy:
+              required_status_checks:
+                contexts:
+                - serverless-jenkins
+      protect-tested-repos: true
+    deck:
+      spyglass: {}
+    gerrit: {}
+    owners_dir_blacklist:
+      default: null
+      repos: null
+    plank: {}
+    pod_namespace: jx
+    postsubmits:
+      testOrg/environment-cluster-dev-cluster-production:
+      - agent: tekton
+        branches:
+        - master
+        context: ""
+        name: promotion
+      testOrg/environment-cluster-dev-cluster-staging:
+      - agent: tekton
+        branches:
+        - master
+        context: ""
+        name: promotion
+      testOrg/p22:
+      - agent: tekton
+        branches:
+        - master
+        context: ""
+        name: release
+      jenkins-x/dummy:
+      - agent: tekton
+        branches:
+        - master
+        context: ""
+        name: release
+    presubmits:
+      testOrg/environment-cluster-dev-cluster-production:
+      - agent: tekton
+        always_run: true
+        context: promotion-build
+        name: promotion-build
+        rerun_command: /test this
+        trigger: (?m)^/test( all| this),?(\s+|$)
+      testOrg/environment-cluster-dev-cluster-staging:
+      - agent: tekton
+        always_run: true
+        context: promotion-build
+        name: promotion-build
+        rerun_command: /test this
+        trigger: (?m)^/test( all| this),?(\s+|$)
+      testOrg/p22:
+      - agent: tekton
+        always_run: true
+        context: serverless-jenkins
+        name: serverless-jenkins
+        rerun_command: /test this
+        trigger: (?m)^/test( all| this),?(\s+|$)
+      jenkins-x/dummy:
+      - agent: tekton
+        always_run: true
+        context: serverless-jenkins
+        name: serverless-jenkins
+        rerun_command: /test this
+        trigger: (?m)^/test( all| this),?(\s+|$)
+    prowjob_namespace: jx
+    push_gateway: {}
+    sinker: {}
+    tide:
+      context_options:
+        from-branch-protection: true
+        required-if-present-contexts: null
+        skip-unknown-contexts: false
+      queries:
+      - labels:
+        - approved
+        missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-ok-to-test
+        - needs-rebase
+        repos:
+        - jenkins-x/dummy
+        - testOrg/p22
+      - missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-ok-to-test
+        - needs-rebase
+        repos:
+        - jenkins-x/dummy-environment
+        - testOrg/environment-cluster-dev-cluster-staging
+        - testOrg/environment-cluster-dev-cluster-production
+      target_url: http://deck.jx.35.241.163.166.nip.io
+kind: ConfigMap
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"config.yaml":"branch-protection:\n  orgs:\n    testOrg:\n      repos:\n        environment-cluster-dev-cluster-production:\n          required_status_checks:\n            contexts:\n            - promotion-build\n        environment-cluster-dev-cluster-staging:\n          required_status_checks:\n            contexts:\n            - promotion-build\n        p22:\n          required_status_checks:\n            contexts:\n            - serverless-jenkins\n    jenkins-x:\n      repos:\n        dummy:\n          required_status_checks:\n            contexts:\n            - serverless-jenkins\n  protect-tested-repos: true\ndeck:\n  spyglass: {}\ngerrit: {}\nowners_dir_blacklist:\n  default: null\n  repos: null\nplank: {}\npod_namespace: jx\npostsubmits:\n  testOrg/environment-cluster-dev-cluster-production:\n  - agent: tekton\n    branches:\n    - master\n    context: \"\"\n    name: promotion\n  testOrg/environment-cluster-dev-cluster-staging:\n  - agent: tekton\n    branches:\n    - master\n    context: \"\"\n    name: promotion\n  testOrg/p22:\n  - agent: tekton\n    branches:\n    - master\n    context: \"\"\n    name: release\n  jenkins-x/dummy:\n  - agent: tekton\n    branches:\n    - master\n    context: \"\"\n    name: release\npresubmits:\n  testOrg/environment-cluster-dev-cluster-production:\n  - agent: tekton\n    always_run: true\n    context: promotion-build\n    name: promotion-build\n    rerun_command: /test this\n    trigger: (?m)^/test( all| this),?(\\s+|$)\n  testOrg/environment-cluster-dev-cluster-staging:\n  - agent: tekton\n    always_run: true\n    context: promotion-build\n    name: promotion-build\n    rerun_command: /test this\n    trigger: (?m)^/test( all| this),?(\\s+|$)\n  testOrg/p22:\n  - agent: tekton\n    always_run: true\n    context: serverless-jenkins\n    name: serverless-jenkins\n    rerun_command: /test this\n    trigger: (?m)^/test( all| this),?(\\s+|$)\n  jenkins-x/dummy:\n  - agent: tekton\n    always_run: true\n    context: serverless-jenkins\n    name: serverless-jenkins\n    rerun_command: /test this\n    trigger: (?m)^/test( all| this),?(\\s+|$)\nprowjob_namespace: jx\npush_gateway: {}\nsinker: {}\ntide:\n  context_options:\n    from-branch-protection: true\n    required-if-present-contexts: null\n    skip-unknown-contexts: false\n  queries:\n  - labels:\n    - approved\n    missingLabels:\n    - do-not-merge\n    - do-not-merge/hold\n    - do-not-merge/work-in-progress\n    - needs-ok-to-test\n    - needs-rebase\n    repos:\n    - jenkins-x/dummy\n    - testOrg/p22\n  - missingLabels:\n    - do-not-merge\n    - do-not-merge/hold\n    - do-not-merge/work-in-progress\n    - needs-ok-to-test\n    - needs-rebase\n    repos:\n    - jenkins-x/dummy-environment\n    - testOrg/environment-cluster-dev-cluster-staging\n    - testOrg/environment-cluster-dev-cluster-production\n  target_url: http://deck.jx.35.241.163.166.nip.io\n"},"kind":"ConfigMap","metadata":{"annotations":{},"creationTimestamp":"2019-05-24T08:33:35Z","name":"config","namespace":"jx","resourceVersion":"1392357","selfLink":"/api/v1/namespaces/jx/configmaps/config","uid":"9f1ca775-7dfe-11e9-8c23-42010a84008a"}}
+  creationTimestamp: "2019-05-24T08:33:35Z"
+  name: config
+  initializers:
+    result:
+      status: "status"
+  namespace: jx
+  resourceVersion: "1393930"
+  selfLink: /api/v1/namespaces/jx/configmaps/config
+  uid: 9f1ca775-7dfe-11e9-8c23-42010a84008a


### PR DESCRIPTION
…gMaps and literal json/yamls in the Data field

feature: changed the way the patch is applied

feature: added needed dependency

fix: removed unused file

feature: added a step to apply json patches to config maps and second level embedded items in config maps
Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
As a first step to be able to modify the configuration based on installed apps / addons, a step has to be created to aply JSON patches to ConfigMaps as some of them have second level embedded properties which are yaml / json themselves and Kubectl couldn't handle those.

You can specify the usual json patch types and follow the standard syntax.

Specifying the `first-level-property` flag would apply the patch into the value of the specified property only in JSONPatch format, if and only if the value is a valid yaml / json string.

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
