### PR TITLE
fix(tekton): Properly handle non-step overrides for packs using jx syntax

### DIFF
--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -395,7 +395,10 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			err = createTask.setBuildValues()
 			assert.NoError(t, err)
 
-			effectiveProjectConfig, _ := createTask.createEffectiveProjectConfig(packsDir, projectConfig, projectConfigFile, resolver, ns)
+			effectiveProjectConfig, err := createTask.createEffectiveProjectConfig(packsDir, projectConfig, projectConfigFile, resolver, ns)
+			if err != nil && strings.Contains(err.Error(), "validation failed for Pipeline") {
+				t.Fatalf("Validation failure for effective pipeline: %s", err)
+			}
 			if effectiveProjectConfig != nil {
 				err = createTask.setBuildVersion(effectiveProjectConfig.PipelineConfig)
 				assert.NoError(t, err)

--- a/pkg/cmd/step/create/test_data/step_create_task/overrides-with-buildpack-using-jenkins-x-syntax/jenkins-x.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/overrides-with-buildpack-using-jenkins-x-syntax/jenkins-x.yml
@@ -1,0 +1,11 @@
+buildPack: jx-syntax-in-buildpack
+pipelineConfig:
+  pipelines:
+    overrides:
+      - pipeline: release
+        stage: build
+        name: flake8
+        step:
+          command: echo hi there
+          name: hi-there
+        type: after

--- a/pkg/cmd/step/create/test_data/step_create_task/packs/jx-syntax-in-buildpack/pipeline.yaml
+++ b/pkg/cmd/step/create/test_data/step_create_task/packs/jx-syntax-in-buildpack/pipeline.yaml
@@ -1,0 +1,28 @@
+agent:
+  label: jenkins-maven
+  container: maven
+pipelines:
+  pullRequest:
+    pipeline:
+      agent:
+        image:
+          maven
+      stages:
+        - name: build
+          steps:
+            - command: source /root/.bashrc && flake8
+              name: flake8
+              image: maven
+              dir: /workspace/source
+  release:
+    pipeline:
+      agent:
+        image:
+          maven
+      stages:
+        - name: build
+          steps:
+            - command: source /root/.bashrc && flake8
+              name: flake8
+              image: maven
+              dir: /workspace/source

--- a/pkg/cmd/step/syntax/step_syntax_effective.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective.go
@@ -382,6 +382,13 @@ func (o *StepSyntaxEffectiveOptions) createPipelineForKind(kind string, lifecycl
 
 	if lifecycles != nil && lifecycles.Pipeline != nil {
 		parsed = lifecycles.Pipeline
+		if projectConfig.BuildPack == "" || projectConfig.BuildPack == "none" {
+			for _, override := range pipelines.Overrides {
+				if override.MatchesPipeline(kind) {
+					parsed = syntax.ApplyStepOverridesToPipeline(parsed, override)
+				}
+			}
+		}
 	} else {
 		args := jenkinsfile.CreatePipelineArguments{
 			Lifecycles:        lifecycles,
@@ -422,7 +429,7 @@ func (o *StepSyntaxEffectiveOptions) createPipelineForKind(kind string, lifecycl
 
 	for _, override := range pipelines.Overrides {
 		if override.MatchesPipeline(kind) {
-			parsed = syntax.ExtendParsedPipeline(parsed, override)
+			parsed = syntax.ApplyNonStepOverridesToPipeline(parsed, override)
 		}
 	}
 

--- a/pkg/jenkinsfile/pipeline.go
+++ b/pkg/jenkinsfile/pipeline.go
@@ -693,7 +693,7 @@ func ExtendPipelines(pipelineName string, parent, base *PipelineLifecycles, over
 				return &PipelineLifecycles{}
 			}
 
-			l.Pipeline = syntax.ExtendParsedPipeline(l.Pipeline, override)
+			l.Pipeline = syntax.ApplyStepOverridesToPipeline(l.Pipeline, override)
 		}
 	}
 	return l


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Applying the overrides as we had been twice for build packs worked fine for `jenkins-x.yml`-defined pipelines or build packs that use the traditional build pack syntax. But for build packs using `jenkins-x.yml` syntax, it resulted in duplicate steps being added. So instead, let's split the step override from the non-step override.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

n/a