### PR TITLE
feat: use the docker image that we just built as step image in pipelines

### DIFF
--- a/jenkins-x-bdd.yml
+++ b/jenkins-x-bdd.yml
@@ -62,26 +62,26 @@ pipelineConfig:
 
               - name: build-and-push-image
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=docker.io/jenkinsxio/jx:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-nodejs
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=docker.io/jenkinsxio/builder-nodejs:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=gcr.io/jenkinsxio/builder-nodejs:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-maven
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=docker.io/jenkinsxio/builder-maven:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=gcr.io/jenkinsxio/builder-maven:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-go
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=docker.io/jenkinsxio/builder-go:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: e2e-tests
-                image: gcr.io/jenkinsxio/builder-go:0.1.537
+                image: gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}
                 command: ./jx/scripts/ci.sh
 
               - name: stash-test-results
-                image: gcr.io/jenkinsxio/builder-jx:0.1.553
+                image: gcr.io/jenkinsxio/jx:covered-${inputs.params.version}
                 command: jx
                 # TODO force it to use the gs bucket until we sort out why the team setting gets wiped
                 args: ['step', 'stash', '-c', 'e2e-tests', '-p', 'build/reports/junit.xml', '--bucket-url', 'gs://jx-prod-logs']

--- a/jenkins-x-bdd.yml
+++ b/jenkins-x-bdd.yml
@@ -44,8 +44,22 @@ pipelineConfig:
                 value: e2e
               - name: VERSION_PREFIX
                 value: covered-
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /builder/home/kaniko-secret.json
 
             steps:
+              - image: jenkinsxio/jx:1.3.963
+                command: jx
+                args:
+                  - step
+                  - credential
+                  - -s
+                  - kaniko-secret
+                  - -k
+                  - kaniko-secret
+                  - -f
+                  - /builder/home/kaniko-secret.json
+
               - name: build-binary
                 image: docker.io/golang:1.11.5
                 command: make

--- a/jenkins-x-bdd.yml
+++ b/jenkins-x-bdd.yml
@@ -5,8 +5,23 @@ pipelineConfig:
       pipeline:
         agent:
           image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+            env:
+              - name: CODECOV_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    key: token
+                    name: codecov-token
         stages:
-          - name: ci
+          - name: build
             environment:
               - name: GIT_COMMITTER_EMAIL
                 value: jenkins-x@googlegroups.com
@@ -29,21 +44,6 @@ pipelineConfig:
                 value: e2e
               - name: VERSION_PREFIX
                 value: covered-
-            options:
-              containerOptions:
-                resources:
-                  limits:
-                    cpu: 4
-                    memory: 6144Mi
-                  requests:
-                    cpu: 1
-                    memory: 2048Mi
-                env:
-                  - name: CODECOV_TOKEN
-                    valueFrom:
-                      secretKeyRef:
-                        key: token
-                        name: codecov-token
 
             steps:
               - name: build-binary
@@ -76,6 +76,31 @@ pipelineConfig:
                 command: /kaniko/executor
                 args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
+          - name: e2e-tests
+            environment:
+              - name: GIT_COMMITTER_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_NAME
+                value: jenkins-x-bot
+              - name: GIT_COMMITTER_NAME
+                value: jenkins-x-bot
+              - name: BASE_WORKSPACE
+                value: /workspace/source
+              - name: GOPROXY
+                value: http://jenkins-x-athens-proxy:80
+              - name: PARALLEL_BUILDS
+                value: "2"
+                # Build a binary that can emit coverage
+              - name: COVERED_BINARY
+                value: "true"
+              - name: CODECOV_NAME
+                value: e2e
+              - name: VERSION_PREFIX
+                value: covered-
+
+            steps:
               - name: e2e-tests
                 image: gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}
                 command: ./jx/scripts/ci.sh

--- a/jenkins-x-images.yml
+++ b/jenkins-x-images.yml
@@ -22,6 +22,8 @@ pipelineConfig:
                 value: http://jenkins-x-athens-proxy:80
               - name: PARALLEL_BUILDS
                 value: "2"
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /builder/home/kaniko-secret.json
             options:
               containerOptions:
                 resources:
