### PR TITLE
feat: Added an abstraction for logs and enabled long term storage in the CLI

### DIFF
--- a/pkg/builds/build_info.go
+++ b/pkg/builds/build_info.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"

--- a/pkg/cmd/get/get_build_logs_test.go
+++ b/pkg/cmd/get/get_build_logs_test.go
@@ -1,12 +1,17 @@
 package get
 
 import (
+	"fmt"
+	"github.com/acarl005/stripansi"
+	"github.com/jenkins-x/jx/pkg/cmd/clients/fake"
+	"github.com/jenkins-x/jx/pkg/kube"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"testing"
 
-	"github.com/acarl005/stripansi"
 	jxfake "github.com/jenkins-x/jx/pkg/client/clientset/versioned/fake"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -14,14 +19,143 @@ import (
 	"github.com/stretchr/testify/assert"
 	tektonfake "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	"k8s.io/apimachinery/pkg/runtime"
-	kube_mocks "k8s.io/client-go/kubernetes/fake"
+	kubeMocks "k8s.io/client-go/kubernetes/fake"
 )
+
+func TestGetTektonLogsForRunningBuild(t *testing.T) {
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	commonOpts.BatchMode = true
+	testCaseDir := path.Join("test_data", "get_build_logs", "tekton_build_logs")
+
+	activities := tekton_helpers_test.AssertLoadSinglePipelineActivity(t, testCaseDir)
+	jxClient := jxfake.NewSimpleClientset(activities)
+
+	tektonObjects := []runtime.Object{tekton_helpers_test.AssertLoadSinglePipelineRun(t, testCaseDir)}
+	tektonClient := tektonfake.NewSimpleClientset(tektonObjects...)
+
+	pod := tekton_helpers_test.AssertLoadSinglePod(t, testCaseDir)
+	kubeClient := kubeMocks.NewSimpleClientset(pod)
+
+	ns := "jx"
+
+	o := &GetBuildLogsOptions{
+		GetOptions: GetOptions{
+			CommonOptions: &commonOpts,
+		},
+	}
+
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+	o.CommonOptions.Out = fakeStdout
+
+	_, err := o.getTektonLogs(kubeClient, tektonClient, jxClient, ns)
+	assert.NoError(t, err)
+
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	output := stripansi.Strip(string(outBytes))
+
+	containers, _, _ := kube.GetContainersWithStatusAndIsInit(pod)
+	assert.Contains(t, output, "Build logs for fakeowner/fakerepo/fakebranch #1")
+	for _, c := range containers {
+		assert.Contains(t, output, fmt.Sprintf("Showing logs for build fakeowner/fakerepo/fakebranch #1 stage %s and container %s", pod.Labels["jenkins.io/task-stage-name"], c.Name))
+	}
+}
+
+func TestGetTektonLogsForRunningBuildWithWaitTime(t *testing.T) {
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	commonOpts.BatchMode = true
+	testCaseDir := path.Join("test_data", "get_build_logs", "tekton_build_logs")
+
+	activities := tekton_helpers_test.AssertLoadSinglePipelineActivity(t, testCaseDir)
+	jxClient := jxfake.NewSimpleClientset(activities)
+
+	tektonObjects := []runtime.Object{tekton_helpers_test.AssertLoadSinglePipelineRun(t, testCaseDir)}
+	tektonClient := tektonfake.NewSimpleClientset(tektonObjects...)
+
+	pod := tekton_helpers_test.AssertLoadSinglePod(t, testCaseDir)
+	pod2 := pod.DeepCopy()
+	pod.Namespace = ""
+	kubeClient := kubeMocks.NewSimpleClientset(pod2, pod)
+
+	ns := "jx"
+
+	o := &GetBuildLogsOptions{
+		GetOptions: GetOptions{
+			CommonOptions: &commonOpts,
+		},
+	}
+
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+	o.CommonOptions.Out = fakeStdout
+
+	_, err := o.getTektonLogs(kubeClient, tektonClient, jxClient, ns)
+	assert.NoError(t, err)
+
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	output := stripansi.Strip(string(outBytes))
+
+	containers, _, _ := kube.GetContainersWithStatusAndIsInit(pod)
+	assert.Contains(t, output, "Build logs for fakeowner/fakerepo/fakebranch #1")
+	for _, c := range containers {
+		assert.Contains(t, output, fmt.Sprintf("Showing logs for build fakeowner/fakerepo/fakebranch #1 stage %s and container %s", pod.Labels["jenkins.io/task-stage-name"], c.Name))
+	}
+}
+
+func TestGetTektonLogsForStoredLogs(t *testing.T) {
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	commonOpts.BatchMode = true
+	testCaseDir := path.Join("test_data", "get_build_logs", "tekton_build_logs")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprintf(w, `Logs stored in a bucket`)
+	}))
+
+	pipelineActivity := tekton_helpers_test.AssertLoadSinglePipelineActivity(t, testCaseDir)
+	pipelineActivity.Spec.BuildLogsURL = server.URL
+	jxClient := jxfake.NewSimpleClientset(pipelineActivity)
+
+	tektonObjects := []runtime.Object{tekton_helpers_test.AssertLoadSinglePipelineRun(t, testCaseDir)}
+	tektonClient := tektonfake.NewSimpleClientset(tektonObjects...)
+
+	pod := tekton_helpers_test.AssertLoadSinglePod(t, testCaseDir)
+	kubeClient := kubeMocks.NewSimpleClientset(pod)
+
+	ns := "jx"
+
+	o := &GetBuildLogsOptions{
+		GetOptions: GetOptions{
+			CommonOptions: &commonOpts,
+		},
+	}
+
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+	o.CommonOptions.Out = fakeStdout
+
+	_, err := o.getTektonLogs(kubeClient, tektonClient, jxClient, ns)
+	assert.NoError(t, err)
+
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	output := stripansi.Strip(string(outBytes))
+
+	assert.Contains(t, output, "Logs stored in a bucket")
+}
 
 func TestWithMetapipeline(t *testing.T) {
 	testCaseDir := path.Join("test_data", "get_build_logs", "with-metapipeline")
 
+	activities := tekton_helpers_test.AssertLoadSinglePipelineActivity(t, testCaseDir)
 	structures := tekton_helpers_test.AssertLoadPipelineStructures(t, testCaseDir)
-	jxClient := jxfake.NewSimpleClientset(structures)
+	jxClient := jxfake.NewSimpleClientset(structures, activities)
 
 	tektonObjects := []runtime.Object{tekton_helpers_test.AssertLoadPipelineRuns(t, testCaseDir), tekton_helpers_test.AssertLoadPipelines(t, testCaseDir)}
 	tektonObjects = append(tektonObjects, tekton_helpers_test.AssertLoadTasks(t, testCaseDir))
@@ -29,7 +163,7 @@ func TestWithMetapipeline(t *testing.T) {
 	tektonClient := tektonfake.NewSimpleClientset(tektonObjects...)
 
 	podList := tekton_helpers_test.AssertLoadPods(t, testCaseDir)
-	kubeClient := kube_mocks.NewSimpleClientset(podList)
+	kubeClient := kubeMocks.NewSimpleClientset(podList)
 
 	ns := "jx"
 
@@ -41,28 +175,18 @@ func TestWithMetapipeline(t *testing.T) {
 		},
 	}
 
-	names, defaultName, pipelineMap, err := o.loadPipelines(kubeClient, tektonClient, jxClient, ns)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(names))
-	assert.Equal(t, "", defaultName)
-
-	pipelineName := names[0]
-	assert.Equal(t, "abayer/js-test-repo/build-pack #8", pipelineName)
-
-	assert.Equal(t, 2, len(pipelineMap[pipelineName]))
-
 	r, fakeStdout, _ := os.Pipe()
 	log.SetOutput(fakeStdout)
 	o.CommonOptions.Out = fakeStdout
-	o.Args = []string{pipelineName}
+	o.Args = []string{"fakeowner/fakerepo/fakebranch #1"}
 
-	err = o.getProwBuildLog(kubeClient, tektonClient, jxClient, ns, true)
+	err := o.getProwBuildLog(kubeClient, tektonClient, jxClient, ns, true)
 	assert.NoError(t, err)
 
 	fakeStdout.Close()
 	outBytes, _ := ioutil.ReadAll(r)
 	r.Close()
 	output := stripansi.Strip(string(outBytes))
