### PR TITLE
Specifying the builders version for the release step

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -107,7 +107,7 @@ pipelineConfig:
               - name: release
                 #image: docker.io/golang:1.11.5
                 # needs helm in the image for install_gitops_integration_test.go
-                image: gcr.io/jenkinsxio/builder-go
+                image: gcr.io/jenkinsxio/builder-go:532
                 command: make
                 args: ['release']
 


### PR DESCRIPTION
It seems that the default builders version within the platform version is too old to contain goreleaser

