### PR TITLE
fix: various fixes for the fork / rebase logic

### DIFF
--- a/pkg/cmd/step/create/pr/step_create_pr.go
+++ b/pkg/cmd/step/create/pr/step_create_pr.go
@@ -386,6 +386,7 @@ func (o *StepCreatePrOptions) CreateDependencyUpdatePRDetails(kind string, srcRe
 		}
 	}
 	message.WriteString(fmt.Sprintf("\n\nCommand run was `%s`", strings.Join(os.Args, " ")))
+	commitMessage.WriteString(fmt.Sprintf("\n\nCommand run was `%s`", strings.Join(os.Args, " ")))
 	return commitMessage.String(), &gits.PullRequestDetails{
 		BranchName: fmt.Sprintf("bump-%s-version-%s", kind, string(uuid.NewUUID())),
 		Title:      title.String(),

--- a/pkg/gits/errors.go
+++ b/pkg/gits/errors.go
@@ -1,0 +1,16 @@
+package gits
+
+import "strings"
+
+// IsEmptyCommitError checks if the error during git rebase is caused by the commit being empty at the end of the cherry-pick
+func IsEmptyCommitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, `If you wish to commit it anyway, use:
+
+    git commit --allow-empty
+
+Otherwise, please use 'git reset'`)
+}

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -557,7 +557,7 @@ func (g *GitFake) MergeTheirs(dir string, commitish string) error {
 }
 
 //RebaseTheirs does nothing
-func (g *GitFake) RebaseTheirs(dir string, upstream string, branch string) error {
+func (g *GitFake) RebaseTheirs(dir string, upstream string, branch string, skipEmpty bool) error {
 	return nil
 }
 

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -425,8 +425,8 @@ func (g *GitLocal) MergeTheirs(dir string, commitish string) error {
 }
 
 // RebaseTheirs runs git rebase upstream branch
-func (g *GitLocal) RebaseTheirs(dir string, upstream string, branch string) error {
-	return g.GitCLI.RebaseTheirs(dir, upstream, branch)
+func (g *GitLocal) RebaseTheirs(dir string, upstream string, branch string, skipEmpty bool) error {
+	return g.GitCLI.RebaseTheirs(dir, upstream, branch, false)
 }
 
 // GetCommits returns the commits in a range, exclusive of startSha and inclusive of endSha

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -366,6 +366,7 @@ func (p *GitHubProvider) ForkRepository(originalOrg string, name string, destina
 		CloneURL:         asText(repo.CloneURL),
 		HTMLURL:          asText(repo.HTMLURL),
 		SSHURL:           asText(repo.SSHURL),
+		Fork:             true,
 	}
 	return answer, nil
 }

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -231,7 +231,7 @@ type Gitter interface {
 	Merge(dir string, commitish string) error
 	MergeTheirs(dir string, commitish string) error
 	ResetHard(dir string, commitish string) error
-	RebaseTheirs(dir string, upstream string, branch string) error
+	RebaseTheirs(dir string, upstream string, branch string, skipEmpty bool) error
 
 	Stash(dir string) error
 

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -958,11 +958,11 @@ func (mock *MockGitter) PushTag(_param0 string, _param1 string) error {
 	return ret0
 }
 
-func (mock *MockGitter) RebaseTheirs(_param0 string, _param1 string, _param2 string) error {
+func (mock *MockGitter) RebaseTheirs(_param0 string, _param1 string, _param2 string, _param3 bool) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
 	}
-	params := []pegomock.Param{_param0, _param1, _param2}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("RebaseTheirs", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
@@ -3038,8 +3038,8 @@ func (c *MockGitter_PushTag_OngoingVerification) GetAllCapturedArguments() (_par
 	return
 }
 
-func (verifier *VerifierMockGitter) RebaseTheirs(_param0 string, _param1 string, _param2 string) *MockGitter_RebaseTheirs_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1, _param2}
+func (verifier *VerifierMockGitter) RebaseTheirs(_param0 string, _param1 string, _param2 string, _param3 bool) *MockGitter_RebaseTheirs_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "RebaseTheirs", params, verifier.timeout)
 	return &MockGitter_RebaseTheirs_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -3049,12 +3049,12 @@ type MockGitter_RebaseTheirs_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockGitter_RebaseTheirs_OngoingVerification) GetCapturedArguments() (string, string, string) {
-	_param0, _param1, _param2 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1]
+func (c *MockGitter_RebaseTheirs_OngoingVerification) GetCapturedArguments() (string, string, string, bool) {
+	_param0, _param1, _param2, _param3 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1]
 }
 
-func (c *MockGitter_RebaseTheirs_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string) {
+func (c *MockGitter_RebaseTheirs_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string, _param3 []bool) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(params[0]))
@@ -3068,6 +3068,10 @@ func (c *MockGitter_RebaseTheirs_OngoingVerification) GetAllCapturedArguments() 
 		_param2 = make([]string, len(params[2]))
 		for u, param := range params[2] {
 			_param2[u] = param.(string)
+		}
+		_param3 = make([]bool, len(params[3]))
+		for u, param := range params[3] {
+			_param3[u] = param.(bool)
 		}
 	}
 	return


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Previously we were using the origin remote as the upstream, which works fine if the users fork is correct (i.e. has the branch which is to be updated) but fails if it doesn’t (e.g. a different user runs the command). By switching to the `pull/<ID>/head` remote on the upstream, we’re guaranteed to always be able to do fetch the branch.

We were also always trying to update a PR, regardless of owner, which won’t work.

Finally, we need to handle the case that rebases don’t ignore
empty commits. This seems to only happen in some cases. This patch
adds the ability to look out for those errors and run `git rebase —skip` if they happen.
#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