-	assert.Contains(t, output, "stage app extension")
-	assert.Contains(t, output, "stage from build pack")
+	assert.Contains(t, output, "stage app-extension")
+	assert.Contains(t, output, "stage from-buil-dpack")
 }

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/activity.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/activity.yml
@@ -1,0 +1,105 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  generation: 1
+  labels:
+    branch: fakebranch
+    build: "1"
+    owner: fakeowner
+    provider: github
+    repository: fakerepo
+    sourcerepository: fakeowner-fakerepo
+  name: fakeowner-fakerepo-fakebranch-1
+  namespace: jx
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/fakeowner-fakerepo-fakebranch-1
+spec:
+  author: fakeowner
+  batchPipelineActivity: {}
+  build: "1"
+  completedTimestamp: "2019-07-03T15:38:41Z"
+  gitBranch: fakebranch
+  gitOwner: fakeowner
+  gitRepository: fakerepo
+  gitUrl: https://github.com/fakeowner/fakerepo.git
+  lastCommitMessage: Draft create
+  lastCommitSHA: 1d0699fd4a7a84cddaddae3bf92f8ea1f7268012
+  pipeline: fakeowner/fakerepo/fakebranch
+  releaseNotesURL: https://github.com/fakeowner/fakerepo/releases/tag/v0.0.1
+  startedTimestamp: "2019-07-03T15:36:00Z"
+  status: Succeeded
+  steps:
+    - kind: Stage
+      stage:
+        completedTimestamp: "2019-07-03T15:38:41Z"
+        name: from build pack
+        startedTimestamp: "2019-07-03T15:36:00Z"
+        status: Succeeded
+        steps:
+          - completedTimestamp: "2019-07-03T15:36:00Z"
+            name: Credential Initializer V2f7m
+            startedTimestamp: "2019-07-03T15:36:00Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:02Z"
+            name: Working Dir Initializer Q9w2f
+            startedTimestamp: "2019-07-03T15:36:02Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:03Z"
+            name: Place Tools
+            startedTimestamp: "2019-07-03T15:36:03Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:07Z"
+            description: https://github.com/fakeowner/fakerepo
+            name: Git Source fakeowner fakerepo fakebranch 229l5
+            startedTimestamp: "2019-07-03T15:36:05Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:36Z"
+            name: Git Merge
+            startedTimestamp: "2019-07-03T15:36:36Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:46Z"
+            name: Setup Jx Git Credentials
+            startedTimestamp: "2019-07-03T15:36:46Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:47Z"
+            name: Build Python Unittest
+            startedTimestamp: "2019-07-03T15:36:46Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:58Z"
+            name: Build Container Build
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:59Z"
+            name: Build Post Build
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:37:05Z"
+            name: Promote Changelog
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:37:08Z"
+            name: Promote Helm Release
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:38:41Z"
+            name: Promote Jx Promote
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+    - kind: Promote
+      promote:
+        completedTimestamp: "2019-07-03T15:38:41Z"
+        environment: staging
+        pullRequest:
+          completedTimestamp: "2019-07-03T15:38:40Z"
+          mergeCommitSHA: 01b1c6aef237e677cbf3b9b09394f401d2649590
+          pullRequestURL: https://github.com/fakeowner/environment-daniel-dev-cluster0001-staging/pull/1
+          startedTimestamp: "2019-07-03T15:37:14Z"
+          status: Succeeded
+        startedTimestamp: "2019-07-03T15:37:14Z"
+        status: Succeeded
+        update:
+          completedTimestamp: "2019-07-03T15:38:41Z"
+          startedTimestamp: "2019-07-03T15:38:40Z"
+          status: Succeeded
+  version: 0.0.1
+  workflowStatus: Running
+status: {}

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pipelinerun.yml
@@ -1,0 +1,36 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generation: 1
+  labels:
+    branch: fakebranch
+    build: "1"
+    created-by-prow: "true"
+    owner: fakeowner
+    prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
+    repo: fakerepo
+    tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
+  name: fakeowner-fakerepo-fakebranch-1
+  namespace: jx
+  ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: pipeline
+      name: fakeowner-fakerepo-fakebranch-1
+      uid: 3fe9c5ff-9da8-11e9-8283-42010a840059
+  selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/fakeowner-fakerepo-fakebranch-1
+spec:
+  params:
+    - name: version
+      value: 0.0.1
+    - name: build_id
+      value: "1"
+  pipelineRef:
+    apiVersion: tekton.dev/v1alpha1
+    name: fakeowner-fakerepo-fakebranch-1
+  resources:
+    - name: fakeowner-fakerepo-fakebranch
+      resourceRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: fakeowner-fakerepo-fakebranch
+  serviceAccount: tekton-bot
+  timeout: 240h0m0s

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pod.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pod.yml
@@ -1,0 +1,497 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    sidecar.istio.io/inject: "false"
+  creationTimestamp: "2019-07-02T12:34:45Z"
+  labels:
+    branch: fakebranch
+    build: "1"
+    jenkins.io/task-stage-name: app-extension
+    owner: fakeowner
+    repo: fakerepo
+    tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
+    tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1
+    tekton.dev/task: meta-fakeowner-fakerepo-build-app-extension-8
+    tekton.dev/taskRun: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6
+  name: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6-pod-fcf1fe
+  namespace: jx
+  ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: TaskRun
+      name: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6
+      uid: c5c20379-9cc5-11e9-aa2e-42010a8a00fe
+  resourceVersion: "235888"
+  selfLink: /api/v1/namespaces/jx/pods/meta-fakeowner-fakerepo-build-1-app-extension-kvvp6-pod-fcf1fe
+  uid: c5c6d6f9-9cc5-11e9-aa2e-42010a8a00fe
+spec:
+  containers:
+    - args:
+        - -wait_file
+        - ""
+        - -post_file
+        - /builder/tools/0
+        - -entrypoint
+        - /ko-app/git-init
+        - --
+        - -url
+        - https://github.com/fakeowner/fakerepo
+        - -revision
+        - fakebranch
+        - -path
+        - /workspace/source
+      command:
+        - /builder/tools/entrypoint
+      env:
+        - name: HOME
+          value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-git-source-meta-fakeowner-fakerepo-build-v7hvv
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace
+    - args:
+        - -wait_file
+        - /builder/tools/0
+        - -post_file
+        - /builder/tools/1
+        - -entrypoint
+        - jx
+        - --
+        - step
+        - git
+        - merge
+        - --verbose
+      command:
+        - /builder/tools/entrypoint
+      env:
+        - name: HOME
+          value: /builder/home
+        - name: APP_NAME
+          value: fakerepo
+        - name: BRANCH_NAME
+          value: fakebranch
+        - name: BUILD_NUMBER
+          value: "1"
+        - name: JOB_NAME
+          value: fakeowner/fakerepo/fakebranch
+        - name: JX_LOG_FORMAT
+          value: json
+        - name: PIPELINE_KIND
+          value: release
+        - name: REPO_NAME
+          value: fakerepo
+        - name: REPO_OWNER
+          value: fakeowner
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-git-merge
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace/source
+    - args:
+        - -wait_file
+        - /builder/tools/1
+        - -post_file
+        - /builder/tools/2
+        - -entrypoint
+        - /bin/sh
+        - --
+        - -c
+        - jx step syntax effective --output-dir .
+      command:
+        - /builder/tools/entrypoint
+      env:
+        - name: HOME
+          value: /builder/home
+        - name: APP_NAME
+          value: fakerepo
+        - name: BRANCH_NAME
+          value: fakebranch
+        - name: BUILD_NUMBER
+          value: "1"
+        - name: JOB_NAME
+          value: fakeowner/fakerepo/fakebranch
+        - name: JX_LOG_FORMAT
+          value: json
+        - name: PIPELINE_KIND
+          value: release
+        - name: REPO_NAME
+          value: fakerepo
+        - name: REPO_OWNER
+          value: fakeowner
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-create-effective-pipeline
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace/source
+    - args:
+        - -wait_file
+        - /builder/tools/2
+        - -post_file
+        - /builder/tools/3
+        - -entrypoint
+        - /bin/sh
+        - --
+        - -c
+        - jx step create task --clone-dir /workspace/source --build-number 8 --trigger
+          manual --service-account tekton-bot --source source --branch fakebranch
+      command:
+        - /builder/tools/entrypoint
+      env:
+        - name: HOME
+          value: /builder/home
+        - name: APP_NAME
+          value: fakerepo
+        - name: BRANCH_NAME
+          value: fakebranch
+        - name: BUILD_NUMBER
+          value: "1"
+        - name: JOB_NAME
+          value: fakeowner/fakerepo/fakebranch
+        - name: JX_LOG_FORMAT
+          value: json
+        - name: PIPELINE_KIND
+          value: release
+        - name: REPO_NAME
+          value: fakerepo
+        - name: REPO_OWNER
+          value: fakeowner
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-create-tekton-crds
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace/source
+    - args:
+        - -wait_file
+        - /builder/tools/3
+        - -post_file
+        - /builder/tools/4
+        - -entrypoint
+        - /ko-app/nop
+        - --
+      command:
+        - /builder/tools/entrypoint
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: nop
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+  dnsPolicy: ClusterFirst
+  initContainers:
+    - args:
+        - -basic-git=knative-git-user-pass=https://github.com
+      command:
+        - /ko-app/creds-init
+      env:
+        - name: HOME
+          value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-credential-initializer-xht92
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/build-secrets/knative-git-user-pass
+          name: secret-volume-knative-git-user-pass-6zhjb
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace
+    - args:
+        - -args
+        - mkdir -p /workspace/source
+      command:
+        - /ko-app/bash
+      env:
+        - name: HOME
+          value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-working-dir-initializer-8c9w5
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace
+    - args:
+        - -c
+        - cp /ko-app/entrypoint /builder/tools/entrypoint
+      command:
+        - /bin/sh
+      env:
+        - name: HOME
+          value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-place-tools
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace
+  nodeName: gke-fakeowner-test-cluster-default-pool-666b1aa4-k4xk
+  priority: 0
+  restartPolicy: Never
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: tekton-bot
+  serviceAccountName: tekton-bot
+  terminationGracePeriodSeconds: 30
+  tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+  volumes:
+    - emptyDir: {}
+      name: tools
+    - emptyDir: {}
+      name: workspace
+    - emptyDir: {}
+      name: home
+    - name: secret-volume-knative-git-user-pass-6zhjb
+      secret:
+        defaultMode: 420
+        secretName: knative-git-user-pass
+    - name: tekton-bot-token-kbbrz
+      secret:
+        defaultMode: 420
+        secretName: tekton-bot-token-kbbrz
+status:
+  conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:49Z"
+      reason: PodCompleted
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:45Z"
+      reason: PodCompleted
+      status: "False"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:45Z"
+      reason: PodCompleted
+      status: "False"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:45Z"
+      status: "True"
+      type: PodScheduled
+  containerStatuses:
+    - containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+      lastState: {}
+      name: build-step-create-effective-pipeline
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:52Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+    - containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+      lastState: {}
+      name: build-step-create-tekton-crds
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:56Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+    - containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+      lastState: {}
+      name: build-step-git-merge
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:50Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+    - containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:4b91c31560f18a8f09c68d5288f2261797b6df31522a57a9d7350bc0060a1284
+      lastState: {}
+      name: build-step-git-source-meta-fakeowner-fakerepo-build-v7hvv
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:49Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+    - containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop@sha256:9160ed41b20b2822d06e907d89f6398ea866c86a971f83371efb9e147fba079f
+      lastState: {}
+      name: nop
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:57Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:50Z"
+  hostIP: 10.138.0.56
+  initContainerStatuses:
+    - containerID: docker://5e897a5dfaf1687cad1692d9c8c6261108735e595ed37e03b43bcf51f86a7330
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:b4877c99d928fad3cf26c995d171674b34d206178d6f9f0efb337ebff01bb34b
+      lastState: {}
+      name: build-step-credential-initializer-xht92
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://5e897a5dfaf1687cad1692d9c8c6261108735e595ed37e03b43bcf51f86a7330
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:46Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:46Z"
+    - containerID: docker://1e68c4fcfc19db3c695ff5ac3cbd7b4f2cf8c5a92637267fd2745a97eaf21150
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash@sha256:0355a9b21a7c0cc9466bf75071648e266de07b5e13fbfd271ec791c45a818bdb
+      lastState: {}
+      name: build-step-working-dir-initializer-8c9w5
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://1e68c4fcfc19db3c695ff5ac3cbd7b4f2cf8c5a92637267fd2745a97eaf21150
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:47Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:47Z"
+    - containerID: docker://4109f59817a239085ce4084ae87cec62297ada549cb42e247160cd41f7479426
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:4d1fe990ca06ecc671370dfeab31d857efa8ccf81d632a672561c60482fd9aae
+      lastState: {}
+      name: build-step-place-tools
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://4109f59817a239085ce4084ae87cec62297ada549cb42e247160cd41f7479426
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:48Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:48Z"
+  phase: Succeeded
+  podIP: 10.28.0.32
+  qosClass: BestEffort
+  startTime: "2019-07-02T12:34:45Z"

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/activity.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/activity.yml
@@ -1,0 +1,105 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  generation: 1
+  labels:
+    branch: fakebranch
+    build: "1"
+    owner: fakeowner
+    provider: github
+    repository: fakerepo
+    sourcerepository: fakeowner-fakerepo
+  name: fakeowner-fakerepo-fakebranch-1
+  namespace: jx
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/fakeowner-fakerepo-fakebranch-1
+spec:
+  author: fakeowner
+  batchPipelineActivity: {}
+  build: "1"
+  completedTimestamp: "2019-07-03T15:38:41Z"
+  gitBranch: fakebranch
+  gitOwner: fakeowner
+  gitRepository: fakerepo
+  gitUrl: https://github.com/fakeowner/fakerepo.git
+  lastCommitMessage: Draft create
+  lastCommitSHA: 1d0699fd4a7a84cddaddae3bf92f8ea1f7268012
+  pipeline: fakeowner/fakerepo/fakebranch
+  releaseNotesURL: https://github.com/fakeowner/fakerepo/releases/tag/v0.0.1
+  startedTimestamp: "2019-07-03T15:36:00Z"
+  status: Succeeded
+  steps:
+    - kind: Stage
+      stage:
+        completedTimestamp: "2019-07-03T15:38:41Z"
+        name: from build pack
+        startedTimestamp: "2019-07-03T15:36:00Z"
+        status: Succeeded
+        steps:
+          - completedTimestamp: "2019-07-03T15:36:00Z"
+            name: Credential Initializer V2f7m
+            startedTimestamp: "2019-07-03T15:36:00Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:02Z"
+            name: Working Dir Initializer Q9w2f
+            startedTimestamp: "2019-07-03T15:36:02Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:03Z"
+            name: Place Tools
+            startedTimestamp: "2019-07-03T15:36:03Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:07Z"
+            description: https://github.com/fakeowner/fakerepo
+            name: Git Source fakeowner fakerepo fakebranch 229l5
+            startedTimestamp: "2019-07-03T15:36:05Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:36Z"
+            name: Git Merge
+            startedTimestamp: "2019-07-03T15:36:36Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:46Z"
+            name: Setup Jx Git Credentials
+            startedTimestamp: "2019-07-03T15:36:46Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:47Z"
+            name: Build Python Unittest
+            startedTimestamp: "2019-07-03T15:36:46Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:58Z"
+            name: Build Container Build
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:59Z"
+            name: Build Post Build
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:37:05Z"
+            name: Promote Changelog
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:37:08Z"
+            name: Promote Helm Release
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:38:41Z"
+            name: Promote Jx Promote
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+    - kind: Promote
+      promote:
+        completedTimestamp: "2019-07-03T15:38:41Z"
+        environment: staging
+        pullRequest:
+          completedTimestamp: "2019-07-03T15:38:40Z"
+          mergeCommitSHA: 01b1c6aef237e677cbf3b9b09394f401d2649590
+          pullRequestURL: https://github.com/fakeowner/environment-daniel-dev-cluster0001-staging/pull/1
+          startedTimestamp: "2019-07-03T15:37:14Z"
+          status: Succeeded
+        startedTimestamp: "2019-07-03T15:37:14Z"
+        status: Succeeded
+        update:
+          completedTimestamp: "2019-07-03T15:38:41Z"
+          startedTimestamp: "2019-07-03T15:38:40Z"
+          status: Succeeded
+  version: 0.0.1
+  workflowStatus: Running
+status: {}

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelineruns.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelineruns.yml
@@ -1,234 +1,248 @@
 apiVersion: tekton.dev/v1alpha1
 items:
