### PR TITLE
fix: jx create quickstart --org and --name options

### DIFF
--- a/pkg/cmd/create/create_quickstart.go
+++ b/pkg/cmd/create/create_quickstart.go
@@ -152,7 +152,8 @@ func (o *CreateQuickstartOptions) Run() error {
 	}
 
 	var details *gits.CreateRepoData
-
+	o.GitRepositoryOptions.Owner = o.ImportOptions.Organisation
+	o.GitRepositoryOptions.RepoName = o.ImportOptions.Repository
 	if !o.BatchMode {
 		details, err = o.GetGitRepositoryDetails()
 		if err != nil {

--- a/pkg/gits/git_repo.go
+++ b/pkg/gits/git_repo.go
@@ -82,6 +82,7 @@ func PickNewOrExistingGitRepository(batchMode bool, authConfigSvc auth.ConfigSer
 	if userAuth == nil {
 		if repoOptions.Username != "" {
 			userAuth = config.GetOrCreateUserAuth(url, repoOptions.Username)
+			log.Logger().Infof(util.QuestionAnswer("Using Git user name", repoOptions.Username))
 		} else {
 			if batchMode {
 				if len(server.Users) == 0 {
@@ -139,19 +140,29 @@ func PickNewOrExistingGitRepository(batchMode bool, authConfigSvc auth.ConfigSer
 	if err != nil {
 		return nil, err
 	}
+
 	owner := repoOptions.Owner
 	if owner == "" {
 		owner, err = GetOwner(batchMode, provider, gitUsername, in, out, errOut)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		log.Logger().Infof(util.QuestionAnswer("Using organisation", owner))
 	}
+
 	repoName := repoOptions.RepoName
 	if repoName == "" {
 		repoName, err = GetRepoName(batchMode, allowExistingRepo, provider, defaultRepoName, owner, in, out, errOut)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		err := provider.ValidateRepositoryName(owner, repoName)
+		if err != nil {
+			return nil, err
+		}
+		log.Logger().Infof(util.QuestionAnswer("Using repository", repoName))
 	}
 
 	fullName := git.RepoName(owner, repoName)


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
jx create quickstart --org and --name options now work.
Added additional feedback and repo flag `--name` validation to check if it already exists

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #4549

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
