### PR TITLE
fix: disable brew update by goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -157,7 +157,7 @@ brews:
     # If set to auto, the release will not be uploaded to the homebrew tap
     # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
     # Default is false.
-    skip_upload: false
+    skip_upload: true
 
     # So you can `brew test` your formula.
     # Default is empty.


### PR DESCRIPTION
Associated with #4596 
`goreleaser` is currently updating jenkins-x/homebrew-jx, however it's doing so by a direct commit to master which is a little dirty in our eyes :). So we'll be moving to our now internal version of `updatebot` (`jx step create pr brew ...`) once it's merged (https://github.com/jenkins-x/jx/pull/4561) to perform the update of the jx binary and it's sha256 sum.
Signed-off-by: Cai Cooper <caicooper82@gmail.com>