### PR TITLE
fix(tekton): Use pod template name for default image

### DIFF
--- a/pkg/tekton/syntax/constants.go
+++ b/pkg/tekton/syntax/constants.go
@@ -14,5 +14,5 @@ const (
 	KanikoDockerImage = "gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6"
 
 	// DefaultContainerImage - the default image used for pipelines if none is specified.
-	DefaultContainerImage = "gcr.io/jenkinsxio/builder-maven"
+	DefaultContainerImage = "maven"
 )


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

For a while now, #4615 has resulted in `gcr.io/jenkinsxio/builder-maven` (and similarly image URLs without tags) always using `latest`, rather than the latest in the version stream. The desired result, however, is to use the pod template image, so let's just be cleaner and use the pod template name here. That'll always resolve correctly in practice.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

n/a