### PR TITLE
fix(tekton): Look for run by labels, not name

### DIFF
--- a/pkg/cmd/step/create/step_create_meta_pipeline.go
+++ b/pkg/cmd/step/create/step_create_meta_pipeline.go
@@ -142,7 +142,7 @@ func (o *StepCreatePipelineOptions) Run() error {
 	}
 
 	pipelineName := tekton.PipelineResourceNameFromGitInfo(gitInfo, o.Branch, o.Context, tekton.MetaPipeline)
-	buildNumber, err := tekton.GenerateNextBuildNumber(tektonClient, jxClient, ns, gitInfo, o.Branch, retryDuration, pipelineName)
+	buildNumber, err := tekton.GenerateNextBuildNumber(tektonClient, jxClient, ns, gitInfo, o.Branch, retryDuration, o.Context)
 	if err != nil {
 		return errors.Wrap(err, "unable to determine next build number")
 	}

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -380,7 +380,7 @@ func (o *StepCreateTaskOptions) createEffectiveProjectConfigFromOptions(tektonCl
 		o.BuildNumber = "1"
 	} else {
 		log.Logger().Debugf("generating build number...")
-		o.BuildNumber, err = tekton.GenerateNextBuildNumber(tektonClient, jxClient, ns, o.GitInfo, o.Branch, o.Duration, pipelineName)
+		o.BuildNumber, err = tekton.GenerateNextBuildNumber(tektonClient, jxClient, ns, o.GitInfo, o.Branch, o.Duration, o.Context)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

`PipelineRun` names may be truncated to the point where they're not unique across branches and contexts, so we should be looking them up for determining the next build number by looking at their labels instead.

#### Special notes for the reviewer(s)

/assign @hferentschik 
/assign @jstrachan 
/assign @dwnusbaum 

#### Which issue this PR fixes

fixes #4523