-- apiVersion: tekton.dev/v1alpha1
-  kind: PipelineRun
-  metadata:
-    creationTimestamp: "2019-07-02T12:34:56Z"
-    generation: 1
-    labels:
-      tekton.dev/pipeline: abayer-js-test-repo-build-pack-8
-    name: abayer-js-test-repo-build-pack-8
-    namespace: jx
-    ownerReferences:
-    - apiVersion: tekton.dev/v1alpha1
-      kind: pipeline
-      name: abayer-js-test-repo-build-pack-8
-      uid: cc57794e-9cc5-11e9-aa2e-42010a8a00fe
-    resourceVersion: "236414"
-    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/abayer-js-test-repo-build-pack-8
-    uid: cc59f237-9cc5-11e9-aa2e-42010a8a00fe
-  spec:
-    params:
-    - name: version
-      value: 0.0.7
-    - name: build_id
-      value: "8"
-    pipelineRef:
-      apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-build-pack-8
-    resources:
-    - name: abayer-js-test-repo-build-pack
-      resourceRef:
+  - apiVersion: tekton.dev/v1alpha1
+    kind: PipelineRun
+    metadata:
+      creationTimestamp: "2019-07-02T12:34:56Z"
+      generation: 1
+      labels:
+        tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-8
+        branch: fakebranch
+        build: "1"
+        created-by-prow: "true"
+        owner: fakeowner
+        prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
+        repo: fakerepo
+        tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
+      name: fakeowner-fakerepo-fakebranch-8
+      namespace: jx
+      ownerReferences:
+        - apiVersion: tekton.dev/v1alpha1
+          kind: pipeline
+          name: fakeowner-fakerepo-fakebranch-8
+          uid: cc57794e-9cc5-11e9-aa2e-42010a8a00fe
+      resourceVersion: "236414"
+      selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/fakeowner-fakerepo-fakebranch-8
+      uid: cc59f237-9cc5-11e9-aa2e-42010a8a00fe
+    spec:
+      params:
+        - name: version
+          value: 0.0.7
+        - name: build_id
+          value: "1"
+      pipelineRef:
         apiVersion: tekton.dev/v1alpha1
