### PR TITLE
fix: use better URLs for BitBucket Server

### DIFF
--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -944,12 +944,16 @@ func (options *ImportOptions) addProwConfig(gitURL string, gitKind string) error
 			return err
 		}
 		callback := func(sr *v1.SourceRepository) {
+			u := gitInfo.URLWithoutUser()
 			sr.Spec.ProviderKind = gitKind
-			sr.Spec.URL = gitInfo.HTMLURL
+			sr.Spec.URL = u
 			if sr.Spec.URL == "" {
-				sr.Spec.URL = gitInfo.URL
+				sr.Spec.URL = gitInfo.HTMLURL
 			}
-			sr.Spec.HTTPCloneURL = gitInfo.HttpCloneURL()
+			sr.Spec.HTTPCloneURL = u
+			if sr.Spec.HTTPCloneURL == "" {
+				sr.Spec.HTTPCloneURL = gitInfo.HttpCloneURL()
+			}
 			sr.Spec.SSHCloneURL = gitInfo.SSHURL
 		}
 		sr, err := kube.GetOrCreateSourceRepositoryCallback(jxClient, currentNamespace, gitInfo.Name, gitInfo.Organisation, gitInfo.HostURLWithoutUser(), callback)

--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -72,6 +72,23 @@ func (i *GitRepository) HostURL() string {
 	return answer
 }
 
+func (i *GitRepository) URLWithoutUser() string {
+	u := i.URL
+	if u != "" {
+		u2, err := url.Parse(u)
+		if err == nil {
+			u2.User = nil
+			return u2.String()
+		}
+
+	}
+	host := i.Host
+	if !strings.Contains(host, ":/") {
+		host = "https://" + host
+	}
+	return host
+}
+
 func (i *GitRepository) HostURLWithoutUser() string {
 	u := i.URL
 	if u != "" {

--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -72,6 +72,7 @@ func (i *GitRepository) HostURL() string {
 	return answer
 }
 
+// URLWithoutUser returns the URL without any user/password
 func (i *GitRepository) URLWithoutUser() string {
 	u := i.URL
 	if u != "" {

--- a/pkg/tekton/pipelines.go
+++ b/pkg/tekton/pipelines.go
@@ -182,6 +182,11 @@ func GenerateSourceRepoResource(name string, gitInfo *gits.GitRepository, revisi
 
 	}
 
+	// lets use the URL property as this preserves any provider specific paths; e.g. `/scm` on bitbucket server
+	u := gitInfo.URL
+	if u == "" {
+		u = gitInfo.HttpsURL()
+	}
 	resource := &pipelineapi.PipelineResource{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: syntax.TektonAPIVersion,
@@ -199,7 +204,7 @@ func GenerateSourceRepoResource(name string, gitInfo *gits.GitRepository, revisi
 				},
 				{
 					Name:  "url",
-					Value: gitInfo.HttpsURL(),
+					Value: u,
 				},
 			},
 		},


### PR DESCRIPTION
for creating SourceRepository and meta pipeline - as bitbucket server can use `/scm` after the host for clone URLs

Signed-off-by: James Strachan <james.strachan@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