@@ -33,6 +35,18 @@ pipelineConfig:
                     memory: 3072Mi
 
             steps:
+              - image: jenkinsxio/jx:1.3.963
+                command: jx
+                args:
+                  - step
+                  - credential
+                  - -s
+                  - kaniko-secret
+                  - -k
+                  - kaniko-secret
+                  - -f
+                  - /builder/home/kaniko-secret.json
+
               - name: build-binary
                 image: docker.io/golang:1.11.5
                 command: make

--- a/jenkins-x-images.yml
+++ b/jenkins-x-images.yml
@@ -45,16 +45,16 @@ pipelineConfig:
 
               - name: build-and-push-image
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=docker.io/jenkinsxio/jx:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-nodejs
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=docker.io/jenkinsxio/builder-nodejs:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-maven
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=docker.io/jenkinsxio/builder-maven:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-go
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=docker.io/jenkinsxio/builder-go:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -116,7 +116,7 @@ pipelineConfig:
                 command: ./jx/bdd/tekton/ci.sh
 
               - name: stash-test-results
-                image: gcr.io/jenkinsxio/builder-jx:covered-${inputs.params.version}
+                image: gcr.io/jenkinsxio/jx:covered-${inputs.params.version}
                 command: jx
                 # TODO force it to use the gs bucket until we sort out why the team setting gets wiped
                 args: ['step', 'stash', '-c', 'tekton-e2e-tests', '-p', 'build/reports/junit.xml', '--bucket-url', 'gs://jx-prod-logs']

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -44,8 +44,22 @@ pipelineConfig:
                 value: tektone2e
               - name: VERSION_PREFIX
                 value: covered-
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /builder/home/kaniko-secret.json
 
             steps:
+              - image: jenkinsxio/jx:1.3.963
+                command: jx
+                args:
+                  - step
+                  - credential
+                  - -s
+                  - kaniko-secret
+                  - -k
+                  - kaniko-secret
+                  - -f
+                  - /builder/home/kaniko-secret.json
+
               - name: build-binary
                 image: docker.io/golang:1.11.5
                 command: make

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -58,26 +58,26 @@ pipelineConfig:
 
               - name: build-and-push-image
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=docker.io/jenkinsxio/jx:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-nodejs
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=docker.io/jenkinsxio/builder-nodejs:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=gcr.io/jenkinsxio/builder-nodejs:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-maven
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=docker.io/jenkinsxio/builder-maven:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=gcr.io/jenkinsxio/builder-maven:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-go
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=docker.io/jenkinsxio/builder-go:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: tekton-e2e-tests
-                image: gcr.io/jenkinsxio/builder-go:0.1.537
+                image: gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}
                 command: ./jx/bdd/tekton/ci.sh
 
               - name: stash-test-results
-                image: gcr.io/jenkinsxio/builder-jx:0.1.553
+                image: gcr.io/jenkinsxio/builder-jx:covered-${inputs.params.version}
                 command: jx
                 # TODO force it to use the gs bucket until we sort out why the team setting gets wiped
                 args: ['step', 'stash', '-c', 'tekton-e2e-tests', '-p', 'build/reports/junit.xml', '--bucket-url', 'gs://jx-prod-logs']

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -5,8 +5,23 @@ pipelineConfig:
       pipeline:
         agent:
           image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+            env:
+              - name: CODECOV_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    key: token
+                    name: codecov-token
         stages:
-          - name: ci
+          - name: build
             environment:
               - name: GIT_COMMITTER_EMAIL
                 value: jenkins-x@googlegroups.com
@@ -29,21 +44,6 @@ pipelineConfig:
                 value: tektone2e
               - name: VERSION_PREFIX
                 value: covered-
-            options:
-              containerOptions:
-                resources:
-                  limits:
-                    cpu: 4
-                    memory: 6144Mi
-                  requests:
-                    cpu: 1
-                    memory: 2048Mi
-                env:
-                  - name: CODECOV_TOKEN
-                    valueFrom:
-                      secretKeyRef:
-                        key: token
-                        name: codecov-token
 
             steps:
               - name: build-binary
@@ -72,6 +72,31 @@ pipelineConfig:
                 command: /kaniko/executor
                 args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