-        name: abayer-js-test-repo-build-pack
-    serviceAccount: tekton-bot
-    timeout: 240h0m0s
-  status:
-    completionTime: "2019-07-02T12:36:47Z"
-    conditions:
-    - lastTransitionTime: "2019-07-02T12:36:47Z"
-      message: TaskRun abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t has failed
-      reason: Failed
-      status: "False"
-      type: Succeeded
-    startTime: "2019-07-02T12:34:56Z"
-    taskRuns:
-      abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t:
-        pipelineTaskName: from-build-pack
-        status:
-          completionTime: "2019-07-02T12:36:47Z"
-          conditions:
-          - lastTransitionTime: "2019-07-02T12:36:47Z"
-            message: '"build-step-promote-jx-promote" exited with code 1 (image: "docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82");
-              for logs run: kubectl -n jx logs abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t-pod-1682b0
+        name: fakeowner-fakerepo-fakebranch-8
+      resources:
+        - name: fakeowner-fakerepo-fakebranch
+          resourceRef:
+            apiVersion: tekton.dev/v1alpha1
+            name: fakeowner-fakerepo-fakebranch
+      serviceAccount: tekton-bot
+      timeout: 240h0m0s
+    status:
+      completionTime: "2019-07-02T12:36:47Z"
+      conditions:
+        - lastTransitionTime: "2019-07-02T12:36:47Z"
+          message: TaskRun fakeowner-fakerepo-fakebranch-1-from-fakebranch-rbw8t has failed
+          reason: Failed
+          status: "False"
+          type: Succeeded
+      startTime: "2019-07-02T12:34:56Z"
+      taskRuns:
+        fakeowner-fakerepo-fakebranch-1-from-fakebranch-rbw8t:
+          pipelineTaskName: from-fakebranch
+          status:
+            completionTime: "2019-07-02T12:36:47Z"
+            conditions:
+              - lastTransitionTime: "2019-07-02T12:36:47Z"
+                message: '"build-step-promote-jx-promote" exited with code 1 (image: "docker-pullable://gcr.io/jenkinsxio/builder-nodejs@sha256:41fb7143aa5ff044e29dd608e6bfc9b4ac37705f70ba6ae0f45b1ebddc89aa82");
+              for logs run: kubectl -n jx logs fakeowner-fakerepo-fakebranch-1-from-fakebranch-rbw8t-pod-1682b0
               -c build-step-promote-jx-promote'
