### PR TITLE
fix: Deferred execution of add dummy app for gitOps mode, resolves #4801

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -1858,6 +1858,18 @@ func (options *InstallOptions) setupGitOpsPostApply(ns string) error {
 			if err != nil {
 				return errors.Wrap(err, "configuring Jenkins")
 			}
+		} else {
+			client, devNamespace, err := options.KubeClientAndDevNamespace()
+
+			settings, err := options.TeamSettings()
+			if err != nil {
+				return errors.Wrap(err, "reading the team settings")
+			}
+
+			options.AddDummyApplication(client, devNamespace, settings)
+			if err != nil {
+				return errors.Wrap(err, "adding dummy application")
+			}
 		}
 
 		jxClient, devNs, err := options.JXClientAndDevNamespace()

--- a/pkg/cmd/opts/install.go
+++ b/pkg/cmd/opts/install.go
@@ -1640,6 +1640,7 @@ func GetSafeUsername(username string) string {
 	return username
 }
 
+// AddDummyApplication creates the dummy prow jenkins app
 func (o *CommonOptions) AddDummyApplication(client kubernetes.Interface, devNamespace string, settings *jenkinsv1.TeamSettings) error {
 
 	var err error


### PR DESCRIPTION
fix: Deferred execution of adding dummy app for prow if gitOps mode is enabled to after gitOps config has been applied to environment. resolves #4801

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description

Currently when installing both prow and enabling gitOps the absence of the ingress ConfigMap prevents addition of the dummy prow app as it assumes the presence of it on the cluster already. This PR defers execution of this dummy app addition in the case of gitOps mode until after the gitOps changes have been applied to the environment. 

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #4801 

