### PR TITLE
fix: add a 'jx boot' command

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
 )
 
+// BootOptions options for the command
 type BootOptions struct {
 	*opts.CommonOptions
 
@@ -42,6 +43,7 @@ var (
 `)
 )
 
+// NewCmdBoot creates the command
 func NewCmdBoot(commonOpts *opts.CommonOptions) *cobra.Command {
 	options := &BootOptions{
 		CommonOptions: commonOpts,
@@ -63,6 +65,7 @@ func NewCmdBoot(commonOpts *opts.CommonOptions) *cobra.Command {
 	return cmd
 }
 
+// Run runs this command
 func (o *BootOptions) Run() error {
 	requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir)
 	if err != nil {

--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -1,0 +1,159 @@
+package boot
+
+import (
+	"fmt"
+
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/cmd/namespace"
+	"github.com/jenkins-x/jx/pkg/cmd/step/create"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/templates"
+)
+
+type BootOptions struct {
+	*opts.CommonOptions
+
+	Dir string
+}
+
+var (
+	bootLong = templates.LongDesc(`
+		Boots up Jenkins X in a Kubernetes cluster using GitOps and a Jenkins X Pipeline
+
+`)
+
+	bootExample = templates.Examples(`
+		# create a kubernetes cluster via Terraform or via jx
+		jx create cluster gke --skip-installation
+
+		# lets get the GitOps repository source code
+		git clone https://github.com/jstrachan/environment-simple-tekton.git my-jx-config
+		cd my-jx-config
+
+		# now lets boot up Jenkins X installing/upgrading whatever is needed
+		jx boot 
+`)
+)
+
+func NewCmdBoot(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := &BootOptions{
+		CommonOptions: commonOpts,
+	}
+	cmd := &cobra.Command{
+		Use:     "boot",
+		Aliases: []string{"bootstrap"},
+		Short:   "Boots up Jenkins X in a Kubernetes cluster using GitOps and a Jenkins X Pipeline",
+		Long:    bootLong,
+		Example: bootExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+	cmd.Flags().StringVarP(&options.Dir, "dir", "d", ".", "the directory to look for the Jenkins X Pipeline, requirements and charts")
+	return cmd
+}
+
+func (o *BootOptions) Run() error {
+	requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir)
+	if err != nil {
+		return err
+	}
+	exists, err := util.FileExists(requirementsFile)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("No requirements file %s are you sure you are running this command inside a GitOps clone?", requirementsFile)
+	}
+
+	err = o.verifyRequirements(requirements, requirementsFile)
+	if err != nil {
+		return err
+	}
+	projectConfig, pipelineFile, err := config.LoadProjectConfig(o.Dir)
+	if err != nil {
+		return err
+	}
+	exists, err = util.FileExists(requirementsFile)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("No pipeline file %s are you sure you are running this command inside a GitOps clone?", pipelineFile)
+	}
+
+	log.Logger().Infof("booting up Jenkins X\n")
+
+	// now lets really boot
+	_, so := create.NewCmdStepCreateTaskAndOption(o.CommonOptions)
+	so.InterpretMode = true
+	so.NoReleasePrepare = true
+	so.AdditionalEnvVars = map[string]string{
+		"JX_NO_TILLER": "true",
+	}
+	err = so.Run()
+	if err != nil {
+		return errors.Wrapf(err, "failed to interpret pipeline file %s", pipelineFile)
+	}
+
+	// if we can find the deploy namespace lets switch kubernetes context to it so the user can use `jx` commands immediately
+	ns := FindBootNamespace(projectConfig, requirements)
+	if ns != "" {
+		info := util.ColorInfo
+		no := &namespace.NamespaceOptions{}
+		no.CommonOptions = o.CommonOptions
+		no.Args = []string{ns}
+		log.Logger().Infof("switching to the namespace %s so that you can use %s commands on the installation\n", info(ns), info("jx"))
+		return no.Run()
+	}
+	return nil
+}
+
+func (o *BootOptions) verifyRequirements(requirements *config.RequirementsConfig, requirementsFile string) error {
+	provider := requirements.Provider
+	if provider == "" {
+		return o.missingRequirement("provider", requirementsFile)
+	}
+	if provider == "" {
+		if requirements.ProjectID == "" {
+			return o.missingRequirement("project", requirementsFile)
+		}
+	}
+	return nil
+}
+
+func (o *BootOptions) missingRequirement(property string, fileName string) error {
+	return fmt.Errorf("missing property: %s in file %s", property, fileName)
+}
+
+// FindBootNamespace finds the namespace to boot Jenkins X into based on the pipeline and requirements
+func FindBootNamespace(projectConfig *config.ProjectConfig, requirementsConfig *config.RequirementsConfig) string {
+	// TODO should we add the deploy namepace to jx-requirements.yml?
+	if projectConfig != nil {
+		pipelineConfig := projectConfig.PipelineConfig
+		if pipelineConfig != nil {
+			release := pipelineConfig.Pipelines.Release
+			if release != nil {
+				pipeline := release.Pipeline
+				if pipeline != nil {
+					for _, env := range pipeline.Environment {
+						if env.Name == "DEPLOY_NAMESPACE" && env.Value != "" {
+							return env.Value
+						}
+					}
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/cmd/boot/boot_test.go
+++ b/pkg/cmd/boot/boot_test.go
@@ -1,0 +1,25 @@
+package boot_test
+
+import (
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/cmd/boot"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindBootNamespace(t *testing.T) {
+	t.Parallel()
+
+	dir := "test_data"
+	projectConfig, _, err := config.LoadProjectConfig(dir)
+	require.NoError(t, err, "could not load Jenkins X Pipeline")
+
+	requirements, _, err := config.LoadRequirementsConfig(dir)
+	require.NoError(t, err, "could not load Jenkins X Requirements")
+
+	ns := boot.FindBootNamespace(projectConfig, requirements)
+
+	assert.Equal(t, "jx", ns, "FindBootNamespace")
+}

--- a/pkg/cmd/boot/test_data/jenkins-x.yml
+++ b/pkg/cmd/boot/test_data/jenkins-x.yml
@@ -1,0 +1,69 @@
+buildPack: none
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: docker.io/rawlingsj80/builder-go:wip71
+        environment:
+          - name: DEPLOY_NAMESPACE
+            value: jx
+        stages:
+          - name: release
+            steps:
+              - name: verify-preintall
+                dir: /workspace/source/env
+                command: jx
+                args: ['step','verify','preinstall']
+              - name: cert-manager-crds
+                dir: /workspace/source
+                command: kubectl
+                args: ['apply', '--wait', '--validate=true', '-f', 'https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml']
+                env:
+                  - name: DEPLOY_NAMESPACE
+                    value: cert-manager
+              - name: jx-crds
+                command: jx
+                args: ['upgrade','crd']
+              - name: kube-system
+                dir: /workspace/source/systems/jxing
+                command: jx
+                args: ['step','helm','apply', '--remote', '--name', 'jxing']
+                env:
+                  - name: DEPLOY_NAMESPACE
+                    value: kube-system
+              - name: cert-manager
+                dir: /workspace/source/systems/cm
+                command: jx
+                args: ['step','helm','apply', '--remote', '--name', 'jx']
+                env:
+                  - name: DEPLOY_NAMESPACE
+                    value: cert-manager
+              - name: helm-cluster-values
+                dir: /workspace/source/env
+                command: jx
+                args: ['step','create','install', 'values', '-b']
+              - name: helm-populate-params
+                dir: /workspace/source/env
+                command: jx
+                args: ['step', 'create', 'values', '--name', 'parameters']
+              - name: helm-build
+                dir: /workspace/source/env
+                command: jx
+                args: ['step','helm','apply', '--remote', '--name', 'jenkins-x']
+              - name: verify-install
+                dir: /workspace/source/env
+                command: jx
+                args: ['step','verify','install']
+    pullRequest:
+      pipeline:
+        agent:
+          image: docker.io/rawlingsj80/builder-go:wip70
+        stages:
+          - name: release
+            steps:
+              - name: helm-build
+                dir: /workspace/source/env
+                command: make
+                args: ['build']
+

--- a/pkg/cmd/boot/test_data/jx-requirements.yml
+++ b/pkg/cmd/boot/test_data/jx-requirements.yml
@@ -1,0 +1,5 @@
+provider: gke
+kaniko: true
+secretStorage: local
+project: my-project-id
+clusterName: my-cluster-name

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"fmt"
+
+	"github.com/jenkins-x/jx/pkg/cmd/boot"
 	"github.com/jenkins-x/jx/pkg/cmd/cloudbees"
 	"github.com/jenkins-x/jx/pkg/cmd/compliance"
 	"github.com/jenkins-x/jx/pkg/cmd/controller"
@@ -90,6 +92,7 @@ func NewJXCommand(f clients.Factory, in terminal.FileReader, out terminal.FileWr
 	updateCommands := update.NewCmdUpdate(commonOpts)
 
 	installCommands := []*cobra.Command{
+		boot.NewCmdBoot(commonOpts),
 		create.NewCmdInstall(commonOpts),
 		uninstall.NewCmdUninstall(commonOpts),
 		upgrade.NewCmdUpgrade(commonOpts),


### PR DESCRIPTION
to bootstrap an installation using a flexible GitOps pipeline on any kubernetes cluster; created via Teraform, by hand or by `jx create cluster --skip-install`

fixes #4404

Signed-off-by: James Strachan <james.strachan@gmail.com>