-            status: "False"
-            type: Succeeded
-          podName: abayer-js-test-repo-build-pack-8-from-build-pack-rbw8t-pod-1682b0
-          startTime: "2019-07-02T12:34:56Z"
-          steps:
-          - name: build-container-build
-            terminated:
-              containerID: docker://ee94afd22cdb071ffd2566ec3478d1290b54185b87d530cf907908c02e63195b
-              exitCode: 0
-              finishedAt: "2019-07-02T12:36:05Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:02Z"
-          - name: build-npm-install
-            terminated:
-              containerID: docker://60fae7303bc984339e5ad90c9279910bc873e16a19efa026d024c421c2c77056
-              exitCode: 0
-              finishedAt: "2019-07-02T12:35:38Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:01Z"
-          - name: build-npm-test
-            terminated:
-              containerID: docker://15b3ad11f0ee9a47ec69033f17375670f26810a6e4dbba6ed4f01821c8f4ff6c
-              exitCode: 0
-              finishedAt: "2019-07-02T12:35:41Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:02Z"
-          - name: build-npmrc
-            terminated:
-              containerID: docker://5f6fe39d8b812945a914dd7ff10c386f1bebd70c4f8dbe023360f92289ceca7e
-              exitCode: 0
-              finishedAt: "2019-07-02T12:35:03Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:01Z"
-          - name: build-post-build
-            terminated:
-              containerID: docker://b02211c50527464acb6133331904f156b1b1b09c472aa50c463123dc9a101533
-              exitCode: 0
-              finishedAt: "2019-07-02T12:36:06Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:02Z"
-          - name: git-merge
-            terminated:
-              containerID: docker://bf9a1b3872c8e343ca9b17d5e999692abadadd1b0c49084a12c93cefdea1e828
-              exitCode: 0
-              finishedAt: "2019-07-02T12:35:02Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:01Z"
-          - name: git-source-abayer-js-test-repo-build-pack-72kkp
-            terminated:
-              containerID: docker://087e23e897b77226706cf686a074a942ce9d4a50fc651d3bf9a54b2b1aeb8b40
-              exitCode: 0
-              finishedAt: "2019-07-02T12:35:02Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:00Z"
-          - name: promote-changelog
-            terminated:
-              containerID: docker://5780df05616c5f396b108d2549359061fc79d7eec5fc062c237f70472fa2f95d
-              exitCode: 0
-              finishedAt: "2019-07-02T12:36:12Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:02Z"
-          - name: promote-helm-release
-            terminated:
-              containerID: docker://fda8599e3607d47d86d7e62ad68eb96cb4646e912b53166500d2b1c54b6a1835
-              exitCode: 0
-              finishedAt: "2019-07-02T12:36:17Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:02Z"
-          - name: promote-jx-promote
-            terminated:
-              containerID: docker://d4abd70d8942c22bcd1d9fa1ec8a9440fa65ef4143c15b0286e0589f1dbb2a22
-              exitCode: 1
-              finishedAt: "2019-07-02T12:36:46Z"
-              reason: Error
-              startedAt: "2019-07-02T12:35:03Z"
-          - name: setup-jx-git-credentials
-            terminated:
-              containerID: docker://8ef0a0090393a926ac59b0ed792d9e4fa32ed93443a2da251d0f8913688d1c10
-              exitCode: 0
-              finishedAt: "2019-07-02T12:35:03Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:01Z"
-          - name: nop
-            terminated:
-              containerID: docker://654321b1884f8d3d7408e9a19b0a6371275b42f8a62cc765def420941ce8b835
-              exitCode: 0
-              finishedAt: "2019-07-02T12:36:47Z"
-              reason: Completed
-              startedAt: "2019-07-02T12:35:03Z"
-- apiVersion: tekton.dev/v1alpha1
-  kind: PipelineRun
-  metadata:
-    creationTimestamp: "2019-07-02T12:34:45Z"
-    generation: 1
-    labels:
-      branch: build-pack
-      build: "8"
-      owner: abayer
-      repo: js-test-repo
-      tekton.dev/pipeline: meta-abayer-js-test-repo-build-8
-    name: meta-abayer-js-test-repo-build-8
-    namespace: jx
-    ownerReferences:
-      - apiVersion: tekton.dev/v1alpha1
-        kind: pipeline
-        name: meta-abayer-js-test-repo-build-8
-        uid: c5ad1626-9cc5-11e9-aa2e-42010a8a00fe
-    resourceVersion: "235902"
-    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/meta-abayer-js-test-repo-build-8
-    uid: c5bd38e9-9cc5-11e9-aa2e-42010a8a00fe
-  spec:
-    pipelineRef:
-      apiVersion: tekton.dev/v1alpha1
-      name: meta-abayer-js-test-repo-build-8
-    resources:
-      - name: meta-abayer-js-test-repo-build
-        resourceRef:
-          apiVersion: tekton.dev/v1alpha1
-          name: meta-abayer-js-test-repo-build
-    serviceAccount: tekton-bot
-    timeout: 240h0m0s
-  status:
-    completionTime: "2019-07-02T12:34:59Z"
-    conditions:
-      - lastTransitionTime: "2019-07-02T12:34:59Z"
-        message: All Tasks have completed executing
-        reason: Succeeded
-        status: "True"
-        type: Succeeded
-    startTime: "2019-07-02T12:34:45Z"
-    taskRuns:
-      meta-abayer-js-test-repo-build-8-app-extension-kvvp6:
-        pipelineTaskName: app-extension
-        status:
-          completionTime: "2019-07-02T12:34:57Z"
-          conditions:
-            - lastTransitionTime: "2019-07-02T12:34:57Z"
-              status: "True"
-              type: Succeeded
-          podName: meta-abayer-js-test-repo-build-8-app-extension-kvvp6-pod-fcf1fe
-          startTime: "2019-07-02T12:34:45Z"
-          steps:
-            - name: create-effective-pipeline
-              terminated:
-                containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
-                exitCode: 0
-                finishedAt: "2019-07-02T12:34:52Z"
-                reason: Completed
-                startedAt: "2019-07-02T12:34:49Z"
-            - name: create-tekton-crds
-              terminated:
-                containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
-                exitCode: 0
-                finishedAt: "2019-07-02T12:34:56Z"
-                reason: Completed
-                startedAt: "2019-07-02T12:34:49Z"
-            - name: git-merge
-              terminated:
-                containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
-                exitCode: 0
-                finishedAt: "2019-07-02T12:34:50Z"
-                reason: Completed
-                startedAt: "2019-07-02T12:34:49Z"
-            - name: git-source-meta-abayer-js-test-repo-build-v7hvv
-              terminated:
-                containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
-                exitCode: 0
-                finishedAt: "2019-07-02T12:34:49Z"
-                reason: Completed
-                startedAt: "2019-07-02T12:34:49Z"
-            - name: nop
-              terminated:
-                containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
-                exitCode: 0
-                finishedAt: "2019-07-02T12:34:57Z"
-                reason: Completed
-                startedAt: "2019-07-02T12:34:50Z"
+                status: "False"
+                type: Succeeded
+            podName: fakeowner-fakerepo-fakebranch-1-from-fakebranch-rbw8t-pod-1682b0
+            startTime: "2019-07-02T12:34:56Z"
+            steps:
+              - name: build-container-build
+                terminated:
+                  containerID: docker://ee94afd22cdb071ffd2566ec3478d1290b54185b87d530cf907908c02e63195b
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:36:05Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:02Z"
+              - name: build-npm-install
+                terminated:
+                  containerID: docker://60fae7303bc984339e5ad90c9279910bc873e16a19efa026d024c421c2c77056
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:35:38Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:01Z"
+              - name: build-npm-test
+                terminated:
+                  containerID: docker://15b3ad11f0ee9a47ec69033f17375670f26810a6e4dbba6ed4f01821c8f4ff6c
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:35:41Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:02Z"
+              - name: build-npmrc
+                terminated:
+                  containerID: docker://5f6fe39d8b812945a914dd7ff10c386f1bebd70c4f8dbe023360f92289ceca7e
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:35:03Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:01Z"
+              - name: build-post-build
+                terminated:
+                  containerID: docker://b02211c50527464acb6133331904f156b1b1b09c472aa50c463123dc9a101533
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:36:06Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:02Z"
+              - name: git-merge
+                terminated:
+                  containerID: docker://bf9a1b3872c8e343ca9b17d5e999692abadadd1b0c49084a12c93cefdea1e828
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:35:02Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:01Z"
+              - name: git-source-fakeowner-fakerepo-fakebranch-72kkp
+                terminated:
+                  containerID: docker://087e23e897b77226706cf686a074a942ce9d4a50fc651d3bf9a54b2b1aeb8b40
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:35:02Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:00Z"
+              - name: promote-changelog
+                terminated:
+                  containerID: docker://5780df05616c5f396b108d2549359061fc79d7eec5fc062c237f70472fa2f95d
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:36:12Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:02Z"
+              - name: promote-helm-release
+                terminated:
+                  containerID: docker://fda8599e3607d47d86d7e62ad68eb96cb4646e912b53166500d2b1c54b6a1835
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:36:17Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:02Z"
+              - name: promote-jx-promote
+                terminated:
+                  containerID: docker://d4abd70d8942c22bcd1d9fa1ec8a9440fa65ef4143c15b0286e0589f1dbb2a22
+                  exitCode: 1
+                  finishedAt: "2019-07-02T12:36:46Z"
+                  reason: Error
+                  startedAt: "2019-07-02T12:35:03Z"
+              - name: setup-jx-git-credentials
+                terminated:
+                  containerID: docker://8ef0a0090393a926ac59b0ed792d9e4fa32ed93443a2da251d0f8913688d1c10
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:35:03Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:01Z"
+              - name: nop
+                terminated:
+                  containerID: docker://654321b1884f8d3d7408e9a19b0a6371275b42f8a62cc765def420941ce8b835
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:36:47Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:35:03Z"
+  - apiVersion: tekton.dev/v1alpha1
+    kind: PipelineRun
+    metadata:
+      creationTimestamp: "2019-07-02T12:34:45Z"
+      generation: 1
+      labels:
+        branch: fakebranch
+        build: "1"
+        created-by-prow: "true"
+        owner: fakeowner
+        prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
+        repo: fakerepo
+        tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
+        branch: fakebranch
+        build: "1"
+        owner: fakeowner
+        repo: fakerepo
+        tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
+      name: meta-fakeowner-fakerepo-build-1
+      namespace: jx
+      ownerReferences:
+        - apiVersion: tekton.dev/v1alpha1
+          kind: pipeline
+          name: meta-fakeowner-fakerepo-build-1
+          uid: c5ad1626-9cc5-11e9-aa2e-42010a8a00fe
+      resourceVersion: "235902"
+      selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/meta-fakeowner-fakerepo-build-8
+      uid: c5bd38e9-9cc5-11e9-aa2e-42010a8a00fe
+    spec:
+      pipelineRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: meta-fakeowner-fakerepo-build-8
+      resources:
+        - name: meta-fakeowner-fakerepo-build
+          resourceRef:
+            apiVersion: tekton.dev/v1alpha1
+            name: meta-fakeowner-fakerepo-build
+      serviceAccount: tekton-bot
+      timeout: 240h0m0s
+    status:
+      completionTime: "2019-07-02T12:34:59Z"
+      conditions:
+        - lastTransitionTime: "2019-07-02T12:34:59Z"
+          message: All Tasks have completed executing
+          reason: Succeeded
+          status: "True"
+          type: Succeeded
+      startTime: "2019-07-02T12:34:45Z"
+      taskRuns:
+        meta-fakeowner-fakerepo-build-8-app-extension-kvvp6:
+          pipelineTaskName: app-extension
+          status:
+            completionTime: "2019-07-02T12:34:57Z"
+            conditions:
+              - lastTransitionTime: "2019-07-02T12:34:57Z"
+                status: "True"
+                type: Succeeded
+            podName: meta-fakeowner-fakerepo-build-8-app-extension-kvvp6-pod-fcf1fe
+            startTime: "2019-07-02T12:34:45Z"
+            steps:
+              - name: create-effective-pipeline
+                terminated:
+                  containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:34:52Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:34:49Z"
+              - name: create-tekton-crds
+                terminated:
+                  containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:34:56Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:34:49Z"
+              - name: git-merge
+                terminated:
+                  containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:34:50Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:34:49Z"
+              - name: git-source-meta-fakeowner-fakerepo-build-v7hvv
+                terminated:
+                  containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:34:49Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:34:49Z"
+              - name: nop
+                terminated:
+                  containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+                  exitCode: 0
+                  finishedAt: "2019-07-02T12:34:57Z"
+                  reason: Completed
+                  startedAt: "2019-07-02T12:34:50Z"
 kind: List
 metadata:
   resourceVersion: ""

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelines.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelines.yml
@@ -1,77 +1,77 @@
 apiVersion: tekton.dev/v1alpha1
 items:
