### PR TITLE
fix: add a path to enable semantic releases

### DIFF
--- a/pkg/cmd/controller/controller_pipelinerunner.go
+++ b/pkg/cmd/controller/controller_pipelinerunner.go
@@ -40,6 +40,7 @@ type ControllerPipelineRunnerOptions struct {
 	Path                 string
 	Port                 int
 	NoGitCredentialsInit bool
+	SemanticRelease      bool
 }
 
 // PipelineRunRequest the request to trigger a pipeline run
@@ -98,6 +99,7 @@ func NewCmdControllerPipelineRunner(commonOpts *opts.CommonOptions) *cobra.Comma
 		"The path to listen on for requests to trigger a pipeline run.")
 	cmd.Flags().StringVarP(&options.ServiceAccount, "service-account", "", "tekton-bot", "The Kubernetes ServiceAccount to use to run the pipeline")
 	cmd.Flags().BoolVarP(&options.NoGitCredentialsInit, "no-git-init", "", false, "Disables checking we have setup git credentials on startup")
+	cmd.Flags().BoolVarP(&options.SemanticRelease, "semantic-release", "", false, "Enable semantic releases")
 	return cmd
 }
 
@@ -235,6 +237,10 @@ func (o *ControllerPipelineRunnerOptions) startPipelineRun(w http.ResponseWriter
 	// turn map into string array with = separator to match type of custom env vars which are CLI flags
 	for key, value := range envs {
 		pr.CustomEnvs = append(pr.CustomEnvs, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	if o.SemanticRelease {
+		o.SemanticRelease = true
 	}
 
 	log.Logger().Infof("triggering pipeline for repo %s branch %s revision %s context %s", sourceURL, branch, revision, pj.Context)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
For now, let’s just add a `--semantic-release` flag to `jx step create task` and the `pipelinerunner` so that we can optionally use semantic-release as a `jx step next-version` strategy.

Once meta-pipeline is in, and stabilises, we can perhaps do the `jx step next-version` in there, and use it to customise the semantic release.

#### Special notes for the reviewer(s)
This is not ideal

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
