### PR TITLE
fix: jx create quickstart "--org" and "--name" options doesn't work

### DIFF
--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -1446,6 +1446,9 @@ func (options *ImportOptions) GetGitRepositoryDetails() (*gits.CreateRepoData, e
 	if err != nil {
 		return nil, err
 	}
+	//config git repositoryoptions parameters: Owner and RepoName
+	options.GitRepositoryOptions.Owner = options.Organisation
+	options.GitRepositoryOptions.RepoName = options.Repository
 	details, err := gits.PickNewOrExistingGitRepository(options.BatchMode, authConfigSvc,
 		"", &options.GitRepositoryOptions, nil, nil, options.Git(), false, options.In, options.Out, options.Err)
 	if err != nil {


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Run command line below and found --org and --name parameters doesn't work.
"jx create quickstart --git-username='sonyafenge' --org='sonyafenge' --name='demo070207'"

Check the file "import.go" and found "--org" and "--name" stored in struct "ImportOptions", not in struct "GitGitRepositoryOptions", so config GitGitRepositoryOptions.Owner and GitGitRepositoryOptions.RepoName before func "GetGitRepositoryDetails" call func "PickNewOrExistingGitRepository".

Two rows code changed in function "GetGitRepositoryDetails":
	options.GitRepositoryOptions.Owner = options.Organisation
	options.GitRepositoryOptions.RepoName = options.Repository

#### Special notes for the reviewer(s)
This fix is to reduce the impact to minimum. another way is to fix "AddGitRepoOptionsArguments" in "git.go".

#### Which issue this PR fixes

fixes #4549 


