### PR TITLE
fix: Just push to jx-docs once in update-website.sh

### DIFF
--- a/jx/scripts/update-website.sh
+++ b/jx/scripts/update-website.sh
@@ -13,7 +13,6 @@ pushd jx-docs/content/commands
   git add *
   git commit --allow-empty -a -m "updated jx commands & API docs from $VERSION"
   git fetch origin && git rebase origin/master
-  git push origin
 popd
 
 
@@ -25,7 +24,6 @@ pushd jx-docs/content
   git add *
   git commit --allow-empty -a -m "updated jx Json Schema from $VERSION"
   git fetch origin && git rebase origin/master
-  git push origin
 popd
 
 echo "Updating the JX CLI & API reference docs"
@@ -36,6 +34,8 @@ pushd jx-docs/static/apidocs
   git add *
   git commit --allow-empty -a -m "updated jx API docs from $VERSION"
   git fetch origin && git rebase origin/master
-  git push origin
 popd
 
+pushd jx-docs
+  git push origin
+popd


### PR DESCRIPTION
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This does mean we could lose changes if there's an error in one of the steps and it never gets to the push, but I don't think that's a real problem compared to the disruption that results from `unadvertised object` errors in `pipelinerunner` when `master` changes this rapidly and three release builds get kicked off.

#### Special notes for the reviewer(s)

/assign @pmuir 

#### Which issue this PR fixes

fixes #4840
