### PR TITLE
fix(tekton): Wait for a PipelineRun to have TaskRuns before logging

### DIFF
--- a/jx/bdd/tekton/ci.sh
+++ b/jx/bdd/tekton/ci.sh
@@ -36,5 +36,5 @@ git config --global --add user.name JenkinsXBot
 git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
-jx step bdd --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/tekton/cluster.yaml --gopath /tmp  --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tekton --tests install --tests test-create-spring
+jx step bdd --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/tekton/cluster.yaml --gopath /tmp  --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tekton --tests install --tests test-create-spring --tests test-quickstart-golang-http
 

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pipelinerun.yml
@@ -34,3 +34,15 @@ spec:
         name: fakeowner-fakerepo-fakebranch
   serviceAccount: tekton-bot
   timeout: 240h0m0s
+status:
+  conditions:
+    - lastTransitionTime: 2019-07-19T18:30:02Z
+      message: Not all Tasks in the Pipeline have finished executing
+      reason: Running
+      status: Unknown
+      type: Succeeded
+  startTime: 2019-07-19T18:30:02Z
+  taskRuns:
+    faketaskrun:
+      pipelineTaskName: faketask
+      status:

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_legacy_label/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_legacy_label/pipelinerun.yml
@@ -34,3 +34,15 @@ spec:
         name: fakeowner-fakerepo-fakebranch
   serviceAccount: tekton-bot
   timeout: 240h0m0s
+status:
+  conditions:
+    - lastTransitionTime: 2019-07-19T18:30:02Z
+      message: Not all Tasks in the Pipeline have finished executing
+      reason: Running
+      status: Unknown
+      type: Succeeded
+  startTime: 2019-07-19T18:30:02Z
+  taskRuns:
+    faketaskrun:
+      pipelineTaskName: faketask
+      status:

--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -72,7 +72,7 @@ func GetTektonPipelinesWithActivePipelineActivity(jxClient versioned.Interface, 
 			prBuildNumber = findLegacyPipelineRunBuildNumber(&pr)
 		}
 		paName := createPipelineActivityName(pr.Labels, prBuildNumber)
-		if _, exists := paMap[paName]; exists {
+		if _, exists := paMap[paName]; exists && len(pr.Status.TaskRuns) > 0 {
 			nameWithContext := fmt.Sprintf("%s %s", paName, pr.Labels["context"])
 			replacePipelineActivityNameWithEnrichedName(paMap, paName, nameWithContext)
 			names = append(names, nameWithContext)

--- a/pkg/logs/tekton_logging_test.go
+++ b/pkg/logs/tekton_logging_test.go
@@ -62,6 +62,9 @@ func TestGetTektonPipelinesWithActivePipelineActivitySingleBuild(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
+	taskRunStatusMap := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
+	taskRunStatusMap["faketaskrun"] = &v1alpha1.PipelineRunTaskRunStatus{}
+
 	_, err = tektonClient.TektonV1alpha1().PipelineRuns(ns).Create(&v1alpha1.PipelineRun{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      "PR1",
@@ -78,6 +81,9 @@ func TestGetTektonPipelinesWithActivePipelineActivitySingleBuild(t *testing.T) {
 				{Name: "version", Value: "v1"},
 				{Name: "build_id", Value: "1"},
 			},
+		},
+		Status: v1alpha1.PipelineRunStatus{
+			TaskRuns: taskRunStatusMap,
 		},
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

There's a race condition where we've created the `PipelineRun` and `PipelineActivity`, but the `PipelineRun` hasn't been reconciled yet, so there are no `TaskRun`s on its status yet. Let's wait until there are before we consider this as a valid run.

#### Special notes for the reviewer(s)

I turned on `test-quickstart-golang-http` in the `tekton` tests, since @dgozalo saw this in another context only on that test.

/assign @dgozalo 

#### Which issue this PR fixes

fixes #4805