### PR TITLE
feat: Verify boot cluster connection

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -74,6 +74,11 @@ func NewCmdBoot(commonOpts *opts.CommonOptions) *cobra.Command {
 func (o *BootOptions) Run() error {
 	info := util.ColorInfo
 
+	err := o.verifyClusterConnection()
+	if err != nil {
+		return err
+	}
+
 	projectConfig, pipelineFile, err := config.LoadProjectConfig(o.Dir)
 	if err != nil {
 		return err
@@ -240,4 +245,13 @@ func FindBootNamespace(projectConfig *config.ProjectConfig, requirementsConfig *
 		}
 	}
 	return ""
+}
+
+func (o *BootOptions) verifyClusterConnection() error {
+	_, err := o.KubeClient()
+	if err != nil {
+		return fmt.Errorf("You are not currently connected to a cluster, please connect to the cluster that you intend to %s\n" +
+			"Alternatively create a new cluster using %s", util.ColorInfo("jx boot"), util.ColorInfo("jx create cluster"))
+	}
+	return nil
 }

--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -250,7 +250,7 @@ func FindBootNamespace(projectConfig *config.ProjectConfig, requirementsConfig *
 func (o *BootOptions) verifyClusterConnection() error {
 	_, err := o.KubeClient()
 	if err != nil {
-		return fmt.Errorf("You are not currently connected to a cluster, please connect to the cluster that you intend to %s\n" +
+		return fmt.Errorf("You are not currently connected to a cluster, please connect to the cluster that you intend to %s\n"+
 			"Alternatively create a new cluster using %s", util.ColorInfo("jx boot"), util.ColorInfo("jx create cluster"))
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Verify user is connected to a cluster before attempting to `jx boot` 