### PR TITLE
fix(tekton): Fixes for metapipeline run from prow

### DIFF
--- a/pkg/cmd/get/get_build_logs.go
+++ b/pkg/cmd/get/get_build_logs.go
@@ -436,7 +436,7 @@ func (o *GetBuildLogsOptions) getTektonLogs(kubeClient kubernetes.Interface, tek
 
 	_ = logWriter.WriteLog(fmt.Sprintf("Build logs for %s", util.ColorInfo(name)))
 	name = strings.TrimSuffix(name, " ")
-	return false, logs.GetRunningBuildLogs(pa, name, kubeClient, logWriter)
+	return false, logs.GetRunningBuildLogs(pa, name, kubeClient, tektonClient, logWriter)
 }
 
 // StreamLog implementation of LogWriter.StreamLog for CLILogWriter, this implementation will tail logs for the provided pod /container through the defined logger

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -720,27 +720,6 @@ func (o *StepCreateTaskOptions) combineLabels(labels map[string]string) error {
 	return nil
 }
 
-func (o *StepCreateTaskOptions) combineEnvVars(projectConfig *jenkinsfile.PipelineConfig) error {
-	// add any custom env vars
-	envMap := make(map[string]corev1.EnvVar)
-	for _, e := range projectConfig.Env {
-		envMap[e.Name] = e
-	}
-	for _, customEnvVar := range o.CustomEnvs {
-		parts := strings.Split(customEnvVar, "=")
-		if len(parts) != 2 {
-			return errors.Errorf("expected 2 parts to env var but got %v", len(parts))
-		}
-		e := corev1.EnvVar{
-			Name:  parts[0],
-			Value: parts[1],
-		}
-		envMap[e.Name] = e
-	}
-	projectConfig.Env = syntax.EnvMapToSlice(envMap)
-	return nil
-}
-
 func (o *StepCreateTaskOptions) getWorkspaceDir() string {
 	return filepath.Join("/workspace", o.SourceName)
 }

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -269,6 +269,11 @@ func (o *StepCreateTaskOptions) Run() error {
 
 	pipelineName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline, tektonClient, ns)
 
