### PR TITLE
fix: Allow updating multiple charts in a single `jx step create pr chart`

### DIFF
--- a/pkg/cmd/step/create/pr/step_create_pr_chart.go
+++ b/pkg/cmd/step/create/pr/step_create_pr_chart.go
@@ -33,7 +33,7 @@ var (
 type StepCreatePullRequestChartsOptions struct {
 	StepCreatePrOptions
 
-	Name string
+	Names []string
 }
 
 // NewCmdStepCreatePullRequestChart Creates a new Command object
@@ -62,7 +62,7 @@ func NewCmdStepCreatePullRequestChart(commonOpts *opts.CommonOptions) *cobra.Com
 		},
 	}
 	AddStepCreatePrFlags(cmd, &options.StepCreatePrOptions)
-	cmd.Flags().StringVarP(&options.Name, "name", "n", "", "The name of the property to update")
+	cmd.Flags().StringArrayVarP(&options.Names, "name", "n", make([]string, 0), "The name of the property to update")
 	return cmd
 }
 
@@ -71,7 +71,7 @@ func (o *StepCreatePullRequestChartsOptions) ValidateChartsOptions() error {
 	if err := o.ValidateOptions(); err != nil {
 		return errors.WithStack(err)
 	}
-	if o.Name == "" {
+	if len(o.Names) == 0 {
 		return util.MissingOption("name")
 	}
 	if o.SrcGitURL == "" {
@@ -97,7 +97,9 @@ func (o *StepCreatePullRequestChartsOptions) Run() error {
 					if err != nil {
 						return errors.Wrapf(err, "loading %s", path)
 					}
-					oldVersions = append(oldVersions, helm.UpdateRequirementsToNewVersion(requirements, o.Name, o.Version)...)
+					for _, name := range o.Names {
+						oldVersions = append(oldVersions, helm.UpdateRequirementsToNewVersion(requirements, name, o.Version)...)
+					}
 					err = helm.SaveFile(path, *requirements)
 					if err != nil {
 						return errors.Wrapf(err, "saving %s", path)
@@ -107,18 +109,21 @@ func (o *StepCreatePullRequestChartsOptions) Run() error {
 					if err != nil {
 						return errors.Wrapf(err, "reading %s", path)
 					}
-					re, err := regexp.Compile(fmt.Sprintf(`(?m)^\s*Image: %s:(.*)$`, o.Name))
-					if err != nil {
-						return errors.WithStack(err)
-					}
-					newValues := util.ReplaceAllStringSubmatchFunc(re, string(values), func(groups []util.Group) []string {
-						answer := make([]string, 0)
-						for i := range groups {
-							oldVersions = append(oldVersions, groups[i].Value)
-							answer = append(answer, o.Version)
+					newValues := string(values)
+					for _, name := range o.Names {
+						re, err := regexp.Compile(fmt.Sprintf(`(?m)^\s*Image: %s:(.*)$`, name))
+						if err != nil {
+							return errors.WithStack(err)
 						}
-						return answer
-					})
+						newValues = util.ReplaceAllStringSubmatchFunc(re, newValues, func(groups []util.Group) []string {
+							answer := make([]string, 0)
+							for i := range groups {
+								oldVersions = append(oldVersions, groups[i].Value)
+								answer = append(answer, o.Version)
+							}
+							return answer
+						})
+					}
 					err = ioutil.WriteFile(path, []byte(newValues), info.Mode())
 					if err != nil {
 						return errors.Wrapf(err, "writing %s", path)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This helps with #4771 (though I don't think it fixes _everything_, since we still end up making changes to the PR for each `jx step create pr ...` call rather than batching all those changes into one push), so I think it's worth doing on its own.

Not sure how to test this without writing a full-on test framework for `jx step create pr ...`, which we obviously do need to do, but that's a followup IMO.

#### Special notes for the reviewer(s)

/assign @daveconde 
/assign @pmuir 
/assign @cagiti 

#### Which issue this PR fixes

n/a