-- apiVersion: tekton.dev/v1alpha1
-  kind: Pipeline
-  metadata:
-    creationTimestamp: "2019-07-02T12:34:56Z"
-    generation: 1
-    name: abayer-js-test-repo-build-pack-8
-    namespace: jx
-    ownerReferences:
-    - apiVersion: jenkins.io/v1
-      kind: PipelineActivity
-      name: abayer-js-test-repo-build-pack-8
-      uid: c5e1fa64-9cc5-11e9-aa2e-42010a8a00fe
-    resourceVersion: "235864"
-    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/abayer-js-test-repo-build-pack-8
-    uid: cc57794e-9cc5-11e9-aa2e-42010a8a00fe
-  spec:
-    params:
-    - default: 0.0.7
-      description: the version number for this pipeline which is used as a tag on docker
-        images and helm charts
-      name: version
-    - default: "8"
-      description: the PipelineRun build number
-      name: build_id
-    resources:
-    - name: abayer-js-test-repo-build-pack
-      type: git
-    tasks:
-    - name: from-build-pack
+  - apiVersion: tekton.dev/v1alpha1
+    kind: Pipeline
+    metadata:
+      creationTimestamp: "2019-07-02T12:34:56Z"
+      generation: 1
+      name: fakeowner-fakerepo-fakebranch-1
+      namespace: jx
+      ownerReferences:
+        - apiVersion: jenkins.io/v1
+          kind: PipelineActivity
+          name: fakeowner-fakerepo-fakebranch-1
+          uid: c5e1fa64-9cc5-11e9-aa2e-42010a8a00fe
+      resourceVersion: "235864"
+      selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/fakeowner-fakerepo-fakebranch-1
+      uid: cc57794e-9cc5-11e9-aa2e-42010a8a00fe
+    spec:
       params:
-      - name: version
-        value: ${params.version}
-      - name: build_id
-        value: ${params.build_id}
+        - default: 0.0.7
+          description: the version number for this pipeline which is used as a tag on docker
+            images and helm charts
+          name: version
+        - default: "1"
+          description: the PipelineRun build number
+          name: build_id
       resources:
-        inputs:
-        - name: workspace
-          resource: abayer-js-test-repo-build-pack
-      taskRef:
-        name: abayer-js-test-repo-build-pack-from-build-pack-8
-- apiVersion: tekton.dev/v1alpha1
-  kind: Pipeline
-  metadata:
-    creationTimestamp: "2019-07-02T12:34:45Z"
-    generation: 1
-    labels:
-      branch: build-pack
-      build: "8"
-      owner: abayer
-      repo: js-test-repo
-    name: meta-abayer-js-test-repo-build-8
-    namespace: jx
-    ownerReferences:
-      - apiVersion: jenkins.io/v1
-        kind: PipelineActivity
-        name: abayer-js-test-repo-build-pack-meta-8
-        uid: c57379a2-9cc5-11e9-aa2e-42010a8a00fe
-    resourceVersion: "235775"
-    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/meta-abayer-js-test-repo-build-8
-    uid: c5ad1626-9cc5-11e9-aa2e-42010a8a00fe
-  spec:
-    resources:
-      - name: meta-abayer-js-test-repo-build
-        type: git
-    tasks:
-      - name: app-extension
-        resources:
-          inputs:
-            - name: workspace
-              resource: meta-abayer-js-test-repo-build
-        taskRef:
-          name: meta-abayer-js-test-repo-build-app-extension-8
+        - name: fakeowner-fakerepo-fakebranch
+          type: git
+      tasks:
+        - name: from-fakebranch
+          params:
+            - name: version
+              value: ${params.version}
+            - name: build_id
+              value: ${params.build_id}
+          resources:
+            inputs:
+              - name: workspace
+                resource: fakeowner-fakerepo-fakebranch
+          taskRef:
+            name: fakeowner-fakerepo-fakebranch-from-fakebranch-8
+  - apiVersion: tekton.dev/v1alpha1
+    kind: Pipeline
+    metadata:
+      creationTimestamp: "2019-07-02T12:34:45Z"
+      generation: 1
+      labels:
+        branch: fakebranch
+        build: "1"
+        owner: fakeowner
+        repo: fakerepo
+      name: meta-fakeowner-fakerepo-build-1
+      namespace: jx
+      ownerReferences:
+        - apiVersion: jenkins.io/v1
+          kind: PipelineActivity
+          name: fakeowner-fakerepo-fakebranch-meta-1
+          uid: c57379a2-9cc5-11e9-aa2e-42010a8a00fe
+      resourceVersion: "235775"
+      selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/meta-fakeowner-fakerepo-build-8
+      uid: c5ad1626-9cc5-11e9-aa2e-42010a8a00fe
+    spec:
+      resources:
+        - name: meta-fakeowner-fakerepo-build
+          type: git
+      tasks:
+        - name: app-extension
+          resources:
+            inputs:
+              - name: workspace
+                resource: meta-fakeowner-fakerepo-build
+          taskRef:
+            name: meta-fakeowner-fakerepo-build-app-extension-8
 kind: List
 metadata:
   resourceVersion: ""