+	err = o.setBuildValues()
+	if err != nil {
+		return err
+	}
+
 	exists, err = o.effectiveProjectConfigExists()
 	if err != nil {
 		return err
@@ -459,11 +464,6 @@ func (o *StepCreateTaskOptions) createEffectiveProjectConfigFromOptions(tektonCl
 
 // createEffectiveProjectConfig creates the effective parsed pipeline which is then used to generate the Tekton CRDs.
 func (o *StepCreateTaskOptions) createEffectiveProjectConfig(packsDir string, projectConfig *config.ProjectConfig, projectConfigFile string, resolver jenkinsfile.ImportFileResolver, ns string) (*config.ProjectConfig, error) {
-	err := o.setBuildValues()
-	if err != nil {
-		return nil, err
-	}
-
 	createEffective := &syntaxstep.StepSyntaxEffectiveOptions{
 		Pack:              o.Pack,
 		BuildPackURL:      o.BuildPackURL,

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -269,11 +269,6 @@ func (o *StepCreateTaskOptions) Run() error {
 
 	pipelineName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline, tektonClient, ns)
 
-	err = o.setBuildValues()
-	if err != nil {
-		return err
-	}
-
 	exists, err = o.effectiveProjectConfigExists()
 	if err != nil {
 		return err
@@ -288,6 +283,11 @@ func (o *StepCreateTaskOptions) Run() error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create effective project configuration")
 		}
+	}
+
+	err = o.setBuildValues()
+	if err != nil {
+		return err
 	}
 
 	log.Logger().Debug("setting build version")

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -390,15 +390,17 @@ func (o *StepCreateTaskOptions) createEffectiveProjectConfigFromOptions(tektonCl
 		}
 	}
 
-	if viper.GetBool(noApplyOptionName) || o.DryRun || o.InterpretMode {
-		o.BuildNumber = "1"
-	} else {
-		log.Logger().Debugf("generating build number...")
-		o.BuildNumber, err = tekton.GenerateNextBuildNumber(tektonClient, jxClient, ns, o.GitInfo, o.Branch, o.Duration, o.Context)
-		if err != nil {
-			return nil, err
+	if o.BuildNumber == "" {
+		if viper.GetBool(noApplyOptionName) || o.DryRun || o.InterpretMode {
+			o.BuildNumber = "1"
+		} else {
+			log.Logger().Debugf("generating build number...")
+			o.BuildNumber, err = tekton.GenerateNextBuildNumber(tektonClient, jxClient, ns, o.GitInfo, o.Branch, o.Duration, o.Context)
+			if err != nil {
+				return nil, err
+			}
+			log.Logger().Debugf("generated build number %s for %s", o.BuildNumber, o.CloneGitURL)
 		}
-		log.Logger().Debugf("generated build number %s for %s", o.BuildNumber, o.CloneGitURL)
 	}
 	projectConfig, projectConfigFile, err := o.loadProjectConfig()
 	if err != nil {

--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -383,6 +383,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			// Create a single duplicate PipelineResource for the name used by the 'kaniko_entrypoint' test case to verify that the deduplication logic works correctly.
 			tektonClient := tektonfake.NewSimpleClientset(tekton_helpers_test.AssertLoadPipelineResources(t, path.Join(testData, "prepopulated")))
 
+			createTask.setBuildValues()
 			effectiveProjectConfig, _ := createTask.createEffectiveProjectConfig(packsDir, projectConfig, projectConfigFile, resolver, ns)
 			if effectiveProjectConfig != nil {
 				createTask.setBuildVersion(effectiveProjectConfig.PipelineConfig)

--- a/pkg/logs/test_data/pipelinerun.yml
+++ b/pkg/logs/test_data/pipelinerun.yml
@@ -1,0 +1,36 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generation: 1
+  labels:
+    branch: fakebranch
+    build: "1"
+    created-by-prow: "true"
+    owner: fakeowner
+    prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
+    repo: fakerepo
+    tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
+  name: fakeowner-fakerepo-fakebranch-1
+  namespace: jx
+  ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: pipeline
+      name: fakeowner-fakerepo-fakebranch-1
+      uid: 3fe9c5ff-9da8-11e9-8283-42010a840059
+  selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/fakeowner-fakerepo-fakebranch-1
+spec:
+  params:
+    - name: version
+      value: 0.0.1
+    - name: build_id
+      value: "1"
+  pipelineRef:
+    apiVersion: tekton.dev/v1alpha1
+    name: fakeowner-fakerepo-fakebranch-1
+  resources:
+    - name: fakeowner-fakerepo-fakebranch
+      resourceRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: fakeowner-fakerepo-fakebranch
+  serviceAccount: tekton-bot
+  timeout: 240h0m0s

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -2,15 +2,14 @@ package metapipeline
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/prow"
 	"path/filepath"
-	"strings"
 
 	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/apps"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/prow"
 	"github.com/jenkins-x/jx/pkg/tekton"
 	"github.com/jenkins-x/jx/pkg/tekton/syntax"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -220,8 +219,8 @@ func stepCreateTektonCRDs(params CRDCreationParameters) syntax.Step {
 	if params.Context != "" {
 		args = append(args, "--context", params.Context)
 	}
-	if len(params.Labels) > 0 {
-		args = append(args, "--label", strings.Join(params.Labels, ","))
+	for _, l := range params.Labels {
+		args = append(args, "--label", l)
 	}
 	for _, e := range params.EnvVars {
 		args = append(args, "--env", e)

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -222,8 +222,8 @@ func stepCreateTektonCRDs(params CRDCreationParameters) syntax.Step {
 	if len(params.Labels) > 0 {
 		args = append(args, "--label", strings.Join(params.Labels, ","))
 	}
-	if len(params.EnvVars) > 0 {
-		args = append(args, "--env", strings.Join(params.EnvVars, ","))
+	for _, e := range params.EnvVars {
+		args = append(args, "--env", e)
 	}
 	step := syntax.Step{
 		Name:      createTektonCRDsStepName,

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -216,6 +216,7 @@ func stepCreateTektonCRDs(params CRDCreationParameters) syntax.Step {
 	args = append(args, "--service-account", params.ServiceAccount)
 	args = append(args, "--source", params.SourceDir)
 	args = append(args, "--branch", params.BranchIdentifier)
+	args = append(args, "--build-number", params.BuildNumber)
 	if params.Context != "" {
 		args = append(args, "--context", params.Context)
 	}

--- a/pkg/tekton/metapipeline/metapipeline_test.go
+++ b/pkg/tekton/metapipeline/metapipeline_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Meta pipeline", func() {
 
 			It("should have correct step create task args", func() {
 				step := actualCRDs.Tasks()[0].Spec.Steps[3]
-				Expect(step.Args).Should(Equal([]string{"jx step create task --clone-dir /workspace/source --kind pullrequest --pr-number 42 --trigger manual --service-account tekton-bot --source source --branch master --label someLabel=someValue --env SOME_VAR=SOME_VAL"}))
+				Expect(step.Args).Should(Equal([]string{"jx step create task --clone-dir /workspace/source --kind pullrequest --pr-number 42 --trigger manual --service-account tekton-bot --source source --branch master --build-number 1 --label someLabel=someValue --env SOME_VAR=SOME_VAL"}))
 			})
 		})
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Fixes for a number of issues uncovered in the process of getting #4610 to pass.
* Env vars can contain commas, so pass as separate --env
* Pass build number to create task in metapipeline
* Handle logs for runs started after get build logs is called
* Labels should be specified individually as well
* Remove unused combineEnvVars function

#### Special notes for the reviewer(s)

/assign @hferentschik 
/assign @dgozalo 

#### Which issue this PR fixes

fixes #4361 