### PR TITLE
fix: Isolate machine-learning quickstarts from conventional quickstarts

### DIFF
--- a/pkg/cmd/get/get_quickstarts.go
+++ b/pkg/cmd/get/get_quickstarts.go
@@ -2,9 +2,10 @@ package get
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/log"
-	"strings"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -65,6 +66,7 @@ func NewCmdGetQuickstarts(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Filter.Owner, "owner", "", "", "The owner to filter on")
 	cmd.Flags().StringVarP(&options.Filter.Language, "language", "l", "", "The language to filter on")
 	cmd.Flags().StringVarP(&options.Filter.Framework, "framework", "", "", "The framework to filter on")
+	cmd.Flags().BoolVarP(&options.Filter.AllowML, "machine-learning", "", false, "Allow machine-learning quickstarts in results")
 	cmd.Flags().BoolVarP(&options.ShortFormat, "short", "s", false, "return minimal details")
 
 	return cmd

--- a/pkg/quickstarts/model_test.go
+++ b/pkg/quickstarts/model_test.go
@@ -112,3 +112,114 @@ func TestQuickstartModelFilterTextMatchesOneExactly(t *testing.T) {
 	assert.Equal(t, 1, len(results))
 	assert.Contains(t, results, quickstart1)
 }
+
+func TestQuickstartModelFilterExcludesMachineLearning(t *testing.T) {
+	t.Parallel()
+
+	quickstart1 := &quickstarts.Quickstart{
+		ID:   "jenkins-x-quickstarts/node-http",
+		Name: "node-http",
+	}
+	quickstart2 := &quickstarts.Quickstart{
+		ID:   "jenkins-x-quickstarts/node-http-watch-pipeline-activity",
+		Name: "node-http-watch-pipeline-activity",
+	}
+	quickstart3 := &quickstarts.Quickstart{
+		ID:   "machine-learning-quickstarts/ML-is-a-machine-learning-quickstart",
+		Name: "ML-is-a-machine-learning-quickstart",
+	}
+
+	qstarts := make(map[string]*quickstarts.Quickstart)
+	qstarts["node-http"] = quickstart1
+	qstarts["node-http-watch-pipeline-activity"] = quickstart2
+	qstarts["ML-is-a-machine-learning-quickstart"] = quickstart3
+
+	quickstartModel := &quickstarts.QuickstartModel{
+		Quickstarts: qstarts,
+	}
+
+	quickstartFilter := &quickstarts.QuickstartFilter{
+		AllowML: false,
+	}
+
+	results := quickstartModel.Filter(quickstartFilter)
+
+	assert.Equal(t, 2, len(results))
+	assert.Contains(t, results, quickstart1)
+	assert.Contains(t, results, quickstart2)
+	assert.NotContains(t, results, quickstart3)
+}
+
+func TestQuickstartModelFilterIncludesMachineLearning(t *testing.T) {
+	t.Parallel()
+
+	quickstart1 := &quickstarts.Quickstart{
+		ID:   "jenkins-x-quickstarts/node-http",
+		Name: "node-http",
+	}
+	quickstart2 := &quickstarts.Quickstart{
+		ID:   "jenkins-x-quickstarts/node-http-watch-pipeline-activity",
+		Name: "node-http-watch-pipeline-activity",
+	}
+	quickstart3 := &quickstarts.Quickstart{
+		ID:   "machine-learning-quickstarts/ML-is-a-machine-learning-quickstart",
+		Name: "ML-is-a-machine-learning-quickstart",
+	}
+
+	qstarts := make(map[string]*quickstarts.Quickstart)
+	qstarts["node-http"] = quickstart1
+	qstarts["node-http-watch-pipeline-activity"] = quickstart2
+	qstarts["ML-is-a-machine-learning-quickstart"] = quickstart3
+
+	quickstartModel := &quickstarts.QuickstartModel{
+		Quickstarts: qstarts,
+	}
+
+	quickstartFilter := &quickstarts.QuickstartFilter{
+		AllowML: true,
+	}
+
+	results := quickstartModel.Filter(quickstartFilter)
+
+	assert.Equal(t, 3, len(results))
+	assert.Contains(t, results, quickstart1)
+	assert.Contains(t, results, quickstart2)
+	assert.Contains(t, results, quickstart3)
+}
+
+func TestQuickstartModelFilterDefaultsToNoMachineLearning(t *testing.T) {
+	t.Parallel()
+
+	quickstart1 := &quickstarts.Quickstart{
+		ID:   "jenkins-x-quickstarts/node-http",
+		Name: "node-http",
+	}
+	quickstart2 := &quickstarts.Quickstart{
+		ID:   "jenkins-x-quickstarts/node-http-watch-pipeline-activity",
+		Name: "node-http-watch-pipeline-activity",
+	}
+	quickstart3 := &quickstarts.Quickstart{
+		ID:   "machine-learning-quickstarts/ML-is-a-machine-learning-quickstart",
+		Name: "ML-is-a-machine-learning-quickstart",
+	}
+
+	qstarts := make(map[string]*quickstarts.Quickstart)
+	qstarts["node-http"] = quickstart1
+	qstarts["node-http-watch-pipeline-activity"] = quickstart2
+	qstarts["ML-is-a-machine-learning-quickstart"] = quickstart3
+
+	quickstartModel := &quickstarts.QuickstartModel{
+		Quickstarts: qstarts,
+	}
+
+	quickstartFilter := &quickstarts.QuickstartFilter{
+		Text: "",
+	}
+
+	results := quickstartModel.Filter(quickstartFilter)
+
+	assert.Equal(t, 2, len(results))
+	assert.Contains(t, results, quickstart1)
+	assert.Contains(t, results, quickstart2)
+	assert.NotContains(t, results, quickstart3)
+}

