### PR TITLE
feat: create production environment while running bdd tests

### DIFF
--- a/pkg/cmd/step_bdd.go
+++ b/pkg/cmd/step_bdd.go
@@ -592,8 +592,7 @@ func (o *StepBDDOptions) createCluster(cluster *bdd.CreateCluster) error {
 
 			// lets ensure that there's git repositories setup
 			o.ensureTestEnvironmentRepoSetup(requirements, "staging")
-			// TODO lets not do production just yet to avoid making too many git repos on github.com
-			//ensureTestEnvironmentRepoSetup(requirements, "production")
+			o.ensureTestEnvironmentRepoSetup(requirements, "production")
 
 			err = requirements.SaveConfig(requirementsFile)
 			if err != nil {


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
This will create both staging and production environments while running bdd tests. We can remove the repositories when tests end successfully instead of skipping the production environment. We have too many repositories created for bdd tests that we should remove anyway.

#### Special notes for the reviewer(s)