--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -1,0 +1,194 @@
+package logs
+
+import (
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/builds"
+	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/cloud/buckets"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/step"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/pkg/errors"
+	v1alpha12 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sort"
+	"strings"
+
+	"time"
+)
+
+// LogWriter is an interface that can be implemented to define different ways to stream / write logs
+// it's the implementer's responsibility to route those logs through the corresponding medium
+type LogWriter interface {
+	WriteLog(line string) error
+	StreamLog(ns string, pod *corev1.Pod, containerName *corev1.Container) error
+}
+
+// GetTektonPipelinesWithActivePipelineActivity returns list of all PipelineActivities with corresponding Tekton PipelineRuns ordered by the PipelineRun creation timestamp and a map to obtain its reference once a name has been selected
+func GetTektonPipelinesWithActivePipelineActivity(jxClient versioned.Interface, tektonClient tektonclient.Interface, ns string, filters []string) ([]string, map[string]*v1.PipelineActivity, error) {
+	paList, err := jxClient.JenkinsV1().PipelineActivities(ns).List(metav1.ListOptions{
+		LabelSelector: strings.Replace(strings.Join(filters, ","), "repo=", "repository=", 1),
+	})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "there was a problem getting the PipelineActivities")
+	}
+
+	paMap := make(map[string]*v1.PipelineActivity)
+	for _, pa := range paList.Items {
+		p := pa
+		paMap[createPipelineActivityName(p.Labels, p.Spec.Build)] = &p
+	}
+
+	tektonPRs, _ := tektonClient.TektonV1alpha1().PipelineRuns(ns).List(metav1.ListOptions{
+		LabelSelector: strings.Join(filters, ","),
+	})
+
+	sort.Slice(tektonPRs.Items, func(i, j int) bool {
+		return tektonPRs.Items[i].CreationTimestamp.After(tektonPRs.Items[j].CreationTimestamp.Time)
+	})
+
+	var names []string
+	for _, pr := range tektonPRs.Items {
+		prBuildNumber := pr.Labels[v1.LabelBuild]
+		if prBuildNumber == "" {
+			prBuildNumber = findLegacyPipelineRunBuildNumber(&pr)
+		}
+		paName := createPipelineActivityName(pr.Labels, prBuildNumber)
+		if _, exists := paMap[paName]; exists {
+			nameWithContext := fmt.Sprintf("%s %s", paName, pr.Labels["context"])
+			replacePipelineActivityNameWithEnrichedName(paMap, paName, nameWithContext)
+			names = append(names, nameWithContext)
+		}
+	}
+
+	return names, paMap, nil
+}
+
+func createPipelineActivityName(labels map[string]string, buildNumber string) string {
+	repository := labels[v1.LabelRepository]
+	// The label is called "repo" in the PipelineRun CRD and "repository" in the PipelineActivity CRD
+	if repository == "" {
+		repository = labels["repo"]
+	}
+	return strings.ToLower(fmt.Sprintf("%s/%s/%s #%s", labels[v1.LabelOwner], repository, labels[v1.LabelBranch], buildNumber))
+}
+
+func replacePipelineActivityNameWithEnrichedName(paMap map[string]*v1.PipelineActivity, formerName string, newName string) {
+	paMap[newName] = paMap[formerName]
+	delete(paMap, formerName)
+}
+
+func findLegacyPipelineRunBuildNumber(pipelineRun *v1alpha12.PipelineRun) string {
+	var buildNumber string
+	for _, p := range pipelineRun.Spec.Params {
+		if p.Name == "build_id" {
+			buildNumber = p.Value
+		}
+	}
+	return buildNumber
+}
+
+// GetRunningBuildLogs obtains the logs of the provided PipelineActivity and streams the running build pods' logs using the provided LogWriter
+func GetRunningBuildLogs(pa *v1.PipelineActivity, buildName string, kubeClient kubernetes.Interface, writer LogWriter) error {
+	pods, err := builds.GetBuildPods(kubeClient, pa.Namespace)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get build pods in namespace %s", pa.Namespace)
+	}
+
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].CreationTimestamp.Before(&pods[j].CreationTimestamp)
+	})
+
+	foundLogs := false
+	// This method will be executed by both the CLI and the UI, we don't know if the UI has color enabled, so we are using a local instance instead of the global one
+	c := color.New(color.FgGreen)
+	c.EnableColor()
+	for _, pod := range pods {
+		stageName := pod.Labels["jenkins.io/task-stage-name"]
+		params := builds.CreateBuildPodInfo(pod)
+		if params.Organisation == pa.Spec.GitOwner && params.Repository == pa.Spec.GitRepository &&
+			strings.ToLower(params.Branch) == strings.ToLower(pa.Spec.GitBranch) && params.Build == pa.Spec.Build {
+			foundLogs = true
+			containers, _, _ := kube.GetContainersWithStatusAndIsInit(pod)
+			for i, ic := range containers {
+				pod, err = waitForContainerToStart(kubeClient, pa.Namespace, pod, i, writer)
+				err = writer.WriteLog(fmt.Sprintf("Showing logs for build %v stage %s and container %s\n", c.Sprintf(buildName), c.Sprintf(stageName), c.Sprintf(ic.Name)))
+				if err != nil {
+					return errors.Wrapf(err, "there was a problem writing a single line into the logs writer")
+				}
+				err = writer.StreamLog(pa.Namespace, pod, &ic)
+				if err != nil {
+					return errors.Wrapf(err, "there was a problem writing into the stream writer")
+				}
+			}
+		}
+	}
+
+	if len(pods) == 0 || !foundLogs {
+		return errors.New("the build pods for this build have been garbage collected and the log was not found in the long term storage bucket")
+	}
+
+	return nil
+}
+
+func waitForContainerToStart(kubeClient kubernetes.Interface, ns string, pod *corev1.Pod, idx int, logWriter LogWriter) (*corev1.Pod, error) {
+	if pod.Status.Phase == corev1.PodFailed {
+		log.Logger().Warnf("pod %s has failed", pod.Name)
+		return pod, nil
+	}
+	if kube.HasContainerStarted(pod, idx) {
+		return pod, nil
+	}
+	containerName := ""
+	containers, _, _ := kube.GetContainersWithStatusAndIsInit(pod)
+	if idx < len(containers) {
+		containerName = containers[idx].Name
+	}
+	// This method will be executed by both the CLI and the UI, we don't know if the UI has color enabled, so we are using a local instance instead of the global one
+	c := color.New(color.FgGreen)
+	c.EnableColor()
+	if err := logWriter.WriteLog(fmt.Sprintf("waiting for pod %s container %s to start...\n", c.Sprintf(pod.Name), c.Sprintf(containerName))); err != nil {
+		log.Logger().Warn("There was a problem writing a single line into the writeFN")
+	}
+	for {
+		time.Sleep(time.Second)
+
+		p, err := kubeClient.CoreV1().Pods(ns).Get(pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return p, errors.Wrapf(err, "failed to load pod %s", pod.Name)
+		}
+		if kube.HasContainerStarted(p, idx) {
+			return p, nil
+		}
+	}
+}
+
+// StreamPipelinePersistentLogs reads logs from the provided bucker URL and writes them using the provided LogWriter
+func StreamPipelinePersistentLogs(logWriter LogWriter, logsURL string, co *opts.CommonOptions) error {
+	httpFn := createBucketHTTPFn(co)
+	data, err := buckets.ReadURL(logsURL, time.Second*20, httpFn)
+	if err != nil {
+		return err
+	}
+	return logWriter.WriteLog(string(data))
+}
+
+func createBucketHTTPFn(co *opts.CommonOptions) func(urlString string) (string, error) {
+	httpFn := func(urlString string) (string, error) {
+		// Only access the auth service when the httpFn is actually called - then we don't need to grant extra permissions
+		// e.g. in gcs case
+		authSvc, err := co.CreateGitAuthConfigService()
+		if err != nil {
+			return "", err
+		}
+		inner := step.CreateBucketHTTPFn(authSvc)
+		return inner(urlString)
+	}
+	return httpFn
+}

