### PR TITLE
fix: If no pods are found for a pipeline, don't loop looking for logs

### DIFF
--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -2,6 +2,10 @@ package logs
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+	"time"
+
 	"github.com/fatih/color"
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/builds"
@@ -17,10 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"sort"
-	"strings"
-
-	"time"
 )
 
 // LogWriter is an interface that can be implemented to define different ways to stream / write logs
@@ -164,6 +164,9 @@ func GetRunningBuildLogs(pa *v1.PipelineActivity, buildName string, kubeClient k
 		}
 		for k, v := range runsSeenForPods {
 			pipelineRunsLogged[k] = v
+		}
+		if !foundLogs {
+			break
 		}
 	}
 	if !foundLogs {

--- a/pkg/logs/tekton_logging_test.go
+++ b/pkg/logs/tekton_logging_test.go
@@ -56,7 +56,10 @@ func TestGetTektonPipelinesWithActivePipelineActivitySingleBuild(t *testing.T) {
 			},
 		},
 		Spec: v1.PipelineActivitySpec{
-			Build: "1",
+			Build:         "1",
+			GitBranch:     "fakebranch",
+			GitRepository: "fakerepo",
+			GitOwner:      "fakeowner",
 		},
 	})
 	assert.NoError(t, err)
@@ -119,7 +122,40 @@ func TestGetRunningBuildLogsNoBuildPods(t *testing.T) {
 			},
 		},
 		Spec: v1.PipelineActivitySpec{
-			Build: "1",
+			Build:         "1",
+			GitBranch:     "fakebranch",
+			GitRepository: "fakerepo",
+			GitOwner:      "fakeowner",
+		},
+	}
+
+	err := GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", kubeClient, tektonClient, nil)
+	assert.Error(t, err)
+	assert.Equal(t, "the build pods for this build have been garbage collected and the log was not found in the long term storage bucket", err.Error())
+}
+
+func TestGetRunningBuildLogsWithPipelineRunButNoBuildPods(t *testing.T) {
+	testCaseDir := path.Join("test_data")
+	_, _, kubeClient, _, ns := getFakeClientsAndNs(t)
+
+	pipelineRun := tekton_helpers_test.AssertLoadSinglePipelineRun(t, testCaseDir)
+	tektonClient := tektonMocks.NewSimpleClientset(pipelineRun)
+
+	pa := &v1.PipelineActivity{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      "PA1",
+			Namespace: ns,
+			Labels: map[string]string{
+				v1.LabelRepository: "fakerepo",
+				v1.LabelBranch:     "fakebranch",
+				v1.LabelOwner:      "fakeowner",
+			},
+		},
+		Spec: v1.PipelineActivitySpec{
+			Build:         "1",
+			GitBranch:     "fakebranch",
+			GitRepository: "fakerepo",
+			GitOwner:      "fakeowner",
 		},
 	}
 
@@ -146,7 +182,10 @@ func TestGetRunningBuildLogsNoMatchingBuildPods(t *testing.T) {
 			},
 		},
 		Spec: v1.PipelineActivitySpec{
-			Build: "1",
+			Build:         "1",
+			GitBranch:     "fakebranch",
+			GitRepository: "fakerepo",
+			GitOwner:      "fakeowner",
 		},
 	}
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Fixes an infinite loop when running `jx get build logs` for a pipeline without `GetBuildLogsURL` or any active pods.

#### Special notes for the reviewer(s)

/assign @dgozalo 

#### Which issue this PR fixes

n/a