+          - name: e2e-tests
+            environment:
+              - name: GIT_COMMITTER_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_NAME
+                value: jenkins-x-bot
+              - name: GIT_COMMITTER_NAME
+                value: jenkins-x-bot
+              - name: BASE_WORKSPACE
+                value: /workspace/source
+              - name: GOPROXY
+                value: http://jenkins-x-athens-proxy:80
+              - name: PARALLEL_BUILDS
+                value: "2"
+                # Build a binary that can emit coverage
+              - name: COVERED_BINARY
+                value: "true"
+              - name: CODECOV_NAME
+                value: tektone2e
+              - name: VERSION_PREFIX
+                value: covered-
+
+            steps:
               - name: tekton-e2e-tests
                 image: gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}
                 command: ./jx/bdd/tekton/ci.sh

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -145,7 +145,7 @@ pipelineConfig:
                 - /workspace/source/charts/jx/Makefile
 
               - name: update-bot
-                image: gcr.io/jenkinsxio/builder-jx:covered-${inputs.params.version}
+                image: gcr.io/jenkinsxio/jx:covered-${inputs.params.version}
                 command: ./jx/scripts/update-bot.sh
 
               #- name: distro

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -35,6 +35,8 @@ pipelineConfig:
                 value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms1G -Xmx4G
               - name: PARALLEL_BUILDS
                 value: "2"
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /builder/home/kaniko-secret.json
             options:
               containerOptions:
                 resources:
@@ -103,6 +105,19 @@ pipelineConfig:
                   - BASIC_AUTH_PASS
                   - -f
                   - /builder/home/basic-auth-pass
+
+              - image: jenkinsxio/jx:1.3.963
+                command: jx
+                args:
+                  - step
+                  - credential
+                  - -s
+                  - kaniko-secret
+                  - -k
+                  - kaniko-secret
+                  - -f
+                  - /builder/home/kaniko-secret.json
+
 
               - name: release
                 #image: docker.io/golang:1.11.5

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -107,22 +107,22 @@ pipelineConfig:
               - name: release
                 #image: docker.io/golang:1.11.5
                 # needs helm in the image for install_gitops_integration_test.go
-                image: gcr.io/jenkinsxio/builder-go:0.1.537
+                image: gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}
                 command: make
                 args: ['release']
 
               - name: codecov-upload
-                image: gcr.io/jenkinsxio/builder-go:0.1.537
+                image: gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}
                 command: make
                 args: ['codecov-upload']
 
               - name: build-and-push-image
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=docker.io/jenkinsxio/jx:${inputs.params.version}','--context=/workspace/source','--cache-dir=/workspace']
+                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:${inputs.params.version}','--context=/workspace/source','--cache-dir=/workspace']
 
               - name: release-charts
-                image: gcr.io/jenkinsxio/builder-go:0.1.537
+                image: gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}
                 command: make
                 args:
                 - "release"
@@ -130,7 +130,7 @@ pipelineConfig:
                 - /workspace/source/charts/jx/Makefile
 
               - name: update-bot
-                image: gcr.io/jenkinsxio/builder-jx:0.1.553
+                image: gcr.io/jenkinsxio/builder-jx:covered-${inputs.params.version}
                 command: ./jx/scripts/update-bot.sh
 
               #- name: distro
@@ -141,10 +141,10 @@ pipelineConfig:
               #  args: ['release-distro']
 
               - name: update-docs
-                image: gcr.io/jenkinsxio/builder-go:0.1.537
+                image: gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}
                 command: ./jx/scripts/update-website.sh
 
               - name: update-clients
                 # Needs maven as openapi tools are written in Java!
-                image: gcr.io/jenkinsxio/builder-maven:0.1.537
+                image: gcr.io/jenkinsxio/builder-maven:covered-${inputs.params.version}
                 command: ./jx/scripts/update-clients.sh

--- a/jx/bdd/tekton/ci.sh
+++ b/jx/bdd/tekton/ci.sh
@@ -2,7 +2,6 @@
 set -e
 
 echo "verifying Pull Request"
-JX=./build/linux/jx
 
 export GH_USERNAME="jenkins-x-bot-test"
 export GH_OWNER="cb-kubecd"
