### PR TITLE
fix: Revert use of viper on step_create_task and step_create_meta_pipeline

### DIFF
--- a/pkg/cmd/controller/pipelinerunner.go
+++ b/pkg/cmd/controller/pipelinerunner.go
@@ -59,6 +59,8 @@ type PipelineRunnerOptions struct {
 	UseMetaPipeline      bool
 	MetaPipelineImage    string
 	SemanticRelease      bool
+	noApply              bool
+	outDir               string
 }
 
 // PipelineRunRequest the request to trigger a pipeline run
@@ -340,6 +342,8 @@ func (o *PipelineRunnerOptions) buildStepCreateTaskOption(prowJobSpec prowapi.Pr
 	createTaskOption.Branch = branch
 	createTaskOption.Revision = revision
 	createTaskOption.ServiceAccount = o.ServiceAccount
+	createTaskOption.NoApply = o.noApply
+	createTaskOption.OutDir = o.outDir
 	// turn map into string array with = separator to match type of custom labels which are CLI flags
 	for key, value := range pipelineRun.Labels {
 		createTaskOption.CustomLabels = append(createTaskOption.CustomLabels, fmt.Sprintf("%s=%s", key, value))
@@ -371,7 +375,8 @@ func (o *PipelineRunnerOptions) buildStepCreatePipelineOption(pipelineRun Pipeli
 
 	createPipelineOption.ServiceAccount = o.ServiceAccount
 	createPipelineOption.DefaultImage = o.MetaPipelineImage
-
+	createPipelineOption.NoApply = o.noApply
+	createPipelineOption.OutDir = o.outDir
 	// turn map into string array with = separator to match type of custom labels which are CLI flags
 	for key, value := range pipelineRun.Labels {
 		createPipelineOption.CustomLabels = append(createPipelineOption.CustomLabels, fmt.Sprintf("%s=%s", key, value))

--- a/pkg/cmd/controller/pipelinerunner_integration_test.go
+++ b/pkg/cmd/controller/pipelinerunner_integration_test.go
@@ -79,19 +79,12 @@ var _ = Describe("Pipeline Runner Integration", func() {
 		testOutDir, err = ioutil.TempDir("", "jx-pipelinerunner-tests")
 		Expect(err).Should(BeNil())
 
-		err = os.Setenv("OUTPUT", testOutDir)
-		Expect(err).Should(BeNil())
-		err = os.Setenv("NO_APPLY", "true")
-		Expect(err).Should(BeNil())
-
 		port, _ = getFreePort()
 	})
 
 	AfterEach(func() {
 		cancel()
 		_ = os.RemoveAll(testOutDir)
-		_ = os.Unsetenv("OUTPUT")
-		_ = os.Unsetenv("NO_APPLY")
 	})
 
 	Describe("when running in meta pipeline mode", func() {
@@ -106,6 +99,8 @@ var _ = Describe("Pipeline Runner Integration", func() {
 				Port:                 port,
 				NoGitCredentialsInit: true,
 				UseMetaPipeline:      true,
+				noApply:              true,
+				outDir:               testOutDir,
 			}
 
 			go func() {
@@ -169,6 +164,8 @@ var _ = Describe("Pipeline Runner Integration", func() {
 				BindAddress:          "0.0.0.0",
 				Port:                 port,
 				NoGitCredentialsInit: true,
+				noApply:              true,
+				outDir:               testOutDir,
 			}
 
 			go func() {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

For some reason I can't figure out, the viper addition here resulted in `--no-apply` and `--output=whatever` just not registering _at all_. So let's get rid of viper here until we can figure out what's happening.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

n/a