### PR TITLE
Sanitize bucket labels

### DIFF
--- a/pkg/cloud/gke/gcloud.go
+++ b/pkg/cloud/gke/gcloud.go
@@ -915,7 +915,8 @@ func IsGCSWriteRoleEnabled(cluster string, zone string) (bool, error) {
 func UserLabel() string {
 	user, err := osUser.Current()
 	if err == nil && user != nil && user.Username != "" {
-		return fmt.Sprintf("created-by:%s", user.Username)
+		userLabel := util.SanitizeLabel(user.Username)
+		return fmt.Sprintf("created-by:%s", userLabel)
 	}
 	return ""
 }

--- a/pkg/cmd/create/create_cluster_gke.go
+++ b/pkg/cmd/create/create_cluster_gke.go
@@ -16,8 +16,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/features"
 	"github.com/jenkins-x/jx/pkg/kube"
 
-	"regexp"
-
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
@@ -85,7 +83,6 @@ var (
 		jx create cluster gke
 
 `)
-	disallowedLabelCharacters = regexp.MustCompile("[^a-z0-9-]")
 )
 
 // NewCmdCreateClusterGKE creates a command object for the generic "init" action, which
@@ -575,18 +572,13 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 
 // AddLabel adds the given label key and value to the label string
 func AddLabel(labels string, name string, value string) string {
-	username := sanitizeLabel(value)
+	username := util.SanitizeLabel(value)
 	if username != "" {
 		sep := ""
 		if labels != "" {
 			sep = ","
 		}
-		labels += sep + sanitizeLabel(name) + "=" + username
+		labels += sep + util.SanitizeLabel((name)+"="+username)
 	}
 	return labels
-}
-
-func sanitizeLabel(username string) string {
-	sanitized := strings.ToLower(username)
-	return disallowedLabelCharacters.ReplaceAllString(sanitized, "-")
 }

--- a/pkg/cmd/create/create_cluster_gke_terraform.go
+++ b/pkg/cmd/create/create_cluster_gke_terraform.go
@@ -278,7 +278,7 @@ func (o *CreateClusterGKETerraformOptions) createClusterGKETerraform() error {
 	if err != nil {
 		return err
 	}
-	username := sanitizeLabel(user.Username)
+	username := util.SanitizeLabel(user.Username)
 
 	// create .tfvars file in .jx folder
 	terraformVars := filepath.Join(terraformDir, "terraform.tfvars")
@@ -340,7 +340,7 @@ func (o *CreateClusterGKETerraformOptions) createClusterGKETerraform() error {
 
 	labels := o.Flags.Labels
 	if err == nil && user != nil {
-		username := sanitizeLabel(user.Username)
+		username := util.SanitizeLabel(user.Username)
 		if username != "" {
 			sep := ""
 			if labels != "" {

--- a/pkg/cmd/create/create_cluster_gke_test.go
+++ b/pkg/cmd/create/create_cluster_gke_test.go
@@ -6,25 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_sanitizeLabel(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name     string
-		username string
-		want     string
-	}{
-		{"Replaces . in username for -", "test.person", "test-person"},
-		{"Replaces _ in username for -", "test_person", "test-person"},
-		{"Replaces uppercase in username for lowercase", "Test", "test"},
-		{"Doesn't do anything for empty user names", "", ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, sanitizeLabel(tt.username), tt.want)
-		})
-	}
-}
-
 func Test_validateClusterName(t *testing.T) {
 	var bigLongName = string("this-name-is-too-long-by-one")
 	var capitalName = string("NameWithCapitalLetters")

--- a/pkg/cmd/create/create_terraform.go
+++ b/pkg/cmd/create/create_terraform.go
@@ -136,7 +136,7 @@ func (g GKECluster) CreateTfVarsFile(path string) error {
 	if err != nil {
 		username = "unknown"
 	} else {
-		username = sanitizeLabel(user.Username)
+		username = util.SanitizeLabel(user.Username)
 	}
 
 	tf := terraformFileWriter{}

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -3264,7 +3264,7 @@ func validateClusterName(clustername string) error {
 	}
 	// Now we need only make sure that clustername is limited to
 	// lowercase alphanumerics and dashes.
-	if disallowedLabelCharacters.MatchString(clustername) {
+	if util.DisallowedLabelCharacters.MatchString(clustername) {
 		err := fmt.Errorf("cluster name %v contains invalid characters. Permitted are lowercase alphanumerics and `-`", clustername)
 		return err
 	}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -11,6 +11,9 @@ import (
 	"time"
 )
 
+//DisallowedLabelCharacters regex of chars not allowed in lables
+var DisallowedLabelCharacters = regexp.MustCompile("[^a-z0-9-]")
+
 // RegexpSplit splits a string into an array using the regexSep as a separator
 func RegexpSplit(text string, regexSeperator string) []string {
 	reg := regexp.MustCompile(regexSeperator)
@@ -223,4 +226,10 @@ func YesNo(t bool) string {
 // QuestionAnswer returns strings like Cobra question/answers for default cli options
 func QuestionAnswer(question string, answer string) string {
 	return fmt.Sprintf("%s %s: %s", ColorBold(ColorInfo("?")), ColorBold(question), ColorAnswer(answer))
+}
+
+//SanitizeLabel returns a label with disallowed characters removed
+func SanitizeLabel(label string) string {
+	sanitized := strings.ToLower(label)
+	return DisallowedLabelCharacters.ReplaceAllString(sanitized, "-")
 }

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -90,3 +90,22 @@ func TestYesNo(t *testing.T) {
 func TestQuestionAnswer(t *testing.T) {
 	assert.Equal(t, "? This is a question: and answer", util.QuestionAnswer("This is a question", "and answer"))
 }
+
+func Test_sanitizeLabel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		username string
+		want     string
+	}{
+		{"Replaces . in username for -", "test.person", "test-person"},
+		{"Replaces _ in username for -", "test_person", "test-person"},
+		{"Replaces uppercase in username for lowercase", "Test", "test"},
+		{"Doesn't do anything for empty user names", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, util.SanitizeLabel(tt.username), tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Bucket labels failing when containg a `.`, move and utilise an existing SanitizeLabel function 
