### PR TITLE
chore: Cut down on resource requests for BDD tests

### DIFF
--- a/jenkins-x-bdd.yml
+++ b/jenkins-x-bdd.yml
@@ -36,8 +36,8 @@ pipelineConfig:
                     cpu: 4
                     memory: 6144Mi
                   requests:
-                    cpu: 3
-                    memory: 3072Mi
+                    cpu: 1
+                    memory: 2048Mi
                 env:
                   - name: CODECOV_TOKEN
                     valueFrom:

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -26,7 +26,7 @@ pipelineConfig:
               - name: COVERED_BINARY
                 value: "true"
               - name: CODECOV_NAME
-                value: tekton-e2e
+                value: tektone2e
               - name: VERSION_PREFIX
                 value: covered-
             options:

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -36,8 +36,8 @@ pipelineConfig:
                     cpu: 4
                     memory: 6144Mi
                   requests:
-                    cpu: 3
-                    memory: 3072Mi
+                    cpu: 1
+                    memory: 2048Mi
                 env:
                   - name: CODECOV_TOKEN
                     valueFrom:

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -276,7 +276,7 @@ pipelineConfig:
               - name: tekton
                 env:
                   - name: CODECOV_NAME
-                    value: tekton-e2e
+                    value: tektone2e
                 steps:
                   - name: tekton-e2e-tests
                     image: gcr.io/jenkinsxio/builder-go:0.1.537


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

3 CPUs and 3gb RAM was overkill for the request, IMO. Let's drop the CPU to 1 and the RAM to 2gb.

Adding the `tekton` context has resulted in a bunch of `PENDING` pods due to requests not being satisfied, hence this.

#### Special notes for the reviewer(s)

/assign @daveconde 
/assign @pmuir 

#### Which issue this PR fixes

fixes #4574 