### PR TITLE
fix: jx import does not respect --git-username and --git-api-token

### DIFF
--- a/pkg/auth/auth_config.go
+++ b/pkg/auth/auth_config.go
@@ -356,13 +356,15 @@ func (c *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defaultUse
 			return err
 		}
 	}
-	if fn != nil {
-		err := fn(auth.Username)
-		if err != nil {
-			return err
+	if auth.ApiToken == "" {
+		if fn != nil {
+			err := fn(auth.Username)
+			if err != nil {
+				return err
+			}
 		}
+		auth.ApiToken, err = util.PickPassword("API Token:", "", in, out, outErr)
 	}
-	auth.ApiToken, err = util.PickPassword("API Token:", "", in, out, outErr)
 	return err
 }
 

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -251,6 +251,9 @@ func (options *ImportOptions) Run() error {
 
 		if options.UseDefaultGit {
 			userAuth = config.CurrentUser(server, options.CommonOptions.InCluster())
+		} else if options.GitRepositoryOptions.Username != "" {
+			userAuth = config.GetOrCreateUserAuth(server.URL, options.GitRepositoryOptions.Username)
+			log.Logger().Infof("Using Git user name: %s", options.GitRepositoryOptions.Username)
 		} else {
 			// Get the org in case there is more than one user auth on the server and batchMode is true
 			org := options.getOrganisationOrCurrentUser()
@@ -270,7 +273,10 @@ func (options *ImportOptions) Run() error {
 				options.Git().PrintCreateRepositoryGenerateAccessToken(server, username, options.Out)
 				return nil
 			}
-			err = config.EditUserAuth(server.Label(), userAuth, userAuth.Username, true, options.BatchMode, f, options.In, options.Out, options.Err)
+			if options.GitRepositoryOptions.ApiToken != "" {
+				userAuth.ApiToken = options.GitRepositoryOptions.ApiToken
+			}
+			err = config.EditUserAuth(server.Label(), userAuth, userAuth.Username, false, options.BatchMode, f, options.In, options.Out, options.Err)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Run command line below and found --git-username and --git-api-token doesn't work:
"jx import --git-username='sonyafenge' --git-api-token='**************************'"

#### Special notes for the reviewer(s)
- updated 'pkg/cmd/importcmd/import.go':
        if options.GitRepositoryOptions.Username existing,  use this name to get userAuth; if not, then ask user to input.
        if options.GitRepositoryOptions.ApiToken existing, grant this ApiToken to userAuth;
- updated 'pkg/auth/auth_config.go':
       only request user input when userAuth.ApiToken == ""


#### Which issue this PR fixes

fixes #4752 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
