### PR TITLE
fix(tekton): deriving build related meta information from pull refs

### DIFF
--- a/pkg/cmd/step/create/step_create_meta_pipeline_test.go
+++ b/pkg/cmd/step/create/step_create_meta_pipeline_test.go
@@ -2,37 +2,38 @@ package create
 
 import (
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/jenkinsfile"
+	"github.com/jenkins-x/jx/pkg/prow"
 	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
 
-type testData struct {
+type testOptions struct {
 	options      []string
 	values       []string
 	expectError  bool
 	errorMessage string
 }
 
+type testPullRef struct {
+	pullRef  string
+	expected string
+}
+
 func Test_required_options_for_meta_pipeline_creation_need_to_be_passed(t *testing.T) {
-	testCases := []testData{
+	testCases := []testOptions{
 		{
 			[]string{""}, []string{}, true, "Missing option: --source-url",
 		},
 		{
-			[]string{"SourceURL"}, []string{"https://github.com/jenkins-x/jx.git"}, true, "Missing option: --branch",
+			[]string{"SourceURL"}, []string{"https://github.com/jenkins-x/jx.git"}, true, "Missing option: --job",
 		},
 		{
-			[]string{"SourceURL", "Branch"}, []string{"https://github.com/jenkins-x/jx.git", "master"}, true, "Missing option: --kind",
+			[]string{"SourceURL", "Job"}, []string{"https://github.com/jenkins-x/jx.git", "5108a21c-9d6b-11e9-b835-9a460f5ab90f"}, true, "Missing option: --pull-refs",
 		},
 		{
-			[]string{"SourceURL", "Branch", "PipelineKind"}, []string{"https://github.com/jenkins-x/jx.git", "master", "release"}, true, "Missing option: --job",
-		},
-		{
-			[]string{"SourceURL"}, []string{"foo"}, true, "unable to determine needed git info",
-		},
-		{
-			[]string{"SourceURL", "Branch", "PipelineKind", "Job"}, []string{"https://github.com/jenkins-x/jx.git", "master", "release", "job-id"}, false, "",
+			[]string{"SourceURL", "Job", "PullRefs"}, []string{"https://github.com/jenkins-x/jx.git", "master", "master:0967f9ecd7dd2d0acf883c7656c9dc2ad2bf9815,4554:1c313425db5b014271d0d074dd5aac635ffc617e"}, false, "",
 		},
 	}
 
@@ -48,7 +49,53 @@ func Test_required_options_for_meta_pipeline_creation_need_to_be_passed(t *testi
 	}
 }
 
-func setTestOptions(data testData) StepCreatePipelineOptions {
+func Test_determine_branch_identifier_from_pull_refs(t *testing.T) {
+	testCases := []testPullRef{
+		{
+			"master:0967f9ecd7dd2d0acf883c7656c9dc2ad2bf9815", "master",
+		},
+		{
+			"feature-1:0967f9ecd7dd2d0acf883c7656c9dc2ad2bf9815", "feature-1",
+		},
+		{
+			"master:0967f9ecd7dd2d0acf883c7656c9dc2ad2bf9815,4554:1c313425db5b014271d0d074dd5aac635ffc617e", "PR-4554",
+		},
+		{
+			"master:0967f9ecd7dd2d0acf883c7656c9dc2ad2bf9815,4554:1c313425db5b014271d0d074dd5aac635ffc617e,5555:1c313425db8b014271d0d074dd5aac635ffc617e", "batch",
+		},
+	}
+
+	option := StepCreatePipelineOptions{}
+
+	for _, testCase := range testCases {
+		pullRefs, err := prow.ParsePullRefs(testCase.pullRef)
+		assert.NoError(t, err)
+		actualBranchName := option.determineBranchIdentifier(*pullRefs)
+		assert.Equal(t, testCase.expected, actualBranchName)
+	}
+}
+
+func Test_determine_pipeline_kind(t *testing.T) {
+	testCases := []testPullRef{
+		{
+			"master:0967f9ecd7dd2d0acf883c7656c9dc2ad2bf9815", jenkinsfile.PipelineKindRelease,
+		},
+		{
+			"master:0967f9ecd7dd2d0acf883c7656c9dc2ad2bf9815,4554:1c313425db5b014271d0d074dd5aac635ffc617e", jenkinsfile.PipelineKindPullRequest,
+		},
+	}
+
+	option := StepCreatePipelineOptions{}
+
+	for _, testCase := range testCases {
+		pullRefs, err := prow.ParsePullRefs(testCase.pullRef)
+		assert.NoError(t, err)
+		actualPipelineKind := option.determinePipelineKind(*pullRefs)
+		assert.Equal(t, testCase.expected, actualPipelineKind)
+	}
+}
+
+func setTestOptions(data testOptions) StepCreatePipelineOptions {
 	o := StepCreatePipelineOptions{}
 	for i, option := range data.options {
 		if option != "" {

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -190,7 +190,6 @@ func (o *StepCreateTaskOptions) AddCommonFlags(cmd *cobra.Command) {
 
 // Run implements this command
 func (o *StepCreateTaskOptions) Run() error {
-	var pr *prow.PullRefs
 	var effectiveProjectConfig *config.ProjectConfig
 	var err error
 
@@ -204,6 +203,11 @@ func (o *StepCreateTaskOptions) Run() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	pr, err := o.parsePullRefs()
+	if err != nil {
+		return errors.Wrapf(err, "Unable to find or parse PULL_REFS from custom environment")
 	}
 
 	exists, err := o.effectiveProjectConfigExists()
@@ -243,11 +247,6 @@ func (o *StepCreateTaskOptions) Run() error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to find git branch from dir %s", o.CloneDir)
 		}
-	}
-
-	pr, err = o.parsePullRefs()
-	if err != nil {
-		return errors.Wrapf(err, "Unable to find or parse PULL_REFS from custom environment")
 	}
 
 	o.PodTemplates, err = kube.LoadPodTemplates(kubeClient, ns)


### PR DESCRIPTION
- removing parameters which can be derived from step_create_meta_pipeline
- adding step to merge pull refs in meta pipeline
- making sure the right parameters are passed in step create task in meta pipeline

fixes issue #4551

