### PR TITLE
fix: lets default to jenkins x pipelines if there's a missing importmode

### DIFF
--- a/pkg/apis/jenkins.io/v1/types_environment.go
+++ b/pkg/apis/jenkins.io/v1/types_environment.go
@@ -330,6 +330,9 @@ func (t *TeamSettings) SetStorageLocation(classifier string, storage StorageLoca
 // GetImportMode returns the import mode - returning a default value if it has not been populated yet
 func (t *TeamSettings) GetImportMode() ImportModeType {
 	if string(t.ImportMode) == "" {
+		if t.IsJenkinsXPipelines() {
+			return ImportModeTypeYAML
+		}
 		return ImportModeTypeJenkinsfile
 	}
 	return t.ImportMode


### PR DESCRIPTION
if we lose the import mode for some reason on the teamSettings, lets default to jenkins x pipelines if we prow/tekton

fixes #4456

Signed-off-by: James Strachan <james.strachan@gmail.com>