### PR TITLE
fix: select install type before checkFlags

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -547,15 +547,16 @@ func (options *InstallOptions) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "getting install configuration")
 	}
-	// Check the provided flags before starting any installation
-	err = options.CheckFlags()
-	if err != nil {
-		return errors.Wrap(err, "checking the provided flags")
-	}
 
 	err = options.selectJenkinsInstallation()
 	if err != nil {
 		return errors.Wrap(err, "selecting the Jenkins installation type")
+	}
+
+	// Check the provided flags before starting any installation
+	err = options.CheckFlags()
+	if err != nil {
+		return errors.Wrap(err, "checking the provided flags")
 	}
 
 	if options.Flags.CloudBeesDomain != "" {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
CheckFlags() is setting up some flags / variables without knowing if the cluster is a static or serverless one, defaulting to wrong values if you want to create a serverless tekton cluster.
We should ask which type of installation the users wants before calling CheckFlags().

#### Special notes for the reviewer(s)
Testing locally installing a new cluster using `jx create cluster gke` then creating a new quickstart.
Without the fix the pipeline was not triggered with the following logs in the pipeline runner:
```{"level":"error","msg":"failed to create effective project configuration: Missing option: --docker-registry failed to create effective project configuration: Missing option: --docker-registry","time":"2019-07-15T09:29:50Z"}```
With this fix, the pipeline is running fine.

#### Which issue this PR fixes

fixes #4557