@@ -22,8 +21,8 @@ KUBECONFIG="/tmp/jxhome/config"
 mkdir -p $JX_HOME
 
 # Disable coverage for jx version as we don't validate the output at all
-COVER_JX_BINARY=false ${JX} version
-${JX} step git credentials
+COVER_JX_BINARY=false jx version
+jx step git credentials
 
 gcloud auth activate-service-account --key-file $GKE_SA
 
@@ -36,9 +35,6 @@ sed -e s/\$VERSION/${VERSION_PREFIX}${VERSION}/g -e s/\$CODECOV_TOKEN/${CODECOV_
 git config --global --add user.name JenkinsXBot
 git config --global --add user.email jenkins-x@googlegroups.com
 
-cp ${JX} /usr/bin
-
 echo "running the BDD tests with JX_HOME = $JX_HOME"
-
 jx step bdd --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/tekton/cluster.yaml --gopath /tmp  --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tekton --tests install --tests test-create-spring
 

--- a/jx/bdd/tekton/ci.sh
+++ b/jx/bdd/tekton/ci.sh
@@ -8,7 +8,7 @@ export GH_OWNER="cb-kubecd"
 
 export GH_CREDS_PSW="$(jx step credential -s jenkins-x-bot-test-github | sed -e 's/PASS//' -e 's/coverage: [0-9\.]*% of statements in [\w\.\/]*//' | tr -d [:space:])"
 export JENKINS_CREDS_PSW="$(jx step credential -s  test-jenkins-user | sed -e 's/PASS//' -e 's/coverage: [0-9\.]*% of statements in [\w\.\/]*//' | tr -d [:space:])"
-export GKE_SA="$(jx step credential -k bdd-credentials.json -s bdd-secret -f sa.json)"
+export GKE_SA="$(jx step credential -k bdd-credentials.json -s bdd-secret -f sa.json | sed -e 's/PASS//' -e 's/coverage: [0-9\.]*% of statements in [\w\.\/]*//' | tr -d [:space:])"
 export REPORTS_DIR="${BASE_WORKSPACE}/build/reports"
 export GINKGO_ARGS="-v"
 

--- a/jx/scripts/ci.sh
+++ b/jx/scripts/ci.sh
@@ -6,9 +6,9 @@ export ORG="jenkinsxio"
 export APP_NAME="jx"
 export TEAM="$(echo ${BRANCH_NAME}-$BUILD_ID  | tr '[:upper:]' '[:lower:]')"
 
-export GHE_CREDS_PSW="$(${JX} step credential -s jx-pipeline-git-github-ghe | sed -e 's/PASS//' -e 's/coverage: [0-9\.]*% of statements in [\w\.\/]*//' | tr -d [:space:])"
-export JENKINS_CREDS_PSW="$(${JX} step credential -s  test-jenkins-user | sed -e 's/PASS//' -e 's/coverage: [0-9\.]*% of statements in [\w\.\/]*//' | tr -d [:space:])"
-export GKE_SA="$(${JX} step credential -s gke-sa | sed -e 's/PASS//' -e 's/coverage: [0-9\.]*% of statements in [\w\.\/]*//' | tr -d [:space:])"
+export GHE_CREDS_PSW="$(jx step credential -s jx-pipeline-git-github-ghe | sed -e 's/PASS//' -e 's/coverage: [0-9\.]*% of statements in [\w\.\/]*//' | tr -d [:space:])"
+export JENKINS_CREDS_PSW="$(jx step credential -s  test-jenkins-user | sed -e 's/PASS//' -e 's/coverage: [0-9\.]*% of statements in [\w\.\/]*//' | tr -d [:space:])"
+export GKE_SA="$(jx step credential -s gke-sa | sed -e 's/PASS//' -e 's/coverage: [0-9\.]*% of statements in [\w\.\/]*//' | tr -d [:space:])"
 
 export REPORTS_DIR="${BASE_WORKSPACE}/build/reports"
 

--- a/jx/scripts/ci.sh
+++ b/jx/scripts/ci.sh
@@ -2,7 +2,6 @@
 set -e
 
 echo "verifying Pull Request"
-JX=./build/linux/jx
 export ORG="jenkinsxio"
 export APP_NAME="jx"
 export TEAM="$(echo ${BRANCH_NAME}-$BUILD_ID  | tr '[:upper:]' '[:lower:]')"
@@ -34,8 +33,8 @@ export GIT_COMMITTER_NAME="dev1"
 mkdir -p $JX_HOME
 
 # Disable coverage for jx version as we don't validate the output at all
-COVER_JX_BINARY=false ${JX} version
-${JX} step git credentials
+COVER_JX_BINARY=false jx version
+jx step git credentials
 
 # lets create a team for this PR and run the BDD tests
 gcloud auth activate-service-account --key-file ${GKE_SA}
@@ -51,10 +50,8 @@ echo "creating team: $TEAM"
 git config --global --add user.name JenkinsXBot
 git config --global --add user.email jenkins-x@googlegroups.com
 
-cp ${JX} /usr/bin
-
 # lets trigger the BDD tests in a new team and git provider
-${JX} step bdd -b --provider=gke --git-provider=ghe --git-provider-url=https://github.beescloud.com --git-username dev1 --git-api-token $GHE_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+jx step bdd -b --provider=gke --git-provider=ghe --git-provider-url=https://github.beescloud.com --git-username dev1 --git-api-token $GHE_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
 
 # Reset the namespace back to jx after test for any followup steps
-COVER_JX_BINARY=false ${JX} ns jx
+COVER_JX_BINARY=false jx ns jx

--- a/myvalues.yaml.tekton.template
+++ b/myvalues.yaml.tekton.template
@@ -5,19 +5,19 @@ jenkins:
       Maven:
         Containers:
           Maven:
-            Image: jenkinsxio/builder-maven:$VERSION
+            Image: gcr.io/jenkinsxio/builder-maven:$VERSION
         EnvVars:
           CODECOV_TOKEN: $CODECOV_TOKEN
       Nodejs:
         Containers:
           Nodejs:
-            Image: jenkinsxio/builder-nodejs:$VERSION
+            Image: gcr.io/jenkinsxio/builder-nodejs:$VERSION
         EnvVars:
           CODECOV_TOKEN: $CODECOV_TOKEN
       Go:
         Containers:
           Go:
-            Image: jenkinsxio/builder-go:$VERSION
+            Image: gcr.io/jenkinsxio/builder-go:$VERSION
         EnvVars:
           CODECOV_TOKEN: $CODECOV_TOKEN
 

--- a/myvalues.yaml.tekton.template
+++ b/myvalues.yaml.tekton.template
@@ -24,7 +24,7 @@ jenkins:
 # override the pipelinerunner image
 pipelinerunner:
   image:
-    repository: docker.io/jenkinsxio/builder-maven
+    repository: gcr.io/jenkinsxio/builder-maven
     tag: $VERSION
   env:
     GIT_AUTHOR_NAME: "jenkins-x-bot"

--- a/myvalues.yaml.template
+++ b/myvalues.yaml.template
@@ -5,19 +5,19 @@ jenkins:
       Maven:
         Containers:
           Maven:
-            Image: jenkinsxio/builder-maven:$VERSION
+            Image: gcr.io/jenkinsxio/builder-maven:$VERSION
         EnvVars:
           CODECOV_TOKEN: $CODECOV_TOKEN
       Nodejs:
         Containers:
           Nodejs:
-            Image: jenkinsxio/builder-nodejs:$VERSION
+            Image: gcr.io/jenkinsxio/builder-nodejs:$VERSION
         EnvVars:
           CODECOV_TOKEN: $CODECOV_TOKEN
       Go:
         Containers:
           Go:
-            Image: jenkinsxio/builder-go:$VERSION
+            Image: gcr.io/jenkinsxio/builder-go:$VERSION
         EnvVars:
           CODECOV_TOKEN: $CODECOV_TOKEN
 # disable stuff


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
When running e2e tests, Instead of copying the jx binary with the PR changes into an old jx docker image, use the docker image build and pushed by the pipeline.

#### Special notes for the reviewer(s)
I've also replaced the references to Docker Hub registry with Google Cloud Registry.

