### PR TITLE
feat(tekton): Add support for specifying volumes to add to stage pods

### DIFF
--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -315,6 +315,14 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			kind:         "release",
 			useKaniko:    false,
 		},
+		{
+			name:         "volume-in-overrides",
+			language:     "maven",
+			repoName:     "jx-demo-qs",
+			organization: "abayer",
+			branch:       "master",
+			kind:         "release",
+		},
 	}
 
 	k8sObjects := []runtime.Object{

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/jenkins-x.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/jenkins-x.yml
@@ -1,0 +1,20 @@
+pipelineConfig:
+  env:
+    - name: FRUIT
+      value: BANANA
+    - name: GIT_AUTHOR_NAME
+      value: somebodyelse
+  pipelines:
+    overrides:
+      # Add a volume and mount it
+      - pipeline: release
+        stage: build
+        volumes:
+          - name: top-level-volume
+            persistentVolumeClaim:
+              claimName: top-level-volume
+              readOnly: true
+        containerOptions:
+          volumeMounts:
+            - mountPath: /some/path
+              name: top-level-volume

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipeline.yml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: master
+    build: "1"
+    owner: abayer
+    repository: jx-demo-qs
+  name: abayer-jx-demo-qs-master-1
+  namespace: jx
+spec:
+  params:
+  - default: 0.0.1
+    description: the version number for this pipeline which is used as a tag on docker
+      images and helm charts
+    name: version
+  resources:
+  - name: abayer-jx-demo-qs-master
+    type: git
+  tasks:
+  - name: from-build-pack
+    params:
+    - name: version
+      value: ${params.version}
+    resources:
+      inputs:
+      - name: workspace
+        resource: abayer-jx-demo-qs-master
+    retries: 0
+    taskRef:
+      name: abayer-jx-demo-qs-master-from-build-pack-1
+status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelineresources.yml
@@ -1,0 +1,15 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    creationTimestamp: null
+    name: abayer-jx-demo-qs-master
+  spec:
+    params:
+    - name: revision
+      value: v0.0.1
+    - name: url
+      value: https://github.com/abayer/jx-demo-qs
+    type: git
+  status: {}
+metadata: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelinerun.yml
@@ -1,0 +1,27 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: master
+    build: "1"
+    owner: abayer
+    repository: jx-demo-qs
+  name: abayer-jx-demo-qs-master-1
+spec:
+  params:
+  - name: version
+    value: 0.0.1
+  pipelineRef:
+    apiVersion: tekton.dev/v1alpha1
+    name: abayer-jx-demo-qs-master-1
+  resources:
+  - name: abayer-jx-demo-qs-master
+    resourceRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: abayer-jx-demo-qs-master
+  serviceAccount: tekton-bot
+  timeout: 240h0m0s
+  trigger:
+    type: manual
+status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/structure.yml
@@ -1,0 +1,14 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: master
+    build: "1"
+    owner: abayer
+    repository: jx-demo-qs
+  name: abayer-jx-demo-qs-master-1
+pipelineRef: null
+pipelineRunRef: null
+stages:
+- depth: 0
+  name: from-build-pack
+  taskRef: abayer-jx-demo-qs-master-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
@@ -1,0 +1,433 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: null
+    labels:
+      branch: master
+      build: "1"
+      jenkins.io/task-stage-name: from-build-pack
+      owner: abayer
+      repository: jx-demo-qs
+    name: abayer-jx-demo-qs-master-from-build-pack-1
+    namespace: jx
+  spec:
+    inputs:
+      params:
+      - default: 0.0.1
+        description: the version number for this pipeline which is used as a tag on
+          docker images and helm charts
+        name: version
+      resources:
+      - name: workspace
+        targetPath: source
+        type: git
+    steps:
+    - args:
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - jx
+      env:
+      - name: FRUIT
+        value: BANANA
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: APP_NAME
+        value: jx-demo-qs
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-jx:0.1.527
+      name: git-merge
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /some/path
+        name: top-level-volume
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - jx step git credentials
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: APP_NAME
+        value: jx-demo-qs
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: setup-jx-git-credentials
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /some/path
+        name: top-level-volume
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - jx step changelog --version v${VERSION}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: APP_NAME
+        value: jx-demo-qs
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: promote-changelog
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /some/path
+        name: top-level-volume
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source/charts/jx-demo-qs
+    - args:
+      - jx step helm release
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: APP_NAME
+        value: jx-demo-qs
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: promote-helm-release
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /some/path
+        name: top-level-volume
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source/charts/jx-demo-qs
+    - args:
+      - jx promote -b --all-auto --timeout 1h --version ${VERSION}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: jx-demo-qs
+      - name: JOB_NAME
+        value: abayer/jx-demo-qs/master
+      - name: APP_NAME
+        value: jx-demo-qs
+      - name: BRANCH_NAME
+        value: master
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-maven-java11:0.1.235
+      name: promote-jx-promote
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /some/path
+        name: top-level-volume
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source/charts/jx-demo-qs
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: top-level-volume
+      persistentVolumeClaim:
+        claimName: top-level-volume
+        readOnly: true
+    - name: volume-0
+      secret:
+        secretName: jenkins-maven-settings
+    - name: volume-1
+      secret:
+        secretName: jenkins-docker-cfg
+    - name: volume-2
+      secret:
+        secretName: jenkins-release-gpg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+metadata: {}

--- a/pkg/cmd/step/syntax/step_syntax_effective.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective.go
@@ -379,11 +379,6 @@ func (o *StepSyntaxEffectiveOptions) createPipelineForKind(kind string, lifecycl
 
 	if lifecycles != nil && lifecycles.Pipeline != nil {
 		parsed = lifecycles.Pipeline
-		for _, override := range pipelines.Overrides {
-			if override.MatchesPipeline(kind) {
-				parsed = syntax.ExtendParsedPipeline(parsed, override)
-			}
-		}
 	} else {
 		args := jenkinsfile.CreatePipelineArguments{
 			Lifecycles:        lifecycles,
@@ -420,6 +415,12 @@ func (o *StepSyntaxEffectiveOptions) createPipelineForKind(kind string, lifecycl
 			return nil, errors.Wrapf(err, "Could not merge containerOptions from parent")
 		}
 		parsed.Options.ContainerOptions = mergedContainer
+	}
+
+	for _, override := range pipelines.Overrides {
+		if override.MatchesPipeline(kind) {
+			parsed = syntax.ExtendParsedPipeline(parsed, override)
+		}
 	}
 
 	// TODO: Seeing weird behavior seemingly related to https://golang.org/doc/faq#nil_error

--- a/pkg/jenkinsfile/pipeline.go
+++ b/pkg/jenkinsfile/pipeline.go
@@ -689,7 +689,7 @@ func ExtendPipelines(pipelineName string, parent, base *PipelineLifecycles, over
 	for _, override := range overrides {
 		if override.MatchesPipeline(pipelineName) {
 			// If no name, stage, or agent is specified, remove the whole pipeline.
-			if override.Name == "" && override.Stage == "" && override.Agent == nil {
+			if override.Name == "" && override.Stage == "" && override.Agent == nil && override.ContainerOptions == nil && len(override.Volumes) == 0 {
 				return &PipelineLifecycles{}
 			}
 

--- a/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
+++ b/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
@@ -159,6 +159,29 @@ func PipelineOptions(ops ...PipelineOptionsOp) PipelineOp {
 	}
 }
 
+// PipelineVolume adds a volume to the RootOptions for the pipeline
+func PipelineVolume(volume *corev1.Volume) PipelineOptionsOp {
+	return func(options *syntax.RootOptions) {
+		if options.Volumes == nil {
+			options.Volumes = []*corev1.Volume{}
+		}
+		options.Volumes = append(options.Volumes, volume)
+	}
+}
+
+// StageVolume adds a volume to the StageOptions for the stage
+func StageVolume(volume *corev1.Volume) StageOptionsOp {
+	return func(options *syntax.StageOptions) {
+		if options.RootOptions == nil {
+			options.RootOptions = &syntax.RootOptions{}
+		}
+		if options.Volumes == nil {
+			options.Volumes = []*corev1.Volume{}
+		}
+		options.Volumes = append(options.Volumes, volume)
+	}
+}
+
 // PipelineContainerOptions sets the containerOptions for the pipeline
 func PipelineContainerOptions(ops ...builder.ContainerOp) PipelineOptionsOp {
 	return func(options *syntax.RootOptions) {

--- a/pkg/tekton/syntax/test_data/validation_failures/volume_missing_name/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/volume_missing_name/jenkins-x.yml
@@ -1,0 +1,17 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        options:
+          volumes:
+            - name: ""
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such

--- a/pkg/tekton/syntax/test_data/volumes/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/volumes/jenkins-x.yml
@@ -1,0 +1,25 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        options:
+          volumes:
+            - name: top-level-volume
+              persistentVolumeClaim:
+                claimName: top-level-volume
+                readOnly: true
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            options:
+              volumes:
+                - name: stage-level-volume
+                  gcePersistentDisk:
+                    pdName: stage-level-volume
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such

--- a/pkg/tekton/syntax/zz_generated.deepcopy.go
+++ b/pkg/tekton/syntax/zz_generated.deepcopy.go
@@ -245,6 +245,18 @@ func (in *RootOptions) DeepCopyInto(out *RootOptions) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]*v1.Volume, len(*in))
+		for i := range *in {
+			if (*in)[i] == nil {
+				(*out)[i] = nil
+			} else {
+				(*out)[i] = new(v1.Volume)
+				(*in)[i].DeepCopyInto((*out)[i])
+			}
+		}
+	}
 	return
 }
 

--- a/pkg/tekton/syntax/zz_generated.deepcopy.go
+++ b/pkg/tekton/syntax/zz_generated.deepcopy.go
@@ -165,6 +165,27 @@ func (in *PipelineOverride) DeepCopyInto(out *PipelineOverride) {
 			**out = **in
 		}
 	}
+	if in.ContainerOptions != nil {
+		in, out := &in.ContainerOptions, &out.ContainerOptions
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Container)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]*v1.Volume, len(*in))
+		for i := range *in {
+			if (*in)[i] == nil {
+				(*out)[i] = nil
+			} else {
+				(*out)[i] = new(v1.Volume)
+				(*in)[i].DeepCopyInto((*out)[i])
+			}
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This will allow pipeline authors to add existing volumes to the pods created for their stages, which can then be mounted via `containerOptions`. Note that this will result in errors for volumes that don't exist, and could cause problems, depending on the volume's configuration, with parallel stages using the same volume.

Docs PR: https://github.com/jenkins-x/jx-docs/pull/1776

#### Special notes for the reviewer(s)

/assign @hferentschik 
/assign @dwnusbaum 
cc @tdcox 

#### Which issue this PR fixes

fixes #4665
