### PR TITLE
fix: Push jenkinsxio/jx:VERSION to docker.io, not gcr.io

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -134,7 +134,7 @@ pipelineConfig:
               - name: build-and-push-image
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:${inputs.params.version}','--context=/workspace/source','--cache-dir=/workspace']
+                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=docker.io/jenkinsxio/jx:${inputs.params.version}','--context=/workspace/source','--cache-dir=/workspace']
 
               - name: release-charts
                 image: gcr.io/jenkinsxio/builder-go:0.1.576


### PR DESCRIPTION
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This got changed inadvertently and overlooked, so now `controllerworkflow` can't start, because it's using `jenkinsxio/jx:VERSION`, not `gcr.io/jenkinsxio/jx:VERSION`. So...let's roll that back to push to docker.io. Figured this out due to failures on https://github.com/jenkins-x/jenkins-x-versions/pull/331.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a