### PR TITLE
fix: PipelineActivity doesn't have context label so skip in filter

### DIFF
--- a/pkg/builds/build_info.go
+++ b/pkg/builds/build_info.go
@@ -194,6 +194,21 @@ func CreateBuildPodInfo(pod *corev1.Pod) *BuildPodInfo {
 	return answer
 }
 
+// LabelSelectorsForActivity returns a slice of label selectors relevant to PipelineActivity corresponding to the filter
+func (o *BuildPodInfoFilter) LabelSelectorsForActivity() []string {
+	var labelSelectors []string
+	if o.Owner != "" {
+		labelSelectors = append(labelSelectors, "owner="+o.Owner)
+	}
+	if o.Repository != "" {
+		labelSelectors = append(labelSelectors, "repo="+o.Repository)
+	}
+	if o.Branch != "" {
+		labelSelectors = append(labelSelectors, "branch="+o.Branch)
+	}
+	return labelSelectors
+}
+
 // LabelSelectorsForBuild returns a slice of label selectors corresponding to the filter
 func (o *BuildPodInfoFilter) LabelSelectorsForBuild() []string {
 	var labelSelectors []string

--- a/pkg/builds/build_info.go
+++ b/pkg/builds/build_info.go
@@ -201,7 +201,7 @@ func (o *BuildPodInfoFilter) LabelSelectorsForActivity() []string {
 		labelSelectors = append(labelSelectors, "owner="+o.Owner)
 	}
 	if o.Repository != "" {
-		labelSelectors = append(labelSelectors, "repo="+o.Repository)
+		labelSelectors = append(labelSelectors, "repository="+o.Repository)
 	}
 	if o.Branch != "" {
 		labelSelectors = append(labelSelectors, "branch="+o.Branch)

--- a/pkg/cmd/get/get_build_logs.go
+++ b/pkg/cmd/get/get_build_logs.go
@@ -388,7 +388,7 @@ func (o *GetBuildLogsOptions) getLogForKnative(kubeClient kubernetes.Interface, 
 
 func (o *GetBuildLogsOptions) getTektonLogs(kubeClient kubernetes.Interface, tektonClient tektonclient.Interface, jxClient versioned.Interface, ns string) (bool, error) {
 	var defaultName string
-	names, paMap, err := logs.GetTektonPipelinesWithActivePipelineActivity(jxClient, tektonClient, ns, o.BuildFilter.LabelSelectorsForBuild())
+	names, paMap, err := logs.GetTektonPipelinesWithActivePipelineActivity(jxClient, tektonClient, ns, o.BuildFilter.LabelSelectorsForActivity())
 	if err != nil {
 		return true, err
 	}

--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -32,7 +32,7 @@ type LogWriter interface {
 // GetTektonPipelinesWithActivePipelineActivity returns list of all PipelineActivities with corresponding Tekton PipelineRuns ordered by the PipelineRun creation timestamp and a map to obtain its reference once a name has been selected
 func GetTektonPipelinesWithActivePipelineActivity(jxClient versioned.Interface, tektonClient tektonclient.Interface, ns string, filters []string) ([]string, map[string]*v1.PipelineActivity, error) {
 	paList, err := jxClient.JenkinsV1().PipelineActivities(ns).List(metav1.ListOptions{
-		LabelSelector: strings.Replace(strings.Join(filters, ","), "repo=", "repository=", 1),
+		LabelSelector: strings.Join(filters, ","),
 	})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "there was a problem getting the PipelineActivities")


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

`PipelineActivity` doesn't have the `context` label, so if you specify `--context=whatever` to `jx get build logs`, it never finds anything. Let's add a function to get the `PipelineActivity`-specific label selectors.

#### Special notes for the reviewer(s)

/assign @dgozalo 

#### Which issue this PR fixes

n/a