### PR TITLE
fix(tekton): Activity and get build logs should support metapipeline

### DIFF
--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -606,7 +606,7 @@ func (o *ControllerBuildOptions) updatePipelineActivityForRun(kubeClient kuberne
 	spec := &activity.Spec
 	var biggestFinishedAt metav1.Time
 
-	allCompleted := true
+	allStagesCompleted := true
 	failed := false
 	running := true
 	for i := range spec.Steps {
@@ -634,18 +634,18 @@ func (o *ControllerBuildOptions) updatePipelineActivityForRun(kubeClient kuberne
 					failed = true
 				}
 			} else {
-				allCompleted = false
+				allStagesCompleted = false
 			}
 			if stage.Status == v1.ActivityStatusTypeRunning {
 				running = true
 			}
 			if stage.Status == v1.ActivityStatusTypeRunning || stage.Status == v1.ActivityStatusTypePending {
-				allCompleted = false
+				allStagesCompleted = false
 			}
 		}
 	}
 
-	if allCompleted {
+	if allStagesCompleted {
 		if failed {
 			spec.Status = v1.ActivityStatusTypeFailed
 		} else if pri.Type == tekton.MetaPipeline {

--- a/pkg/cmd/get/get_build_logs_test.go
+++ b/pkg/cmd/get/get_build_logs_test.go
@@ -1,0 +1,69 @@
+package get_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/acarl005/stripansi"
+	jxfake "github.com/jenkins-x/jx/pkg/client/clientset/versioned/fake"
+	"github.com/jenkins-x/jx/pkg/cmd/get"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/tekton/tekton_helpers_test"
+	"github.com/stretchr/testify/assert"
+	tektonfake "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	kube_mocks "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestWithMetapipeline(t *testing.T) {
+	testCaseDir := path.Join("test_data", "get_build_logs", "with-metapipeline")
+
+	structures := tekton_helpers_test.AssertLoadPipelineStructures(t, testCaseDir)
+	jxClient := jxfake.NewSimpleClientset(structures)
+
+	tektonObjects := []runtime.Object{tekton_helpers_test.AssertLoadPipelineRuns(t, testCaseDir), tekton_helpers_test.AssertLoadPipelines(t, testCaseDir)}
+	tektonObjects = append(tektonObjects, tekton_helpers_test.AssertLoadTasks(t, testCaseDir))
+	tektonObjects = append(tektonObjects, tekton_helpers_test.AssertLoadTaskRuns(t, testCaseDir))
+	tektonClient := tektonfake.NewSimpleClientset(tektonObjects...)
+
+	podList := tekton_helpers_test.AssertLoadPods(t, testCaseDir)
+	kubeClient := kube_mocks.NewSimpleClientset(podList)
+
+	ns := "jx"
+
+	o := &get.GetBuildLogsOptions{
+		GetOptions: get.GetOptions{
+			CommonOptions: &opts.CommonOptions{
+				BatchMode: true,
+			},
+		},
+	}
+
+	names, defaultName, pipelineMap, err := o.LoadPipelines(kubeClient, tektonClient, jxClient, ns)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(names))
+	assert.Equal(t, "", defaultName)
+
+	pipelineName := names[0]
+	assert.Equal(t, "abayer/js-test-repo/build-pack #8", pipelineName)
+
+	assert.Equal(t, 2, len(pipelineMap[pipelineName]))
+
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+	o.CommonOptions.Out = fakeStdout
+	o.Args = []string{pipelineName}
+
+	err = o.GetProwBuildLog(kubeClient, tektonClient, jxClient, ns, true)
+	assert.NoError(t, err)
+
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	output := stripansi.Strip(string(outBytes))
+	assert.Contains(t, output, "stage app extension")
+	assert.Contains(t, output, "stage from build pack")
+}

--- a/pkg/cmd/get/get_build_logs_test.go
+++ b/pkg/cmd/get/get_build_logs_test.go
@@ -1,4 +1,4 @@
-package get_test
+package get
 
 import (
 	"io/ioutil"
@@ -8,7 +8,6 @@ import (
 
 	"github.com/acarl005/stripansi"
 	jxfake "github.com/jenkins-x/jx/pkg/client/clientset/versioned/fake"
-	"github.com/jenkins-x/jx/pkg/cmd/get"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/tekton/tekton_helpers_test"
@@ -34,15 +33,15 @@ func TestWithMetapipeline(t *testing.T) {
 
 	ns := "jx"
 
-	o := &get.GetBuildLogsOptions{
-		GetOptions: get.GetOptions{
+	o := &GetBuildLogsOptions{
+		GetOptions: GetOptions{
 			CommonOptions: &opts.CommonOptions{
 				BatchMode: true,
 			},
 		},
 	}
 
-	names, defaultName, pipelineMap, err := o.LoadPipelines(kubeClient, tektonClient, jxClient, ns)
+	names, defaultName, pipelineMap, err := o.loadPipelines(kubeClient, tektonClient, jxClient, ns)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(names))
 	assert.Equal(t, "", defaultName)
@@ -57,7 +56,7 @@ func TestWithMetapipeline(t *testing.T) {
 	o.CommonOptions.Out = fakeStdout
 	o.Args = []string{pipelineName}
 
-	err = o.GetProwBuildLog(kubeClient, tektonClient, jxClient, ns, true)
+	err = o.getProwBuildLog(kubeClient, tektonClient, jxClient, ns, true)
 	assert.NoError(t, err)
 
 	fakeStdout.Close()

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelineruns.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelineruns.yml
@@ -1,0 +1,235 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineRun
+  metadata:
+    creationTimestamp: "2019-07-02T12:34:56Z"
+    generation: 1
+    labels:
+      tekton.dev/pipeline: abayer-js-test-repo-build-pack-8
+    name: abayer-js-test-repo-build-pack-8
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: pipeline
+      name: abayer-js-test-repo-build-pack-8
+      uid: cc57794e-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "236414"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/abayer-js-test-repo-build-pack-8
+    uid: cc59f237-9cc5-11e9-aa2e-42010a8a00fe
+  spec:
+    params:
+    - name: version
+      value: 0.0.7
+    - name: build_id
+      value: "8"
+    pipelineRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: abayer-js-test-repo-build-pack-8
+    resources:
+    - name: abayer-js-test-repo-build-pack
+      resourceRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: abayer-js-test-repo-build-pack
+    serviceAccount: tekton-bot
+    timeout: 240h0m0s
+  status:
+    completionTime: "2019-07-02T12:36:47Z"
+    conditions:
+    - lastTransitionTime: "2019-07-02T12:36:47Z"
+      message: TaskRun abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t has failed
+      reason: Failed
+      status: "False"
+      type: Succeeded
+    startTime: "2019-07-02T12:34:56Z"
+    taskRuns:
+      abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t:
+        pipelineTaskName: from-build-pack
+        status:
+          completionTime: "2019-07-02T12:36:47Z"
+          conditions:
+          - lastTransitionTime: "2019-07-02T12:36:47Z"
+            message: '"build-step-promote-jx-promote" exited with code 1 (image: "docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82");
+              for logs run: kubectl -n jx logs abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t-pod-1682b0
+              -c build-step-promote-jx-promote'
+            status: "False"
+            type: Succeeded
+          podName: abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t-pod-1682b0
+          startTime: "2019-07-02T12:34:56Z"
+          steps:
+          - name: build-container-build
+            terminated:
+              containerID: docker://ee94afd22cdb071ffd2566ec3478d1290b54185b87d530cf907908c02e63195b
+              exitCode: 0
+              finishedAt: "2019-07-02T12:36:05Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:02Z"
+          - name: build-npm-install
+            terminated:
+              containerID: docker://60fae7303bc984339e5ad90c9279910bc873e16a19efa026d024c421c2c77056
+              exitCode: 0
+              finishedAt: "2019-07-02T12:35:38Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:01Z"
+          - name: build-npm-test
+            terminated:
+              containerID: docker://15b3ad11f0ee9a47ec69033f17375670f26810a6e4dbba6ed4f01821c8f4ff6c
+              exitCode: 0
+              finishedAt: "2019-07-02T12:35:41Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:02Z"
+          - name: build-npmrc
+            terminated:
+              containerID: docker://5f6fe39d8b812945a914dd7ff10c386f1bebd70c4f8dbe023360f92289ceca7e
+              exitCode: 0
+              finishedAt: "2019-07-02T12:35:03Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:01Z"
+          - name: build-post-build
+            terminated:
+              containerID: docker://b02211c50527464acb6133331904f156b1b1b09c472aa50c463123dc9a101533
+              exitCode: 0
+              finishedAt: "2019-07-02T12:36:06Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:02Z"
+          - name: git-merge
+            terminated:
+              containerID: docker://bf9a1b3872c8e343ca9b17d5e999692abadadd1b0c49084a12c93cefdea1e828
+              exitCode: 0
+              finishedAt: "2019-07-02T12:35:02Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:01Z"
+          - name: git-source-abayer-js-test-repo-build-pack-72kkp
+            terminated:
+              containerID: docker://087e23e897b77226706cf686a074a942ce9d4a50fc651d3bf9a54b2b1aeb8b40
+              exitCode: 0
+              finishedAt: "2019-07-02T12:35:02Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:00Z"
+          - name: promote-changelog
+            terminated:
+              containerID: docker://5780df05616c5f396b108d2549359061fc79d7eec5fc062c237f70472fa2f95d
+              exitCode: 0
+              finishedAt: "2019-07-02T12:36:12Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:02Z"
+          - name: promote-helm-release
+            terminated:
+              containerID: docker://fda8599e3607d47d86d7e62ad68eb96cb4646e912b53166500d2b1c54b6a1835
+              exitCode: 0
+              finishedAt: "2019-07-02T12:36:17Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:02Z"
+          - name: promote-jx-promote
+            terminated:
+              containerID: docker://d4abd70d8942c22bcd1d9fa1ec8a9440fa65ef4143c15b0286e0589f1dbb2a22
+              exitCode: 1
+              finishedAt: "2019-07-02T12:36:46Z"
+              reason: Error
+              startedAt: "2019-07-02T12:35:03Z"
+          - name: setup-jx-git-credentials
+            terminated:
+              containerID: docker://8ef0a0090393a926ac59b0ed792d9e4fa32ed93443a2da251d0f8913688d1c10
+              exitCode: 0
+              finishedAt: "2019-07-02T12:35:03Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:01Z"
+          - name: nop
+            terminated:
+              containerID: docker://654321b1884f8d3d7408e9a19b0a6371275b42f8a62cc765def420941ce8b835
+              exitCode: 0
+              finishedAt: "2019-07-02T12:36:47Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:35:03Z"
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineRun
+  metadata:
+    creationTimestamp: "2019-07-02T12:34:45Z"
+    generation: 1
+    labels:
+      branch: build-pack
+      build: "8"
+      owner: abayer
+      repo: js-test-repo
+      tekton.dev/pipeline: meta-abayer-js-test-repo-build-8
+    name: meta-abayer-js-test-repo-build-8
+    namespace: jx
+    ownerReferences:
+      - apiVersion: tekton.dev/v1alpha1
+        kind: pipeline
+        name: meta-abayer-js-test-repo-build-8
+        uid: c5ad1626-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "235902"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/meta-abayer-js-test-repo-build-8
+    uid: c5bd38e9-9cc5-11e9-aa2e-42010a8a00fe
+  spec:
+    pipelineRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: meta-abayer-js-test-repo-build-8
+    resources:
+      - name: meta-abayer-js-test-repo-build
+        resourceRef:
+          apiVersion: tekton.dev/v1alpha1
+          name: meta-abayer-js-test-repo-build
+    serviceAccount: tekton-bot
+    timeout: 240h0m0s
+  status:
+    completionTime: "2019-07-02T12:34:59Z"
+    conditions:
+      - lastTransitionTime: "2019-07-02T12:34:59Z"
+        message: All Tasks have completed executing
+        reason: Succeeded
+        status: "True"
+        type: Succeeded
+    startTime: "2019-07-02T12:34:45Z"
+    taskRuns:
+      meta-abayer-js-test-repo-build-8-app-extension-kvvp6:
+        pipelineTaskName: app-extension
+        status:
+          completionTime: "2019-07-02T12:34:57Z"
+          conditions:
+            - lastTransitionTime: "2019-07-02T12:34:57Z"
+              status: "True"
+              type: Succeeded
+          podName: meta-abayer-js-test-repo-build-8-app-extension-kvvp6-pod-fcf1fe
+          startTime: "2019-07-02T12:34:45Z"
+          steps:
+            - name: create-effective-pipeline
+              terminated:
+                containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+                exitCode: 0
+                finishedAt: "2019-07-02T12:34:52Z"
+                reason: Completed
+                startedAt: "2019-07-02T12:34:49Z"
+            - name: create-tekton-crds
+              terminated:
+                containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+                exitCode: 0
+                finishedAt: "2019-07-02T12:34:56Z"
+                reason: Completed
+                startedAt: "2019-07-02T12:34:49Z"
+            - name: git-merge
+              terminated:
+                containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+                exitCode: 0
+                finishedAt: "2019-07-02T12:34:50Z"
+                reason: Completed
+                startedAt: "2019-07-02T12:34:49Z"
+            - name: git-source-meta-abayer-js-test-repo-build-v7hvv
+              terminated:
+                containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+                exitCode: 0
+                finishedAt: "2019-07-02T12:34:49Z"
+                reason: Completed
+                startedAt: "2019-07-02T12:34:49Z"
+            - name: nop
+              terminated:
+                containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+                exitCode: 0
+                finishedAt: "2019-07-02T12:34:57Z"
+                reason: Completed
+                startedAt: "2019-07-02T12:34:50Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelines.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelines.yml
@@ -1,0 +1,78 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Pipeline
+  metadata:
+    creationTimestamp: "2019-07-02T12:34:56Z"
+    generation: 1
+    name: abayer-js-test-repo-build-pack-8
+    namespace: jx
+    ownerReferences:
+    - apiVersion: jenkins.io/v1
+      kind: PipelineActivity
+      name: abayer-js-test-repo-build-pack-8
+      uid: c5e1fa64-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "235864"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/abayer-js-test-repo-build-pack-8
+    uid: cc57794e-9cc5-11e9-aa2e-42010a8a00fe
+  spec:
+    params:
+    - default: 0.0.7
+      description: the version number for this pipeline which is used as a tag on docker
+        images and helm charts
+      name: version
+    - default: "8"
+      description: the PipelineRun build number
+      name: build_id
+    resources:
+    - name: abayer-js-test-repo-build-pack
+      type: git
+    tasks:
+    - name: from-build-pack
+      params:
+      - name: version
+        value: ${params.version}
+      - name: build_id
+        value: ${params.build_id}
+      resources:
+        inputs:
+        - name: workspace
+          resource: abayer-js-test-repo-build-pack
+      taskRef:
+        name: abayer-js-test-repo-build-pack-from-build-pack-8
+- apiVersion: tekton.dev/v1alpha1
+  kind: Pipeline
+  metadata:
+    creationTimestamp: "2019-07-02T12:34:45Z"
+    generation: 1
+    labels:
+      branch: build-pack
+      build: "8"
+      owner: abayer
+      repo: js-test-repo
+    name: meta-abayer-js-test-repo-build-8
+    namespace: jx
+    ownerReferences:
+      - apiVersion: jenkins.io/v1
+        kind: PipelineActivity
+        name: abayer-js-test-repo-build-pack-meta-8
+        uid: c57379a2-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "235775"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/meta-abayer-js-test-repo-build-8
+    uid: c5ad1626-9cc5-11e9-aa2e-42010a8a00fe
+  spec:
+    resources:
+      - name: meta-abayer-js-test-repo-build
+        type: git
+    tasks:
+      - name: app-extension
+        resources:
+          inputs:
+            - name: workspace
+              resource: meta-abayer-js-test-repo-build
+        taskRef:
+          name: meta-abayer-js-test-repo-build-app-extension-8
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pods.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pods.yml
@@ -1,0 +1,1870 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      sidecar.istio.io/inject: "false"
+    creationTimestamp: "2019-07-02T12:34:45Z"
+    labels:
+      branch: build-pack
+      build: "8"
+      jenkins.io/task-stage-name: app-extension
+      owner: abayer
+      repo: js-test-repo
+      tekton.dev/pipeline: meta-abayer-js-test-repo-build-8
+      tekton.dev/pipelineRun: meta-abayer-js-test-repo-build-8
+      tekton.dev/task: meta-abayer-js-test-repo-build-app-extension-8
+      tekton.dev/taskRun: meta-abayer-js-test-repo-build-8-app-extension-kvvp6
+    name: meta-abayer-js-test-repo-build-8-app-extension-kvvp6-pod-fcf1fe
+    namespace: jx
+    ownerReferences:
+      - apiVersion: tekton.dev/v1alpha1
+        blockOwnerDeletion: true
+        controller: true
+        kind: TaskRun
+        name: meta-abayer-js-test-repo-build-8-app-extension-kvvp6
+        uid: c5c20379-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "235888"
+    selfLink: /api/v1/namespaces/jx/pods/meta-abayer-js-test-repo-build-8-app-extension-kvvp6-pod-fcf1fe
+    uid: c5c6d6f9-9cc5-11e9-aa2e-42010a8a00fe
+  spec:
+    containers:
+      - args:
+          - -wait_file
+          - ""
+          - -post_file
+          - /builder/tools/0
+          - -entrypoint
+          - /ko-app/git-init
+          - --
+          - -url
+          - https://github.com/abayer/js-test-repo
+          - -revision
+          - build-pack
+          - -path
+          - /workspace/source
+        command:
+          - /builder/tools/entrypoint
+        env:
+          - name: HOME
+            value: /builder/home
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.4.0
+        imagePullPolicy: IfNotPresent
+        name: build-step-git-source-meta-abayer-js-test-repo-build-v7hvv
+        resources:
+          requests:
+            cpu: "0"
+            ephemeral-storage: "0"
+            memory: "0"
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /builder/tools
+            name: tools
+          - mountPath: /workspace
+            name: workspace
+          - mountPath: /builder/home
+            name: home
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: tekton-bot-token-kbbrz
+            readOnly: true
+        workingDir: /workspace
+      - args:
+          - -wait_file
+          - /builder/tools/0
+          - -post_file
+          - /builder/tools/1
+          - -entrypoint
+          - jx
+          - --
+          - step
+          - git
+          - merge
+          - --verbose
+        command:
+          - /builder/tools/entrypoint
+        env:
+          - name: HOME
+            value: /builder/home
+          - name: APP_NAME
+            value: js-test-repo
+          - name: BRANCH_NAME
+            value: build-pack
+          - name: BUILD_NUMBER
+            value: "8"
+          - name: JOB_NAME
+            value: abayer/js-test-repo/build-pack
+          - name: JX_LOG_FORMAT
+            value: json
+          - name: PIPELINE_KIND
+            value: release
+          - name: REPO_NAME
+            value: js-test-repo
+          - name: REPO_OWNER
+            value: abayer
+        image: gcr.io/jenkinsxio/builder-maven:0.1.542
+        imagePullPolicy: IfNotPresent
+        name: build-step-git-merge
+        resources:
+          requests:
+            cpu: "0"
+            ephemeral-storage: "0"
+            memory: "0"
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /builder/tools
+            name: tools
+          - mountPath: /workspace
+            name: workspace
+          - mountPath: /builder/home
+            name: home
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: tekton-bot-token-kbbrz
+            readOnly: true
+        workingDir: /workspace/source
+      - args:
+          - -wait_file
+          - /builder/tools/1
+          - -post_file
+          - /builder/tools/2
+          - -entrypoint
+          - /bin/sh
+          - --
+          - -c
+          - jx step syntax effective --output-dir .
+        command:
+          - /builder/tools/entrypoint
+        env:
+          - name: HOME
+            value: /builder/home
+          - name: APP_NAME
+            value: js-test-repo
+          - name: BRANCH_NAME
+            value: build-pack
+          - name: BUILD_NUMBER
+            value: "8"
+          - name: JOB_NAME
+            value: abayer/js-test-repo/build-pack
+          - name: JX_LOG_FORMAT
+            value: json
+          - name: PIPELINE_KIND
+            value: release
+          - name: REPO_NAME
+            value: js-test-repo
+          - name: REPO_OWNER
+            value: abayer
+        image: gcr.io/jenkinsxio/builder-maven:0.1.542
+        imagePullPolicy: IfNotPresent
+        name: build-step-create-effective-pipeline
+        resources:
+          requests:
+            cpu: "0"
+            ephemeral-storage: "0"
+            memory: "0"
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /builder/tools
+            name: tools
+          - mountPath: /workspace
+            name: workspace
+          - mountPath: /builder/home
+            name: home
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: tekton-bot-token-kbbrz
+            readOnly: true
+        workingDir: /workspace/source
+      - args:
+          - -wait_file
+          - /builder/tools/2
+          - -post_file
+          - /builder/tools/3
+          - -entrypoint
+          - /bin/sh
+          - --
+          - -c
+          - jx step create task --clone-dir /workspace/source --build-number 8 --trigger
+            manual --service-account tekton-bot --source source --branch build-pack
+        command:
+          - /builder/tools/entrypoint
+        env:
+          - name: HOME
+            value: /builder/home
+          - name: APP_NAME
+            value: js-test-repo
+          - name: BRANCH_NAME
+            value: build-pack
+          - name: BUILD_NUMBER
+            value: "8"
+          - name: JOB_NAME
+            value: abayer/js-test-repo/build-pack
+          - name: JX_LOG_FORMAT
+            value: json
+          - name: PIPELINE_KIND
+            value: release
+          - name: REPO_NAME
+            value: js-test-repo
+          - name: REPO_OWNER
+            value: abayer
+        image: gcr.io/jenkinsxio/builder-maven:0.1.542
+        imagePullPolicy: IfNotPresent
+        name: build-step-create-tekton-crds
+        resources:
+          requests:
+            cpu: "0"
+            ephemeral-storage: "0"
+            memory: "0"
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /builder/tools
+            name: tools
+          - mountPath: /workspace
+            name: workspace
+          - mountPath: /builder/home
+            name: home
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: tekton-bot-token-kbbrz
+            readOnly: true
+        workingDir: /workspace/source
+      - args:
+          - -wait_file
+          - /builder/tools/3
+          - -post_file
+          - /builder/tools/4
+          - -entrypoint
+          - /ko-app/nop
+          - --
+        command:
+          - /builder/tools/entrypoint
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.4.0
+        imagePullPolicy: IfNotPresent
+        name: nop
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /builder/tools
+            name: tools
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: tekton-bot-token-kbbrz
+            readOnly: true
+    dnsPolicy: ClusterFirst
+    initContainers:
+      - args:
+          - -basic-git=knative-git-user-pass=https://github.com
+        command:
+          - /ko-app/creds-init
+        env:
+          - name: HOME
+            value: /builder/home
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.4.0
+        imagePullPolicy: IfNotPresent
+        name: build-step-credential-initializer-xht92
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /workspace
+            name: workspace
+          - mountPath: /builder/home
+            name: home
+          - mountPath: /var/build-secrets/knative-git-user-pass
+            name: secret-volume-knative-git-user-pass-6zhjb
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: tekton-bot-token-kbbrz
+            readOnly: true
+        workingDir: /workspace
+      - args:
+          - -args
+          - mkdir -p /workspace/source
+        command:
+          - /ko-app/bash
+        env:
+          - name: HOME
+            value: /builder/home
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
+        imagePullPolicy: IfNotPresent
+        name: build-step-working-dir-initializer-8c9w5
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /workspace
+            name: workspace
+          - mountPath: /builder/home
+            name: home
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: tekton-bot-token-kbbrz
+            readOnly: true
+        workingDir: /workspace
+      - args:
+          - -c
+          - cp /ko-app/entrypoint /builder/tools/entrypoint
+        command:
+          - /bin/sh
+        env:
+          - name: HOME
+            value: /builder/home
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.4.0
+        imagePullPolicy: IfNotPresent
+        name: build-step-place-tools
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /builder/tools
+            name: tools
+          - mountPath: /workspace
+            name: workspace
+          - mountPath: /builder/home
+            name: home
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: tekton-bot-token-kbbrz
+            readOnly: true
+        workingDir: /workspace
+    nodeName: gke-abayer-test-cluster-default-pool-666b1aa4-k4xk
+    priority: 0
+    restartPolicy: Never
+    schedulerName: default-scheduler
+    securityContext: {}
+    serviceAccount: tekton-bot
+    serviceAccountName: tekton-bot
+    terminationGracePeriodSeconds: 30
+    tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 300
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 300
+    volumes:
+      - emptyDir: {}
+        name: tools
+      - emptyDir: {}
+        name: workspace
+      - emptyDir: {}
+        name: home
+      - name: secret-volume-knative-git-user-pass-6zhjb
+        secret:
+          defaultMode: 420
+          secretName: knative-git-user-pass
+      - name: tekton-bot-token-kbbrz
+        secret:
+          defaultMode: 420
+          secretName: tekton-bot-token-kbbrz
+  status:
+    conditions:
+      - lastProbeTime: null
+        lastTransitionTime: "2019-07-02T12:34:49Z"
+        reason: PodCompleted
+        status: "True"
+        type: Initialized
+      - lastProbeTime: null
+        lastTransitionTime: "2019-07-02T12:34:45Z"
+        reason: PodCompleted
+        status: "False"
+        type: Ready
+      - lastProbeTime: null
+        lastTransitionTime: "2019-07-02T12:34:45Z"
+        reason: PodCompleted
+        status: "False"
+        type: ContainersReady
+      - lastProbeTime: null
+        lastTransitionTime: "2019-07-02T12:34:45Z"
+        status: "True"
+        type: PodScheduled
+    containerStatuses:
+      - containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+        image: gcr.io/jenkinsxio/builder-maven:0.1.542
+        imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+        lastState: {}
+        name: build-step-create-effective-pipeline
+        ready: false
+        restartCount: 0
+        state:
+          terminated:
+            containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+            exitCode: 0
+            finishedAt: "2019-07-02T12:34:52Z"
+            reason: Completed
+            startedAt: "2019-07-02T12:34:49Z"
+      - containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+        image: gcr.io/jenkinsxio/builder-maven:0.1.542
+        imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+        lastState: {}
+        name: build-step-create-tekton-crds
+        ready: false
+        restartCount: 0
+        state:
+          terminated:
+            containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+            exitCode: 0
+            finishedAt: "2019-07-02T12:34:56Z"
+            reason: Completed
+            startedAt: "2019-07-02T12:34:49Z"
+      - containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+        image: gcr.io/jenkinsxio/builder-maven:0.1.542
+        imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+        lastState: {}
+        name: build-step-git-merge
+        ready: false
+        restartCount: 0
+        state:
+          terminated:
+            containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+            exitCode: 0
+            finishedAt: "2019-07-02T12:34:50Z"
+            reason: Completed
+            startedAt: "2019-07-02T12:34:49Z"
+      - containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.4.0
+        imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:4b91c31560f18a8f09c68d5288f2261797b6df31522a57a9d7350bc0060a1284
+        lastState: {}
+        name: build-step-git-source-meta-abayer-js-test-repo-build-v7hvv
+        ready: false
+        restartCount: 0
+        state:
+          terminated:
+            containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+            exitCode: 0
+            finishedAt: "2019-07-02T12:34:49Z"
+            reason: Completed
+            startedAt: "2019-07-02T12:34:49Z"
+      - containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.4.0
+        imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop@sha256:9160ed41b20b2822d06e907d89f6398ea866c86a971f83371efb9e147fba079f
+        lastState: {}
+        name: nop
+        ready: false
+        restartCount: 0
+        state:
+          terminated:
+            containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+            exitCode: 0
+            finishedAt: "2019-07-02T12:34:57Z"
+            reason: Completed
+            startedAt: "2019-07-02T12:34:50Z"
+    hostIP: 10.138.0.56
+    initContainerStatuses:
+      - containerID: docker://5e897a5dfaf1687cad1692d9c8c6261108735e595ed37e03b43bcf51f86a7330
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.4.0
+        imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:b4877c99d928fad3cf26c995d171674b34d206178d6f9f0efb337ebff01bb34b
+        lastState: {}
+        name: build-step-credential-initializer-xht92
+        ready: true
+        restartCount: 0
+        state:
+          terminated:
+            containerID: docker://5e897a5dfaf1687cad1692d9c8c6261108735e595ed37e03b43bcf51f86a7330
+            exitCode: 0
+            finishedAt: "2019-07-02T12:34:46Z"
+            reason: Completed
+            startedAt: "2019-07-02T12:34:46Z"
+      - containerID: docker://1e68c4fcfc19db3c695ff5ac3cbd7b4f2cf8c5a92637267fd2745a97eaf21150
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
+        imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash@sha256:0355a9b21a7c0cc9466bf75071648e266de07b5e13fbfd271ec791c45a818bdb
+        lastState: {}
+        name: build-step-working-dir-initializer-8c9w5
+        ready: true
+        restartCount: 0
+        state:
+          terminated:
+            containerID: docker://1e68c4fcfc19db3c695ff5ac3cbd7b4f2cf8c5a92637267fd2745a97eaf21150
+            exitCode: 0
+            finishedAt: "2019-07-02T12:34:47Z"
+            reason: Completed
+            startedAt: "2019-07-02T12:34:47Z"
+      - containerID: docker://4109f59817a239085ce4084ae87cec62297ada549cb42e247160cd41f7479426
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.4.0
+        imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:4d1fe990ca06ecc671370dfeab31d857efa8ccf81d632a672561c60482fd9aae
+        lastState: {}
+        name: build-step-place-tools
+        ready: true
+        restartCount: 0
+        state:
+          terminated:
+            containerID: docker://4109f59817a239085ce4084ae87cec62297ada549cb42e247160cd41f7479426
+            exitCode: 0
+            finishedAt: "2019-07-02T12:34:48Z"
+            reason: Completed
+            startedAt: "2019-07-02T12:34:48Z"
+    phase: Succeeded
+    podIP: 10.28.0.32
+    qosClass: BestEffort
+    startTime: "2019-07-02T12:34:45Z"
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      sidecar.istio.io/inject: "false"
+    creationTimestamp: "2019-07-02T12:34:56Z"
+    labels:
+      jenkins.io/task-stage-name: from-build-pack
+      tekton.dev/pipeline: abayer-js-test-repo-build-pack-8
+      tekton.dev/pipelineRun: abayer-js-test-repo-build-pack-8
+      tekton.dev/task: abayer-js-test-repo-build-pack-from-build-pack-8
+      tekton.dev/taskRun: abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t
+    name: abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t-pod-1682b0
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: TaskRun
+      name: abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t
+      uid: cc5f7217-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "236411"
+    selfLink: /api/v1/namespaces/jx/pods/abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t-pod-1682b0
+    uid: cc659335-9cc5-11e9-aa2e-42010a8a00fe
+  spec:
+    containers:
+    - args:
+      - -wait_file
+      - ""
+      - -post_file
+      - /builder/tools/0
+      - -entrypoint
+      - /ko-app/git-init
+      - --
+      - -url
+      - https://github.com/abayer/js-test-repo
+      - -revision
+      - v0.0.7
+      - -path
+      - /workspace/source
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-git-source-abayer-js-test-repo-build-pack-72kkp
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -wait_file
+      - /builder/tools/0
+      - -post_file
+      - /builder/tools/1
+      - -entrypoint
+      - jx
+      - --
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.7
+      - name: BUILD_ID
+        value: "8"
+      - name: PREVIEW_VERSION
+        value: 0.0.7
+      image: gcr.io/jenkinsxio/builder-jx:0.1.527
+      imagePullPolicy: IfNotPresent
+      name: build-step-git-merge
+      resources:
+        requests:
+          cpu: 400m
+          ephemeral-storage: "0"
+          memory: 512Mi
+      securityContext:
+        privileged: true
+        procMount: Default
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/1
+      - -post_file
+      - /builder/tools/2
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step git credentials
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.7
+      - name: BUILD_ID
+        value: "8"
+      - name: PREVIEW_VERSION
+        value: 0.0.7
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-setup-jx-git-credentials
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+        procMount: Default
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/2
+      - -post_file
+      - /builder/tools/3
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step credential -s npm-token -k file -f /builder/home/.npmrc --optional=true
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.7
+      - name: BUILD_ID
+        value: "8"
+      - name: PREVIEW_VERSION
+        value: 0.0.7
+      image: jenkinsxio/jx:2.0.119
+      imagePullPolicy: IfNotPresent
+      name: build-step-build-npmrc
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+        procMount: Default
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/3
+      - -post_file
+      - /builder/tools/4
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - npm install
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.7
+      - name: BUILD_ID
+        value: "8"
+      - name: PREVIEW_VERSION
+        value: 0.0.7
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-build-npm-install
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+        procMount: Default
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/4
+      - -post_file
+      - /builder/tools/5
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - CI=true DISPLAY=:99 npm test
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.7
+      - name: BUILD_ID
+        value: "8"
+      - name: PREVIEW_VERSION
+        value: 0.0.7
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-build-npm-test
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+        procMount: Default
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/5
+      - -post_file
+      - /builder/tools/6
+      - -entrypoint
+      - /kaniko/executor
+      - --
+      - --cache=true
+      - --cache-dir=/workspace
+      - --context=/workspace/source
+      - --dockerfile=/workspace/source/Dockerfile
+      - --destination=gcr.io/abayer-jx-experiment/js-test-repo:0.0.7
+      - --cache-repo=gcr.io/abayer-jx-experiment/cache
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.7
+      - name: BUILD_ID
+        value: "8"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /kaniko-secret/secret.json
+      - name: PREVIEW_VERSION
+        value: 0.0.7
+      image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+      imagePullPolicy: IfNotPresent
+      name: build-step-build-container-build
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+        procMount: Default
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /kaniko-secret
+        name: kaniko-secret
+        readOnly: true
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/6
+      - -post_file
+      - /builder/tools/7
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:${VERSION}
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.7
+      - name: BUILD_ID
+        value: "8"
+      - name: PREVIEW_VERSION
+        value: 0.0.7
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-build-post-build
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+        procMount: Default
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/7
+      - -post_file
+      - /builder/tools/8
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step changelog --batch-mode --version v${VERSION}
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.7
+      - name: BUILD_ID
+        value: "8"
+      - name: PREVIEW_VERSION
+        value: 0.0.7
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-promote-changelog
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+        procMount: Default
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace/source/charts/js-test-repo
+    - args:
+      - -wait_file
+      - /builder/tools/8
+      - -post_file
+      - /builder/tools/9
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step helm release
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.7
+      - name: BUILD_ID
+        value: "8"
+      - name: PREVIEW_VERSION
+        value: 0.0.7
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-promote-helm-release
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+        procMount: Default
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace/source/charts/js-test-repo
+    - args:
+      - -wait_file
+      - /builder/tools/9
+      - -post_file
+      - /builder/tools/10
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx promote -b --all-auto --timeout 1h --version ${VERSION}
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.7
+      - name: BUILD_ID
+        value: "8"
+      - name: PREVIEW_VERSION
+        value: 0.0.7
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-promote-jx-promote
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+        procMount: Default
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace/source/charts/js-test-repo
+    - args:
+      - -wait_file
+      - /builder/tools/10
+      - -post_file
+      - /builder/tools/11
+      - -entrypoint
+      - /ko-app/nop
+      - --
+      command:
+      - /builder/tools/entrypoint
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: nop
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    initContainers:
+    - args:
+      - -basic-git=knative-git-user-pass=https://github.com
+      command:
+      - /ko-app/creds-init
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-credential-initializer-6ld8g
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/build-secrets/knative-git-user-pass
+        name: secret-volume-knative-git-user-pass-s4qfr
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -args
+      - mkdir -p /workspace/source /workspace/source/charts/js-test-repo
+      command:
+      - /ko-app/bash
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-working-dir-initializer-fw2sv
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -c
+      - cp /ko-app/entrypoint /builder/tools/entrypoint
+      command:
+      - /bin/sh
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-place-tools
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-kbbrz
+        readOnly: true
+      workingDir: /workspace
+    nodeName: gke-abayer-test-cluster-default-pool-666b1aa4-k4xk
+    priority: 0
+    restartPolicy: Never
+    schedulerName: default-scheduler
+    securityContext: {}
+    serviceAccount: tekton-bot
+    serviceAccountName: tekton-bot
+    terminationGracePeriodSeconds: 30
+    tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+        type: ""
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        defaultMode: 420
+        secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        defaultMode: 420
+        items:
+        - fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+    - name: kaniko-secret
+      secret:
+        defaultMode: 420
+        items:
+        - key: kaniko-secret
+          path: secret.json
+        secretName: kaniko-secret
+    - emptyDir: {}
+      name: tools
+    - emptyDir: {}
+      name: workspace
+    - emptyDir: {}
+      name: home
+    - name: secret-volume-knative-git-user-pass-s4qfr
+      secret:
+        defaultMode: 420
+        secretName: knative-git-user-pass
+    - name: tekton-bot-token-kbbrz
+      secret:
+        defaultMode: 420
+        secretName: tekton-bot-token-kbbrz
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:35:00Z"
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:56Z"
+      message: 'containers with unready status: [build-step-git-source-abayer-js-test-repo-build-pack-72kkp
+        build-step-git-merge build-step-setup-jx-git-credentials build-step-build-npmrc
+        build-step-build-npm-install build-step-build-npm-test build-step-build-container-build
+        build-step-build-post-build build-step-promote-changelog build-step-promote-helm-release
+        build-step-promote-jx-promote nop]'
+      reason: ContainersNotReady
+      status: "False"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:56Z"
+      message: 'containers with unready status: [build-step-git-source-abayer-js-test-repo-build-pack-72kkp
+        build-step-git-merge build-step-setup-jx-git-credentials build-step-build-npmrc
+        build-step-build-npm-install build-step-build-npm-test build-step-build-container-build
+        build-step-build-post-build build-step-promote-changelog build-step-promote-helm-release
+        build-step-promote-jx-promote nop]'
+      reason: ContainersNotReady
+      status: "False"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:56Z"
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://ee94afd22cdb071ffd2566ec3478d1290b54185b87d530cf907908c02e63195b
+      image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+      imageID: docker-pullable://gcr.io/kaniko-project/executor@sha256:94c69a4be5eccf88070e640bc682c969a53996c8a4490e39776c9411b974d8fa
+      lastState: {}
+      name: build-step-build-container-build
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://ee94afd22cdb071ffd2566ec3478d1290b54185b87d530cf907908c02e63195b
+          exitCode: 0
+          finishedAt: "2019-07-02T12:36:05Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:02Z"
+    - containerID: docker://60fae7303bc984339e5ad90c9279910bc873e16a19efa026d024c421c2c77056
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82
+      lastState: {}
+      name: build-step-build-npm-install
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://60fae7303bc984339e5ad90c9279910bc873e16a19efa026d024c421c2c77056
+          exitCode: 0
+          finishedAt: "2019-07-02T12:35:38Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:01Z"
+    - containerID: docker://15b3ad11f0ee9a47ec69033f17375670f26810a6e4dbba6ed4f01821c8f4ff6c
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82
+      lastState: {}
+      name: build-step-build-npm-test
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://15b3ad11f0ee9a47ec69033f17375670f26810a6e4dbba6ed4f01821c8f4ff6c
+          exitCode: 0
+          finishedAt: "2019-07-02T12:35:41Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:02Z"
+    - containerID: docker://5f6fe39d8b812945a914dd7ff10c386f1bebd70c4f8dbe023360f92289ceca7e
+      image: jenkinsxio/jx:2.0.119
+      imageID: docker-pullable://jenkinsxio/jx@sha256:c0c9cb728d14a2cd34ace9e57933679afd2e05f9adf660d620bce3b6aec4d85d
+      lastState: {}
+      name: build-step-build-npmrc
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://5f6fe39d8b812945a914dd7ff10c386f1bebd70c4f8dbe023360f92289ceca7e
+          exitCode: 0
+          finishedAt: "2019-07-02T12:35:03Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:01Z"
+    - containerID: docker://b02211c50527464acb6133331904f156b1b1b09c472aa50c463123dc9a101533
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82
+      lastState: {}
+      name: build-step-build-post-build
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://b02211c50527464acb6133331904f156b1b1b09c472aa50c463123dc9a101533
+          exitCode: 0
+          finishedAt: "2019-07-02T12:36:06Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:02Z"
+    - containerID: docker://bf9a1b3872c8e343ca9b17d5e999692abadadd1b0c49084a12c93cefdea1e828
+      image: gcr.io/jenkinsxio/builder-jx:0.1.527
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-jx@sha256:0480f76a8799e56363ae0597621364fe6a7b152480aec29daba096e5d6cfced5
+      lastState: {}
+      name: build-step-git-merge
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://bf9a1b3872c8e343ca9b17d5e999692abadadd1b0c49084a12c93cefdea1e828
+          exitCode: 0
+          finishedAt: "2019-07-02T12:35:02Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:01Z"
+    - containerID: docker://087e23e897b77226706cf686a074a942ce9d4a50fc651d3bf9a54b2b1aeb8b40
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:4b91c31560f18a8f09c68d5288f2261797b6df31522a57a9d7350bc0060a1284
+      lastState: {}
+      name: build-step-git-source-abayer-js-test-repo-build-pack-72kkp
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://087e23e897b77226706cf686a074a942ce9d4a50fc651d3bf9a54b2b1aeb8b40
+          exitCode: 0
+          finishedAt: "2019-07-02T12:35:02Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:00Z"
+    - containerID: docker://5780df05616c5f396b108d2549359061fc79d7eec5fc062c237f70472fa2f95d
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82
+      lastState: {}
+      name: build-step-promote-changelog
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://5780df05616c5f396b108d2549359061fc79d7eec5fc062c237f70472fa2f95d
+          exitCode: 0
+          finishedAt: "2019-07-02T12:36:12Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:02Z"
+    - containerID: docker://fda8599e3607d47d86d7e62ad68eb96cb4646e912b53166500d2b1c54b6a1835
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82
+      lastState: {}
+      name: build-step-promote-helm-release
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://fda8599e3607d47d86d7e62ad68eb96cb4646e912b53166500d2b1c54b6a1835
+          exitCode: 0
+          finishedAt: "2019-07-02T12:36:17Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:02Z"
+    - containerID: docker://d4abd70d8942c22bcd1d9fa1ec8a9440fa65ef4143c15b0286e0589f1dbb2a22
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82
+      lastState: {}
+      name: build-step-promote-jx-promote
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://d4abd70d8942c22bcd1d9fa1ec8a9440fa65ef4143c15b0286e0589f1dbb2a22
+          exitCode: 1
+          finishedAt: "2019-07-02T12:36:46Z"
+          reason: Error
+          startedAt: "2019-07-02T12:35:03Z"
+    - containerID: docker://8ef0a0090393a926ac59b0ed792d9e4fa32ed93443a2da251d0f8913688d1c10
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82
+      lastState: {}
+      name: build-step-setup-jx-git-credentials
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://8ef0a0090393a926ac59b0ed792d9e4fa32ed93443a2da251d0f8913688d1c10
+          exitCode: 0
+          finishedAt: "2019-07-02T12:35:03Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:01Z"
+    - containerID: docker://654321b1884f8d3d7408e9a19b0a6371275b42f8a62cc765def420941ce8b835
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop@sha256:9160ed41b20b2822d06e907d89f6398ea866c86a971f83371efb9e147fba079f
+      lastState: {}
+      name: nop
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://654321b1884f8d3d7408e9a19b0a6371275b42f8a62cc765def420941ce8b835
+          exitCode: 0
+          finishedAt: "2019-07-02T12:36:47Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:35:03Z"
+    hostIP: 10.138.0.56
+    initContainerStatuses:
+    - containerID: docker://11fcf2e3bb368d3e0abced635ab2bd510dc868ddb7a3415e2531c1568ac5176d
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:b4877c99d928fad3cf26c995d171674b34d206178d6f9f0efb337ebff01bb34b
+      lastState: {}
+      name: build-step-credential-initializer-6ld8g
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://11fcf2e3bb368d3e0abced635ab2bd510dc868ddb7a3415e2531c1568ac5176d
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:57Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:57Z"
+    - containerID: docker://f599bda88e52ea33e644bdbfe8cc0263fcb5f97695ce365561be985ca1e08b35
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash@sha256:0355a9b21a7c0cc9466bf75071648e266de07b5e13fbfd271ec791c45a818bdb
+      lastState: {}
+      name: build-step-working-dir-initializer-fw2sv
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://f599bda88e52ea33e644bdbfe8cc0263fcb5f97695ce365561be985ca1e08b35
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:58Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:58Z"
+    - containerID: docker://ce1d2f15170ca36a4c4024ce5fa3b86476843e9d4c7f340feffa537fdaad0372
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:4d1fe990ca06ecc671370dfeab31d857efa8ccf81d632a672561c60482fd9aae
+      lastState: {}
+      name: build-step-place-tools
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://ce1d2f15170ca36a4c4024ce5fa3b86476843e9d4c7f340feffa537fdaad0372
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:59Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:59Z"
+    phase: Failed
+    podIP: 10.28.0.33
+    qosClass: Burstable
+    startTime: "2019-07-02T12:34:56Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/structures.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/structures.yml
@@ -1,0 +1,53 @@
+apiVersion: jenkins.io/v1
+items:
+- apiVersion: jenkins.io/v1
+  kind: PipelineStructure
+  metadata:
+    creationTimestamp: "2019-07-02T12:34:56Z"
+    generation: 1
+    name: abayer-js-test-repo-build-pack-8
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: pipeline
+      name: abayer-js-test-repo-build-pack-8
+      uid: cc57794e-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "235866"
+    selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/abayer-js-test-repo-build-pack-8
+    uid: cc5c12bc-9cc5-11e9-aa2e-42010a8a00fe
+  pipelineRef: abayer-js-test-repo-build-pack-8
+  pipelineRunRef: abayer-js-test-repo-build-pack-8
+  stages:
+  - depth: 0
+    name: from-build-pack
+    taskRef: abayer-js-test-repo-build-pack-from-build-pack-8
+- apiVersion: jenkins.io/v1
+  kind: PipelineStructure
+  metadata:
+    creationTimestamp: "2019-07-02T12:34:45Z"
+    generation: 1
+    labels:
+      branch: build-pack
+      build: "8"
+      owner: abayer
+      repo: js-test-repo
+    name: meta-abayer-js-test-repo-build-8
+    namespace: jx
+    ownerReferences:
+      - apiVersion: tekton.dev/v1alpha1
+        kind: pipeline
+        name: meta-abayer-js-test-repo-build-8
+        uid: c5ad1626-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "235785"
+    selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/meta-abayer-js-test-repo-build-8
+    uid: c5cdca7a-9cc5-11e9-aa2e-42010a8a00fe
+  pipelineRef: meta-abayer-js-test-repo-build-8
+  pipelineRunRef: meta-abayer-js-test-repo-build-8
+  stages:
+    - depth: 0
+      name: app-extension
+      taskRef: meta-abayer-js-test-repo-build-app-extension-8
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/taskruns.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/taskruns.yml
@@ -1,0 +1,223 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: TaskRun
+  metadata:
+    creationTimestamp: "2019-07-02T12:34:56Z"
+    generation: 1
+    labels:
+      jenkins.io/task-stage-name: from-build-pack
+      tekton.dev/pipeline: abayer-js-test-repo-build-pack-8
+      tekton.dev/pipelineRun: abayer-js-test-repo-build-pack-8
+      tekton.dev/task: abayer-js-test-repo-build-pack-from-build-pack-8
+    name: abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PipelineRun
+      name: abayer-js-test-repo-build-pack-8
+      uid: cc59f237-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "236413"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/taskruns/abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t
+    uid: cc5f7217-9cc5-11e9-aa2e-42010a8a00fe
+  spec:
+    inputs:
+      params:
+      - name: version
+        value: 0.0.7
+      - name: build_id
+        value: "8"
+      resources:
+      - name: workspace
+        resourceRef:
+          name: abayer-js-test-repo-build-pack
+    outputs: {}
+    serviceAccount: tekton-bot
+    taskRef:
+      kind: Task
+      name: abayer-js-test-repo-build-pack-from-build-pack-8
+    timeout: 240h0m0s
+  status:
+    completionTime: "2019-07-02T12:36:47Z"
+    conditions:
+    - lastTransitionTime: "2019-07-02T12:36:47Z"
+      message: '"build-step-promote-jx-promote" exited with code 1 (image: "docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82");
+        for logs run: kubectl -n jx logs abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t-pod-1682b0
+        -c build-step-promote-jx-promote'
+      status: "False"
+      type: Succeeded
+    podName: abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t-pod-1682b0
+    startTime: "2019-07-02T12:34:56Z"
+    steps:
+    - name: build-container-build
+      terminated:
+        containerID: docker://ee94afd22cdb071ffd2566ec3478d1290b54185b87d530cf907908c02e63195b
+        exitCode: 0
+        finishedAt: "2019-07-02T12:36:05Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:02Z"
+    - name: build-npm-install
+      terminated:
+        containerID: docker://60fae7303bc984339e5ad90c9279910bc873e16a19efa026d024c421c2c77056
+        exitCode: 0
+        finishedAt: "2019-07-02T12:35:38Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:01Z"
+    - name: build-npm-test
+      terminated:
+        containerID: docker://15b3ad11f0ee9a47ec69033f17375670f26810a6e4dbba6ed4f01821c8f4ff6c
+        exitCode: 0
+        finishedAt: "2019-07-02T12:35:41Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:02Z"
+    - name: build-npmrc
+      terminated:
+        containerID: docker://5f6fe39d8b812945a914dd7ff10c386f1bebd70c4f8dbe023360f92289ceca7e
+        exitCode: 0
+        finishedAt: "2019-07-02T12:35:03Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:01Z"
+    - name: build-post-build
+      terminated:
+        containerID: docker://b02211c50527464acb6133331904f156b1b1b09c472aa50c463123dc9a101533
+        exitCode: 0
+        finishedAt: "2019-07-02T12:36:06Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:02Z"
+    - name: git-merge
+      terminated:
+        containerID: docker://bf9a1b3872c8e343ca9b17d5e999692abadadd1b0c49084a12c93cefdea1e828
+        exitCode: 0
+        finishedAt: "2019-07-02T12:35:02Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:01Z"
+    - name: git-source-abayer-js-test-repo-build-pack-72kkp
+      terminated:
+        containerID: docker://087e23e897b77226706cf686a074a942ce9d4a50fc651d3bf9a54b2b1aeb8b40
+        exitCode: 0
+        finishedAt: "2019-07-02T12:35:02Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:00Z"
+    - name: promote-changelog
+      terminated:
+        containerID: docker://5780df05616c5f396b108d2549359061fc79d7eec5fc062c237f70472fa2f95d
+        exitCode: 0
+        finishedAt: "2019-07-02T12:36:12Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:02Z"
+    - name: promote-helm-release
+      terminated:
+        containerID: docker://fda8599e3607d47d86d7e62ad68eb96cb4646e912b53166500d2b1c54b6a1835
+        exitCode: 0
+        finishedAt: "2019-07-02T12:36:17Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:02Z"
+    - name: promote-jx-promote
+      terminated:
+        containerID: docker://d4abd70d8942c22bcd1d9fa1ec8a9440fa65ef4143c15b0286e0589f1dbb2a22
+        exitCode: 1
+        finishedAt: "2019-07-02T12:36:46Z"
+        reason: Error
+        startedAt: "2019-07-02T12:35:03Z"
+    - name: setup-jx-git-credentials
+      terminated:
+        containerID: docker://8ef0a0090393a926ac59b0ed792d9e4fa32ed93443a2da251d0f8913688d1c10
+        exitCode: 0
+        finishedAt: "2019-07-02T12:35:03Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:01Z"
+    - name: nop
+      terminated:
+        containerID: docker://654321b1884f8d3d7408e9a19b0a6371275b42f8a62cc765def420941ce8b835
+        exitCode: 0
+        finishedAt: "2019-07-02T12:36:47Z"
+        reason: Completed
+        startedAt: "2019-07-02T12:35:03Z"
+- apiVersion: tekton.dev/v1alpha1
+  kind: TaskRun
+  metadata:
+    creationTimestamp: "2019-07-02T12:34:45Z"
+    generation: 1
+    labels:
+      branch: build-pack
+      build: "8"
+      jenkins.io/task-stage-name: app-extension
+      owner: abayer
+      repo: js-test-repo
+      tekton.dev/pipeline: meta-abayer-js-test-repo-build-8
+      tekton.dev/pipelineRun: meta-abayer-js-test-repo-build-8
+      tekton.dev/task: meta-abayer-js-test-repo-build-app-extension-8
+    name: meta-abayer-js-test-repo-build-8-app-extension-kvvp6
+    namespace: jx
+    ownerReferences:
+      - apiVersion: tekton.dev/v1alpha1
+        blockOwnerDeletion: true
+        controller: true
+        kind: PipelineRun
+        name: meta-abayer-js-test-repo-build-8
+        uid: c5bd38e9-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "235893"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/taskruns/meta-abayer-js-test-repo-build-8-app-extension-kvvp6
+    uid: c5c20379-9cc5-11e9-aa2e-42010a8a00fe
+  spec:
+    inputs:
+      resources:
+        - name: workspace
+          resourceRef:
+            name: meta-abayer-js-test-repo-build
+    outputs: {}
+    serviceAccount: tekton-bot
+    taskRef:
+      kind: Task
+      name: meta-abayer-js-test-repo-build-app-extension-8
+    timeout: 240h0m0s
+  status:
+    completionTime: "2019-07-02T12:34:57Z"
+    conditions:
+      - lastTransitionTime: "2019-07-02T12:34:57Z"
+        status: "True"
+        type: Succeeded
+    podName: meta-abayer-js-test-repo-build-8-app-extension-kvvp6-pod-fcf1fe
+    startTime: "2019-07-02T12:34:45Z"
+    steps:
+      - name: create-effective-pipeline
+        terminated:
+          containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:52Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+      - name: create-tekton-crds
+        terminated:
+          containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:56Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+      - name: git-merge
+        terminated:
+          containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:50Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+      - name: git-source-meta-abayer-js-test-repo-build-v7hvv
+        terminated:
+          containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:49Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+      - name: nop
+        terminated:
+          containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:57Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:50Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/tasks.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/tasks.yml
@@ -1,0 +1,841 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: "2019-07-02T12:34:56Z"
+    generation: 1
+    labels:
+      jenkins.io/task-stage-name: from-build-pack
+    name: abayer-js-test-repo-build-pack-from-build-pack-8
+    namespace: jx
+    ownerReferences:
+    - apiVersion: jenkins.io/v1
+      kind: PipelineActivity
+      name: abayer-js-test-repo-build-pack-8
+      uid: c5e1fa64-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "235863"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/tasks/abayer-js-test-repo-build-pack-from-build-pack-8
+    uid: cc516f23-9cc5-11e9-aa2e-42010a8a00fe
+  spec:
+    inputs:
+      params:
+      - default: 0.0.7
+        description: the version number for this pipeline which is used as a tag on
+          docker images and helm charts
+        name: version
+      - default: "8"
+        description: the PipelineRun build number
+        name: build_id
+      resources:
+      - name: workspace
+        outputImageDir: ""
+        targetPath: source
+        type: git
+    steps:
+    - args:
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - jx
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: BUILD_ID
+        value: ${inputs.params.build_id}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-jx:0.1.527
+      name: git-merge
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - jx step git credentials
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: BUILD_ID
+        value: ${inputs.params.build_id}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      name: setup-jx-git-credentials
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - jx step credential -s npm-token -k file -f /builder/home/.npmrc --optional=true
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: BUILD_ID
+        value: ${inputs.params.build_id}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/jx:2.0.119
+      name: build-npmrc
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - npm install
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: BUILD_ID
+        value: ${inputs.params.build_id}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      name: build-npm-install
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - CI=true DISPLAY=:99 npm test
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: BUILD_ID
+        value: ${inputs.params.build_id}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      name: build-npm-test
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - --cache=true
+      - --cache-dir=/workspace
+      - --context=/workspace/source
+      - --dockerfile=/workspace/source/Dockerfile
+      - --destination=gcr.io/abayer-jx-experiment/js-test-repo:${inputs.params.version}
+      - --cache-repo=gcr.io/abayer-jx-experiment/cache
+      command:
+      - /kaniko/executor
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: BUILD_ID
+        value: ${inputs.params.build_id}
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /kaniko-secret/secret.json
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+      name: build-container-build
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /kaniko-secret
+        name: kaniko-secret
+        readOnly: true
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:${VERSION}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: BUILD_ID
+        value: ${inputs.params.build_id}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      name: build-post-build
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - jx step changelog --batch-mode --version v${VERSION}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: BUILD_ID
+        value: ${inputs.params.build_id}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      name: promote-changelog
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source/charts/js-test-repo
+    - args:
+      - jx step helm release
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: BUILD_ID
+        value: ${inputs.params.build_id}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      name: promote-helm-release
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source/charts/js-test-repo
+    - args:
+      - jx promote -b --all-auto --timeout 1h --version ${VERSION}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "8"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: BUILD_ID
+        value: ${inputs.params.build_id}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-nodejs:0.1.542
+      name: promote-jx-promote
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source/charts/js-test-repo
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+    - name: kaniko-secret
+      secret:
+        items:
+        - key: kaniko-secret
+          path: secret.json
+        secretName: kaniko-secret
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: "2019-07-02T12:34:44Z"
+    generation: 1
+    labels:
+      branch: build-pack
+      build: "8"
+      jenkins.io/task-stage-name: app-extension
+      owner: abayer
+      repo: js-test-repo
+    name: meta-abayer-js-test-repo-build-app-extension-8
+    namespace: jx
+    ownerReferences:
+      - apiVersion: jenkins.io/v1
+        kind: PipelineActivity
+        name: abayer-js-test-repo-build-pack-meta-8
+        uid: c57379a2-9cc5-11e9-aa2e-42010a8a00fe
+    resourceVersion: "235774"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/tasks/meta-abayer-js-test-repo-build-app-extension-8
+    uid: c59e3421-9cc5-11e9-aa2e-42010a8a00fe
+  spec:
+    inputs:
+      resources:
+        - name: workspace
+          outputImageDir: ""
+          targetPath: source
+          type: git
+    steps:
+      - args:
+          - step
+          - git
+          - merge
+          - --verbose
+        command:
+          - jx
+        env:
+          - name: APP_NAME
+            value: js-test-repo
+          - name: BRANCH_NAME
+            value: build-pack
+          - name: BUILD_NUMBER
+            value: "8"
+          - name: JOB_NAME
+            value: abayer/js-test-repo/build-pack
+          - name: JX_LOG_FORMAT
+            value: json
+          - name: PIPELINE_KIND
+            value: release
+          - name: REPO_NAME
+            value: js-test-repo
+          - name: REPO_OWNER
+            value: abayer
+        image: gcr.io/jenkinsxio/builder-maven:0.1.542
+        name: git-merge
+        resources: {}
+        workingDir: /workspace/source
+      - args:
+          - jx step syntax effective --output-dir .
+        command:
+          - /bin/sh
+          - -c
+        env:
+          - name: APP_NAME
+            value: js-test-repo
+          - name: BRANCH_NAME
+            value: build-pack
+          - name: BUILD_NUMBER
+            value: "8"
+          - name: JOB_NAME
+            value: abayer/js-test-repo/build-pack
+          - name: JX_LOG_FORMAT
+            value: json
+          - name: PIPELINE_KIND
+            value: release
+          - name: REPO_NAME
+            value: js-test-repo
+          - name: REPO_OWNER
+            value: abayer
+        image: gcr.io/jenkinsxio/builder-maven:0.1.542
+        name: create-effective-pipeline
+        resources: {}
+        workingDir: /workspace/source
+      - args:
+          - jx step create task --clone-dir /workspace/source --build-number 8 --trigger
+            manual --service-account tekton-bot --source source --branch build-pack
+        command:
+          - /bin/sh
+          - -c
+        env:
+          - name: APP_NAME
+            value: js-test-repo
+          - name: BRANCH_NAME
+            value: build-pack
+          - name: BUILD_NUMBER
+            value: "8"
+          - name: JOB_NAME
+            value: abayer/js-test-repo/build-pack
+          - name: JX_LOG_FORMAT
+            value: json
+          - name: PIPELINE_KIND
+            value: release
+          - name: REPO_NAME
+            value: js-test-repo
+          - name: REPO_OWNER
+            value: abayer
+        image: gcr.io/jenkinsxio/builder-maven:0.1.542
+        name: create-tekton-crds
+        resources: {}
+        workingDir: /workspace/source
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -408,7 +408,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 					resourceList.Items = append(resourceList.Items, *resource)
 				}
 
-				if d := cmp.Diff(tekton_helpers_test.AssertLoadPipeline(t, caseDir), crds.Pipeline()); d != "" {
+				if d := cmp.Diff(tekton_helpers_test.AssertLoadSinglePipeline(t, caseDir), crds.Pipeline()); d != "" {
 					t.Errorf("Generated Pipeline did not match expected: \n%s", d)
 				}
 				if d, _ := kmp.SafeDiff(tekton_helpers_test.AssertLoadTasks(t, caseDir), taskList, cmpopts.IgnoreFields(corev1.ResourceRequirements{}, "Requests")); d != "" {
@@ -418,10 +418,10 @@ func TestGenerateTektonCRDs(t *testing.T) {
 					t.Errorf("Generated PipelineResources did not match expected: %s", d)
 				}
 
-				if d := cmp.Diff(tekton_helpers_test.AssertLoadPipelineRun(t, caseDir), crds.PipelineRun()); d != "" {
+				if d := cmp.Diff(tekton_helpers_test.AssertLoadSinglePipelineRun(t, caseDir), crds.PipelineRun()); d != "" {
 					t.Errorf("Generated PipelineRun did not match expected: %s", d)
 				}
-				if d := cmp.Diff(tekton_helpers_test.AssertLoadPipelineStructure(t, caseDir), crds.Structure()); d != "" {
+				if d := cmp.Diff(tekton_helpers_test.AssertLoadSinglePipelineStructure(t, caseDir), crds.Structure()); d != "" {
 					t.Errorf("Generated PipelineStructure did not match expected: %s", d)
 				}
 

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -38,6 +38,8 @@ type PipelineRunInfo struct {
 	GitURL            string
 	GitInfo           *gits.GitRepository
 	Stages            []*StageInfo
+	Type              PipelineType
+	CreatedTime       time.Time
 }
 
 // StageInfo provides information on a particular stage, including its pod info or info on its nested stages
@@ -144,6 +146,12 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 		Name:        PipelineResourceName(pr.Labels[LabelOwner], pr.Labels[LabelRepo], pr.Labels[LabelBranch], pr.Labels[LabelContext], BuildPipeline, nil, "") + "-" + pr.Labels[LabelBuild],
 		PipelineRun: pr.Name,
 		Pipeline:    pr.Spec.PipelineRef.Name,
+		Type:        BuildPipeline,
+		CreatedTime: pr.CreationTimestamp.Time,
+	}
+
+	if strings.HasPrefix(pr.Name, "metapipeline-") {
+		pri.Type = MetaPipeline
 	}
 
 	var pod *corev1.Pod

--- a/pkg/tekton/pipeline_info_test.go
+++ b/pkg/tekton/pipeline_info_test.go
@@ -52,6 +52,8 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 				TaskRun:        "abayer-jx-demo-qs-master-1-build-vhz8d",
 				Parents:        []string{},
 			}},
+			Type:        tekton.BuildPipeline,
+			CreatedTime: *parseTime(t, "2019-02-21T17:10:48-05:00"),
 		},
 		prName: "abayer-jx-demo-qs-master-1",
 	}, {
@@ -91,6 +93,8 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 				TaskRun:        "abayer-js-test-repo-master-1-second-9czt5",
 				Parents:        []string{},
 			}},
+			Type:        tekton.BuildPipeline,
+			CreatedTime: *parseTime(t, "2019-02-21T17:02:43-05:00"),
 		},
 		prName: "abayer-js-test-repo-master-1",
 	}, {
@@ -134,6 +138,8 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 					Parents:        []string{"Parent"},
 				}},
 			}},
