### PR TITLE
fix: Allow post preview jobs without ingress

### DIFF
--- a/pkg/kube/services/services.go
+++ b/pkg/kube/services/services.go
@@ -185,6 +185,7 @@ func GetServiceURL(svc *v1.Service) string {
 	return url
 }
 
+// FindServiceSchemePort parses the service definition and interprets http scheme in the absence of an external ingress
 func FindServiceSchemePort(client kubernetes.Interface, namespace string, name string) (string, string, error) {
 	svc, err := client.CoreV1().Services(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
@@ -451,6 +452,7 @@ func CleanServiceAnnotations(c kubernetes.Interface, ns string, services ...stri
 	return nil
 }
 
+// ExtractServiceSchemePort is a utility function to interpret http scheme and port information from k8s service definitions
 func ExtractServiceSchemePort(svc *v1.Service) (string, string, error) {
 	scheme := ""
 	port := ""

--- a/pkg/kube/services/services_test.go
+++ b/pkg/kube/services/services_test.go
@@ -1,0 +1,288 @@
+package services_test
+
+import (
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/kube/services"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExtractServiceSchemePortDefault(t *testing.T) {
+	t.Parallel()
+	s := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-spring-boot-demo2",
+			Namespace: "default-staging",
+			Labels: map[string]string{
+				"chart": "preview-0.0.0-SNAPSHOT-PR-29-28",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: "TCP",
+					Port:     80,
+				},
+			},
+		},
+	}
+	schema, port, _ := services.ExtractServiceSchemePort(s)
+	assert.Equal(t, "http", schema)
+	assert.Equal(t, "80", port)
+}
+func TestExtractServiceSchemePortHttps(t *testing.T) {
+	t.Parallel()
+	s := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-spring-boot-demo2",
+			Namespace: "default-staging",
+			Labels: map[string]string{
+				"chart": "preview-0.0.0-SNAPSHOT-PR-29-28",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "https",
+					Protocol: "TCP",
+					Port:     443,
+				},
+			},
+		},
+	}
+	schema, port, _ := services.ExtractServiceSchemePort(s)
+	assert.Equal(t, "https", schema)
+	assert.Equal(t, "443", port)
+}
+func TestExtractServiceSchemePortHttpsFirst(t *testing.T) {
+	t.Parallel()
+	s := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-spring-boot-demo2",
+			Namespace: "default-staging",
+			Labels: map[string]string{
+				"chart": "preview-0.0.0-SNAPSHOT-PR-29-28",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: "TCP",
+					Port:     80,
+				},
+				{
+					Name:     "https",
+					Protocol: "TCP",
+					Port:     443,
+				},
+			},
+		},
+	}
+	schema, port, _ := services.ExtractServiceSchemePort(s)
+	assert.Equal(t, "https", schema)
+	assert.Equal(t, "443", port)
+}
+
+func TestExtractServiceSchemePortHttpsOdd(t *testing.T) {
+	t.Parallel()
+	s := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-spring-boot-demo2",
+			Namespace: "default-staging",
+			Labels: map[string]string{
+				"chart": "preview-0.0.0-SNAPSHOT-PR-29-28",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "brian",
+					Protocol: "TCP",
+					Port:     443,
+				},
+			},
+		},
+	}
+	schema, port, _ := services.ExtractServiceSchemePort(s)
+	assert.Equal(t, "https", schema)
+	assert.Equal(t, "443", port)
+}
+
+func TestExtractServiceSchemePortHttpsNamed(t *testing.T) {
+	t.Parallel()
+	s := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-spring-boot-demo2",
+			Namespace: "default-staging",
+			Labels: map[string]string{
+				"chart": "preview-0.0.0-SNAPSHOT-PR-29-28",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "dave",
+					Protocol: "UDP",
+					Port:     800,
+				},
+				{
+					Name:     "brian",
+					Protocol: "TCP",
+					Port:     444,
+				},
+				{
+					Name:     "https",
+					Protocol: "TCP",
+					Port:     443,
+				},
+			},
+		},
+	}
+	schema, port, _ := services.ExtractServiceSchemePort(s)
+	assert.Equal(t, "https", schema)
+	assert.Equal(t, "443", port)
+}
+
+func TestExtractServiceSchemePortHttpNamed(t *testing.T) {
+	t.Parallel()
+	s := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-spring-boot-demo2",
+			Namespace: "default-staging",
+			Labels: map[string]string{
+				"chart": "preview-0.0.0-SNAPSHOT-PR-29-28",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "dave",
+					Protocol: "UDP",
+					Port:     800,
+				},
+				{
+					Name:     "brian",
+					Protocol: "TCP",
+					Port:     444,
+				},
+				{
+					Name:     "http",
+					Protocol: "TCP",
+					Port:     8083,
+				},
+			},
+		},
+	}
+	schema, port, _ := services.ExtractServiceSchemePort(s)
+	assert.Equal(t, "http", schema)
+	assert.Equal(t, "8083", port)
+}
+
+func TestExtractServiceSchemePortHttpNotNamed(t *testing.T) {
+	t.Parallel()
+	s := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-spring-boot-demo2",
+			Namespace: "default-staging",
+			Labels: map[string]string{
+				"chart": "preview-0.0.0-SNAPSHOT-PR-29-28",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: "TCP",
+					Port:     8088,
+				},
+				{
+					Name:     "alan",
+					Protocol: "TCP",
+					Port:     80,
+				},
+			},
+		},
+	}
+	schema, port, _ := services.ExtractServiceSchemePort(s)
+	assert.Equal(t, "http", schema)
+	assert.Equal(t, "80", port)
+}
+
+func TestExtractServiceSchemePortNamedPrefHttps(t *testing.T) {
+	t.Parallel()
+	s := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-spring-boot-demo2",
+			Namespace: "default-staging",
+			Labels: map[string]string{
+				"chart": "preview-0.0.0-SNAPSHOT-PR-29-28",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "ssh",
+					Protocol: "UDP",
+					Port:     22,
+				},
+				{
+					Name:     "hiddenhttp",
+					Protocol: "TCP",
+					Port:     8083,
+				},
+				{
+					Name:     "sctp-tunneling",
+					Protocol: "TCP",
+					Port:     9899,
+				},
+				{
+					Name:     "https",
+					Protocol: "TCP",
+					Port:     8443,
+				},
+			},
+		},
+	}
+	schema, port, _ := services.ExtractServiceSchemePort(s)
+	assert.Equal(t, "https", schema)
+	assert.Equal(t, "8443", port)
+}
+
+func TestExtractServiceSchemePortInconclusive(t *testing.T) {
+	t.Parallel()
+	s := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-spring-boot-demo2",
+			Namespace: "default-staging",
+			Labels: map[string]string{
+				"chart": "preview-0.0.0-SNAPSHOT-PR-29-28",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "ssh",
+					Protocol: "UDP",
+					Port:     22,
+				},
+				{
+					Name:     "hiddenhttp",
+					Protocol: "TCP",
+					Port:     8083,
+				},
+				{
+					Name:     "sctp-tunneling",
+					Protocol: "TCP",
+					Port:     9899,
+				},
+			},
+		},
+	}
+	schema, port, _ := services.ExtractServiceSchemePort(s)
+	assert.Equal(t, "", schema)
+	assert.Equal(t, "", port)
+}


### PR DESCRIPTION
Signed-off-by: Terry Cox <terry@bootstrap.je>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
This PR changes the behaviour of the setup for post preview jobs. The environment variable `JX_PREVIEW_URL` will now be set to the URL of the external ingress if one is configured, otherwise it will be set to the URL of the internal service local to the namespace.

Construction of the internal URL prefers https over http and common ports over named exotic ports.

Additionally, some new environment variables are created to permit more flexiblity for composing post preview jobs.

#### Special notes for the reviewer(s)
I am unable to test RunPostPreviewSteps in a build environment so I would be grateful if someone could smoke test this build or send me a copy of the executable so I can run manual tests?

This fix addresses problems with the owasp-zap addon. Consideration needs to be given to any other existing post preview jobs that I may not have visibility of.

#### Which issue this PR fixes

fixes #4591

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