--- a/pkg/logs/tekton_logging_test.go
+++ b/pkg/logs/tekton_logging_test.go
@@ -1,0 +1,252 @@
+package logs
+
+import (
+	"fmt"
+	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/cmd/clients/fake"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/tekton"
+	"github.com/jenkins-x/jx/pkg/tekton/tekton_helpers_test"
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+
+	kubeMocks "k8s.io/client-go/kubernetes/fake"
+	"path"
+	"testing"
+)
+
+type TestWriter struct{}
+
+func TestGetTektonPipelinesWithActivePipelineActivityNoData(t *testing.T) {
+	jxClient, tektonClient, _, _, ns := getFakeClientsAndNs(t)
+
+	names, paNames, err := GetTektonPipelinesWithActivePipelineActivity(jxClient, tektonClient, ns, []string{})
+
+	assert.NoError(t, err, "There shouldn't be any error obtaining PipelineActivities and PipelineRuns")
+	assert.Empty(t, names, "There shouldn't be any returned build names")
+	assert.Empty(t, paNames, "There shouldn't be any returned PipelineActivities")
+}
+
+func TestGetTektonPipelinesWithActivePipelineActivitySingleBuild(t *testing.T) {
+	jxClient, tektonClient, _, _, ns := getFakeClientsAndNs(t)
+
+	_, err := jxClient.JenkinsV1().PipelineActivities(ns).Create(&v1.PipelineActivity{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      "PA1",
+			Namespace: ns,
+			Labels: map[string]string{
+				v1.LabelRepository: "fakerepo",
+				v1.LabelBranch:     "fakebranch",
+				v1.LabelOwner:      "fakeowner",
+			},
+		},
+		Spec: v1.PipelineActivitySpec{
+			Build: "1",
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = tektonClient.TektonV1alpha1().PipelineRuns(ns).Create(&v1alpha1.PipelineRun{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      "PR1",
+			Namespace: ns,
+			Labels: map[string]string{
+				tekton.LabelRepo:    "fakerepo",
+				tekton.LabelBranch:  "fakebranch",
+				tekton.LabelOwner:   "fakeowner",
+				tekton.LabelContext: "tekton",
+			},
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			Params: []v1alpha1.Param{
+				{Name: "version", Value: "v1"},
+				{Name: "build_id", Value: "1"},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = tektonClient.TektonV1alpha1().PipelineRuns(ns).Create(&v1alpha1.PipelineRun{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      "PR2",
+			Namespace: ns,
+			Labels: map[string]string{
+				tekton.LabelBuild:   "2",
+				tekton.LabelRepo:    "fakerepo",
+				tekton.LabelBranch:  "fakebranch",
+				tekton.LabelOwner:   "fakeowner",
+				tekton.LabelContext: "tekton",
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	names, paNames, err := GetTektonPipelinesWithActivePipelineActivity(jxClient, tektonClient, ns, []string{})
+
+	assert.NoError(t, err, "There shouldn't be any error obtaining PipelineActivities and PipelineRuns")
+	assert.Equal(t, "fakeowner/fakerepo/fakebranch #1 tekton", names[0], "There should be a match build in the returned names")
+	_, exists := paNames[names[0]]
+	assert.True(t, exists, "There should be a matching PipelineActivity in the paMap")
+	assert.Equal(t, len(names), len(paNames))
+}
+
+func TestGetRunningBuildLogsNoBuildPods(t *testing.T) {
+	_, _, kubeClient, _, ns := getFakeClientsAndNs(t)
+
+	pa := &v1.PipelineActivity{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      "PA1",
+			Namespace: ns,
+			Labels: map[string]string{
+				v1.LabelRepository: "fakerepo",
+				v1.LabelBranch:     "fakebranch",
+				v1.LabelOwner:      "fakeowner",
+			},
+		},
+		Spec: v1.PipelineActivitySpec{
+			Build: "1",
+		},
+	}
+
+	err := GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", kubeClient, nil)
+	assert.Error(t, err)
+	assert.Equal(t, "the build pods for this build have been garbage collected and the log was not found in the long term storage bucket", err.Error())
+}
+
+func TestGetRunningBuildLogsNoMatchingBuildPods(t *testing.T) {
+	testCaseDir := path.Join("test_data")
+	_, _, _, _, ns := getFakeClientsAndNs(t)
+
+	podsList := tekton_helpers_test.AssertLoadPods(t, testCaseDir)
+	kubeClient := kubeMocks.NewSimpleClientset(podsList)
+
+	pa := &v1.PipelineActivity{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      "PA1",
+			Namespace: ns,
+			Labels: map[string]string{
+				v1.LabelRepository: "fakerepo",
+				v1.LabelBranch:     "fakebranch",
+				v1.LabelOwner:      "fakeowner",
+			},
+		},
+		Spec: v1.PipelineActivitySpec{
+			Build: "1",
+		},
+	}
+
+	err := GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", kubeClient, nil)
+	assert.Error(t, err)
+	assert.Equal(t, "the build pods for this build have been garbage collected and the log was not found in the long term storage bucket", err.Error())
+}
+
+func TestGetRunningBuildLogsWithMatchingBuildPods(t *testing.T) {
+	testCaseDir := path.Join("test_data")
+	_, _, _, _, ns := getFakeClientsAndNs(t)
+
+	podsList := tekton_helpers_test.AssertLoadPods(t, testCaseDir)
+	kubeClient := kubeMocks.NewSimpleClientset(podsList)
+
+	pa := &v1.PipelineActivity{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      "PA1",
+			Namespace: ns,
+			Labels: map[string]string{
+				v1.LabelRepository: "fakerepo",
+				v1.LabelBranch:     "fakebranch",
+				v1.LabelOwner:      "fakeowner",
+			},
+		},
+		Spec: v1.PipelineActivitySpec{
+			Build:         "1",
+			GitBranch:     "fakebranch",
+			GitRepository: "fakerepo",
+			GitOwner:      "fakeowner",
+		},
+	}
+
+	writer := TestWriter{}
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+
+	err := GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", kubeClient, writer)
+
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+
+	aORb := regexp.MustCompile("Pod logs...")
+	n := aORb.FindAllStringIndex(string(outBytes), -1)
+	fmt.Println(len(n))
+
+	containers1, _, _ := kube.GetContainersWithStatusAndIsInit(&podsList.Items[0])
+	containers2, _, _ := kube.GetContainersWithStatusAndIsInit(&podsList.Items[1])
+	containersNumber := len(containers1) + len(containers2)
+
+	assert.NoError(t, err)
+	assert.Equal(t, containersNumber, len(n))
+}
+
+func TestStreamPipelinePersistentLogs(t *testing.T) {
+	_, _, _, opts, _ := getFakeClientsAndNs(t)
+	opts.SkipAuthSecretsMerge = true
+	writer := TestWriter{}
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprintf(w, `Logs stored in a bucket`)
+	}))
+
+	err := StreamPipelinePersistentLogs(writer, server.URL, &opts)
+	assert.NoError(t, err)
+
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+
+	assert.Contains(t, string(outBytes), "Logs stored in a bucket")
+}
+
+// Helper method, not supposed to be a test by itself
+func getFakeClientsAndNs(t *testing.T) (versioned.Interface, tektonclient.Interface, kubernetes.Interface, opts.CommonOptions, string) {
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	options := &commonOpts
+	testhelpers.ConfigureTestOptions(options, options.Git(), options.Helm())
+
+	jxClient, ns, err := options.JXClientAndDevNamespace()
+	assert.NoError(t, err, "There shouldn't be any error getting the fake JXClient and DevEnv")
+
+	tektonClient, _, err := options.TektonClient()
+	assert.NoError(t, err, "There shouldn't be any error getting the fake Tekton Client")
+
+	kubeClient, err := options.KubeClient()
+	assert.NoError(t, err, "There shouldn't be any error getting the fake Kube Client")
+
+	return jxClient, tektonClient, kubeClient, commonOpts, ns
+}
+
+func (w TestWriter) WriteLog(line string) error {
+	log.Logger().Info(line)
+	return nil
+}
+
+func (w TestWriter) StreamLog(ns string, pod *corev1.Pod, container *corev1.Container) error {
+	log.Logger().Info("Pod logs...")
+	return nil
+}

--- a/pkg/logs/test_data/pods.yml
+++ b/pkg/logs/test_data/pods.yml
@@ -14,9 +14,9 @@ items:
         repo: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
         tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1
-        tekton.dev/task: meta-fakeowner-fakerepo-build-app-extension-1
+        tekton.dev/task: meta-fakeowner-fakerepo-build-app-extension-8
         tekton.dev/taskRun: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6
-      name: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6-pod-fcf1fe
+      name: meta-fakewoenr-fakerepo-build-1-app-extension-kvvp6-pod-fcf1fe
       namespace: jx
       ownerReferences:
         - apiVersion: tekton.dev/v1alpha1
@@ -287,7 +287,7 @@ items:
               value: /builder/home
           image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
           imagePullPolicy: IfNotPresent
-          name: build-step-working-dir-initializer-1c9w5
+          name: build-step-working-dir-initializer-8c9w5
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -469,7 +469,7 @@ items:
           image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
           imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash@sha256:0355a9b21a7c0cc9466bf75071648e266de07b5e13fbfd271ec791c45a818bdb
           lastState: {}
-          name: build-step-working-dir-initializer-1c9w5
+          name: build-step-working-dir-initializer-8c9w5
           ready: true
           restartCount: 0
           state:
@@ -504,22 +504,22 @@ items:
         sidecar.istio.io/inject: "false"
       creationTimestamp: "2019-07-02T12:34:56Z"
       labels:
-        jenkins.io/task-stage-name: from-buil-dpack
-        tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
-        tekton.dev/pipelineRun: fakeowner-fakerepo-fakebranch-1
-        tekton.dev/task: fakeowner-fakerepo-fakebranch-from-fakebranch-1
-        tekton.dev/taskRun: fakeowner-fakerepo-fakebranch-1-from-fakebranch-rbw8t
-      name: fakeowner-fakerepo-fakebranch-1-from-fakebranch-rbw8t-pod-1682b0
+        jenkins.io/task-stage-name: from-fakebranch
+        tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-8
+        tekton.dev/pipelineRun: fakeowner-fakerepo-fakebranch-8
+        tekton.dev/task: fakeowner-fakerepo-fakebranch-from-fakebranch-8
+        tekton.dev/taskRun: fakeowner-fakerepo-fakebranch-8-from-fakebranch-rbw8t
+      name: fakeowner-fakerepo-fakebranch-8-from-fakebranch-rbw8t-pod-1682b0
       namespace: jx
       ownerReferences:
         - apiVersion: tekton.dev/v1alpha1
           blockOwnerDeletion: true
           controller: true
           kind: TaskRun
-          name: fakeowner-fakerepo-fakebranch-1-from-fakebranch-rbw8t
+          name: fakeowner-fakerepo-fakebranch-8-from-fakebranch-rbw8t
           uid: cc5f7217-9cc5-11e9-aa2e-42010a8a00fe
       resourceVersion: "236411"
-      selfLink: /api/v1/namespaces/jx/pods/fakeowner-fakerepo-fakebranch-1-from-fakebranch-rbw8t-pod-1682b0
+      selfLink: /api/v1/namespaces/jx/pods/fakeowner-fakerepo-fakebranch-8-from-fakebranch-rbw8t-pod-1682b0
       uid: cc659335-9cc5-11e9-aa2e-42010a8a00fe
     spec:
       containers:
@@ -1640,7 +1640,6 @@ items:
         build-step-build-npm-install build-step-build-npm-test build-step-build-container-build
         build-step-build-post-build build-step-promote-changelog build-step-promote-helm-release
         build-step-promote-jx-promote nop]'
-
           reason: ContainersNotReady
           status: "False"
           type: ContainersReady


### PR DESCRIPTION
Added an abstraction for logs and enabled long term storage in the CLI

feature: added changes to filtering

feature: fixed the lookup of pipeline activities

feature: renamed the logging file and fix after rebase

feature: finished refactor and added tests

feature: added tests

feature: added batch capabilities
Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

chore: lint and fmt

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Added an abstraction layer on the logging so both the CLI and the UI can reuse the same logic.

This is done through the interface `LogWriter` which can be implemented by both to define how to 
deal with logs in different mediums.

The CLI's implementation of `LogWriter` is `CLILogWriter` and streams logs for running builds using `TailLogs`which calls Kubectl and single writes are done through the logger.

Also enabled the long term storage logs capabilities in the CLI. The logic has changed so it looks for `PipelineActivities` and their corresponding `PipelineRuns`. This was needed because we only used to let the user to see the logs of currently running builds instead of past builds which may have logs stored in buckets.

#### Which issue this PR fixes

fixes #4413 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