+			Type:        tekton.BuildPipeline,
+			CreatedTime: *parseTime(t, "2019-02-21T17:07:36-05:00"),
 		},
 		prName: "abayer-js-test-repo-nested-1",
 	}, {
@@ -173,6 +179,8 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 				TaskRun:        "abayer-js-test-repo-master-1-second-wglk8",
 				Parents:        []string{},
 			}},
+			Type:        tekton.BuildPipeline,
+			CreatedTime: *parseTime(t, "2019-03-05T15:06:13-05:00"),
 		},
 		prName: "abayer-js-test-repo-master-1",
 	}, {

--- a/pkg/tekton/pipeline_info_test.go
+++ b/pkg/tekton/pipeline_info_test.go
@@ -197,13 +197,13 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testCaseDir := path.Join("test_data", "pipeline_info", tt.name)
 
-			jxObjects := []runtime.Object{tekton_helpers_test.AssertLoadPipelineActivity(t, testCaseDir)}
-			structure := tekton_helpers_test.AssertLoadPipelineStructure(t, testCaseDir)
+			jxObjects := []runtime.Object{tekton_helpers_test.AssertLoadSinglePipelineActivity(t, testCaseDir)}
+			structure := tekton_helpers_test.AssertLoadSinglePipelineStructure(t, testCaseDir)
 			if structure != nil {
 				jxObjects = append(jxObjects, structure)
 			}
 
-			tektonObjects := []runtime.Object{tekton_helpers_test.AssertLoadPipelineRun(t, testCaseDir), tekton_helpers_test.AssertLoadPipeline(t, testCaseDir)}
+			tektonObjects := []runtime.Object{tekton_helpers_test.AssertLoadSinglePipelineRun(t, testCaseDir), tekton_helpers_test.AssertLoadSinglePipeline(t, testCaseDir)}
 			tektonObjects = append(tektonObjects, tekton_helpers_test.AssertLoadTasks(t, testCaseDir))
 			tektonObjects = append(tektonObjects, tekton_helpers_test.AssertLoadTaskRuns(t, testCaseDir))
 			tektonObjects = append(tektonObjects, tekton_helpers_test.AssertLoadPipelineResources(t, testCaseDir))

--- a/pkg/tekton/pipelines.go
+++ b/pkg/tekton/pipelines.go
@@ -43,11 +43,7 @@ func (s PipelineType) String() string {
 
 // GeneratePipelineActivity generates a initial PipelineActivity CRD so UI/get act can get an earlier notification that the jobs have been scheduled
 func GeneratePipelineActivity(buildNumber string, branch string, gitInfo *gits.GitRepository, pr *prow.PullRefs, pipelineType PipelineType) *kube.PromoteStepActivityKey {
-	name := gitInfo.Organisation + "-" + gitInfo.Name + "-" + branch
-	if pipelineType == MetaPipeline {
-		name += "-" + pipelineType.String()
-	}
-	name += "-" + buildNumber
+	name := gitInfo.Organisation + "-" + gitInfo.Name + "-" + branch + "-" + buildNumber
 
 	pipeline := gitInfo.Organisation + "/" + gitInfo.Name + "/" + branch
 	log.Logger().Infof("PipelineActivity for %s", name)

--- a/pkg/tekton/tekton_helpers_test/test_helpers.go
+++ b/pkg/tekton/tekton_helpers_test/test_helpers.go
@@ -56,8 +56,25 @@ func AssertLoadSinglePod(t *testing.T, dir string) *corev1.Pod {
 	return &corev1.Pod{}
 }
 
-// AssertLoadPipeline reads a file containing a Pipeline and returns that Pipeline
-func AssertLoadPipeline(t *testing.T, dir string) *v1alpha1.Pipeline {
+// AssertLoadPipelines reads a file containing a PipelineList and returns that PipelineList
+func AssertLoadPipelines(t *testing.T, dir string) *v1alpha1.PipelineList {
+	fileName := filepath.Join(dir, "pipelines.yml")
+	if tests.AssertFileExists(t, fileName) {
+		pipelineList := &v1alpha1.PipelineList{}
+		data, err := ioutil.ReadFile(fileName)
+		if assert.NoError(t, err, "Failed to load file %s", fileName) {
+			err = yaml.Unmarshal(data, pipelineList)
+			if assert.NoError(t, err, "Failed to unmarshal YAML file %s", fileName) {
+				return pipelineList
+			}
+
+		}
+	}
+	return nil
+}
+
+// AssertLoadSinglePipeline reads a file containing a Pipeline and returns that Pipeline
+func AssertLoadSinglePipeline(t *testing.T, dir string) *v1alpha1.Pipeline {
 	fileName := filepath.Join(dir, "pipeline.yml")
 	if tests.AssertFileExists(t, fileName) {
 		pipeline := &v1alpha1.Pipeline{}
@@ -73,8 +90,25 @@ func AssertLoadPipeline(t *testing.T, dir string) *v1alpha1.Pipeline {
 	return nil
 }
 
-// AssertLoadPipelineRun reads a file containing a PipelineRun and returns that PipelineRun
-func AssertLoadPipelineRun(t *testing.T, dir string) *v1alpha1.PipelineRun {
+// AssertLoadPipelineRuns reads a file containing a PipelineRunList and returns that PipelineRunList
+func AssertLoadPipelineRuns(t *testing.T, dir string) *v1alpha1.PipelineRunList {
+	fileName := filepath.Join(dir, "pipelineruns.yml")
+	if tests.AssertFileExists(t, fileName) {
+		pipelineRunList := &v1alpha1.PipelineRunList{}
+		data, err := ioutil.ReadFile(fileName)
+		if assert.NoError(t, err, "Failed to load file %s", fileName) {
+			err = yaml.Unmarshal(data, pipelineRunList)
+			if assert.NoError(t, err, "Failed to unmarshal YAML file %s", fileName) {
+				return pipelineRunList
+			}
+
+		}
+	}
+	return nil
+}
+
+// AssertLoadSinglePipelineRun reads a file containing a PipelineRun and returns that PipelineRun
+func AssertLoadSinglePipelineRun(t *testing.T, dir string) *v1alpha1.PipelineRun {
 	fileName := filepath.Join(dir, "pipelinerun.yml")
 	if tests.AssertFileExists(t, fileName) {
 		pipelineRun := &v1alpha1.PipelineRun{}
@@ -90,8 +124,25 @@ func AssertLoadPipelineRun(t *testing.T, dir string) *v1alpha1.PipelineRun {
 	return nil
 }
 
-// AssertLoadPipelineActivity reads a file containing a PipelineActivity and returns that PipelineActivity
-func AssertLoadPipelineActivity(t *testing.T, dir string) *v1.PipelineActivity {
+// AssertLoadPipelineActivities reads a file containing a PipelineActivityList and returns that PipelineActivityList
+func AssertLoadPipelineActivities(t *testing.T, dir string) *v1.PipelineActivityList {
+	fileName := filepath.Join(dir, "activities.yml")
+	if tests.AssertFileExists(t, fileName) {
+		activityList := &v1.PipelineActivityList{}
+		data, err := ioutil.ReadFile(fileName)
+		if assert.NoError(t, err, "Failed to load file %s", fileName) {
+			err = yaml.Unmarshal(data, activityList)
+			if assert.NoError(t, err, "Failed to unmarshal YAML file %s", fileName) {
+				return activityList
+			}
+
+		}
+	}
+	return nil
+}
+
+// AssertLoadSinglePipelineActivity reads a file containing a PipelineActivity and returns that PipelineActivity
+func AssertLoadSinglePipelineActivity(t *testing.T, dir string) *v1.PipelineActivity {
 	fileName := filepath.Join(dir, "activity.yml")
 	if tests.AssertFileExists(t, fileName) {
 		activity := &v1.PipelineActivity{}
@@ -107,8 +158,25 @@ func AssertLoadPipelineActivity(t *testing.T, dir string) *v1.PipelineActivity {
 	return nil
 }
 
-// AssertLoadPipelineStructure reads a file containing a PipelineStructure and returns that PipelineStructure
-func AssertLoadPipelineStructure(t *testing.T, dir string) *v1.PipelineStructure {
+// AssertLoadPipelineStructures reads a file containing a PipelineStructureList and returns that PipelineStructureList
+func AssertLoadPipelineStructures(t *testing.T, dir string) *v1.PipelineStructureList {
+	fileName := filepath.Join(dir, "structures.yml")
+	if tests.AssertFileExists(t, fileName) {
+		structureList := &v1.PipelineStructureList{}
+		data, err := ioutil.ReadFile(fileName)
+		if assert.NoError(t, err, "Failed to load file %s", fileName) {
+			err = yaml.Unmarshal(data, structureList)
+			if assert.NoError(t, err, "Failed to unmarshal YAML file %s", fileName) {
+				return structureList
+			}
+
+		}
+	}
+	return nil
+}
+
+// AssertLoadSinglePipelineStructure reads a file containing a PipelineStructure and returns that PipelineStructure
+func AssertLoadSinglePipelineStructure(t *testing.T, dir string) *v1.PipelineStructure {
 	fileName := filepath.Join(dir, "structure.yml")
 	exists, err := util.FileExists(fileName)
 	if err != nil {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

So let's look for all pipelines that match an org/repo/branch/build number, which will give us both the metapipeline and the generated pipeline.

Tests are still needed, just want to see how this, y'know, *builds*.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

fixes #4362
