### PR TITLE
fix(tekton): Git org and repo should be replaced consistently

### DIFF
--- a/pkg/apps/install.go
+++ b/pkg/apps/install.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -600,7 +601,7 @@ func toValidName(appName string, name string, id string) string {
 	if l > 20 {
 		l = 20
 	}
-	return kube.ToValidName(fmt.Sprintf("%s-%s", base[0:l], id))
+	return naming.ToValidName(fmt.Sprintf("%s-%s", base[0:l], id))
 }
 
 func (o *InstallOptions) getPrefixes() []string {

--- a/pkg/cmd/controller/controller_commitstatus.go
+++ b/pkg/cmd/controller/controller_commitstatus.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/prow/config"
@@ -271,7 +272,7 @@ func (o *ControllerCommitStatusOptions) onPod(pod *corev1.Pod, jxClient jenkinsv
 					buildNumber = buildId
 				}
 
-				pipelineActName := kube.ToValidName(fmt.Sprintf("%s-%s-%s-%s", org, repo, branch, buildNumber))
+				pipelineActName := naming.ToValidName(fmt.Sprintf("%s-%s-%s-%s", org, repo, branch, buildNumber))
 
 				// PLM TODO This is a bit of hack, we need a working build controller
 				// Try to add the lastCommitSha and gitUrl to the PipelineActivity
@@ -311,7 +312,7 @@ func (o *ControllerCommitStatusOptions) onPod(pod *corev1.Pod, jxClient jenkinsv
 
 						for _, ctx := range contexts {
 							if pullRequest != "" {
-								name := kube.ToValidName(fmt.Sprintf("%s-%s-%s-%s", org, repo, branch, ctx))
+								name := naming.ToValidName(fmt.Sprintf("%s-%s-%s-%s", org, repo, branch, ctx))
 
 								err = o.UpsertCommitStatusCheck(name, pipelineActName, sourceUrl, sha, pullRequest, ctx, pod.Status.Phase, jxClient, ns)
 								if err != nil {

--- a/pkg/cmd/create/create_chat_token.go
+++ b/pkg/cmd/create/create_chat_token.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/chats"
@@ -145,7 +146,7 @@ func (o *CreateChatTokenOptions) updateChatCredentialsSecret(server *auth.AuthSe
 		return err
 	}
 	options := metav1.GetOptions{}
-	name := kube.ToValidName(kube.SecretJenkinsPipelineChatCredentials + server.Kind + "-" + server.Name)
+	name := naming.ToValidName(kube.SecretJenkinsPipelineChatCredentials + server.Kind + "-" + server.Name)
 	secrets := client.CoreV1().Secrets(ns)
 	secret, err := secrets.Get(name, options)
 	create := false

--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -2,14 +2,6 @@ package create
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/cmd/rsh"
-	"github.com/jenkins-x/jx/pkg/cmd/sync"
-
-	"github.com/jenkins-x/jx/pkg/cmd/helper"
-	"github.com/jenkins-x/jx/pkg/cmd/step/git"
-	"github.com/jenkins-x/jx/pkg/gits"
-	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
-
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -17,6 +9,15 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/cmd/rsh"
+	"github.com/jenkins-x/jx/pkg/cmd/sync"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
+
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/cmd/step/git"
+	"github.com/jenkins-x/jx/pkg/gits"
+	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
@@ -233,7 +234,7 @@ func (o *CreateDevPodOptions) Run() error {
 			log.Logger().Warnf("could not parse the git URL %s: %s", importURL, err.Error())
 		} else {
 			gitLabelKey = fmt.Sprintf("%s-%s-%s-%s", kube.LabelDevPodGitPrefix, gitInfo.Host, gitInfo.Organisation, gitInfo.Name)
-			gitLabelValue = kube.ToValidNameWithDots(importURL)
+			gitLabelValue = naming.ToValidNameWithDots(importURL)
 			// lets query to see if there is a DevPod already for t
 			// his URL
 			matchLabels := map[string]string{
@@ -314,7 +315,7 @@ func (o *CreateDevPodOptions) Run() error {
 			pod.Annotations = map[string]string{}
 		}
 
-		name = kube.ToValidName(userName + "-" + label)
+		name = naming.ToValidName(userName + "-" + label)
 		if o.Suffix != "" {
 			name += "-" + o.Suffix
 		}

--- a/pkg/cmd/create/create_token_addon.go
+++ b/pkg/cmd/create/create_token_addon.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/addon"
 	"github.com/jenkins-x/jx/pkg/auth"
@@ -156,7 +157,7 @@ func (o *CreateTokenAddonOptions) updateAddonCredentialsSecret(server *auth.Auth
 		return err
 	}
 	options := metav1.GetOptions{}
-	name := kube.ToValidName(kube.SecretJenkinsPipelineAddonCredentials + server.Kind + "-" + server.Name)
+	name := naming.ToValidName(kube.SecretJenkinsPipelineAddonCredentials + server.Kind + "-" + server.Name)
 	secrets := client.CoreV1().Secrets(ns)
 	secret, err := secrets.Get(name, options)
 	create := false

--- a/pkg/cmd/create/create_tracker_token.go
+++ b/pkg/cmd/create/create_tracker_token.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
@@ -145,7 +146,7 @@ func (o *CreateTrackerTokenOptions) updateIssueTrackerCredentialsSecret(server *
 		return err
 	}
 	options := metav1.GetOptions{}
-	name := kube.ToValidName(kube.SecretJenkinsPipelineIssueCredentials + server.Kind + "-" + server.Name)
+	name := naming.ToValidName(kube.SecretJenkinsPipelineIssueCredentials + server.Kind + "-" + server.Name)
 	secrets := client.CoreV1().Secrets(ns)
 	secret, err := secrets.Get(name, options)
 	create := false

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -3,22 +3,23 @@ package create
 import (
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
 	"github.com/jenkins-x/jx/pkg/cmd/edit"
 	"github.com/jenkins-x/jx/pkg/cmd/initcmd"
-	"regexp"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/tenant"
 
 	"github.com/jenkins-x/jx/pkg/cmd/step/env"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
-
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"sort"
-	"strings"
-	"time"
 
 	gkeStorage "github.com/jenkins-x/jx/pkg/cloud/gke/storage"
 	"github.com/jenkins-x/jx/pkg/kube/cluster"
@@ -2205,7 +2206,7 @@ func (options *InstallOptions) ConfigureKaniko() error {
 			}
 		}
 
-		serviceAccountName := kube.ToValidNameTruncated(fmt.Sprintf("%s-ko", clusterName), 30)
+		serviceAccountName := naming.ToValidNameTruncated(fmt.Sprintf("%s-ko", clusterName), 30)
 		log.Logger().Infof("Configuring Kaniko service account %s for project %s", util.ColorInfo(serviceAccountName), util.ColorInfo(projectID))
 
 		serviceAccountPath, err := gke.GetOrCreateServiceAccount(serviceAccountName, projectID, serviceAccountDir, gke.KanikoServiceAccountRoles)

--- a/pkg/cmd/deletecmd/delete_application.go
+++ b/pkg/cmd/deletecmd/delete_application.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/environments"
@@ -235,7 +236,7 @@ func (o *DeleteApplicationOptions) deleteProwApplication(repoService jenkinsv1.S
 		}
 		deletedApplications = append(deletedApplications, applicationName)
 
-		srName := kube.ToValidName(org + "-" + applicationName)
+		srName := naming.ToValidName(org + "-" + applicationName)
 		err := repoService.Delete(srName, nil)
 		if err != nil {
 			log.Logger().Warnf("Unable to find application metadata for %s to remove", applicationName)

--- a/pkg/cmd/deletecmd/delete_devpod.go
+++ b/pkg/cmd/deletecmd/delete_devpod.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
@@ -81,7 +82,7 @@ func (o *DeleteDevPodOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	name := kube.ToValidName(userName)
+	name := naming.ToValidName(userName)
 	names, err := kube.GetPodNames(client, ns, name)
 	if err != nil {
 		return err

--- a/pkg/cmd/get/get_preview.go
+++ b/pkg/cmd/get/get_preview.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
-	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -78,7 +78,7 @@ func (o *GetPreviewOptions) CurrentPreviewUrl() error {
 	if pipeline == "" {
 		return fmt.Errorf("No $JOB_NAME defined for the current pipeline job to use")
 	}
-	name := kube.ToValidName(pipeline)
+	name := naming.ToValidName(pipeline)
 
 	client, ns, err := o.JXClientAndDevNamespace()
 	if err != nil {

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/edit"
 	"github.com/jenkins-x/jx/pkg/cmd/initcmd"
 	"github.com/jenkins-x/jx/pkg/cmd/start"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/cenkalti/backoff"
 	"github.com/denormal/go-gitignore"
@@ -358,7 +359,7 @@ func (options *ImportOptions) Run() error {
 		}
 		_, options.AppName = filepath.Split(dir)
 	}
-	options.AppName = kube.ToValidName(strings.ToLower(options.AppName))
+	options.AppName = naming.ToValidName(strings.ToLower(options.AppName))
 
 	if !options.DisableDraft {
 		err = options.DraftCreate()
@@ -992,7 +993,7 @@ func (options *ImportOptions) ensureDockerRepositoryExists() error {
 
 // ReplacePlaceholders replaces app name, git server name, git org, and docker registry org placeholders
 func (options *ImportOptions) ReplacePlaceholders(gitServerName, dockerRegistryOrg string) error {
-	options.Organisation = kube.ToValidName(strings.ToLower(options.Organisation))
+	options.Organisation = naming.ToValidName(strings.ToLower(options.Organisation))
 	log.Logger().Infof("replacing placeholders in directory %s", options.Dir)
 	log.Logger().Infof("app name: %s, git server: %s, org: %s, Docker registry org: %s", options.AppName, gitServerName, options.Organisation, dockerRegistryOrg)
 

--- a/pkg/cmd/importcmd/import_integration_test.go
+++ b/pkg/cmd/importcmd/import_integration_test.go
@@ -5,6 +5,8 @@ package importcmd_test
 import (
 	"github.com/jenkins-x/jx/pkg/cmd/importcmd"
 	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
+
 	"io/ioutil"
 	"os"
 	"path"
@@ -24,7 +26,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/helm"
-	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
@@ -160,7 +161,7 @@ func createFakeGitProvider() *gits.FakeProvider {
 
 func assertImport(t *testing.T, testDir string, testcase string, withRename bool, nextGenPipeline bool) error {
 	_, dirName := filepath.Split(testDir)
-	dirName = kube.ToValidName(dirName)
+	dirName = naming.ToValidName(dirName)
 	o := &importcmd.ImportOptions{
 		CommonOptions: &opts.CommonOptions{},
 	}

--- a/pkg/cmd/initcmd/init.go
+++ b/pkg/cmd/initcmd/init.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/jenkins-x/jx/pkg/cloud"
@@ -287,9 +288,9 @@ func (o *InitOptions) EnableClusterAdminRole() error {
 	if o.Username == "" {
 		return util.MissingOption(optionUsername)
 	}
-	userFormatted := kube.ToValidName(o.Username)
+	userFormatted := naming.ToValidName(o.Username)
 
-	clusterRoleBindingName := kube.ToValidName(userFormatted + "-" + o.Flags.UserClusterRole + "-binding")
+	clusterRoleBindingName := naming.ToValidName(userFormatted + "-" + o.Flags.UserClusterRole + "-binding")
 
 	clusterRoleBindingInterface := client.RbacV1().ClusterRoleBindings()
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{

--- a/pkg/cmd/opts/git.go
+++ b/pkg/cmd/opts/git.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/issues"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
@@ -92,7 +93,7 @@ func (o *CommonOptions) UpdatePipelineGitCredentialsSecret(server *auth.AuthServ
 	}
 	options := metav1.GetOptions{}
 	serverName := server.Name
-	name := kube.ToValidName(kube.SecretJenkinsPipelineGitCredentials + server.Kind + "-" + serverName)
+	name := naming.ToValidName(kube.SecretJenkinsPipelineGitCredentials + server.Kind + "-" + serverName)
 	secrets := client.CoreV1().Secrets(ns)
 	secret, err := secrets.Get(name, options)
 	create := false

--- a/pkg/cmd/opts/team_settings.go
+++ b/pkg/cmd/opts/team_settings.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/jenkins-x/jx/pkg/jenkins"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/users"
 
 	"github.com/jenkins-x/jx/pkg/builds"
@@ -376,7 +377,7 @@ func (o *CommonOptions) GetUsername(userName string) (string, error) {
 		}
 		userName = u.Username
 	}
-	return kube.ToValidNameTruncated(userName, 63), nil
+	return naming.ToValidNameTruncated(userName, 63), nil
 }
 
 // EnableRemoteKubeCluster lets setup this command to work with a remote cluster without a jx install

--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/promote"
 	"github.com/jenkins-x/jx/pkg/cmd/step/pr"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/pkg/errors"
 
@@ -521,7 +522,7 @@ func (o *PreviewOptions) Run() error {
 
 	if url != "" || o.PullRequestURL != "" {
 		if pipeline != "" && build != "" {
-			name := kube.ToValidName(pipeline + "-" + build)
+			name := naming.ToValidName(pipeline + "-" + build)
 			// lets see if we can update the pipeline
 			activities := jxClient.JenkinsV1().PipelineActivities(ns)
 			key := &kube.PromoteStepActivityKey{
@@ -832,7 +833,7 @@ func (o *PreviewOptions) DefaultValues(ns string, warnMissingName bool) error {
 			}
 		}
 	}
-	o.Name = kube.ToValidName(o.Name)
+	o.Name = naming.ToValidName(o.Name)
 	if o.Name == "" {
 		return fmt.Errorf("No name could be defaulted for the Preview Environment. Please supply one!")
 	}
@@ -854,7 +855,7 @@ func (o *PreviewOptions) DefaultValues(ns string, warnMissingName bool) error {
 	if len(o.Namespace) > 63 {
 		return fmt.Errorf("Preview namespace %s is too long. Must be no more than 63 character", o.Namespace)
 	}
-	o.Namespace = kube.ToValidName(o.Namespace)
+	o.Namespace = naming.ToValidName(o.Namespace)
 	if o.Label == "" {
 		o.Label = o.Name
 	}

--- a/pkg/cmd/promote/promote.go
+++ b/pkg/cmd/promote/promote.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/pkg/errors"
-	survey "gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/environments"
@@ -873,7 +874,7 @@ func (o *PromoteOptions) CreatePromoteKey(env *v1.Environment) *kube.PromoteStep
 			}
 		}
 	}
-	name = kube.ToValidName(name)
+	name = naming.ToValidName(name)
 	log.Logger().Debugf("Using pipeline: %s build: %s", util.ColorInfo(pipeline), util.ColorInfo("#"+build))
 	return &kube.PromoteStepActivityKey{
 		PipelineActivityKey: kube.PipelineActivityKey{
@@ -939,7 +940,7 @@ func (o *PromoteOptions) CommentOnIssues(targetNS string, environment *v1.Enviro
 		return err
 	}
 
-	releaseName := kube.ToValidNameWithDots(app + "-" + version)
+	releaseName := naming.ToValidNameWithDots(app + "-" + version)
 	jxClient, _, err := o.JXClient()
 	if err != nil {
 		return err

--- a/pkg/cmd/step/post/step_post_run.go
+++ b/pkg/cmd/step/post/step_post_run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -86,7 +87,7 @@ func (o *StepPostRunOptions) Run() (err error) {
 	build := o.GetBuildNumber()
 	pipeline, build = o.GetPipelineName(gitInfo, pipeline, build, appName)
 	if pipeline != "" && build != "" {
-		name := kube.ToValidName(pipeline + "-" + build)
+		name := naming.ToValidName(pipeline + "-" + build)
 		key := &kube.PromoteStepActivityKey{
 			PipelineActivityKey: kube.PipelineActivityKey{
 				Name:     name,

--- a/pkg/cmd/step/pre/step_pre_extend.go
+++ b/pkg/cmd/step/pre/step_pre_extend.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	jenkinsv1client "github.com/jenkins-x/jx/pkg/client/clientset/versioned/typed/jenkins.io/v1"
 
@@ -114,7 +115,7 @@ func (o *StepPreExtendOptions) Run() error {
 		build := o.GetBuildNumber()
 		pipeline, build = o.GetPipelineName(gitInfo, pipeline, build, appName)
 		if pipeline != "" && build != "" {
-			name := kube.ToValidName(pipeline + "-" + build)
+			name := naming.ToValidName(pipeline + "-" + build)
 			key := &kube.PromoteStepActivityKey{
 				PipelineActivityKey: kube.PipelineActivityKey{
 					Name:     name,

--- a/pkg/cmd/step/step_changelog.go
+++ b/pkg/cmd/step/step_changelog.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/pkg/errors"
 
@@ -483,7 +484,7 @@ func (o *StepChangelogOptions) Run() error {
 		devRelease := *release
 		devRelease.ResourceVersion = ""
 		devRelease.Namespace = devNs
-		devRelease.Name = kube.ToValidName(appName + "-" + cleanVersion)
+		devRelease.Name = naming.ToValidName(appName + "-" + cleanVersion)
 		devRelease.Spec.Name = appName
 		_, err := kube.GetOrCreateRelease(jxClient, devNs, &devRelease)
 		if err != nil {
@@ -497,7 +498,7 @@ func (o *StepChangelogOptions) Run() error {
 	build := o.Build
 	pipeline, build = o.GetPipelineName(gitInfo, pipeline, build, appName)
 	if pipeline != "" && build != "" {
-		name := kube.ToValidName(pipeline + "-" + build)
+		name := naming.ToValidName(pipeline + "-" + build)
 		// lets see if we can update the pipeline
 		activities := jxClient.JenkinsV1().PipelineActivities(devNs)
 		lastCommitSha := ""

--- a/pkg/cmd/step/step_stash.go
+++ b/pkg/cmd/step/step_stash.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/collector"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -218,7 +219,7 @@ func (o *StepStashOptions) Run() error {
 	pipeline := fmt.Sprintf("%s-%s-%s-%s", projectOrg, projectRepoName, projectBranchName, buildNo)
 
 	if pipeline != "" && buildNo != "" {
-		name := kube.ToValidName(pipeline)
+		name := naming.ToValidName(pipeline)
 		key := &kube.PromoteStepActivityKey{
 			PipelineActivityKey: kube.PipelineActivityKey{
 				Name:     name,

--- a/pkg/cmd/step/step_tag.go
+++ b/pkg/cmd/step/step_tag.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/config"
-	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
@@ -213,13 +213,13 @@ func (o *StepTagOptions) updateChartValues(version string, chartsDir string) err
 	for idx, line := range lines {
 		if chartValueRepository != "" && strings.HasPrefix(line, ValuesYamlRepositoryPrefix) && !changedRepository {
 			// lets ensure we use a valid docker image name
-			chartValueRepository = kube.ToValidImageName(chartValueRepository)
+			chartValueRepository = naming.ToValidImageName(chartValueRepository)
 			updated = true
 			changedRepository = true
 			log.Logger().Infof("Updating repository in %s to %s", valuesFile, chartValueRepository)
 			lines[idx] = ValuesYamlRepositoryPrefix + " " + chartValueRepository
 		} else if strings.HasPrefix(line, ValuesYamlTagPrefix) && !changedTag {
-			version = kube.ToValidImageVersion(version)
+			version = naming.ToValidImageVersion(version)
 			updated = true
 			changedTag = true
 			log.Logger().Infof("Updating tag in %s to %s", valuesFile, version)

--- a/pkg/cmd/step/verify/step_verify_pod_count.go
+++ b/pkg/cmd/step/verify/step_verify_pod_count.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -156,7 +157,7 @@ func (o *StepVerifyPodCountOptions) detectPipelineActivity(jxClient versioned.In
 	if pipeline == "" || build == "" {
 		return nil, errors.New("JOB_NAME or BUILD_NUMBER environment variables not set")
 	}
-	name := kube.ToValidName(pipeline + "-" + build)
+	name := naming.ToValidName(pipeline + "-" + build)
 	activities := jxClient.JenkinsV1().PipelineActivities(namespace)
 	activity, err := activities.Get(name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/cmd/step_bdd.go
+++ b/pkg/cmd/step_bdd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cloud"
 	"github.com/jenkins-x/jx/pkg/cmd/create"
 	"github.com/jenkins-x/jx/pkg/cmd/deletecmd"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
@@ -213,7 +214,7 @@ func (o *StepBDDOptions) runOnCurrentCluster() error {
 		if o.InstallOptions.Flags.Tekton {
 			teamPrefix += "tekton-"
 		}
-		team := kube.ToValidName(teamPrefix + gitProviderName + "-" + o.teamNameSuffix())
+		team := naming.ToValidName(teamPrefix + gitProviderName + "-" + o.teamNameSuffix())
 		log.Logger().Infof("Creating team %s", util.ColorInfo(team))
 
 		installOptions := o.InstallOptions
@@ -538,7 +539,7 @@ func (o *StepBDDOptions) createCluster(cluster *bdd.CreateCluster) error {
 	if buildNum == "" {
 		log.Logger().Warnf("No build number could be found from the environment variable $BUILD_NUMBER!")
 	}
-	baseClusterName := kube.ToValidName(cluster.Name)
+	baseClusterName := naming.ToValidName(cluster.Name)
 	revision := os.Getenv("PULL_PULL_SHA")
 	branch := o.GetBranchName(o.Flags.VersionsDir)
 	if branch == "" {
@@ -558,7 +559,7 @@ func (o *StepBDDOptions) createCluster(cluster *bdd.CreateCluster) error {
 
 	log.Logger().Infof("using versions git repo %s and ref %s", o.InstallOptions.Flags.VersionsRepository, o.InstallOptions.Flags.VersionsGitRef)
 
-	cluster.Name = kube.ToValidName(branch + "-" + buildNum + "-" + cluster.Name)
+	cluster.Name = naming.ToValidName(branch + "-" + buildNum + "-" + cluster.Name)
 	log.Logger().Infof("\nCreating cluster %s", util.ColorInfo(cluster.Name))
 	binary := o.Flags.JxBinary
 	args := cluster.Args

--- a/pkg/io/config_writers.go
+++ b/pkg/io/config_writers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -107,7 +108,7 @@ func (k *KubeSecretsConfigWriter) Write(config *auth.Config) error {
 }
 
 func (k *KubeSecretsConfigWriter) secretName(server *auth.Server) string {
-	return kube.ToValidName(kube.SecretJenkinsPipelinePrefix + string(server.Kind) + "-" + string(server.ServiceKind) + "-" + server.Name)
+	return naming.ToValidName(kube.SecretJenkinsPipelinePrefix + string(server.Kind) + "-" + string(server.ServiceKind) + "-" + server.Name)
 }
 
 func (k *KubeSecretsConfigWriter) labels(server *auth.Server) map[string]string {

--- a/pkg/jenkinsfile/pipeline.go
+++ b/pkg/jenkinsfile/pipeline.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/tekton/syntax"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -968,8 +968,8 @@ func (c *PipelineConfig) createStageForBuildPack(args CreatePipelineArguments) (
 
 // CreatePipelineForBuildPack translates a set of lifecycles into a full pipeline.
 func (c *PipelineConfig) CreatePipelineForBuildPack(args CreatePipelineArguments) (*syntax.ParsedPipeline, int, error) {
-	args.GitOrg = kube.ToValidName(strings.ToLower(args.GitOrg))
-	args.GitName = kube.ToValidName(strings.ToLower(args.GitName))
+	args.GitOrg = naming.ToValidName(strings.ToLower(args.GitOrg))
+	args.GitName = naming.ToValidName(strings.ToLower(args.GitName))
 	args.DockerRegistryOrg = strings.ToLower(args.DockerRegistryOrg)
 
 	stage, newCounter, err := c.createStageForBuildPack(args)

--- a/pkg/kube/activity.go
+++ b/pkg/kube/activity.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/pkg/errors"
 
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -192,7 +193,7 @@ func createSourceRepositoryIfMissing(jxClient versioned.Interface, ns string, ac
 
 // GetOrCreate gets or creates the pipeline activity
 func (k *PipelineActivityKey) GetOrCreate(jxClient versioned.Interface, ns string) (*v1.PipelineActivity, bool, error) {
-	name := ToValidName(k.Name)
+	name := naming.ToValidName(k.Name)
 	create := false
 	defaultActivity := &v1.PipelineActivity{
 		ObjectMeta: metav1.ObjectMeta{
@@ -438,7 +439,7 @@ func updateActivity(k *PipelineActivityKey, activity *v1.PipelineActivity) {
 
 	updateActivitySpec(k, &activity.Spec)
 
-	activity.Labels[v1.LabelSourceRepository] = ToValidName(activity.Spec.GitOwner + "-" + activity.RepositoryName())
+	activity.Labels[v1.LabelSourceRepository] = naming.ToValidName(activity.Spec.GitOwner + "-" + activity.RepositoryName())
 	activity.Labels[v1.LabelProvider] = ToProviderName(activity.Spec.GitURL)
 	activity.Labels[v1.LabelOwner] = activity.RepositoryOwner()
 	activity.Labels[v1.LabelRepository] = activity.RepositoryName()

--- a/pkg/kube/activity_test.go
+++ b/pkg/kube/activity_test.go
@@ -2,10 +2,12 @@ package kube_test
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	jxfake "github.com/jenkins-x/jx/pkg/client/clientset/versioned/fake"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -98,7 +100,7 @@ func TestCreateOrUpdateActivities(t *testing.T) {
 	)
 	expectedPipeline := expectedOrganisation + "/" + expectedName + "/master"
 
-	sourceRepoName := kube.ToValidName(expectedOrganisation + "-" + expectedName)
+	sourceRepoName := naming.ToValidName(expectedOrganisation + "-" + expectedName)
 
 	key := kube.PipelineActivityKey{
 		Name:     expectedName,

--- a/pkg/kube/cluster/cluster.go
+++ b/pkg/kube/cluster/cluster.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"strings"
 
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -44,7 +45,7 @@ func ShortName(kuber kube.Kuber) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "retrieving the cluster name")
 	}
-	return kube.ToValidNameTruncated(clusterName, 16), nil
+	return naming.ToValidNameTruncated(clusterName, 16), nil
 }
 
 // SimplifiedClusterName get the simplified cluster name from the long-winded context cluster name that gets generated

--- a/pkg/kube/git_services.go
+++ b/pkg/kube/git_services.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/log"
 
 	"github.com/pkg/errors"
@@ -57,7 +58,7 @@ func EnsureGitServiceExistsForHost(jxClient versioned.Interface, devNs string, k
 	// not found so lets create a new GitService
 	gitSvc := &v1.GitService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ToValidNameWithDots(name),
+			Name: naming.ToValidNameWithDots(name),
 		},
 		Spec: v1.GitServiceSpec{
 			Name:    name,

--- a/pkg/kube/namespaces.go
+++ b/pkg/kube/namespaces.go
@@ -5,6 +5,7 @@ import (
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -156,7 +157,7 @@ func EnsureEditEnvironmentSetup(kubeClient kubernetes.Interface, jxClient versio
 		}
 	}
 
-	editNS := ToValidName(ns + "-edit-" + username)
+	editNS := naming.ToValidName(ns + "-edit-" + username)
 	labels := map[string]string{
 		LabelTeam:        ns,
 		LabelEnvironment: username,

--- a/pkg/kube/naming/names.go
+++ b/pkg/kube/naming/names.go
@@ -1,4 +1,4 @@
-package kube
+package naming
 
 import (
 	"bytes"

--- a/pkg/kube/naming/names_valid_test.go
+++ b/pkg/kube/naming/names_valid_test.go
@@ -1,9 +1,9 @@
-package kube_test
+package naming_test
 
 import (
 	"testing"
 
-	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,16 +36,16 @@ func TestToValidNameTruncated(t *testing.T) {
 }
 
 func assertToValidNameWithDots(t *testing.T, input string, expected string) {
-	actual := kube.ToValidNameWithDots(input)
+	actual := naming.ToValidNameWithDots(input)
 	assert.Equal(t, expected, actual, "ToValidNameWithDots for input %s", input)
 }
 
 func assertToValidName(t *testing.T, input string, expected string) {
-	actual := kube.ToValidName(input)
+	actual := naming.ToValidName(input)
 	assert.Equal(t, expected, actual, "ToValidName for input %s", input)
 }
 
 func assertToValidNameTruncated(t *testing.T, input string, maxLength int, expected string) {
-	actual := kube.ToValidNameTruncated(input, maxLength)
+	actual := naming.ToValidNameTruncated(input, maxLength)
 	assert.Equal(t, expected, actual, "ToValidNameTruncated for input %s", input)
 }

--- a/pkg/kube/sourcerepositories.go
+++ b/pkg/kube/sourcerepositories.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetOrCreateSourceRepository gets or creates the SourceRepository for the given repository name and organisation
 func GetOrCreateSourceRepository(jxClient versioned.Interface, ns string, name, organisation, providerURL string) (*v1.SourceRepository, error) {
-	resourceName := ToValidName(organisation + "-" + name)
+	resourceName := naming.ToValidName(organisation + "-" + name)
 
 	repositories := jxClient.JenkinsV1().SourceRepositories(ns)
 	description := fmt.Sprintf("Imported application for %s/%s", organisation, name)
@@ -79,7 +80,7 @@ func ToProviderName(gitURL string) string {
 	u, err := url.Parse(gitURL)
 	if err == nil {
 		host := strings.TrimSuffix(u.Host, ".com")
-		return ToValidName(host)
+		return naming.ToValidName(host)
 	}
 	idx := strings.Index(gitURL, "://")
 	if idx > 0 {
@@ -87,14 +88,14 @@ func ToProviderName(gitURL string) string {
 	}
 	gitURL = strings.TrimSuffix(gitURL, "/")
 	gitURL = strings.TrimSuffix(gitURL, ".com")
-	return ToValidName(gitURL)
+	return naming.ToValidName(gitURL)
 }
 
 // CreateSourceRepository creates a repo. If a repo already exists, it will return an error
 func CreateSourceRepository(client versioned.Interface, namespace string, name, organisation, providerURL string) error {
 	//FIXME: repo is not always == name, need to find a better value for ObjectMeta.Name!
 	// for now lets convert to a safe name using the organisation + repo name
-	resourceName := ToValidName(organisation + "-" + name)
+	resourceName := naming.ToValidName(organisation + "-" + name)
 
 	_, err := client.JenkinsV1().SourceRepositories(namespace).Create(&v1.SourceRepository{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kube/teams.go
+++ b/pkg/kube/teams.go
@@ -1,9 +1,11 @@
 package kube
 
 import (
-	"github.com/pkg/errors"
 	"sort"
 	"strings"
+
+	"github.com/jenkins-x/jx/pkg/kube/naming"
+	"github.com/pkg/errors"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -72,7 +74,7 @@ func CreateTeam(ns string, name string, members []string) *v1.Team {
 	kind := v1.TeamKindTypeCD
 	team := &v1.Team{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ToValidName(name),
+			Name:      naming.ToValidName(name),
 			Namespace: ns,
 		},
 		Spec: v1.TeamSpec{

--- a/pkg/kube/vault/vault.go
+++ b/pkg/kube/vault/vault.go
@@ -8,6 +8,7 @@ import (
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/kube/cluster"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/kube/serviceaccount"
 	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/jenkins-x/jx/pkg/vault"
@@ -169,9 +170,9 @@ func SystemVaultName(kuber kube.Kuber) (string, error) {
 
 // SystemVaultNameForCluster returns the system vault name from a given cluster name
 func SystemVaultNameForCluster(clusterName string) string {
-	shortClusterName := kube.ToValidNameTruncated(clusterName, 16)
+	shortClusterName := naming.ToValidNameTruncated(clusterName, 16)
 	fullName := fmt.Sprintf("%s-%s", vault.SystemVaultNamePrefix, shortClusterName)
-	return kube.ToValidNameTruncated(fullName, 22)
+	return naming.ToValidNameTruncated(fullName, 22)
 }
 
 // CreateGKEVault creates a new vault backed by GCP KMS and storage

--- a/pkg/pipelinescheduler/generator.go
+++ b/pkg/pipelinescheduler/generator.go
@@ -2,17 +2,19 @@ package pipelinescheduler
 
 import (
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/jenkins-x/jx/pkg/kube"
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/jenkins-x/jx/pkg/prow"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/prow"
 
 	"github.com/jenkins-x/jx/pkg/environments"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -653,7 +655,7 @@ func (o *GitOpsOptions) AddSchedulersToEnvironmentRepo(sourceRepositoryGroups []
 		}
 
 		for _, repo := range sourceRepositories {
-			repoName := kube.ToValidName(repo.Spec.Org + "-" + repo.Spec.Repo)
+			repoName := naming.ToValidName(repo.Spec.Org + "-" + repo.Spec.Repo)
 			if repo.Name == "" {
 				repo.Name = repoName
 			}

--- a/pkg/tekton/pipelines.go
+++ b/pkg/tekton/pipelines.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	jenkinsio "github.com/jenkins-x/jx/pkg/apis/jenkins.io"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/prow"
 
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -123,7 +124,7 @@ func GenerateNextBuildNumber(tektonClient tektonclient.Interface, jxClient jxCli
 	nextBuildNumber := ""
 	resourceInterface := jxClient.JenkinsV1().SourceRepositories(ns)
 	// TODO: How does SourceRepository handle name overlap?
-	sourceRepoName := kube.ToValidName(gitInfo.Organisation + "-" + gitInfo.Name)
+	sourceRepoName := naming.ToValidName(gitInfo.Organisation + "-" + gitInfo.Name)
 
 	f := func() error {
 		sourceRepo, err := kube.GetOrCreateSourceRepository(jxClient, ns, gitInfo.Name, gitInfo.Organisation, gitInfo.ProviderURL())
@@ -134,7 +135,7 @@ func GenerateNextBuildNumber(tektonClient tektonclient.Interface, jxClient jxCli
 		if sourceRepo.Annotations == nil {
 			sourceRepo.Annotations = make(map[string]string, 1)
 		}
-		annKey := LastBuildNumberAnnotationPrefix + kube.ToValidName(branch)
+		annKey := LastBuildNumberAnnotationPrefix + naming.ToValidName(branch)
 		annVal := sourceRepo.Annotations[annKey]
 		lastBuildNumber := 0
 		if annVal != "" {
@@ -313,7 +314,7 @@ func PipelineResourceName(organisation string, name string, branch string, conte
 	// characters, which is not allowed. Longest known prefix for now is 28
 	// chars (build-step-artifact-copy-to-), so we truncate to 35 so the
 	// generated container names are no more than 63 chars.
-	resourceName := kube.ToValidNameTruncated(dirtyName, 31)
+	resourceName := naming.ToValidNameTruncated(dirtyName, 31)
 	return resourceName
 }
 

--- a/pkg/testkube/secrets.go
+++ b/pkg/testkube/secrets.go
@@ -3,6 +3,7 @@ package testkube
 import (
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -11,7 +12,7 @@ import (
 func CreateTestPipelineGitSecret(gitServiceKind string, name string, gitUrl string, username string, password string) corev1.Secret {
 	return corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kube.ToValidName(name),
+			Name:      naming.ToValidName(name),
 			Namespace: "jx",
 			Annotations: map[string]string{
 				kube.AnnotationURL:  gitUrl,

--- a/pkg/users/git.go
+++ b/pkg/users/git.go
@@ -3,9 +3,9 @@ package users
 import (
 	"fmt"
 
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/pkg/errors"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,7 +95,7 @@ func (r *GitUserResolver) Resolve(user *gits.GitUser) (*jenkinsv1.User, error) {
 			}
 			id = fmt.Sprintf("%s-%d", gitUser.Login, i)
 		}
-		new.Name = kube.ToValidName(id)
+		new.Name = naming.ToValidName(id)
 		return id, possibles, new, nil
 	}
 	return Resolve(user.Login, r.GitProviderKey(), r.JXClient, r.Namespace, selectUsers)

--- a/pkg/users/user_details.go
+++ b/pkg/users/user_details.go
@@ -3,7 +3,7 @@ package users
 import (
 	"fmt"
 
-	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -31,7 +31,7 @@ func (this *UserDetailService) CreateOrUpdateUser(u *v1.UserDetails) error {
 
 	log.Logger().Infof("CreateOrUpdateUser: %s <%s>", u.Login, u.Email)
 
-	id := kube.ToValidName(u.Login)
+	id := naming.ToValidName(u.Login)
 
 	// check for an existing user by email
 	user, err := this.jxClient.JenkinsV1().Users(this.namespace).Get(id, metav1.GetOptions{})

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/log"
 
 	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
@@ -38,7 +38,7 @@ func GetUsers(jxClient versioned.Interface, ns string) (map[string]*jenkinsv1.Us
 
 // CreateUser creates a new default User
 func CreateUser(ns string, login string, name string, email string) *jenkinsv1.User {
-	id := kube.ToValidName(login)
+	id := naming.ToValidName(login)
 	user := &jenkinsv1.User{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      id,
@@ -71,7 +71,7 @@ func AddAccountReference(user *jenkinsv1.User, gitProviderKey string, id string)
 
 // DeleteUser deletes the user resource but does not uninstall the underlying namespaces
 func DeleteUser(jxClient versioned.Interface, ns string, userName string) error {
-	id := kube.ToValidName(userName)
+	id := naming.ToValidName(userName)
 	userInterface := jxClient.JenkinsV1().Users(ns)
 	_, err := userInterface.Get(id, metav1.GetOptions{})
 	if err == nil {

--- a/pkg/workflow/workflows.go
+++ b/pkg/workflow/workflows.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -56,7 +57,7 @@ func CreateDefaultWorkflow(jxClient versioned.Interface, ns string) (*v1.Workflo
 func CreateWorkflow(ns string, name string, steps ...v1.WorkflowStep) *v1.Workflow {
 	return &v1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kube.ToValidName(name),
+			Name:      naming.ToValidName(name),
 			Namespace: ns,
 		},
 		Spec: v1.WorkflowSpec{


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

`import` does the same replacements as `pkg/jenkinsfile/pipeline.go` does, but for Git org and repo, the replacement goes through `kube.ToValidName(strings.ToLower(...))`. We should be doing that in `pipeline.go` for build pack transformation as well.

And while I was here, I moved `pkg/kube/names.go` to `pkg/util/names.go` and renamed the functions to `ToValidKubeName` (and so on), since the `kube` package depends on way too many other packages as is (so I couldn't use it in the `jenkinsfile` package, for example).

#### Special notes for the reviewer(s)

/assign @dwnusbaum 
/assign @hferentschik 

#### Which issue this PR fixes

fixes #4432
