### PR TITLE
fix: import GitLab repos with subgroups

### DIFF
--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -3,6 +3,7 @@ package gits
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/util"
@@ -148,7 +149,7 @@ func ParseGitURL(text string) (*GitRepository, error) {
 			answer.Scheme = "git"
 			answer.Host = arr[0]
 			answer.Organisation = arr[1]
-			answer.Name = arr[2]
+			answer.Name = arr[len(arr)-1]
 			return &answer, nil
 		}
 	}
@@ -202,6 +203,8 @@ func parsePath(path string, info *GitRepository, requireRepo bool) (*GitReposito
 	// This is necessary for Bitbucket Server in other cases
 	trimPath = strings.Replace(trimPath, "/projects", "", 1)
 	trimPath = strings.Replace(trimPath, "/repos", "", 1)
+	re := regexp.MustCompile("/pull-requests/[0-9]+$")
+	trimPath = re.ReplaceAllString(trimPath, "")
 
 	// Remove leading and trailing slashes so that splitting on "/" won't result
 	// in empty strings at the beginning & end of the array.
@@ -212,10 +215,10 @@ func parsePath(path string, info *GitRepository, requireRepo bool) (*GitReposito
 
 	arr := strings.Split(trimPath, "/")
 	if len(arr) >= 2 {
-		// We're assuming the beginning of the path is of the form /<org>/<repo>
+		// We're assuming the beginning of the path is of the form /<org>/<repo> or /<org>/<subgroup>/.../<repo>
 		info.Organisation = arr[0]
 		info.Project = arr[0]
-		info.Name = arr[1]
+		info.Name = arr[len(arr)-1]
 
 		return info, nil
 	} else if len(arr) == 1 && !requireRepo {

--- a/pkg/gits/git_url_test.go
+++ b/pkg/gits/git_url_test.go
@@ -108,6 +108,12 @@ func TestParseGitURL(t *testing.T) {
 			"git@github.com:bar/foo", "github.com", "bar", "foo",
 		},
 		{
+			"git@gitlab.com:bar/subgroup/foo", "gitlab.com", "bar", "foo",
+		},
+		{
+			"https://gitlab.com/bar/subgroup/foo", "gitlab.com", "bar", "foo",
+		},
+		{
 			"bar/foo", "github.com", "bar", "foo",
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
allows import repos created inside subgroups in Gitlab
for example: https://gitlab.com/good-backend/subgroup/test-project

about subgroups: https://gitlab.com/help/user/group/subgroups/index

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
