### PR TITLE
fix: jx boot fails to create storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,9 @@ make-reports-dir:
 test: make-reports-dir ## Run ONLY the tests that have no build flags (and example of a build tag is the "integration" build tag)
 	CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -count=1 $(COVERFLAGS) -failfast -short ./...
 
+test-cloud-gke: make-reports-dir ## Run ONLY the tests that have no build flags (and example of a build tag is the "integration" build tag)
+	CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -count=1 -coverprofile=$(COVER_OUT) --covermode=count --coverpkg=./pkg/cloud/gke -failfast -short ./pkg/cloud/gke
+
 test-report: make-reports-dir get-test-deps test ## Create the test report
 	@gocov convert $(COVER_OUT) | gocov report
 

--- a/pkg/cloud/gke/gcloud.go
+++ b/pkg/cloud/gke/gcloud.go
@@ -11,13 +11,14 @@ import (
 
 	"time"
 
+	osUser "os/user"
+
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	osUser "os/user"
 	"sigs.k8s.io/yaml"
 )
 
@@ -410,9 +411,14 @@ func (g *GCloud) DeleteBucket(bucketName string) error {
 	return nil
 }
 
-// GetRegionFromZone parses the region from a GCP zone name
+// GetRegionFromZone parses the region from a GCP zone name. TODO: Return an error if the format of the zone is not correct
 func GetRegionFromZone(zone string) string {
-	return zone[0 : len(zone)-2]
+	firstDash := strings.Index(zone, "-")
+	lastDash := strings.LastIndex(zone, "-")
+	if firstDash == lastDash { // It's a region, not a zone
+		return zone
+	}
+	return zone[0:lastDash]
 }
 
 // FindServiceAccount checks if a service account exists

--- a/pkg/cloud/gke/gcloud_test.go
+++ b/pkg/cloud/gke/gcloud_test.go
@@ -11,8 +11,11 @@ func TestGetRegionFromZone(t *testing.T) {
 	r := GetRegionFromZone("europe-west1-b")
 	assert.Equal(t, r, "europe-west1")
 
-	r = GetRegionFromZone("uswest1-d")
-	assert.Equal(t, r, "uswest1")
+	r = GetRegionFromZone("us-west1-d")
+	assert.Equal(t, r, "us-west1")
+
+	r = GetRegionFromZone("us-west1")
+	assert.Equal(t, r, "us-west1")
 }
 
 func TestGetManagedZoneName(t *testing.T) {


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description

Return region if `zone` argument is a region instead of a zone.

#### Special notes for the reviewer(s)

The new test case is self descriptive

#### Which issue this PR fixes

fixes #4836
