### PR TITLE
feat: Add a jx create domain command so we can add domains to managed dns services like Googles

### DIFF
--- a/pkg/cloud/gke/gcloud.go
+++ b/pkg/cloud/gke/gcloud.go
@@ -114,6 +114,21 @@ func CreateManagedZone(projectID string, domain string) error {
 	return nil
 }
 
+// CreateDNSZone creates the tenants DNS zone if it doesn't exist
+// and returns the list of name servers for the given domain and project
+func CreateDNSZone(projectID string, domain string) (string, []string, error) {
+	var managedZone, nameServers = "", []string{}
+	err := CreateManagedZone(projectID, domain)
+	if err != nil {
+		return "", []string{}, errors.Wrap(err, "while trying to creating a CloudDNS managed zone")
+	}
+	managedZone, nameServers, err = GetManagedZoneNameServers(projectID, domain)
+	if err != nil {
+		return "", []string{}, errors.Wrap(err, "while trying to retrieve the managed zone name servers")
+	}
+	return managedZone, nameServers, nil
+}
+
 // GetManagedZoneNameServers retrieves a list of name servers associated with a zone
 func GetManagedZoneNameServers(projectID string, domain string) (string, []string, error) {
 	var managedZoneName, nameServers = "", []string{}

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -70,6 +70,7 @@ func NewCmdCreate(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.AddCommand(NewCmdCreateDevPod(commonOpts))
 	cmd.AddCommand(NewCmdCreateDockerAuth(commonOpts))
 	cmd.AddCommand(NewCmdCreateDocs(commonOpts))
+	cmd.AddCommand(NewCmdCreateDomain(commonOpts))
 	cmd.AddCommand(NewCmdCreateEnv(commonOpts))
 	cmd.AddCommand(NewCmdCreateEtcHosts(commonOpts))
 	cmd.AddCommand(NewCmdCreateGkeServiceAccount(commonOpts))

--- a/pkg/cmd/create/create_domain.go
+++ b/pkg/cmd/create/create_domain.go
@@ -1,0 +1,57 @@
+package create
+
+import (
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/spf13/cobra"
+
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/templates"
+)
+
+var (
+	createDomainLong = templates.LongDesc(`
+		Create a Domain in a managed DNS service such as GCP 
+`)
+)
+
+const (
+	// Domain to create within managed DNS services
+	Domain = "domain"
+)
+
+// DomainOptions the options for the create spring command
+type DomainOptions struct {
+	CreateOptions
+
+	SkipMessages bool
+}
+
+// NewCmdCreateDomain creates a command object for the "create" command
+func NewCmdCreateDomain(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := &DomainOptions{
+		CreateOptions: CreateOptions{
+			CommonOptions: commonOpts,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "domain",
+		Short: "Create a domain in a managed DNS service provider",
+		Long:  createDomainLong,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+
+	cmd.AddCommand(NewCmdCreateDomainGKE(commonOpts))
+
+	return cmd
+}
+
+// AddDomainOptionsArguments adds common Domain flags to the given cobra command
+func AddDomainOptionsArguments(cmd *cobra.Command, options *DomainOptions) {
+	cmd.Flags().StringVarP(&options.Domain, Domain, "d", "", "The Domain you wish to be managed")
+}

--- a/pkg/cmd/create/create_domain_gke.go
+++ b/pkg/cmd/create/create_domain_gke.go
@@ -1,0 +1,98 @@
+package create
+
+import (
+	"github.com/jenkins-x/jx/pkg/cloud/gke"
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/templates"
+)
+
+var (
+	createDomainGKELong = templates.LongDesc(`
+		Create a Domain in GCP so it can be used with GKE  
+`)
+
+	createDomainGKEExample = templates.Examples(`
+		# Create the Domain in Google Cloud
+		jx create domain gke -d foo.bar.io
+	`)
+)
+
+// ProjectID the Google Cloud Project ID
+const ProjectID = "project-id"
+
+// DomainGKEOptions the options for the create spring command
+type DomainGKEOptions struct {
+	DomainOptions
+
+	ProjectID string
+}
+
+// NewCmdCreateDomainGKE creates a command object for the "create" command
+func NewCmdCreateDomainGKE(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := &DomainGKEOptions{
+		DomainOptions: DomainOptions{
+			CreateOptions: CreateOptions{
+				CommonOptions: commonOpts,
+			},
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "gke",
+		Short:   "Create a managed domain for GKE",
+		Long:    createDomainGKELong,
+		Example: createDomainGKEExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+	cmd.Flags().StringVarP(&options.ProjectID, ProjectID, "p", "", "Override the current Project ID")
+
+	AddDomainOptionsArguments(cmd, &options.DomainOptions)
+
+	return cmd
+}
+
+// Run implements the command
+func (o *DomainGKEOptions) Run() error {
+
+	if o.Domain == "" {
+		return util.MissingOption(Domain)
+	}
+
+	var err error
+	if o.ProjectID == "" {
+		if o.BatchMode {
+			return errors.Wrapf(err, "please provide a Google Project ID using --%s  when running in batch mode", ProjectID)
+		}
+		o.ProjectID, err = o.GetGoogleProjectId()
+		if err != nil {
+			return errors.Wrap(err, "while trying to get Google Project ID")
+		}
+	}
+	// Create domain if it doesn't exist and return name servers list
+	_, nameServers, err := gke.CreateDNSZone(o.ProjectID, o.Domain)
+	if err != nil {
+		return errors.Wrap(err, "while trying to create the domain zone")
+	}
+
+	if !o.BatchMode {
+		info := util.ColorInfo
+		log.Logger().Info(info("Please update your existing DNS managed servers to use the nameservers below"))
+	}
+
+	log.Logger().Infof("%s", strings.Join(nameServers[:], "\n"))
+
+	return nil
+}

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -559,7 +559,7 @@ func (options *InstallOptions) Run() error {
 	}
 
 	if options.Flags.CloudBeesDomain != "" {
-		cloudbeesDomain := StripTrailingSlash(options.Flags.CloudBeesDomain)
+		cloudbeesDomain := util.StripTrailingSlash(options.Flags.CloudBeesDomain)
 		cloudbeesAuth := options.Flags.CloudBeesAuth
 		domain, err := options.enableTenantCluster(cloudbeesDomain, cloudbeesAuth)
 		if err != nil {
@@ -3391,14 +3391,6 @@ func createTenantsSubDomainDNSZone(projectID string, domain string) (string, []s
 		return "", []string{}, errors.Wrap(err, "while trying to retrieve the managed zone name servers")
 	}
 	return managedZone, nameServers, nil
-}
-
-// StripTrailingSlash removes any trailing forward slashes on the URL
-func StripTrailingSlash(url string) string {
-	if url[len(url)-1:] == "/" {
-		return url[0 : len(url)-1]
-	}
-	return url
 }
 
 func installConfigKey(key string) string {

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -3349,7 +3349,7 @@ func (options *InstallOptions) enableTenantCluster(tenantServiceURL string, tena
 	}
 
 	// Create domain if it doesn't exist and return name servers list
-	managedZone, nameServers, err := createTenantsSubDomainDNSZone(projectID, domain)
+	managedZone, nameServers, err := gke.CreateDNSZone(projectID, domain)
 	if err != nil {
 		return "", errors.Wrap(err, "while trying to create the tenants subdomain zone")
 	}
@@ -3376,21 +3376,6 @@ func ValidateDomainName(domain string) error {
 		return err
 	}
 	return nil
-}
-
-// createTenantsSubDomainDNSZone creates the tenants DNS zone if it doesn't exist
-// and returns the list of name servers for the given domain and project
-func createTenantsSubDomainDNSZone(projectID string, domain string) (string, []string, error) {
-	var managedZone, nameServers = "", []string{}
-	err := gke.CreateManagedZone(projectID, domain)
-	if err != nil {
-		return "", []string{}, errors.Wrap(err, "while trying to creating a CloudDNS managed zone")
-	}
-	managedZone, nameServers, err = gke.GetManagedZoneNameServers(projectID, domain)
-	if err != nil {
-		return "", []string{}, errors.Wrap(err, "while trying to retrieve the managed zone name servers")
-	}
-	return managedZone, nameServers, nil
 }
 
 func installConfigKey(key string) string {

--- a/pkg/cmd/create/install_test.go
+++ b/pkg/cmd/create/install_test.go
@@ -287,13 +287,3 @@ func TestVerifyDomainName(t *testing.T) {
 	domain = "some.really.long.domain.that.should.be.longer.than.the.maximum.63.characters.com"
 	assert.EqualError(t, create.ValidateDomainName(domain), fmt.Sprintf(lengthErr, domain))
 }
-
-func TestStripTrailingSlash(t *testing.T) {
-	t.Parallel()
-
-	url := "http://some.url.com/"
-	assert.Equal(t, create.StripTrailingSlash(url), "http://some.url.com")
-
-	url = "http://some.other.url.com"
-	assert.Equal(t, create.StripTrailingSlash(url), "http://some.other.url.com")
-}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -248,3 +248,11 @@ func SanitizeLabel(label string) string {
 	sanitized := strings.ToLower(label)
 	return DisallowedLabelCharacters.ReplaceAllString(sanitized, "-")
 }
+
+// StripTrailingSlash removes any trailing forward slashes on the URL
+func StripTrailingSlash(url string) string {
+	if url[len(url)-1:] == "/" {
+		return url[0 : len(url)-1]
+	}
+	return url
+}

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -141,3 +141,13 @@ func Test_sanitizeLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestStripTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	url := "http://some.url.com/"
+	assert.Equal(t, util.StripTrailingSlash(url), "http://some.url.com")
+
+	url = "http://some.other.url.com"
+	assert.Equal(t, util.StripTrailingSlash(url), "http://some.other.url.com")
+}


### PR DESCRIPTION

I did debate whether to call the command `jx create domain gcp` but wanted to keep consistency with other create cluster and install commands, so stuck with `gke` so folks don`t have to keep remembering different combinations.

When the command runs it looks like the following:
```
jx create domain gke --domain foo.bar.io
? Google Cloud Project: cheese
Managed Zone exists for foo.bar.io domain.
Getting nameservers for foo.bar.io domain
Please update your existing DNS managed servers to use the nameservers below
ns-foo-bar1.googledomains.com.
ns-foo-bar2.googledomains.com.
ns-foo-bar3.googledomains.com.
ns-foo-bar4.googledomains.com.
```