### PR TITLE
feat(versions): Add support for semantic releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20181008063305-d718d474c7c2
 	github.com/Jeffail/gabs v1.1.1
 	github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e
+	github.com/Masterminds/semver v1.4.2
 	github.com/Netflix/go-expect v0.0.0-20180814212900-124a37274874
 	github.com/Pallinder/go-randomdata v0.0.0-20180616180521-15df0648130a
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect

--- a/pkg/cmd/step/step_changelog.go
+++ b/pkg/cmd/step/step_changelog.go
@@ -243,7 +243,7 @@ func (o *StepChangelogOptions) Run() error {
 		}
 	}
 	if previousRev == "" {
-		previousRev, err = o.Git().GetPreviousGitTagSHA(dir)
+		previousRev, _, err = o.Git().GetPreviousGitTagSHA(dir)
 		if err != nil {
 			return err
 		}
@@ -254,7 +254,7 @@ func (o *StepChangelogOptions) Run() error {
 	}
 	currentRev := o.CurrentRevision
 	if currentRev == "" {
-		currentRev, err = o.Git().GetCurrentGitTagSHA(dir)
+		currentRev, _, err = o.Git().GetCurrentGitTagSHA(dir)
 		if err != nil {
 			return err
 		}

--- a/pkg/gits/bitbucket_cloud.go
+++ b/pkg/gits/bitbucket_cloud.go
@@ -525,7 +525,7 @@ func (b *BitbucketCloudProvider) GetPullRequestCommits(owner string, repository 
 			if commit.Author.User != nil {
 				login = commit.Author.User.Username
 			}
-			// Author.Raw contains the Git commit author in the form: User <email@example.com>
+			// Author.MessageLines contains the Git commit author in the form: User <email@example.com>
 			email = rawEmailMatcher.ReplaceAllString(commit.Author.Raw, "$1")
 		}
 
@@ -1036,4 +1036,9 @@ func (b *BitbucketCloudProvider) ListCommits(owner, repo string, opt *ListCommit
 // AddLabelsToIssue adds labels to issues or pullrequests
 func (b *BitbucketCloudProvider) AddLabelsToIssue(owner, repo string, number int, labels []string) error {
 	return fmt.Errorf("Getting content not supported on bitbucket")
+}
+
+// GetLatestRelease fetches the latest release from the git provider for org and name
+func (b *BitbucketCloudProvider) GetLatestRelease(org string, name string) (*GitRelease, error) {
+	return nil, nil
 }

--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -1085,3 +1085,8 @@ func (b *BitbucketServerProvider) ListCommits(owner, repo string, opt *ListCommi
 func (b *BitbucketServerProvider) AddLabelsToIssue(owner, repo string, number int, labels []string) error {
 	return fmt.Errorf("Getting content not supported on bitbucket")
 }
+
+// GetLatestRelease fetches the latest release from the git provider for org and name
+func (b *BitbucketServerProvider) GetLatestRelease(org string, name string) (*GitRelease, error) {
+	return nil, nil
+}

--- a/pkg/gits/gerrit.go
+++ b/pkg/gits/gerrit.go
@@ -337,3 +337,8 @@ func (p *GerritProvider) ListCommits(owner, repo string, opt *ListCommitsArgumen
 func (p *GerritProvider) AddLabelsToIssue(owner, repo string, number int, labels []string) error {
 	return fmt.Errorf("Getting content not supported on gerrit")
 }
+
+// GetLatestRelease fetches the latest release from the git provider for org and name
+func (p *GerritProvider) GetLatestRelease(org string, name string) (*GitRelease, error) {
+	return nil, nil
+}

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -432,21 +432,21 @@ func (g *GitFake) HasChanges(dir string) (bool, error) {
 }
 
 // GetPreviousGitTagSHA returns the previous git tag SHA
-func (g *GitFake) GetPreviousGitTagSHA(dir string) (string, error) {
+func (g *GitFake) GetPreviousGitTagSHA(dir string) (string, string, error) {
 	len := len(g.Commits)
 	if len < 2 {
-		return "", errors.New("no previous commit found")
+		return "", "", errors.New("no previous commit found")
 	}
-	return g.Commits[len-2].SHA, nil
+	return g.Commits[len-2].SHA, "", nil
 }
 
 // GetCurrentGitTagSHA returns the current git tag sha
-func (g *GitFake) GetCurrentGitTagSHA(dir string) (string, error) {
+func (g *GitFake) GetCurrentGitTagSHA(dir string) (string, string, error) {
 	len := len(g.Commits)
 	if len < 1 {
-		return "", errors.New("no current commit found")
+		return "", "", errors.New("no current commit found")
 	}
-	return g.Commits[len-1].SHA, nil
+	return g.Commits[len-1].SHA, "", nil
 }
 
 // GetLatestCommitMessage returns the last commit message
@@ -559,4 +559,14 @@ func (g *GitFake) MergeTheirs(dir string, commitish string) error {
 //RebaseTheirs does nothing
 func (g *GitFake) RebaseTheirs(dir string, upstream string, branch string) error {
 	return nil
+}
+
+// GetCommits returns the commits in a range, exclusive of startSha and inclusive of endSha
+func (g *GitFake) GetCommits(dir string, startSha string, endSha string) ([]GitCommit, error) {
+	return nil, nil
+}
+
+// RevParse runs git rev-parse on rev
+func (g *GitFake) RevParse(dir string, rev string) (string, error) {
+	return "", nil
 }

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -274,7 +274,7 @@ func (g *GitLocal) RemoteBranchNames(dir string, prefix string) ([]string, error
 }
 
 // GetPreviousGitTagSHA returns the previous git tag from the repository at the given directory
-func (g *GitLocal) GetPreviousGitTagSHA(dir string) (string, error) {
+func (g *GitLocal) GetPreviousGitTagSHA(dir string) (string, string, error) {
 	return g.GitCLI.GetPreviousGitTagSHA(dir)
 }
 
@@ -289,7 +289,7 @@ func (g *GitLocal) GetRevisionBeforeDateText(dir string, dateText string) (strin
 }
 
 // GetCurrentGitTagSHA return the SHA of the current git tag from the repository at the given directory
-func (g *GitLocal) GetCurrentGitTagSHA(dir string) (string, error) {
+func (g *GitLocal) GetCurrentGitTagSHA(dir string) (string, string, error) {
 	return g.GitCLI.GetCurrentGitTagSHA(dir)
 }
 
@@ -427,4 +427,14 @@ func (g *GitLocal) MergeTheirs(dir string, commitish string) error {
 // RebaseTheirs runs git rebase upstream branch
 func (g *GitLocal) RebaseTheirs(dir string, upstream string, branch string) error {
 	return g.GitCLI.RebaseTheirs(dir, upstream, branch)
+}
+
+// GetCommits returns the commits in a range, exclusive of startSha and inclusive of endSha
+func (g *GitLocal) GetCommits(dir string, startSha string, endSha string) ([]GitCommit, error) {
+	return g.GitCLI.GetCommits(dir, startSha, endSha)
+}
+
+// RevParse runs git rev parse
+func (g *GitLocal) RevParse(dir string, rev string) (string, error) {
+	return g.GitCLI.RevParse(dir, rev)
 }

--- a/pkg/gits/gitea.go
+++ b/pkg/gits/gitea.go
@@ -765,3 +765,12 @@ func (p *GiteaProvider) ListCommits(owner, repo string, opt *ListCommitsArgument
 func (p *GiteaProvider) AddLabelsToIssue(owner, repo string, number int, labels []string) error {
 	return fmt.Errorf("Getting content not supported on gitea")
 }
+
+// GetLatestRelease fetches the latest release from the git provider for org and name
+func (p *GiteaProvider) GetLatestRelease(org string, name string) (*GitRelease, error) {
+	releases, err := p.Client.ListReleases(org, name)
+	if err != nil {
+		return nil, errors2.Wrapf(err, "getting releases for %s/%s", org, name)
+	}
+	return toGiteaRelease(org, name, releases[0]), nil
+}

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -1357,3 +1357,12 @@ func (p *GitHubProvider) ListCommits(owner, repo string, opt *ListCommitsArgumen
 	}
 	return commits, nil
 }
+
+// GetLatestRelease fetches the latest release from the git provider for org and name
+func (p *GitHubProvider) GetLatestRelease(org string, name string) (*GitRelease, error) {
+	repoRelease, _, err := p.Client.Repositories.GetLatestRelease(p.Context, org, name)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting latest release for %s/%s", org, name)
+	}
+	return toGitHubRelease(org, name, repoRelease), nil
+}

--- a/pkg/gits/gitlab.go
+++ b/pkg/gits/gitlab.go
@@ -737,3 +737,9 @@ func (g *GitlabProvider) ListCommits(owner, repo string, opt *ListCommitsArgumen
 func (g *GitlabProvider) AddLabelsToIssue(owner, repo string, number int, labels []string) error {
 	return fmt.Errorf("Getting content not supported on gitlab yet")
 }
+
+// GetLatestRelease fetches the latest release from the git provider for org and name
+func (g *GitlabProvider) GetLatestRelease(org string, name string) (*GitRelease, error) {
+	// TODO
+	return nil, nil
+}

--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -611,3 +611,9 @@ func computeBranchName(baseRef string, branchName string, dir string, gitter Git
 func IsUnadvertisedObjectError(err error) bool {
 	return strings.Contains(err.Error(), "Server does not allow request for unadvertised object")
 }
+
+func parseAuthor(l string) (string, string) {
+	open := strings.Index(l, "<")
+	close := strings.Index(l, ">")
+	return strings.TrimSpace(l[:open]), strings.TrimSpace(l[open+1 : close])
+}

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -103,6 +103,8 @@ type GitProvider interface {
 
 	GetRelease(org string, name string, id string) (*GitRelease, error)
 
+	GetLatestRelease(org string, name string) (*GitRelease, error)
+
 	GetContent(org string, name string, path string, ref string) (*GitFileContent, error)
 
 	// returns the path relative to the Jenkins URL to trigger webhooks on this kind of repository
@@ -238,12 +240,14 @@ type Gitter interface {
 	LoadFileFromBranch(dir string, branch string, file string) (string, error)
 
 	GetLatestCommitMessage(dir string) (string, error)
-	GetPreviousGitTagSHA(dir string) (string, error)
-	GetCurrentGitTagSHA(dir string) (string, error)
+	GetPreviousGitTagSHA(dir string) (string, string, error)
+	GetCurrentGitTagSHA(dir string) (string, string, error)
 	FetchTags(dir string) error
 	Tags(dir string) ([]string, error)
 	CreateTag(dir string, tag string, msg string) error
 	GetLatestCommitSha(dir string) (string, error)
+	GetCommits(dir string, startSha string, endSha string) ([]GitCommit, error)
+	RevParse(dir string, rev string) (string, error)
 
 	GetRevisionBeforeDate(dir string, t time.Time) (string, error)
 	GetRevisionBeforeDateText(dir string, dateText string) (string, error)

--- a/pkg/gits/mocks/git_provider.go
+++ b/pkg/gits/mocks/git_provider.go
@@ -280,6 +280,25 @@ func (mock *MockGitProvider) GetIssue(_param0 string, _param1 string, _param2 in
 	return ret0, ret1
 }
 
+func (mock *MockGitProvider) GetLatestRelease(_param0 string, _param1 string) (*gits.GitRelease, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitProvider().")
+	}
+	params := []pegomock.Param{_param0, _param1}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("GetLatestRelease", params, []reflect.Type{reflect.TypeOf((**gits.GitRelease)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 *gits.GitRelease
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(*gits.GitRelease)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockGitProvider) GetPullRequest(_param0 string, _param1 *gits.GitRepository, _param2 int) (*gits.GitPullRequest, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitProvider().")
@@ -1430,6 +1449,37 @@ func (c *MockGitProvider_GetIssue_OngoingVerification) GetAllCapturedArguments()
 		_param2 = make([]int, len(params[2]))
 		for u, param := range params[2] {
 			_param2[u] = param.(int)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitProvider) GetLatestRelease(_param0 string, _param1 string) *MockGitProvider_GetLatestRelease_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetLatestRelease", params, verifier.timeout)
+	return &MockGitProvider_GetLatestRelease_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitProvider_GetLatestRelease_OngoingVerification struct {
+	mock              *MockGitProvider
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitProvider_GetLatestRelease_OngoingVerification) GetCapturedArguments() (string, string) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+}
+
+func (c *MockGitProvider_GetLatestRelease_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(params[0]))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(params[1]))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
 		}
 	}
 	return

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -526,23 +526,46 @@ func (mock *MockGitter) GetAuthorEmailForCommit(_param0 string, _param1 string) 
 	return ret0, ret1
 }
 
-func (mock *MockGitter) GetCurrentGitTagSHA(_param0 string) (string, error) {
+func (mock *MockGitter) GetCommits(_param0 string, _param1 string, _param2 string) ([]gits.GitCommit, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
 	}
-	params := []pegomock.Param{_param0}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("GetCurrentGitTagSHA", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 string
+	params := []pegomock.Param{_param0, _param1, _param2}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("GetCommits", params, []reflect.Type{reflect.TypeOf((*[]gits.GitCommit)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 []gits.GitCommit
 	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(string)
+			ret0 = result[0].([]gits.GitCommit)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(error)
 		}
 	}
 	return ret0, ret1
+}
+
+func (mock *MockGitter) GetCurrentGitTagSHA(_param0 string) (string, string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("GetCurrentGitTagSHA", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 string
+	var ret2 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(string)
+		}
+		if result[2] != nil {
+			ret2 = result[2].(error)
+		}
+	}
+	return ret0, ret1, ret2
 }
 
 func (mock *MockGitter) GetLatestCommitMessage(_param0 string) (string, error) {
@@ -583,23 +606,27 @@ func (mock *MockGitter) GetLatestCommitSha(_param0 string) (string, error) {
 	return ret0, ret1
 }
 
-func (mock *MockGitter) GetPreviousGitTagSHA(_param0 string) (string, error) {
+func (mock *MockGitter) GetPreviousGitTagSHA(_param0 string) (string, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
 	}
 	params := []pegomock.Param{_param0}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("GetPreviousGitTagSHA", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	result := pegomock.GetGenericMockFrom(mock).Invoke("GetPreviousGitTagSHA", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 string
-	var ret1 error
+	var ret1 string
+	var ret2 error
 	if len(result) != 0 {
 		if result[0] != nil {
 			ret0 = result[0].(string)
 		}
 		if result[1] != nil {
-			ret1 = result[1].(error)
+			ret1 = result[1].(string)
+		}
+		if result[2] != nil {
+			ret2 = result[2].(error)
 		}
 	}
-	return ret0, ret1
+	return ret0, ret1, ret2
 }
 
 func (mock *MockGitter) GetRemoteUrl(_param0 *config.Config, _param1 string) string {
@@ -1072,6 +1099,25 @@ func (mock *MockGitter) ResetToUpstream(_param0 string, _param1 string) error {
 		}
 	}
 	return ret0
+}
+
+func (mock *MockGitter) RevParse(_param0 string, _param1 string) (string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0, _param1}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("RevParse", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
 }
 
 func (mock *MockGitter) Server(_param0 string) (string, error) {
@@ -2265,6 +2311,41 @@ func (c *MockGitter_GetAuthorEmailForCommit_OngoingVerification) GetAllCapturedA
 	return
 }
 
+func (verifier *VerifierMockGitter) GetCommits(_param0 string, _param1 string, _param2 string) *MockGitter_GetCommits_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetCommits", params, verifier.timeout)
+	return &MockGitter_GetCommits_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_GetCommits_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_GetCommits_OngoingVerification) GetCapturedArguments() (string, string, string) {
+	_param0, _param1, _param2 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1]
+}
+
+func (c *MockGitter_GetCommits_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(params[0]))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(params[1]))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
+		}
+		_param2 = make([]string, len(params[2]))
+		for u, param := range params[2] {
+			_param2[u] = param.(string)
+		}
+	}
+	return
+}
+
 func (verifier *VerifierMockGitter) GetCurrentGitTagSHA(_param0 string) *MockGitter_GetCurrentGitTagSHA_OngoingVerification {
 	params := []pegomock.Param{_param0}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetCurrentGitTagSHA", params, verifier.timeout)
@@ -3218,6 +3299,37 @@ func (c *MockGitter_ResetToUpstream_OngoingVerification) GetCapturedArguments() 
 }
 
 func (c *MockGitter_ResetToUpstream_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(params[0]))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(params[1]))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) RevParse(_param0 string, _param1 string) *MockGitter_RevParse_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "RevParse", params, verifier.timeout)
+	return &MockGitter_RevParse_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_RevParse_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_RevParse_OngoingVerification) GetCapturedArguments() (string, string) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+}
+
+func (c *MockGitter_RevParse_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(params[0]))

--- a/pkg/gits/provider_fake.go
+++ b/pkg/gits/provider_fake.go
@@ -769,3 +769,12 @@ func (f *FakeProvider) ListCommits(owner, name string, opt *ListCommitsArguments
 func (f *FakeProvider) AddLabelsToIssue(owner, repo string, number int, labels []string) error {
 	return nil
 }
+
+// GetLatestRelease fetches the latest release from the git provider for org and name
+func (f *FakeProvider) GetLatestRelease(org string, name string) (*GitRelease, error) {
+	releases, err := f.ListReleases(org, name)
+	if err != nil {
+		return nil, errors2.WithStack(err)
+	}
+	return releases[len(releases)-1], nil
+}

--- a/pkg/semrel/semrel.go
+++ b/pkg/semrel/semrel.go
@@ -1,0 +1,130 @@
+package semrel
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/jenkins-x/jx/pkg/gits"
+)
+
+var commitPattern = regexp.MustCompile("^(\\w*)(?:\\((.*)\\))?\\: (.*)$")
+var breakingPattern = regexp.MustCompile("BREAKING CHANGES?")
+
+type change struct {
+	Major, Minor, Patch bool
+}
+
+type conventionalCommit struct {
+	*gits.GitCommit
+	MessageLines []string
+	Type         string
+	Scope        string
+	MessageBody  string
+	Change       change
+}
+
+type release struct {
+	SHA     string
+	Version *semver.Version
+}
+
+func calculateChange(commits []*conventionalCommit, latestRelease *release) change {
+	var change change
+	for _, commit := range commits {
+		if latestRelease.SHA == commit.SHA {
+			break
+		}
+		change.Major = change.Major || commit.Change.Major
+		change.Minor = change.Minor || commit.Change.Minor
+		change.Patch = change.Patch || commit.Change.Patch
+	}
+	return change
+}
+
+func applyChange(version *semver.Version, change change) *semver.Version {
+	if version.Major() == 0 {
+		change.Major = true
+	}
+	if !change.Major && !change.Minor && !change.Patch {
+		return nil
+	}
+	var newVersion semver.Version
+	preRel := version.Prerelease()
+	if preRel == "" {
+		switch {
+		case change.Major:
+			newVersion = version.IncMajor()
+			break
+		case change.Minor:
+			newVersion = version.IncMinor()
+			break
+		case change.Patch:
+			newVersion = version.IncPatch()
+			break
+		}
+		return &newVersion
+	}
+	preRelVer := strings.Split(preRel, ".")
+	if len(preRelVer) > 1 {
+		idx, err := strconv.ParseInt(preRelVer[1], 10, 32)
+		if err != nil {
+			idx = 0
+		}
+		preRel = fmt.Sprintf("%s.%d", preRelVer[0], idx+1)
+	} else {
+		preRel += ".1"
+	}
+	newVersion, _ = version.SetPrerelease(preRel)
+	return &newVersion
+}
+
+// GetNewVersion uses the conventional commits in the range of latestTagRev..endSha to increment the version from latestTag
+func GetNewVersion(dir string, endSha string, gitter gits.Gitter, latestTag string, latestTagRev string) (*semver.Version, error) {
+	version, err := semver.NewVersion(strings.TrimPrefix(latestTag, "v"))
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing %s as semantic version", latestTag)
+	}
+	release := release{
+		SHA:     latestTagRev,
+		Version: version,
+	}
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	rawCommits, err := gitter.GetCommits(dir, release.SHA, endSha)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting commits in range %s..%s", release.SHA, endSha)
+	}
+	commits := make([]*conventionalCommit, 0)
+	for _, c := range rawCommits {
+		commits = append(commits, parseCommit(&c))
+	}
+
+	return applyChange(release.Version, calculateChange(commits, &release)), nil
+}
+
+func parseCommit(commit *gits.GitCommit) *conventionalCommit {
+	c := &conventionalCommit{
+		GitCommit: commit,
+	}
+	c.MessageLines = strings.Split(commit.Message, "\n")
+	found := commitPattern.FindAllStringSubmatch(c.MessageLines[0], -1)
+	if len(found) < 1 {
+		return c
+	}
+	c.Type = strings.ToLower(found[0][1])
+	c.Scope = found[0][2]
+	c.MessageBody = found[0][3]
+	c.Change = change{
+		Major: breakingPattern.MatchString(commit.Message),
+		Minor: c.Type == "feat",
+		Patch: c.Type == "fix",
+	}
+	return c
+}


### PR DESCRIPTION
This adds the `--semantic-release` flag to `jx step next-version` which uses conventional commits to work out the next version number

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
