### PR TITLE
fix: Remove pre goreleaser call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,6 @@ test-release: clean build
 release: clean build test-slow-integration linux # Release the binary
 	git fetch --tags
 	git checkout tags/v$(VERSION)
-	GITHUB_TOKEN=$(GITHUB_ACCESS_TOKEN) REV=$(REV) BRANCH=$(BRANCH) BUILDDATE=$(BUILD_DATE) GOVERSION=$(GO_VERSION) ROOTPACKAGE=$(ROOT_PACKAGE) VERSION=$(VERSION) goreleaser release --config=.goreleaser.yml --rm-dist
 	# Don't create a changelog for the distro
 	@if [[ -z "${DISTRO}" ]]; then \
 		./build/linux/jx step changelog --verbose --header-file=docs/dev/changelog-header.md --version=$(VERSION) --rev=$(PULL_BASE_SHA) --output-markdown=changelog.md --update-release=false; \


### PR DESCRIPTION
Removed the goreleaser line which generates a conflict when uploading binaries which are already present
Signed-off-by: Cai Cooper <caicooper82@gmail.com>
