### PR TITLE
fix: Disable manual promotion test in bdd context

### DIFF
--- a/jx/scripts/ci.sh
+++ b/jx/scripts/ci.sh
@@ -20,6 +20,9 @@ export GINKGO_ARGS="-v"
 export JX_DISABLE_DELETE_APP="true"
 export JX_DISABLE_DELETE_REPO="true"
 
+# Disable manual promotion test for bdd context
+export JX_BDD_SKIP_MANUAL_PROMOTION="true"
+
 echo ""
 git config --global credential.helper store
 git config --global --add user.name JenkinsXBot


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

It's failing due to there not being a `production` environment in the `jx-bdd-tests` cluster we reuse for each `bdd` run. With https://github.com/jenkins-x/bdd-jx/pull/47, this env var lets us skip that manual promotion here but leave it on everywhere else.

#### Special notes for the reviewer(s)

/assign @jstrachan 
/assign @fiunchinho 

#### Which issue this PR fixes

n/a