### PR TITLE
fix: get build logs batch mode

### DIFF
--- a/pkg/cmd/get/get_build_logs.go
+++ b/pkg/cmd/get/get_build_logs.go
@@ -254,20 +254,21 @@ func (o *GetBuildLogsOptions) getProwBuildLog(kubeClient kubernetes.Interface, t
 	var buildMap map[string]builds.BaseBuildInfo
 	var pipelineMap map[string]builds.BaseBuildInfo
 
+	var err error
+	if tektonEnabled {
+		names, defaultName, buildMap, pipelineMap, err = o.loadPipelines(kubeClient, tektonClient, jxClient, ns)
+	} else {
+		names, defaultName, buildMap, pipelineMap, err = o.loadBuilds(kubeClient, ns)
+	}
+	if err != nil {
+		return err
+	}
+
 	args := o.Args
 	pickedPipeline := false
 	if len(args) == 0 {
 		if o.BatchMode {
 			return util.MissingArgument("pipeline")
-		}
-		var err error
-		if tektonEnabled {
-			names, defaultName, buildMap, pipelineMap, err = o.loadPipelines(kubeClient, tektonClient, jxClient, ns)
-		} else {
-			names, defaultName, buildMap, pipelineMap, err = o.loadBuilds(kubeClient, ns)
-		}
-		if err != nil {
-			return err
 		}
 		pickedPipeline = true
 		name, err := util.PickNameWithDefault(names, "Which build do you want to view the logs of?: ", defaultName, "", o.In, o.Out, o.Err)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
`buildMap` is not initialized anymore in the case of `jx get build logs -b name-of-the-build`
`(len(args) != 0)` so https://github.com/jenkins-x/jx/pull/3258/files#diff-88a655068fa6bd90e8016b5a9642d098R269 equals nil.

#### Special notes for the reviewer(s)
Not sure of this fix as it's a partial revert of https://github.com/jenkins-x/jx/pull/3258 which was suppose to also fix an issue.
@jstrachan any insights are welcome to be sure it's not making a regression

#### Which issue this PR fixes

fixes #4518 
