### PR TITLE
chore: Fix scheduler docs

### DIFF
--- a/pkg/cmd/step/scheduler/step_scheduler_config_apply.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_apply.go
@@ -13,7 +13,8 @@ import (
 // StepSchedulerConfigApplyOptions contains the command line flags
 type StepSchedulerConfigApplyOptions struct {
 	opts.StepOptions
-	Agent string
+	Agent         string
+	ApplyDirectly bool
 	// allow git to be configured externally before a PR is created
 	ConfigureGitCallback gits.ConfigureGitFn
 }
@@ -52,6 +53,7 @@ func NewCmdStepSchedulerConfigApply(commonOpts *opts.CommonOptions) *cobra.Comma
 	}
 	options.AddCommonFlags(cmd)
 	cmd.Flags().StringVarP(&options.Agent, "agent", "", "prow", "The scheduler agent to use e.g. Prow")
+	cmd.Flags().BoolVarP(&options.ApplyDirectly, "applyDirectly", "", false, "Skip generating a PR and apply the pipeline config directly to the cluster when using gitops mode.")
 	return cmd
 }
 
@@ -77,7 +79,7 @@ func (o *StepSchedulerConfigApplyOptions) Run() error {
 			return errors.WithStack(err)
 		}
 
-		if gitOps {
+		if gitOps && !o.ApplyDirectly {
 			opts := pipelinescheduler.GitOpsOptions{
 				Verbose: o.Verbose,
 				DevEnv:  devEnv,

--- a/pkg/cmd/step/scheduler/step_scheduler_config_apply.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_apply.go
@@ -53,7 +53,7 @@ func NewCmdStepSchedulerConfigApply(commonOpts *opts.CommonOptions) *cobra.Comma
 	}
 	options.AddCommonFlags(cmd)
 	cmd.Flags().StringVarP(&options.Agent, "agent", "", "prow", "The scheduler agent to use e.g. Prow")
-	cmd.Flags().BoolVarP(&options.ApplyDirectly, "applyDirectly", "", false, "Skip generating a PR and apply the pipeline config directly to the cluster when using gitops mode.")
+	cmd.Flags().BoolVarP(&options.ApplyDirectly, "direct", "", false, "Skip generating a PR and apply the pipeline config directly to the cluster when using gitops mode.")
 	return cmd
 }
 

--- a/pkg/cmd/step/scheduler/step_scheduler_config_migrate.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_migrate.go
@@ -25,13 +25,23 @@ type StepSchedulerConfigMigrateOptions struct {
 
 var (
 	stepSchedulerConfigMigrateLong = templates.LongDesc(`
-        This command will transform your pipeline schedulers in to prow config. 
-        If you are using gitops the prow config will be added to your environment repository. 
-        For non-gitops environments the prow config maps will applied to your dev environment.
+        This command will generate pipeline scheduler resources from either the prow config maps or prow config files.
+        For gitops users they will be added to the dev environment git repository.
+        For non gitops users they will be applied directly to the cluster if --dryRun=false.
 `)
 	stepSchedulerConfigMigrateExample = templates.Examples(`
-	
+	# Test the migration but do not apply
 	jx step scheduler config migrate
+
+    # Generate the pipeline schedulers and apply them either via gitops or directly to the cluster
+    jx step scheduler config migrate --dryRun=false
+
+    # Generate the pipeline schedulers from files instead of the existing configmaps in the cluster
+    jx step scheduler config migrate --prow-config-file=config.yaml --prow-plugins-file=plugins.yaml
+
+    # Disable validation checks when migrating to pipeline schedulers
+    jx step scheduler config migrate --skipVerification=true
+    
 `)
 )
 


### PR DESCRIPTION
Update scheduler migration help. Also support applying pipeline schedulers directly to the cluster when using `jx step scheduler config apply --direct=true` in gitops mode.