### PR TITLE
fix: use current cluster in jx boot

### DIFF
--- a/pkg/cloud/gke/helper.go
+++ b/pkg/cloud/gke/helper.go
@@ -4,6 +4,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/jenkins-x/jx/pkg/util"
 )
 
@@ -139,4 +141,13 @@ func GetGoogleMachineTypes() []string {
 		"n1-highcpu-64",
 		"n1-highcpu-96",
 	}
+}
+
+// ParseContext parses the context string for GKE and gets the GKE project, GKE zone and cluster name
+func ParseContext(context string) (string, string, string, error) {
+	parts := strings.Split(context, "_")
+	if len(parts) != 4 {
+		return "", "", "", errors.Errorf("unable to parse %s as <project id>_<zone>_<cluster name>", context)
+	}
+	return parts[1], parts[2], parts[3], nil
 }

--- a/pkg/cloud/gke/helper_test.go
+++ b/pkg/cloud/gke/helper_test.go
@@ -1,0 +1,65 @@
+package gke_test
+
+import (
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/cloud/gke"
+)
+
+func TestParseContext(t *testing.T) {
+	type args struct {
+		context string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   string
+		want2   string
+		wantErr bool
+	}{
+		{
+			name: "facelie",
+			args: args{
+				context: "gke_apps-dev-229310_europe-west1-b_facelie",
+			},
+			want:  "apps-dev-229310",
+			want1: "europe-west1-b",
+			want2: "facelie",
+		},
+		{
+			name: "tekton-mole",
+			args: args{
+				context: "gke_jenkins-x-infra_europe-west1-c_tekton-mole",
+			},
+			want:  "jenkins-x-infra",
+			want1: "europe-west1-c",
+			want2: "tekton-mole",
+		},
+		{
+			name: "malformed",
+			args: args{
+				context: "gke_jenkins_x_infra_europe-west1-c_tekton-mole",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, got2, err := gke.ParseContext(tt.args.context)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseContext() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseContext() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("ParseContext() got1 = %v, want %v", got1, tt.want1)
+			}
+			if got2 != tt.want2 {
+				t.Errorf("ParseContext() got2 = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}

--- a/pkg/cmd/create/create_cluster_gke.go
+++ b/pkg/cmd/create/create_cluster_gke.go
@@ -214,7 +214,7 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 
 	projectId := o.Flags.ProjectId
 	if projectId == "" {
-		projectId, err = o.GetGoogleProjectId()
+		projectId, err = o.GetGoogleProjectID("")
 		if err != nil {
 			return err
 		}
@@ -304,7 +304,7 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 					return err
 				}
 			} else {
-				zone, err = o.GetGoogleZone(projectId)
+				zone, err = o.GetGoogleZone(projectId, "")
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/create/create_domain_gke.go
+++ b/pkg/cmd/create/create_domain_gke.go
@@ -1,11 +1,12 @@
 package create
 
 import (
+	"strings"
+
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -75,7 +76,7 @@ func (o *DomainGKEOptions) Run() error {
 		if o.BatchMode {
 			return errors.Wrapf(err, "please provide a Google Project ID using --%s  when running in batch mode", ProjectID)
 		}
-		o.ProjectID, err = o.GetGoogleProjectId()
+		o.ProjectID, err = o.GetGoogleProjectID("")
 		if err != nil {
 			return errors.Wrap(err, "while trying to get Google Project ID")
 		}

--- a/pkg/cmd/create/create_vault.go
+++ b/pkg/cmd/create/create_vault.go
@@ -2,9 +2,10 @@ package create
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/jenkins-x/jx/pkg/cmd/opts/upgrade"
 	"github.com/jenkins-x/jx/pkg/config"
-	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
@@ -243,7 +244,7 @@ func (o *CreateVaultOptions) createVaultGKE(vaultOperatorClient versioned.Interf
 	}
 
 	if o.GKEProjectID == "" {
-		o.GKEProjectID, err = o.GetGoogleProjectId()
+		o.GKEProjectID, err = o.GetGoogleProjectID("")
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -34,15 +34,15 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"github.com/Pallinder/go-randomdata"
+	randomdata "github.com/Pallinder/go-randomdata"
 	"github.com/jenkins-x/jx/pkg/io/secrets"
 	kubevault "github.com/jenkins-x/jx/pkg/kube/vault"
 	"github.com/jenkins-x/jx/pkg/vault"
 
-	"github.com/jenkins-x/jx/pkg/apis/jenkins.io"
+	jenkinsio "github.com/jenkins-x/jx/pkg/apis/jenkins.io"
 
 	"github.com/jenkins-x/jx/pkg/addon"
-	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/cloud/aks"
 	"github.com/jenkins-x/jx/pkg/cloud/amazon"
@@ -59,8 +59,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/src-d/go-git.v4"
+	survey "gopkg.in/AlecAivazis/survey.v1"
+	git "gopkg.in/src-d/go-git.v4"
 	core_v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2237,7 +2237,7 @@ func (options *InstallOptions) ConfigureKaniko() error {
 			}
 		}
 		if projectID == "" {
-			projectID, err = options.GetGoogleProjectId()
+			projectID, err = options.GetGoogleProjectID("")
 			if err != nil {
 				return errors.Wrap(err, "getting the GCP project ID")
 			}
@@ -2508,7 +2508,7 @@ func (options *InstallOptions) ensureGKEInstallValuesAreFilled() error {
 	}
 
 	if options.installValues[kube.Zone] == "" {
-		gcpCurrentZone, err := options.GetGoogleZone(options.installValues[kube.ProjectID])
+		gcpCurrentZone, err := options.GetGoogleZone(options.installValues[kube.ProjectID], "")
 		if err != nil {
 			return errors.Wrap(err, "asking for the zone to create the bucket into")
 		}

--- a/pkg/cmd/deletecmd/delete_vault.go
+++ b/pkg/cmd/deletecmd/delete_vault.go
@@ -155,11 +155,11 @@ func (o *DeleteVaultOptions) removeGCPResources(vaultName string) error {
 	}
 
 	if o.GKEProjectID == "" {
-		projectId, err := o.GetGoogleProjectId()
+		projectID, err := o.GetGoogleProjectID("")
 		if err != nil {
 			return err
 		}
-		o.GKEProjectID = projectId
+		o.GKEProjectID = projectID
 	}
 	err = o.RunCommandVerbose("gcloud", "config", "set", "project", o.GKEProjectID)
 	if err != nil {
@@ -167,7 +167,7 @@ func (o *DeleteVaultOptions) removeGCPResources(vaultName string) error {
 	}
 
 	if o.GKEZone == "" {
-		zone, err := o.GetGoogleZone(o.GKEProjectID)
+		zone, err := o.GetGoogleZone(o.GKEProjectID, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/gc/gc_gke.go
+++ b/pkg/cmd/gc/gc_gke.go
@@ -3,6 +3,7 @@ package gc
 import (
 	"strings"
 
+	gojenkins "github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
 	"github.com/spf13/cobra"
@@ -15,7 +16,6 @@ import (
 
 	"os"
 
-	"github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -135,11 +135,11 @@ func (o *GCGKEOptions) Run() error {
 			}
 			o.Flags.ProjectID = projectID
 		} else {
-			projectId, err := o.GetGoogleProjectId()
+			projectID, err := o.GetGoogleProjectID("")
 			if err != nil {
 				return err
 			}
-			o.Flags.ProjectID = projectId
+			o.Flags.ProjectID = projectID
 		}
 	}
 

--- a/pkg/cmd/opts/bucket.go
+++ b/pkg/cmd/opts/bucket.go
@@ -3,12 +3,13 @@ package opts
 import (
 	"context"
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	"io"
 	"net/url"
 	"time"
 
-	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/cloud/gke"
+
 	"github.com/jenkins-x/jx/pkg/cloud/buckets"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/kube/cluster"
@@ -101,7 +102,7 @@ func (o *CommonOptions) createGcsBucket(u *url.URL, bucket *blob.Bucket, cb *Cre
 		}
 	}
 	if cb.GKEProjectID == "" {
-		cb.GKEProjectID, err = o.GetGoogleProjectId()
+		cb.GKEProjectID, err = o.GetGoogleProjectID("")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #4792

With this change the user is prompted:

```
...

Currently connected cluster is facelie in europe-west1-b in project apps-dev-229310
? Do you want to jx boot the facelie cluster? Yes

...[? for help] 
```

If they are already connected to a cluster and select Y at the confirmation prompt. If they select N, they will get something like

```

Currently connected cluster is facelie in europe-west1-b in project apps-dev-229310
? Do you want to jx boot the facelie cluster? No

? Google Cloud Project: apps-dev-229310
? Google Cloud Zone: europe-west1-b
? Cluster name [? for help] (facelie)


```

If they aren’t connected to a cluster they will get something like:

```     

Enter the cluster you want to jx boot
? Google Cloud Project: apps-dev-229310
? Google Cloud Zone: <pick list with configured default selected>
? Cluster name [? for help]

```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
