### PR TITLE
fix: environment controller not finding git token if GIT_KIND

### DIFF
--- a/pkg/cmd/controller/controller_enviornmentcontroller.go
+++ b/pkg/cmd/controller/controller_enviornmentcontroller.go
@@ -510,10 +510,17 @@ func (o *ControllerEnvironmentOptions) registerWebHook(webhookURL string, secret
 
 	var provider gits.GitProvider
 	var err error
+
 	if o.GitKind != "" {
-		provider, err = o.GitProviderForGitServerURL(gitURL, o.GitKind)
+		gitInfo, err := gits.ParseGitURL(gitURL)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create git provider for git URL %s kind %s", gitURL, o.GitKind)
+			return err
+		}
+		gitHostURL := gitInfo.HostURL()
+
+		provider, err = o.GitProviderForGitServerURL(gitHostURL, o.GitKind)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create git provider for git URL %s kind %s", gitHostURL, o.GitKind)
 		}
 	} else {
 		provider, err = o.GitProviderForURL(gitURL, "creating webhook git provider")


### PR DESCRIPTION
looks like a regression in the code - using the git repo URL not the git service URL (https://github.com) to find the pipeline auth token

fixes #4316

Signed-off-by: James Strachan <james.strachan@gmail.com>