### PR TITLE
fix: disabling kaniko by default on EKS

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -442,10 +442,12 @@ func (options *InstallOptions) CheckFlags() error {
 
 	// only kaniko is supported as a builder in tekton
 	if flags.Tekton {
-		if !flags.Kaniko {
-			log.Logger().Warnf("When using tekton, only kaniko is supported as a builder")
+		if flags.Provider == cloud.GKE {
+			if !flags.Kaniko {
+				log.Logger().Warnf("When using tekton, only kaniko is supported as a builder")
+			}
+			flags.Kaniko = true
 		}
-		flags.Kaniko = true
 	}
 
 	// check some flags combination for GitOps mode

--- a/pkg/cmd/create/install_test.go
+++ b/pkg/cmd/create/install_test.go
@@ -106,7 +106,7 @@ func TestCheckFlags(t *testing.T) {
 			err:            nil,
 		},
 		{
-			name: "tekton",
+			name: "tekton_and_gke",
 			in: &create.InstallFlags{
 				Tekton:   true,
 				Provider: cloud.GKE,
@@ -118,6 +118,21 @@ func TestCheckFlags(t *testing.T) {
 			knativeBuild:   false,
 			kaniko:         true,
 			dockerRegistry: "gcr.io",
+			err:            nil,
+		},
+		{
+			name: "tekton_and_eks",
+			in: &create.InstallFlags{
+				Tekton:   true,
+				Provider: cloud.EKS,
+			},
+			nextGeneration: false,
+			tekton:         true,
+			prow:           true,
+			staticJenkins:  false,
+			knativeBuild:   false,
+			kaniko:         false,
+			dockerRegistry: "",
 			err:            nil,
 		},
 		{

--- a/pkg/cmd/create/install_test.go
+++ b/pkg/cmd/create/install_test.go
@@ -136,6 +136,22 @@ func TestCheckFlags(t *testing.T) {
 			err:            nil,
 		},
 		{
+			name: "tekton_and_eks_and_kaniko",
+			in: &create.InstallFlags{
+				Tekton:   true,
+				Provider: cloud.EKS,
+				Kaniko:   true,
+			},
+			nextGeneration: false,
+			tekton:         true,
+			prow:           true,
+			staticJenkins:  false,
+			knativeBuild:   false,
+			kaniko:         true,
+			dockerRegistry: "",
+			err:            nil,
+		},
+		{
 			name: "tekton_with_a_custom_docker_registry",
 			in: &create.InstallFlags{
 				Tekton:         true,


### PR DESCRIPTION
a regression was introduced during a recent refactor that force enabled kaniko 
on EKS.