### PR TITLE
fix: Environment prefix defaulting to generated name

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -476,7 +476,12 @@ func (options *InstallOptions) CheckFlags() error {
 	// Make sure that the default environment prefix is configured. Typically it is the cluster
 	// name when the install command is called from create cluster.
 	if flags.DefaultEnvironmentPrefix == "" {
-		flags.DefaultEnvironmentPrefix = strings.ToLower(randomdata.SillyName())
+		clusterName := options.installValues[kube.ClusterName]
+		if clusterName == "" {
+			flags.DefaultEnvironmentPrefix = strings.ToLower(randomdata.SillyName())
+		} else {
+			flags.DefaultEnvironmentPrefix = clusterName
+		}
 	}
 
 	if flags.DockerRegistry == "" {
@@ -490,10 +495,6 @@ func (options *InstallOptions) CheckFlags() error {
 	// lets default the docker registry org to the project id
 	if flags.DockerRegistryOrg == "" {
 		flags.DockerRegistryOrg = options.installValues[kube.ProjectID]
-	}
-
-	if flags.DefaultEnvironmentPrefix == "" {
-		flags.DefaultEnvironmentPrefix = options.installValues[kube.ClusterName]
 	}
 
 	log.Logger().Debugf("flags after checking - %+v", flags)


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Fix for environment prefix defaulting to a generated name, rather than using the cluster name
