### PR TITLE
fix: Use /usr/local/git/bin in path for lint build

### DIFF
--- a/jenkins-x-lint.yml
+++ b/jenkins-x-lint.yml
@@ -13,7 +13,7 @@ pipelineConfig:
               - name: GOPROXY
                 value: http://jenkins-x-athens-proxy
               - name: PATH
-                value: "/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/workspace/go/bin"
+                value: "/usr/local/git/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/workspace/go/bin"
             options:
               containerOptions:
                 resources:


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The container used for the git merge has two gits - one in /usr/local/git/bin, and one in /usr/bin. The latter is too old, and the former is the one we want. We're overriding the path to get go stuff to work, so let's prepend /usr/local/git/bin to that path.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a