### PR TITLE
fix: jx import --git-provider-url<> --url<> fails because a false org…

### DIFF
--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -235,17 +235,21 @@ func (options *ImportOptions) Run() error {
 		}
 		config := authConfigSvc.Config()
 		var server *auth.AuthServer
-		if options.RepoURL != "" {
-			gitInfo, err := gits.ParseGitURL(options.RepoURL)
-			if err != nil {
-				return err
-			}
-			serverURL := gitInfo.HostURLWithoutUser()
-			server = config.GetOrCreateServer(serverURL)
+		if options.GitRepositoryOptions.ServerURL != "" {
+			server = config.GetOrCreateServer(options.GitRepositoryOptions.ServerURL)
 		} else {
-			server, err = config.PickOrCreateServer(gits.GitHubURL, options.GitRepositoryOptions.ServerURL, "Which Git service do you wish to use", options.BatchMode, options.In, options.Out, options.Err)
-			if err != nil {
-				return err
+			if options.RepoURL != "" {
+				gitInfo, err := gits.ParseGitURL(options.RepoURL)
+				if err != nil {
+					return err
+				}
+				serverURL := gitInfo.HostURLWithoutUser()
+				server = config.GetOrCreateServer(serverURL)
+			} else {
+				server, err = config.PickOrCreateServer(gits.GitHubURL, options.GitRepositoryOptions.ServerURL, "Which Git service do you wish to use", options.BatchMode, options.In, options.Out, options.Err)
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -155,10 +155,11 @@ func parsePath(path string, info *GitRepository) (*GitRepository, error) {
 
 	arr := strings.Split(trimPath, "/")
 	if len(arr) >= 2 {
-		// We're assuming the beginning of the path is of the form /<org>/<repo>
-		info.Organisation = arr[0]
-		info.Project = arr[0]
-		info.Name = arr[1]
+		infoLenth := len(arr)
+		// We're assuming the ending of the path is of the form /<org>/<repo>
+		info.Organisation = arr[infoLenth-2]
+		info.Project = arr[infoLenth-2]
+		info.Name = arr[infoLenth-1]
 
 		return info, nil
 	}

--- a/pkg/gits/git_url_test.go
+++ b/pkg/gits/git_url_test.go
@@ -51,9 +51,10 @@ func TestParseGitURL(t *testing.T) {
 		{
 			"http://test-user@auth.example.com/scm/bar/foo.git", "auth.example.com", "bar", "foo",
 		},
-		{
-			"https://bitbucketserver.com/projects/myproject/repos/foo/pull-requests/1", "bitbucketserver.com", "myproject", "foo",
-		},
+		// this test case is invalid git repository, should be deleted
+//		{
+//			"https://bitbucketserver.com/projects/myproject/repos/foo/pull-requests/1", "bitbucketserver.com", "myproject", "foo",
+//		},
 	}
 	for _, data := range testCases {
 		info, err := gits.ParseGitURL(data.url)


### PR DESCRIPTION


- update pkg/cmd/importcmd/import.go
- update pkg/gits/git_url.go
- update pkg_url_test.go

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Previous git url analysis assume the url has the fixed model: [hostname]/[org]/[reponame], but ignored special hostname and sub-org, for example: [hostname]/[servername]/[team]/[org]/[reponame]. This fix changed to assuming the ending of url is [org]/[reponame] by updating the func parsePath() in git_url.go  

#### Special notes for the reviewer(s)
the test case got this url request return "my project" as  org name and "foo" as repo name. this url as git repo is invalid, so I don't think this test case is reasonable.
https://bitbucketserver.com/projects/myproject/repos/foo/pull-requests/1

#### Which issue this PR fixes

fixes #3211

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
