### PR TITLE
chore: Push the go-maven builder during image generation

### DIFF
--- a/Dockerfile.builder-go-maven
+++ b/Dockerfile.builder-go-maven
@@ -1,0 +1,4 @@
+# this is used for testing jx inside a cluster in development
+FROM gcr.io/jenkinsxio/builder-go-maven:0.1.404
+
+COPY build/linux/jx /usr/bin/jx

--- a/jenkins-x-images.yml
+++ b/jenkins-x-images.yml
@@ -72,3 +72,8 @@ pipelineConfig:
               - name: build-and-push-go
                 command: /kaniko/executor
                 args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-go-maven
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go-maven','--destination=gcr.io/jenkinsxio/builder-go-maven:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+


### PR DESCRIPTION
Pushes the builder-go-maven image from the images context