### PR TITLE
fix: create/delete addon envctl functions to handle namespaces

### DIFF
--- a/pkg/cmd/create/create_addon_environment_controller.go
+++ b/pkg/cmd/create/create_addon_environment_controller.go
@@ -24,17 +24,18 @@ import (
 
 const (
 	DefaultEnvCtrlReleaseName = "jxet"
+	DefaultEnvCtrlNamespace   = "jx"
 )
 
 var (
 	createAddonEnvironmentControllerLong = templates.LongDesc(`
-		Create an Environment Controller to handle webhooks and promote changes from GitOps 
+		Create an Environment Controller to handle webhooks and promote changes from GitOps
 `)
 
 	createAddonEnvironmentControllerExample = templates.Examples(`
 		# Creates the environment controller using a specific environment git repository, project, git user, chart repo
 		jx create addon envctl -s https://github.com/myorg/env-production.git --project-id myproject --docker-registry gcr.io --cluster-rbac true --user mygituser --token mygittoken
-		
+
 	`)
 )
 
@@ -269,7 +270,7 @@ func (o *CreateAddonEnvironmentControllerOptions) Run() error {
 		Chart:          "environment-controller",
 		ReleaseName:    o.ReleaseName,
 		Version:        o.Version,
-		Ns:             ns,
+		Ns:             o.Namespace,
 		SetValues:      setValues,
 		HelmUpdate:     true,
 		Repository:     kube.DefaultChartMuseumURL,

--- a/pkg/cmd/deletecmd/delete_addon_environment_controller.go
+++ b/pkg/cmd/deletecmd/delete_addon_environment_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -16,8 +17,8 @@ var (
 `)
 
 	deleteAddonEnvironmentControllerExample = templates.Examples(`
-		# Deletes the environment controller 
-		jx delete addon envctl 
+		# Deletes the environment controller
+		jx delete addon envctl
 	`)
 )
 
@@ -26,6 +27,7 @@ type DeleteAddonEnvironmentControllerOptions struct {
 	DeleteAddonOptions
 
 	ReleaseName string
+	Namespace   string
 }
 
 // NewCmdDeleteAddonEnvironmentController creates a command object for the "create" command
@@ -51,6 +53,7 @@ func NewCmdDeleteAddonEnvironmentController(commonOpts *opts.CommonOptions) *cob
 	}
 
 	cmd.Flags().StringVarP(&options.ReleaseName, opts.OptionRelease, "r", create.DefaultEnvCtrlReleaseName, "The chart release name")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", create.DefaultEnvCtrlNamespace, "The Namespace to delete from")
 	options.addFlags(cmd)
 	return cmd
 }
@@ -62,9 +65,9 @@ func (o *DeleteAddonEnvironmentControllerOptions) Run() error {
 	if o.ReleaseName == "" {
 		return util.MissingOption(opts.OptionRelease)
 	}
-	err := o.DeleteChart(o.ReleaseName, o.Purge)
+	err := o.Helm().DeleteRelease(o.Namespace, o.ReleaseName, o.Purge)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Failed to delete environment-controller chart")
 	}
 	log.Logger().Infof("Addon %s deleted successfully", util.ColorInfo(o.ReleaseName))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
`jx create addon envctl -n jx` would ignore the namespace flag and install the environment-controller chart into the `default` namespace. Additional edits were made to the delete command in order to handle deletion of chart in namespace other than `default`.

#### Which issue this PR fixes

fixes #4739

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
