### PR TITLE
fix(tekton): Make sure PipelineRuns exist and are running before logging.

### DIFF
--- a/jx/bdd/tekton/ci.sh
+++ b/jx/bdd/tekton/ci.sh
@@ -36,5 +36,5 @@ git config --global --add user.name JenkinsXBot
 git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
-jx step bdd --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/tekton/cluster.yaml --gopath /tmp  --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tekton --tests install --tests test-create-spring
+jx step bdd --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/tekton/cluster.yaml --gopath /tmp  --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tekton --tests install --tests test-create-spring --tests test-quickstart-golang-http
 

--- a/pkg/cmd/get/get_build_logs_test.go
+++ b/pkg/cmd/get/get_build_logs_test.go
@@ -63,6 +63,32 @@ func TestGetTektonLogsForRunningBuild(t *testing.T) {
 	}
 }
 
+func TestGetTektonLogsForRunningBuildWithPendingPod(t *testing.T) {
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	commonOpts.BatchMode = true
+	testCaseDir := path.Join("test_data", "get_build_logs", "tekton_build_logs_pending")
+
+	activities := tekton_helpers_test.AssertLoadSinglePipelineActivity(t, testCaseDir)
+	jxClient := jxfake.NewSimpleClientset(activities)
+
+	tektonObjects := []runtime.Object{tekton_helpers_test.AssertLoadSinglePipelineRun(t, testCaseDir)}
+	tektonClient := tektonfake.NewSimpleClientset(tektonObjects...)
+
+	kubeClient := kubeMocks.NewSimpleClientset()
+
+	ns := "jx"
+
+	o := &GetBuildLogsOptions{
+		GetOptions: GetOptions{
+			CommonOptions: &commonOpts,
+		},
+	}
+
+	_, err := o.getTektonLogs(kubeClient, tektonClient, jxClient, ns)
+	assert.NotNil(t, err)
+	assert.Equal(t, "there are no build logs for the supplied filters", err.Error())
+}
+
 func TestGetTektonLogsForRunningBuildWithLegacyRepoLabel(t *testing.T) {
 	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
 	commonOpts.BatchMode = true

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pipelinerun.yml
@@ -34,3 +34,15 @@ spec:
         name: fakeowner-fakerepo-fakebranch
   serviceAccount: tekton-bot
   timeout: 240h0m0s
+status:
+  conditions:
+    - lastTransitionTime: 2019-07-19T18:30:02Z
+      message: Not all Tasks in the Pipeline have finished executing
+      reason: Running
+      status: Unknown
+      type: Succeeded
+  startTime: 2019-07-19T18:30:02Z
+  taskRuns:
+    faketaskrun:
+      pipelineTaskName: faketask
+      status:

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_legacy_label/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_legacy_label/pipelinerun.yml
@@ -46,3 +46,18 @@ status:
     faketaskrun:
       pipelineTaskName: faketask
       status:
+        conditions:
+          - lastTransitionTime: "2019-07-22T17:36:16Z"
+            reason: Building
+            status: Unknown
+            type: Succeeded
+        podName: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6-pod-fcf1fe
+        startTime: "2019-07-22T17:35:01Z"
+        steps:
+          - name: build-container-build
+            terminated:
+              containerID: docker://cc11f0d75b64bb2c33cd2ce495fc2d33fcffbbde4e27643c1a074e2014e9de54
+              exitCode: 0
+              finishedAt: "2019-07-22T17:36:00Z"
+              reason: Completed
+              startedAt: "2019-07-22T17:35:07Z"

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_legacy_label/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_legacy_label/pipelinerun.yml
@@ -34,3 +34,15 @@ spec:
         name: fakeowner-fakerepo-fakebranch
   serviceAccount: tekton-bot
   timeout: 240h0m0s
+status:
+  conditions:
+    - lastTransitionTime: 2019-07-19T18:30:02Z
+      message: Not all Tasks in the Pipeline have finished executing
+      reason: Running
+      status: Unknown
+      type: Succeeded
+  startTime: 2019-07-19T18:30:02Z
+  taskRuns:
+    faketaskrun:
+      pipelineTaskName: faketask
+      status:

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/activity.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/activity.yml
@@ -1,0 +1,105 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  generation: 1
+  labels:
+    branch: fakebranch
+    build: "1"
+    owner: fakeowner
+    provider: github
+    repository: fakerepo
+    sourcerepository: fakeowner-fakerepo
+  name: fakeowner-fakerepo-fakebranch-1
+  namespace: jx
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/fakeowner-fakerepo-fakebranch-1
+spec:
+  author: fakeowner
+  batchPipelineActivity: {}
+  build: "1"
+  completedTimestamp: "2019-07-03T15:38:41Z"
+  gitBranch: fakebranch
+  gitOwner: fakeowner
+  gitRepository: fakerepo
+  gitUrl: https://github.com/fakeowner/fakerepo.git
+  lastCommitMessage: Draft create
+  lastCommitSHA: 1d0699fd4a7a84cddaddae3bf92f8ea1f7268012
+  pipeline: fakeowner/fakerepo/fakebranch
+  releaseNotesURL: https://github.com/fakeowner/fakerepo/releases/tag/v0.0.1
+  startedTimestamp: "2019-07-03T15:36:00Z"
+  status: Succeeded
+  steps:
+    - kind: Stage
+      stage:
+        completedTimestamp: "2019-07-03T15:38:41Z"
+        name: from build pack
+        startedTimestamp: "2019-07-03T15:36:00Z"
+        status: Succeeded
+        steps:
+          - completedTimestamp: "2019-07-03T15:36:00Z"
+            name: Credential Initializer V2f7m
+            startedTimestamp: "2019-07-03T15:36:00Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:02Z"
+            name: Working Dir Initializer Q9w2f
+            startedTimestamp: "2019-07-03T15:36:02Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:03Z"
+            name: Place Tools
+            startedTimestamp: "2019-07-03T15:36:03Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:07Z"
+            description: https://github.com/fakeowner/fakerepo
+            name: Git Source fakeowner fakerepo fakebranch 229l5
+            startedTimestamp: "2019-07-03T15:36:05Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:36Z"
+            name: Git Merge
+            startedTimestamp: "2019-07-03T15:36:36Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:46Z"
+            name: Setup Jx Git Credentials
+            startedTimestamp: "2019-07-03T15:36:46Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:47Z"
+            name: Build Python Unittest
+            startedTimestamp: "2019-07-03T15:36:46Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:58Z"
+            name: Build Container Build
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:36:59Z"
+            name: Build Post Build
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:37:05Z"
+            name: Promote Changelog
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:37:08Z"
+            name: Promote Helm Release
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+          - completedTimestamp: "2019-07-03T15:38:41Z"
+            name: Promote Jx Promote
+            startedTimestamp: "2019-07-03T15:36:49Z"
+            status: Succeeded
+    - kind: Promote
+      promote:
+        completedTimestamp: "2019-07-03T15:38:41Z"
+        environment: staging
+        pullRequest:
+          completedTimestamp: "2019-07-03T15:38:40Z"
+          mergeCommitSHA: 01b1c6aef237e677cbf3b9b09394f401d2649590
+          pullRequestURL: https://github.com/fakeowner/environment-daniel-dev-cluster0001-staging/pull/1
+          startedTimestamp: "2019-07-03T15:37:14Z"
+          status: Succeeded
+        startedTimestamp: "2019-07-03T15:37:14Z"
+        status: Succeeded
+        update:
+          completedTimestamp: "2019-07-03T15:38:41Z"
+          startedTimestamp: "2019-07-03T15:38:40Z"
+          status: Succeeded
+  version: 0.0.1
+  workflowStatus: Running
+status: {}

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pipelinerun.yml
@@ -55,9 +55,5 @@ status:
         startTime: "2019-07-22T17:35:01Z"
         steps:
           - name: build-container-build
-            terminated:
-              containerID: docker://cc11f0d75b64bb2c33cd2ce495fc2d33fcffbbde4e27643c1a074e2014e9de54
-              exitCode: 0
-              finishedAt: "2019-07-22T17:36:00Z"
-              reason: Completed
-              startedAt: "2019-07-22T17:35:07Z"
+            waiting:
+              message: Pending for reasons

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pod.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pod.yml
@@ -1,0 +1,497 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    sidecar.istio.io/inject: "false"
+  creationTimestamp: "2019-07-02T12:34:45Z"
+  labels:
+    branch: fakebranch
+    build: "1"
+    jenkins.io/task-stage-name: app-extension
+    owner: fakeowner
+    repository: fakerepo
+    tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
+    tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1
+    tekton.dev/task: meta-fakeowner-fakerepo-build-app-extension-8
+    tekton.dev/taskRun: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6
+  name: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6-pod-fcf1fe
+  namespace: jx
+  ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: TaskRun
+      name: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6
+      uid: c5c20379-9cc5-11e9-aa2e-42010a8a00fe
+  resourceVersion: "235888"
+  selfLink: /api/v1/namespaces/jx/pods/meta-fakeowner-fakerepo-build-1-app-extension-kvvp6-pod-fcf1fe
+  uid: c5c6d6f9-9cc5-11e9-aa2e-42010a8a00fe
+spec:
+  containers:
+    - args:
+        - -wait_file
+        - ""
+        - -post_file
+        - /builder/tools/0
+        - -entrypoint
+        - /ko-app/git-init
+        - --
+        - -url
+        - https://github.com/fakeowner/fakerepo
+        - -revision
+        - fakebranch
+        - -path
+        - /workspace/source
+      command:
+        - /builder/tools/entrypoint
+      env:
+        - name: HOME
+          value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-git-source-meta-fakeowner-fakerepo-build-v7hvv
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace
+    - args:
+        - -wait_file
+        - /builder/tools/0
+        - -post_file
+        - /builder/tools/1
+        - -entrypoint
+        - jx
+        - --
+        - step
+        - git
+        - merge
+        - --verbose
+      command:
+        - /builder/tools/entrypoint
+      env:
+        - name: HOME
+          value: /builder/home
+        - name: APP_NAME
+          value: fakerepo
+        - name: BRANCH_NAME
+          value: fakebranch
+        - name: BUILD_NUMBER
+          value: "1"
+        - name: JOB_NAME
+          value: fakeowner/fakerepo/fakebranch
+        - name: JX_LOG_FORMAT
+          value: json
+        - name: PIPELINE_KIND
+          value: release
+        - name: REPO_NAME
+          value: fakerepo
+        - name: REPO_OWNER
+          value: fakeowner
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-git-merge
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace/source
+    - args:
+        - -wait_file
+        - /builder/tools/1
+        - -post_file
+        - /builder/tools/2
+        - -entrypoint
+        - /bin/sh
+        - --
+        - -c
+        - jx step syntax effective --output-dir .
+      command:
+        - /builder/tools/entrypoint
+      env:
+        - name: HOME
+          value: /builder/home
+        - name: APP_NAME
+          value: fakerepo
+        - name: BRANCH_NAME
+          value: fakebranch
+        - name: BUILD_NUMBER
+          value: "1"
+        - name: JOB_NAME
+          value: fakeowner/fakerepo/fakebranch
+        - name: JX_LOG_FORMAT
+          value: json
+        - name: PIPELINE_KIND
+          value: release
+        - name: REPO_NAME
+          value: fakerepo
+        - name: REPO_OWNER
+          value: fakeowner
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-create-effective-pipeline
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace/source
+    - args:
+        - -wait_file
+        - /builder/tools/2
+        - -post_file
+        - /builder/tools/3
+        - -entrypoint
+        - /bin/sh
+        - --
+        - -c
+        - jx step create task --clone-dir /workspace/source --build-number 8 --trigger
+          manual --service-account tekton-bot --source source --branch fakebranch
+      command:
+        - /builder/tools/entrypoint
+      env:
+        - name: HOME
+          value: /builder/home
+        - name: APP_NAME
+          value: fakerepo
+        - name: BRANCH_NAME
+          value: fakebranch
+        - name: BUILD_NUMBER
+          value: "1"
+        - name: JOB_NAME
+          value: fakeowner/fakerepo/fakebranch
+        - name: JX_LOG_FORMAT
+          value: json
+        - name: PIPELINE_KIND
+          value: release
+        - name: REPO_NAME
+          value: fakerepo
+        - name: REPO_OWNER
+          value: fakeowner
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imagePullPolicy: IfNotPresent
+      name: build-step-create-tekton-crds
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace/source
+    - args:
+        - -wait_file
+        - /builder/tools/3
+        - -post_file
+        - /builder/tools/4
+        - -entrypoint
+        - /ko-app/nop
+        - --
+      command:
+        - /builder/tools/entrypoint
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: nop
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+  dnsPolicy: ClusterFirst
+  initContainers:
+    - args:
+        - -basic-git=knative-git-user-pass=https://github.com
+      command:
+        - /ko-app/creds-init
+      env:
+        - name: HOME
+          value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-credential-initializer-xht92
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/build-secrets/knative-git-user-pass
+          name: secret-volume-knative-git-user-pass-6zhjb
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace
+    - args:
+        - -args
+        - mkdir -p /workspace/source
+      command:
+        - /ko-app/bash
+      env:
+        - name: HOME
+          value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-working-dir-initializer-8c9w5
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace
+    - args:
+        - -c
+        - cp /ko-app/entrypoint /builder/tools/entrypoint
+      command:
+        - /bin/sh
+      env:
+        - name: HOME
+          value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.4.0
+      imagePullPolicy: IfNotPresent
+      name: build-step-place-tools
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /builder/tools
+          name: tools
+        - mountPath: /workspace
+          name: workspace
+        - mountPath: /builder/home
+          name: home
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tekton-bot-token-kbbrz
+          readOnly: true
+      workingDir: /workspace
+  nodeName: gke-fakeowner-test-cluster-default-pool-666b1aa4-k4xk
+  priority: 0
+  restartPolicy: Never
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: tekton-bot
+  serviceAccountName: tekton-bot
+  terminationGracePeriodSeconds: 30
+  tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+  volumes:
+    - emptyDir: {}
+      name: tools
+    - emptyDir: {}
+      name: workspace
+    - emptyDir: {}
+      name: home
+    - name: secret-volume-knative-git-user-pass-6zhjb
+      secret:
+        defaultMode: 420
+        secretName: knative-git-user-pass
+    - name: tekton-bot-token-kbbrz
+      secret:
+        defaultMode: 420
+        secretName: tekton-bot-token-kbbrz
+status:
+  conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:49Z"
+      reason: PodCompleted
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:45Z"
+      reason: PodCompleted
+      status: "False"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:45Z"
+      reason: PodCompleted
+      status: "False"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2019-07-02T12:34:45Z"
+      status: "True"
+      type: PodScheduled
+  containerStatuses:
+    - containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+      lastState: {}
+      name: build-step-create-effective-pipeline
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:52Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+    - containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+      lastState: {}
+      name: build-step-create-tekton-crds
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:56Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+    - containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+      image: gcr.io/jenkinsxio/builder-maven:0.1.542
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+      lastState: {}
+      name: build-step-git-merge
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:50Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+    - containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:4b91c31560f18a8f09c68d5288f2261797b6df31522a57a9d7350bc0060a1284
+      lastState: {}
+      name: build-step-git-source-meta-fakeowner-fakerepo-build-v7hvv
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:49Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:49Z"
+    - containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop@sha256:9160ed41b20b2822d06e907d89f6398ea866c86a971f83371efb9e147fba079f
+      lastState: {}
+      name: nop
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:57Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:50Z"
+  hostIP: 10.138.0.56
+  initContainerStatuses:
+    - containerID: docker://5e897a5dfaf1687cad1692d9c8c6261108735e595ed37e03b43bcf51f86a7330
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:b4877c99d928fad3cf26c995d171674b34d206178d6f9f0efb337ebff01bb34b
+      lastState: {}
+      name: build-step-credential-initializer-xht92
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://5e897a5dfaf1687cad1692d9c8c6261108735e595ed37e03b43bcf51f86a7330
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:46Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:46Z"
+    - containerID: docker://1e68c4fcfc19db3c695ff5ac3cbd7b4f2cf8c5a92637267fd2745a97eaf21150
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash@sha256:0355a9b21a7c0cc9466bf75071648e266de07b5e13fbfd271ec791c45a818bdb
+      lastState: {}
+      name: build-step-working-dir-initializer-8c9w5
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://1e68c4fcfc19db3c695ff5ac3cbd7b4f2cf8c5a92637267fd2745a97eaf21150
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:47Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:47Z"
+    - containerID: docker://4109f59817a239085ce4084ae87cec62297ada549cb42e247160cd41f7479426
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.4.0
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:4d1fe990ca06ecc671370dfeab31d857efa8ccf81d632a672561c60482fd9aae
+      lastState: {}
+      name: build-step-place-tools
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://4109f59817a239085ce4084ae87cec62297ada549cb42e247160cd41f7479426
+          exitCode: 0
+          finishedAt: "2019-07-02T12:34:48Z"
+          reason: Completed
+          startedAt: "2019-07-02T12:34:48Z"
+  phase: Succeeded
+  podIP: 10.28.0.32
+  qosClass: BestEffort
+  startTime: "2019-07-02T12:34:45Z"

--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -72,7 +72,7 @@ func GetTektonPipelinesWithActivePipelineActivity(jxClient versioned.Interface, 
 			prBuildNumber = findLegacyPipelineRunBuildNumber(&pr)
 		}
 		paName := createPipelineActivityName(pr.Labels, prBuildNumber)
-		if _, exists := paMap[paName]; exists {
+		if _, exists := paMap[paName]; exists && len(pr.Status.TaskRuns) > 0 {
 			nameWithContext := fmt.Sprintf("%s %s", paName, pr.Labels["context"])
 			replacePipelineActivityNameWithEnrichedName(paMap, paName, nameWithContext)
 			names = append(names, nameWithContext)

--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -2,11 +2,12 @@ package logs
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/cloud/gke"
-	"github.com/jenkins-x/jx/pkg/tekton"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/cloud/gke"
+	"github.com/jenkins-x/jx/pkg/tekton"
 
 	"github.com/fatih/color"
 	"github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
@@ -72,7 +73,7 @@ func GetTektonPipelinesWithActivePipelineActivity(jxClient versioned.Interface, 
 			prBuildNumber = findLegacyPipelineRunBuildNumber(&pr)
 		}
 		paName := createPipelineActivityName(pr.Labels, prBuildNumber)
-		if _, exists := paMap[paName]; exists && len(pr.Status.TaskRuns) > 0 {
+		if _, exists := paMap[paName]; exists && pipelineRunIsCompleteOrRunningWithNonPendingPod(&pr) {
 			nameWithContext := fmt.Sprintf("%s %s", paName, pr.Labels["context"])
 			replacePipelineActivityNameWithEnrichedName(paMap, paName, nameWithContext)
 			names = append(names, nameWithContext)
@@ -80,6 +81,24 @@ func GetTektonPipelinesWithActivePipelineActivity(jxClient versioned.Interface, 
 	}
 
 	return names, paMap, nil
+}
+
+func pipelineRunIsCompleteOrRunningWithNonPendingPod(pr *v1alpha12.PipelineRun) bool {
+	if pr.Status.CompletionTime != nil {
+		return true
+	}
+	if len(pr.Status.TaskRuns) > 0 {
+		for _, v := range pr.Status.TaskRuns {
+			if v.Status != nil {
+				for _, stepState := range v.Status.Steps {
+					if stepState.Waiting == nil {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
 }
 
 func modifyFilterForPipelineRun(labelsFilter string, context string) string {

--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -73,7 +73,7 @@ func GetTektonPipelinesWithActivePipelineActivity(jxClient versioned.Interface, 
 			prBuildNumber = findLegacyPipelineRunBuildNumber(&pr)
 		}
 		paName := createPipelineActivityName(pr.Labels, prBuildNumber)
-		if _, exists := paMap[paName]; exists && pipelineRunIsCompleteOrRunningWithNonPendingPod(&pr) {
+		if _, exists := paMap[paName]; exists && tekton.PipelineRunIsNotPending(&pr) {
 			nameWithContext := fmt.Sprintf("%s %s", paName, pr.Labels["context"])
 			replacePipelineActivityNameWithEnrichedName(paMap, paName, nameWithContext)
 			names = append(names, nameWithContext)
@@ -81,24 +81,6 @@ func GetTektonPipelinesWithActivePipelineActivity(jxClient versioned.Interface, 
 	}
 
 	return names, paMap, nil
-}
-
-func pipelineRunIsCompleteOrRunningWithNonPendingPod(pr *v1alpha12.PipelineRun) bool {
-	if pr.Status.CompletionTime != nil {
-		return true
-	}
-	if len(pr.Status.TaskRuns) > 0 {
-		for _, v := range pr.Status.TaskRuns {
-			if v.Status != nil {
-				for _, stepState := range v.Status.Steps {
-					if stepState.Waiting == nil {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
 }
 
 func modifyFilterForPipelineRun(labelsFilter string, context string) string {

--- a/pkg/logs/tekton_logging_test.go
+++ b/pkg/logs/tekton_logging_test.go
@@ -62,6 +62,9 @@ func TestGetTektonPipelinesWithActivePipelineActivitySingleBuild(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
+	taskRunStatusMap := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
+	taskRunStatusMap["faketaskrun"] = &v1alpha1.PipelineRunTaskRunStatus{}
+
 	_, err = tektonClient.TektonV1alpha1().PipelineRuns(ns).Create(&v1alpha1.PipelineRun{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      "PR1",
@@ -78,6 +81,9 @@ func TestGetTektonPipelinesWithActivePipelineActivitySingleBuild(t *testing.T) {
 				{Name: "version", Value: "v1"},
 				{Name: "build_id", Value: "1"},
 			},
+		},
+		Status: v1alpha1.PipelineRunStatus{
+			TaskRuns: taskRunStatusMap,
 		},
 	})
 	assert.NoError(t, err)

--- a/pkg/tekton/pipelines.go
+++ b/pkg/tekton/pipelines.go
@@ -412,3 +412,22 @@ func ApplyPipeline(jxClient versioned.Interface, tektonClient tektonclient.Inter
 
 	return nil
 }
+
+// PipelineRunIsNotPending returns true if the PipelineRun has completed or has running steps.
+func PipelineRunIsNotPending(pr *pipelineapi.PipelineRun) bool {
+	if pr.Status.CompletionTime != nil {
+		return true
+	}
+	if len(pr.Status.TaskRuns) > 0 {
+		for _, v := range pr.Status.TaskRuns {
+			if v.Status != nil {
+				for _, stepState := range v.Status.Steps {
+					if stepState.Waiting == nil {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}

--- a/pkg/tekton/pipelines_test.go
+++ b/pkg/tekton/pipelines_test.go
@@ -1,0 +1,118 @@
+package tekton_test
+
+import (
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/tekton"
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	ns = "jx"
+)
+
+func TestPipelineRunIsNotPendingCompletedRun(t *testing.T) {
+	now := metav1.Now()
+	pr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "PR1",
+			Namespace: ns,
+			Labels: map[string]string{
+				tekton.LabelRepo:    "fakerepo",
+				tekton.LabelBranch:  "fakebranch",
+				tekton.LabelOwner:   "fakeowner",
+				tekton.LabelContext: "fakecontext",
+			},
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			Params: []v1alpha1.Param{
+				{Name: "version", Value: "v1"},
+				{Name: "build_id", Value: "1"},
+			},
+		},
+		Status: v1alpha1.PipelineRunStatus{
+			CompletionTime: &now,
+		},
+	}
+
+	assert.True(t, tekton.PipelineRunIsNotPending(pr))
+}
+
+func TestPipelineRunIsNotPendingRunningSteps(t *testing.T) {
+	taskRunStatusMap := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
+	taskRunStatusMap["faketaskrun"] = &v1alpha1.PipelineRunTaskRunStatus{
+		Status: &v1alpha1.TaskRunStatus{
+			Steps: []v1alpha1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+			}},
+		},
+	}
+
+	pr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "PR1",
+			Namespace: ns,
+			Labels: map[string]string{
+				tekton.LabelRepo:    "fakerepo",
+				tekton.LabelBranch:  "fakebranch",
+				tekton.LabelOwner:   "fakeowner",
+				tekton.LabelContext: "fakecontext",
+			},
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			Params: []v1alpha1.Param{
+				{Name: "version", Value: "v1"},
+				{Name: "build_id", Value: "1"},
+			},
+		},
+		Status: v1alpha1.PipelineRunStatus{
+			TaskRuns: taskRunStatusMap,
+		},
+	}
+
+	assert.True(t, tekton.PipelineRunIsNotPending(pr))
+}
+
+func TestPipelineRunIsNotPendingWaitingSteps(t *testing.T) {
+	taskRunStatusMap := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
+	taskRunStatusMap["faketaskrun"] = &v1alpha1.PipelineRunTaskRunStatus{
+		Status: &v1alpha1.TaskRunStatus{
+			Steps: []v1alpha1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Message: "Pending",
+					},
+				},
+			}},
+		},
+	}
+
+	pr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "PR1",
+			Namespace: ns,
+			Labels: map[string]string{
+				tekton.LabelRepo:    "fakerepo",
+				tekton.LabelBranch:  "fakebranch",
+				tekton.LabelOwner:   "fakeowner",
+				tekton.LabelContext: "fakecontext",
+			},
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			Params: []v1alpha1.Param{
+				{Name: "version", Value: "v1"},
+				{Name: "build_id", Value: "1"},
+			},
+		},
+		Status: v1alpha1.PipelineRunStatus{
+			TaskRuns: taskRunStatusMap,
+		},
+	}
+
+	assert.False(t, tekton.PipelineRunIsNotPending(pr))
+}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This fixes issues around `jx get build log` thinking a `PipelineRun` is valid before it's actually started, tricking it into thinking that the `PipelineRun`'s pods have already been GCed.

#### Special notes for the reviewer(s)

/assign @dgozalo 

#### Which issue this PR fixes

n/a