### PR TITLE
chore: Refactor step boot to contain base command

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	defaultBootRepository          = "https://github.com/jenkins-x/jenkins-x-boot-config.git"
-	defaultCloudBeesBootRepository = "https://github.com/cloudbees/cloudbees-jenkins-x-boot-config"
+	defaultCloudBeesBootRepository = "https://github.com/cloudbees/cloudbees-jenkins-x-boot-config.git"
 )
 
 // BootOptions options for the command

--- a/pkg/cmd/step.go
+++ b/pkg/cmd/step.go
@@ -42,8 +42,7 @@ func NewCmdStep(commonOpts *opts.CommonOptions) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(boot.NewCmdStepBootUpgrade(commonOpts))
-	cmd.AddCommand(boot.NewCmdStepBootVault(commonOpts))
+	cmd.AddCommand(boot.NewCmdStepBoot(commonOpts))
 	cmd.AddCommand(buildpack.NewCmdStepBuildPack(commonOpts))
 	cmd.AddCommand(NewCmdStepBDD(commonOpts))
 	cmd.AddCommand(e2e.NewCmdStepE2E(commonOpts))

--- a/pkg/cmd/step/boot/step_boot.go
+++ b/pkg/cmd/step/boot/step_boot.go
@@ -1,0 +1,41 @@
+package boot
+
+import (
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/spf13/cobra"
+)
+
+// StepBootOptions contains the command line flags
+type StepBootOptions struct {
+	opts.StepOptions
+}
+
+// NewCmdStepBoot Steps a command object for the "step" command
+func NewCmdStepBoot(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := &StepBootOptions{
+		StepOptions: opts.StepOptions{
+			CommonOptions: commonOpts,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "boot",
+		Short:   "boot [command]",
+		Aliases: []string{},
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+	cmd.AddCommand(NewCmdStepBootUpgrade(commonOpts))
+	cmd.AddCommand(NewCmdStepBootVault(commonOpts))
+	return cmd
+}
+
+// Run implements this command
+func (o *StepBootOptions) Run() error {
+	return o.Cmd.Help()
+}

--- a/pkg/cmd/step/boot/step_boot_upgrade.go
+++ b/pkg/cmd/step/boot/step_boot_upgrade.go
@@ -42,7 +42,7 @@ func NewCmdStepBootUpgrade(commonOpts *opts.CommonOptions) *cobra.Command {
 		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
-		Use:     "boot upgrade",
+		Use:     "upgrade",
 		Short:   "This step checks the version stream for updates to jenkins-x charts",
 		Long:    stepBootUpgradeLong,
 		Example: stepBootUpgradeExample,

--- a/pkg/cmd/step/boot/step_boot_vault.go
+++ b/pkg/cmd/step/boot/step_boot_vault.go
@@ -49,7 +49,7 @@ func NewCmdStepBootVault(commonOpts *opts.CommonOptions) *cobra.Command {
 		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
-		Use:     "boot vault",
+		Use:     "vault",
 		Short:   "This step boots up Vault in the current cluster if its enabled in the 'jx-requirements.yml' file and is not already installed",
 		Long:    stepBootVaultLong,
 		Example: stepBootVaultExample,


### PR DESCRIPTION
Fixes a clash with `jx step boot vault` and `jx step boot upgrade`

Signed-off-by: David Conde <dconde@cloudbees.com>