### PR TITLE
fix: gcactivities should check for tekton rather than prow

### DIFF
--- a/pkg/cmd/gc/gc_activities.go
+++ b/pkg/cmd/gc/gc_activities.go
@@ -115,6 +115,8 @@ func (o *GCActivitiesOptions) Run() error {
 		return err
 	}
 
+	prowEnabled, err := o.IsProw()
+
 	pRun, err := apiClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get("pipelineruns.tekton.dev", metav1.GetOptions{})
 	if err != nil {
 		if !strings.Contains(err.Error(), "\"pipelineruns.tekton.dev\" not found") {
@@ -143,7 +145,7 @@ func (o *GCActivitiesOptions) Run() error {
 	}
 
 	var jobNames []string
-	if !tektonEnabled {
+	if !prowEnabled {
 		o.jclient, err = o.JenkinsClient()
 		if err != nil {
 			return err
@@ -189,7 +191,7 @@ func (o *GCActivitiesOptions) Run() error {
 			continue
 		}
 
-		if !tektonEnabled {
+		if !prowEnabled {
 			// if activity has no job in Jenkins delete it
 			matched := false
 			for _, j := range jobNames {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

We have the situation where prow is installed independently on a Jenkins X cluster. This was discussed with @rawlingsj in [this slack thread](https://kubernetes.slack.com/archives/C9LTHT2BB/p1562879271069500) 

This PR fixes the gcactivities pod which incorrectly assumed `tekton` was installed after finding `prow` on the system.

#### Special notes for the reviewer(s)

It works on our clusters. However, I have not tested this on a cluster running tekton. It was be great if someone could do this first. 
* A pre-compiled image is here: docker.io/sboardwell/builder-jx:dev 
* How to test was provided by James [here](https://kubernetes.slack.com/archives/C9LTHT2BB/p1563263288294100?thread_ts=1562879271.069500&cid=C9LTHT2BB)

cc: @jstrachan 