### PR TITLE
fix: Don't do release prepare for bdd and tekton contexts, copy pipeline

### DIFF
--- a/jenkins-x-bdd.yml
+++ b/jenkins-x-bdd.yml
@@ -1,7 +1,133 @@
 buildPack: none
+noReleasePrepare: true
 pipelineConfig:
   pipelines:
+    # TODO: When the JX infra cluster is updated, switch to a default pipeline instead.
     pullRequest:
+      pipeline:
+        agent:
+          image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+            env:
+              - name: CODECOV_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    key: token
+                    name: codecov-token
+        stages:
+          - name: build
+            environment:
+              - name: GIT_COMMITTER_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_NAME
+                value: jenkins-x-bot
+              - name: GIT_COMMITTER_NAME
+                value: jenkins-x-bot
+              - name: BASE_WORKSPACE
+                value: /workspace/source
+              - name: GOPROXY
+                value: http://jenkins-x-athens-proxy:80
+              - name: PARALLEL_BUILDS
+                value: "2"
+                # Build a binary that can emit coverage
+              - name: COVERED_BINARY
+                value: "true"
+              - name: CODECOV_NAME
+                value: e2e
+              - name: VERSION_PREFIX
+                value: covered-
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /builder/home/kaniko-secret.json
+
+            steps:
+              - image: jenkinsxio/jx:1.3.963
+                command: jx
+                args:
+                  - step
+                  - credential
+                  - -s
+                  - kaniko-secret
+                  - -k
+                  - kaniko-secret
+                  - -f
+                  - /builder/home/kaniko-secret.json
+
+              - name: build-binary
+                image: docker.io/golang:1.11.5
+                command: make
+                args: ['linux']
+
+              - name: validate-binary
+                image: docker.io/golang:1.11.5
+                command: "./build/linux/jx"
+                args: ['help']
+                # Supported when we upgrade
+                #env:
+                #- name: COVER_JX_BINARY
+                #  value: false
+
+              - name: build-and-push-image
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-nodejs
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=gcr.io/jenkinsxio/builder-nodejs:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-maven
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=gcr.io/jenkinsxio/builder-maven:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-go
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+          - name: e2e-tests
+            environment:
+              - name: GIT_COMMITTER_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_NAME
+                value: jenkins-x-bot
+              - name: GIT_COMMITTER_NAME
+                value: jenkins-x-bot
+              - name: BASE_WORKSPACE
+                value: /workspace/source
+              - name: GOPROXY
+                value: http://jenkins-x-athens-proxy:80
+              - name: PARALLEL_BUILDS
+                value: "2"
+                # Build a binary that can emit coverage
+              - name: COVERED_BINARY
+                value: "true"
+              - name: CODECOV_NAME
+                value: e2e
+              - name: VERSION_PREFIX
+                value: covered-
+
+            steps:
+              - name: e2e-tests
+                image: gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}
+                command: ./jx/scripts/ci.sh
+
+              - name: stash-test-results
+                image: gcr.io/jenkinsxio/jx:covered-${inputs.params.version}
+                command: jx
+                # TODO force it to use the gs bucket until we sort out why the team setting gets wiped
+                args: ['step', 'stash', '-c', 'e2e-tests', '-p', 'build/reports/junit.xml', '--bucket-url', 'gs://jx-prod-logs']
+
+    release:
       pipeline:
         agent:
           image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -1,7 +1,129 @@
 buildPack: none
+noReleasePrepare: true
 pipelineConfig:
   pipelines:
+    # TODO: When the JX infra cluster is updated, switch to a default pipeline instead.
     pullRequest:
+      pipeline:
+        agent:
+          image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+            env:
+              - name: CODECOV_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    key: token
+                    name: codecov-token
+        stages:
+          - name: build
+            environment:
+              - name: GIT_COMMITTER_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_NAME
+                value: jenkins-x-bot
+              - name: GIT_COMMITTER_NAME
+                value: jenkins-x-bot
+              - name: BASE_WORKSPACE
+                value: /workspace/source
+              - name: GOPROXY
+                value: http://jenkins-x-athens-proxy:80
+              - name: PARALLEL_BUILDS
+                value: "2"
+                # Build a binary that can emit coverage
+              - name: COVERED_BINARY
+                value: "true"
+              - name: CODECOV_NAME
+                value: tektone2e
+              - name: VERSION_PREFIX
+                value: covered-
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /builder/home/kaniko-secret.json
+
+            steps:
+              - image: jenkinsxio/jx:1.3.963
+                command: jx
+                args:
+                  - step
+                  - credential
+                  - -s
+                  - kaniko-secret
+                  - -k
+                  - kaniko-secret
+                  - -f
+                  - /builder/home/kaniko-secret.json
+
+              - name: build-binary
+                image: docker.io/golang:1.11.5
+                command: make
+                args: ['linux']
+
+              - name: validate-binary
+                image: docker.io/golang:1.11.5
+                command: "./build/linux/jx"
+                args: ['help']
+
+              - name: build-and-push-image
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-nodejs
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=gcr.io/jenkinsxio/builder-nodejs:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-maven
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=gcr.io/jenkinsxio/builder-maven:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-go
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+          - name: e2e-tests
+            environment:
+              - name: GIT_COMMITTER_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_NAME
+                value: jenkins-x-bot
+              - name: GIT_COMMITTER_NAME
+                value: jenkins-x-bot
+              - name: BASE_WORKSPACE
+                value: /workspace/source
+              - name: GOPROXY
+                value: http://jenkins-x-athens-proxy:80
+              - name: PARALLEL_BUILDS
+                value: "2"
+                # Build a binary that can emit coverage
+              - name: COVERED_BINARY
+                value: "true"
+              - name: CODECOV_NAME
+                value: tektone2e
+              - name: VERSION_PREFIX
+                value: covered-
+
+            steps:
+              - name: tekton-e2e-tests
+                image: gcr.io/jenkinsxio/builder-go:covered-${inputs.params.version}
+                command: ./jx/bdd/tekton/ci.sh
+
+              - name: stash-test-results
+                image: gcr.io/jenkinsxio/jx:covered-${inputs.params.version}
+                command: jx
+                # TODO force it to use the gs bucket until we sort out why the team setting gets wiped
+                args: ['step', 'stash', '-c', 'tekton-e2e-tests', '-p', 'build/reports/junit.xml', '--bucket-url', 'gs://jx-prod-logs']
+
+    release:
       pipeline:
         agent:
           image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

We're trying to run the `tekton` and `bdd` contexts on post-submit, but they've been failing forever due to there not being a `release` pipeline in either context. But if there _had_ been `release` pipelines, it would have tried to do new release versions for those contexts! So let's copy the `pullRequest` pipeline (until we're on a new enough version on prod that we can switch to `default` pipelines instead) and set `noReleasePrepare: true` to prevent the version number changing too.

#### Special notes for the reviewer(s)

/assign @pmuir 
/assign @warrenbailey 

#### Which issue this PR fixes

n/a