### PR TITLE
fix(install): use YAML import mode for Tekton

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -1622,6 +1622,7 @@ func (options *InstallOptions) configureProwInTeamSettings() error {
 			settings.ProwEngine = v1.ProwEngineTypeKnativeBuild
 			if options.Flags.Tekton {
 				settings.ProwEngine = v1.ProwEngineTypeTekton
+				settings.ImportMode = v1.ImportModeTypeYAML
 			}
 			log.Logger().Debugf("Configuring the TeamSettings for Prow with engine %s", string(settings.ProwEngine))
 			return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests. **(Don't know)**

#### Description

Was testing out a local [kind](https://kind.sigs.k8s.io) cluster to play with Tekton and friends. My install command was:

```
jx install --provider=kubernetes --no-default-environments --default-admin-password=admin --advanced-mode --on-premise --external-ip 'MY_IP' --gitops=false --prow=true --tekton=true --static-jenkins=false --vault=false
```

Then, when I tried to do a quickstart, it applied a normal `Jenkinsfile` instead of `jenkins-x.yaml`.  Turned out the import mode on the dev environment team settings was set to `Jenkinsfile` instead of `YAML`.

#### Special notes for the reviewer(s)

100% guessing on where to fix it. But did test the fix, team settings were correct after the change.

#### Which issue this PR fixes

N/A