### PR TITLE
fix(gke): AddLabel should sanitize key and value, not =.

### DIFF
--- a/pkg/cmd/create/create_cluster_gke.go
+++ b/pkg/cmd/create/create_cluster_gke.go
@@ -578,7 +578,7 @@ func AddLabel(labels string, name string, value string) string {
 		if labels != "" {
 			sep = ","
 		}
-		labels += sep + util.SanitizeLabel((name)+"="+username)
+		labels += sep + util.SanitizeLabel(name)+"="+util.SanitizeLabel(username)
 	}
 	return labels
 }


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We were sanitizing all of "name=value", resulting in a label of `name-value`. We should be sanitizing `name` and `value`, but not the full string.

#### Special notes for the reviewer(s)

/assign @hferentschik 
/assign @pmuir 

#### Which issue this PR fixes

fixes #4467 
