### PR TITLE
fix: Ensure we are tracking a remote branch before attempting a pull …

### DIFF
--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -942,3 +942,8 @@ func (g *GitCLI) RebaseTheirs(dir string, upstream string, branch string, skipEm
 func (g *GitCLI) RevParse(dir string, rev string) (string, error) {
 	return g.gitCmdWithOutput(dir, "rev-parse", rev)
 }
+
+// SetUpstreamTo will set the given branch to track the origin branch with the same name
+func (g *GitCLI) SetUpstreamTo(dir string, branch string) error {
+	return g.gitCmd(dir, "branch", "--set-upstream-to", fmt.Sprintf("origin/%s", branch), branch)
+}

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -570,3 +570,8 @@ func (g *GitFake) GetCommits(dir string, startSha string, endSha string) ([]GitC
 func (g *GitFake) RevParse(dir string, rev string) (string, error) {
 	return "", nil
 }
+
+// SetUpstreamTo will set the given branch to track the origin branch with the same name
+func (g *GitFake) SetUpstreamTo(dir string, branch string) error {
+	return nil
+}

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -438,3 +438,8 @@ func (g *GitLocal) GetCommits(dir string, startSha string, endSha string) ([]Git
 func (g *GitLocal) RevParse(dir string, rev string) (string, error) {
 	return g.GitCLI.RevParse(dir, rev)
 }
+
+// SetUpstreamTo will set the given branch to track the origin branch with the same name
+func (g *GitLocal) SetUpstreamTo(dir string, branch string) error {
+	return g.GitCLI.SetUpstreamTo(dir, branch)
+}

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -261,6 +261,8 @@ type Gitter interface {
 	GetRevisionBeforeDate(dir string, t time.Time) (string, error)
 	GetRevisionBeforeDateText(dir string, dateText string) (string, error)
 	DeleteRemoteBranch(dir string, remoteName string, branch string) error
+
+	SetUpstreamTo(dir string, branch string) error
 }
 
 // ConfigureGitFn callback to optionally configure git before its used for creating commits and PRs

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -1169,6 +1169,21 @@ func (mock *MockGitter) SetRemoteURL(_param0 string, _param1 string, _param2 str
 	return ret0
 }
 
+func (mock *MockGitter) SetUpstreamTo(_param0 string, _param1 string) error {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0, _param1}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("SetUpstreamTo", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(error)
+		}
+	}
+	return ret0
+}
+
 func (mock *MockGitter) SetUsername(_param0 string, _param1 string) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -3436,6 +3451,37 @@ func (c *MockGitter_SetRemoteURL_OngoingVerification) GetAllCapturedArguments() 
 		_param2 = make([]string, len(params[2]))
 		for u, param := range params[2] {
 			_param2[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) SetUpstreamTo(_param0 string, _param1 string) *MockGitter_SetUpstreamTo_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "SetUpstreamTo", params, verifier.timeout)
+	return &MockGitter_SetUpstreamTo_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_SetUpstreamTo_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_SetUpstreamTo_OngoingVerification) GetCapturedArguments() (string, string) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+}
+
+func (c *MockGitter_SetUpstreamTo_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(params[0]))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(params[1]))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
 		}
 	}
 	return

--- a/pkg/jenkinsfile/gitresolver/buildpack_test.go
+++ b/pkg/jenkinsfile/gitresolver/buildpack_test.go
@@ -1,0 +1,83 @@
+package gitresolver
+
+import (
+	"github.com/google/uuid"
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildPackInitClone(t *testing.T) {
+	mainRepo, err := ioutil.TempDir("", uuid.New().String())
+	assert.NoError(t, err)
+
+	remoteRepo, err := ioutil.TempDir("", uuid.New().String())
+	assert.NoError(t, err)
+
+	defer func() {
+		err := os.RemoveAll(mainRepo)
+		err2 := os.RemoveAll(remoteRepo)
+		if err != nil || err2 != nil {
+			log.Logger().Errorf("Error cleaning up tmpdirs because %v", err)
+		}
+	}()
+
+	err = os.Setenv("JX_HOME", mainRepo)
+	assert.NoError(t, err)
+	gitDir := mainRepo + "/draft/packs"
+	err = os.MkdirAll(gitDir, 0755)
+	assert.NoError(t, err)
+
+	gitter := gits.NewGitCLI()
+	assert.NoError(t, err)
+
+	// Prepare a git repo to test - this is our "remote"
+	err = gitter.Init(remoteRepo)
+	assert.NoError(t, err)
+
+	readme := "README"
+	initialReadme := "Cheesy!"
+
+	readmePath := filepath.Join(remoteRepo, readme)
+	err = ioutil.WriteFile(readmePath, []byte(initialReadme), 0600)
+	assert.NoError(t, err)
+	err = gitter.Add(remoteRepo, readme)
+	assert.NoError(t, err)
+	err = gitter.CommitDir(remoteRepo, "Initial Commit")
+	assert.NoError(t, err)
+
+	// Prepare another git repo, this is local repo
+	err = gitter.Init(gitDir)
+	assert.NoError(t, err)
+	// Set up the remote
+	err = gitter.AddRemote(gitDir, "origin", remoteRepo)
+	assert.NoError(t, err)
+	err = gitter.FetchBranch(gitDir, "origin", "master")
+	assert.NoError(t, err)
+	err = gitter.Merge(gitDir, "origin/master")
+	assert.NoError(t, err)
+
+	// Removing the remote tracking information, after executing InitBuildPack, it should have not failed and it should've set a remote tracking branch
+	gits.GitCmd(func(s string, i ...int) {}, gitDir, "branch", "--unset-upstream")
+
+	_, err = InitBuildPack(gitter, "", "master")
+
+	gits.GitCmd(func(s string, i ...int) {}, gitDir, "status", "-sb")
+
+	args := []string{"status", "-sb"}
+	cmd := util.Command{
+		Dir:  gitDir,
+		Name: "git",
+		Args: args,
+	}
+	output, err := cmd.RunWithoutRetry()
+	assert.NoError(t, err, "it should not fail to pull from the branch as remote tracking information has been set")
+
+	// Check the current branch is tracking the origin/master one
+	assert.Equal(t, "## master...origin/master", output)
+}


### PR DESCRIPTION
fix: Ensure we are tracking a remote branch before attempting a pull build packs

Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
In both #3897  and #4001 users reported an error when pulling the buildpacks repository.

Upon investigation and after trying to reproduce the error, the conclusion reached is that the old clone function was sometimes cloning some repositories without setting a remote branch to track so it failed when a `git pull` was attempted.

The fix should attempt to fetch `origin`, checkout to the correct local branch and perform a `git branch --set-upstream-to=origin/<branch>` in order to set tracking information so the `git pull` doesn't 

#### Which issue this PR fixes

fixes #3897
fixes #4001

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