--- a/pkg/quickstarts/quickstarts.go
+++ b/pkg/quickstarts/quickstarts.go
@@ -2,6 +2,8 @@ package quickstarts
 
 import (
 	"strings"
+
+	u "github.com/jenkins-x/jx/pkg/util"
 )
 
 func (q *Quickstart) SurveyName() string {
@@ -30,6 +32,9 @@ func (f *QuickstartFilter) Matches(q *Quickstart) bool {
 	}
 	framework := strings.ToLower(f.Framework)
 	if framework != "" && strings.ToLower(q.Framework) != framework {
+		return false
+	}
+	if !f.AllowML && u.StartsWith(q.Name, "ML-") {
 		return false
 	}
 	return true

--- a/pkg/quickstarts/types.go
+++ b/pkg/quickstarts/types.go
@@ -24,6 +24,7 @@ type QuickstartFilter struct {
 	Text        string
 	ProjectName string
 	Tags        []string
+	AllowML     bool
 }
 
 type QuickstartForm struct {

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -3,13 +3,14 @@ package util
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/pkg/errors"
 	"math/rand"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 //DisallowedLabelCharacters regex of chars not allowed in lables
@@ -255,4 +256,9 @@ func StripTrailingSlash(url string) string {
 		return url[0 : len(url)-1]
 	}
 	return url
+}
+
+// StartsWith returns true if the string starts with the given substring
+func StartsWith(s, substr string) bool {
+	return strings.Index(s, substr) == 0
 }

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -151,3 +151,8 @@ func TestStripTrailingSlash(t *testing.T) {
 	url = "http://some.other.url.com"
 	assert.Equal(t, util.StripTrailingSlash(url), "http://some.other.url.com")
 }
+
+func Test_StartsWith(t *testing.T) {
+	assert.True(t, util.StartsWith("ML-a-machine-learning-quickstart", "ML-"))
+	assert.False(t, util.StartsWith("not-a-machine-learning-quickstart", "ML-"))
+}


### PR DESCRIPTION
Signed-off-by: Terry Cox <terry@bootstrap.je>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
This PR addresses several issues relating to machine-learning quickstarts as a new class of quickstart by adding an additional field to QuickstartFilter such that by default it will filter out machine-learning quickstarts unless they are explicitly requested, either as part of `jx create mlquickstart` or by setting the `--machine-learning` flag on other quickstart commands. It also prevents the accidental usage of machine-learning project sets from within `jx create quickstart`.

Invoking `jx create mlquickstart` results in a survey containing only machine-learning project sets and quickstarts.

Invoking `jx create quickstart` and `jx get quickstarts` now shows only non-machine-learning quickstarts.

Invoking `jx create quickstart --machine-learning` and `jx get quickstarts --machine-learning` now shows all quickstarts including machine-learning and project sets, however a message is displayed should a project set be selected and the action is terminated cleanly. 

#### Special notes for the reviewer(s)
All quickstart git repositories with names starting with the letters `ML-` will now be considered to be machine-learning related. This is perhaps not an ideal solution but given the lack of any way to label repositories within the GitHub API, it does permit segregation based upon convention rather than having to open and parse files within every quickstart repository.

ML project sets are identified by the existence of a projectset file in their respective repository but these are only checked when explicitly selected to avoid performance and API call volume impacts.

#### Which issue this PR fixes

fixes #4329

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
