### PR TITLE
fix: Added Azure command line flag to allow specifying an Azure subscription id

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -99,6 +99,7 @@ type InstallFlags struct {
 	Domain                      string
 	ExposeControllerURLTemplate string
 	ExposeControllerPathMode    string
+	AzureRegistrySubscription   string
 	DockerRegistry              string
 	DockerRegistryOrg           string
 	Provider                    string
@@ -363,6 +364,7 @@ func (options *InstallOptions) AddInstallFlags(cmd *cobra.Command, includesInit 
 	cmd.Flags().BoolVarP(&flags.CleanupTempFiles, "cleanup-temp-files", "", true, "Cleans up any temporary values.yaml used by helm install [default true]")
 	cmd.Flags().BoolVarP(&flags.HelmTLS, "helm-tls", "", false, "Whether to use TLS with helm")
 	cmd.Flags().BoolVarP(&flags.InstallOnly, "install-only", "", false, "Force the install command to fail if there is already an installation. Otherwise lets update the installation")
+	cmd.Flags().StringVarP(&flags.AzureRegistrySubscription, "azure-acr-subscription", "", "", "The Azure subscription under which the specified docker-registry is located")
 	cmd.Flags().StringVarP(&flags.DockerRegistry, "docker-registry", "", "", "The Docker Registry host or host:port which is used when tagging and pushing images. If not specified it defaults to the internal registry unless there is a better provider default (e.g. ECR on AWS/EKS)")
 	cmd.Flags().StringVarP(&flags.DockerRegistryOrg, "docker-registry-org", "", "", "The Docker Registry organiation/user to create images inside. On GCP this is typically your Google Project ID.")
 	cmd.Flags().StringVarP(&flags.ExposeControllerURLTemplate, "exposecontroller-urltemplate", "", "", "The ExposeController urltemplate for how services should be exposed as URLs. Defaults to being empty, which in turn defaults to \"{{.Service}}.{{.Namespace}}.{{.Domain}}\".")
@@ -2067,7 +2069,7 @@ func (options *InstallOptions) configureCloudProviderRegistry(client kubernetes.
 			return "", "", errors.Wrap(err, "getting cluster from Azure")
 		}
 		registryID := ""
-		config, dockerRegistry, registryID, err := azureCLI.GetRegistry(resourceGroup, name, dockerRegistry)
+		config, dockerRegistry, registryID, err := azureCLI.GetRegistry(options.Flags.AzureRegistrySubscription, resourceGroup, name, dockerRegistry)
 		if err != nil {
 			return "", "", errors.Wrap(err, "getting registry configuration from Azure")
 		}


### PR DESCRIPTION
Added Azure command line flag to allow specifying an Azure subscription id for the Azure container registry as existing implementation assumed a shared subscription by both Azure Kubernetes Service and Azure Container Registry

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

It's not an uncommon occurrence for Azure container registry to be housed in a separate subscription from the Azure Kubernetes Service. Currently the existing code assumes they both live under whatever subscription the `az` cli is currently set to i.e. `az account show`. In order to allow installation to proceed with ACR (Azure Container Registry) housed under a different subscription to AKS I've introduced a new CLI install flag to specify the ACR subscription id. This is used in several places to 

- Specify which subscription to query the existing ACR from
- Specify which subscription to get the registry credentials for ACR from
- In the case of a new ACR setup it will specify the subscription under which to create the new ACR.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #4719 

