### PR TITLE
fix: set the release id when a new release is created

### DIFF
--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -1041,7 +1041,10 @@ func (p *GitHubProvider) UpdateRelease(owner string, repo string, tag string, re
 
 	if r != nil && r.StatusCode == 404 {
 		log.Logger().Warnf("No release found for %s/%s and tag %s so creating a new release", owner, repo, tag)
-		_, _, err = p.Client.Repositories.CreateRelease(p.Context, owner, repo, release)
+		rel, _, err := p.Client.Repositories.CreateRelease(p.Context, owner, repo, release)
+		if rel != nil {
+			releaseInfo.ID = util.DereferenceInt64(rel.ID)
+		}
 		return err
 	}
 	id := release.ID


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

Issue reported by @abayer on slack

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
