### PR TITLE
fix(tekton): Preserve overridden step name and fix override test

### DIFF
--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
@@ -114,7 +114,7 @@ items:
             - name: PREVIEW_VERSION
               value: ${inputs.params.version}
           image: jenkinsxio/builder-nodejs:0.1.235
-          name: step2
+          name: build
           resources:
             requests:
               cpu: 400m

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
@@ -287,7 +287,7 @@ items:
             - name: PREVIEW_VERSION
               value: ${inputs.params.version}
           image: jenkinsxio/builder-go:latest
-          name: step2
+          name: say-hi-to-fruit
           resources:
             requests:
               cpu: 0.1

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/jenkins-x.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/jenkins-x.yml
@@ -9,7 +9,7 @@ pipelineConfig:
       # Replace set-version on pullRequest in any stage/lifecycle with "echo hello"
       # This shouldn't affect the release pipeline we actually test with.
       - pipeline: pullRequest
-        name: set-version
+        name: skaffold-version
         step:
           sh: echo hello
       # Remove post-build from release in the build stage/lifecycle
@@ -21,22 +21,24 @@ pipelineConfig:
       - pipeline: pullRequest
         stage: build
         name: container-build
-      # Replace set-version on release in any stage/lifecycle with two steps.
+      # Replace set-version on release in any stage/lifecycle with a new step.
       - pipeline: release
-        name: set-version
-        steps:
-          - sh: echo goodbye
-          - sh: echo wait why am i here
+        name: skaffold-version
+        step:
+          command: echo
+          args: ['goodbye']
       # Add a step before the mvn-deploy step
       - pipeline: release
         name: mvn-deploy
         type: before
         steps:
           - sh: echo before mvn deploy
+            name: before-mvn-deploy
       # Add a step after the skaffold-version step
       - pipeline: release
         name: skaffold-version
         type: after
         steps:
           - sh: echo after skaffold version
+            name: after-skaffold-version
 

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
@@ -224,7 +224,7 @@ items:
             - name: PREVIEW_VERSION
               value: ${inputs.params.version}
           image: jenkinsxio/builder-maven-java11:0.1.235
-          name: build-step3
+          name: build-before-mvn-deploy
           resources:
             requests:
               cpu: 400m
@@ -321,7 +321,7 @@ items:
               readOnly: true
           workingDir: /workspace/source
         - args:
-            - skaffold version
+            - echo goodbye
           command:
             - /bin/sh
             - -c
@@ -446,7 +446,7 @@ items:
             - name: PREVIEW_VERSION
               value: ${inputs.params.version}
           image: jenkinsxio/builder-maven-java11:0.1.235
-          name: build-step6
+          name: build-after-skaffold-version
           resources:
             requests:
               cpu: 400m

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -1920,6 +1920,9 @@ func OverrideStep(step Step, override *PipelineOverride) []Step {
 			var newSteps []Step
 
 			if override.Step != nil {
+				if override.Step.Name == "" {
+					override.Step.Name = step.Name
+				}
 				newSteps = append(newSteps, *override.Step)
 			}
 			if override.Steps != nil {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

I discovered, thanks to @tdcox, that I screwed up and the `override-steps` test was trying to override the `set-version` step, which isn't showing up in our test cases in the first place (since we have `NoReleasePrepare` set to `true`). Whoops. So let's use a different step. And while I'm here, let's preserve the step name when we override a step with a single step and that new step doesn't have a name specified. That just seems nice.

#### Special notes for the reviewer(s)

/assign @hferentschik 
/assign @joseblas 
/assign @wbrefvem 
/assign @dwnusbaum 

#### Which issue this PR fixes

n/a