### PR TITLE
fix: don’t set push urls as remotes

### DIFF
--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"github.com/denormal/go-gitignore"
+	gitignore "github.com/denormal/go-gitignore"
 	gojenkins "github.com/jenkins-x/golang-jenkins"
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/auth"
@@ -30,7 +30,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1"
+	survey "gopkg.in/AlecAivazis/survey.v1"
 	gitcfg "gopkg.in/src-d/go-git.v4/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -394,7 +394,7 @@ func (options *ImportOptions) Run() error {
 		}
 	} else {
 		if shouldClone {
-			err = options.Git().Push(options.Dir)
+			err = options.Git().Push(options.Dir, "origin", false, false, "HEAD")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/opts/pullrequest.go
+++ b/pkg/cmd/opts/pullrequest.go
@@ -175,7 +175,7 @@ func (options *CommonOptions) CreatePullRequest(o *PullRequestDetails, modifyFn 
 		}
 	}
 
-	err = gitter.Push(dir)
+	err = gitter.Push(dir, "origin", false, false, "HEAD")
 	if err != nil {
 		return errors.Wrapf(err, "pushing to %s in dir %q", message, dir)
 	}

--- a/pkg/cmd/step/get/step_get_version_changeset_test.go
+++ b/pkg/cmd/step/get/step_get_version_changeset_test.go
@@ -64,13 +64,13 @@ func TestStepGetVersionChangeSetOptionsBranch(t *testing.T) {
 	version.SaveStableVersion(testDir, version.KindChart, "test-app", stableVersion)
 	gitter.Add(testDir, ".")
 	gitter.AddCommit(testDir, "Initial Commit")
-	gitter.Push(testDir)
+	gitter.Push(testDir, "origin", false, false, "HEAD")
 	gitter.CreateBranch(testDir, testBranch)
 	gitter.Checkout(testDir, testBranch)
 	stableVersion.Version = "1.0.1"
 	version.SaveStableVersion(testDir, version.KindChart, "test-app", stableVersion)
 	gitter.AddCommit(testDir, "Bump version")
-	gitter.Push(testDir)
+	gitter.Push(testDir, "origin", false, false, "HEAD")
 	gitter.Checkout(testDir, stableBranch)
 
 	err = options.Run()
@@ -129,7 +129,7 @@ func TestStepGetVersionChangeSetOptionsPR(t *testing.T) {
 	version.SaveStableVersion(testDir, version.KindChart, "test-app", stableVersion)
 	gitter.Add(testDir, ".")
 	gitter.AddCommit(testDir, "Initial Commit")
-	gitter.Push(testDir)
+	gitter.Push(testDir, "origin", false, false, "HEAD")
 	gitter.CreateBranch(testDir, testBranch)
 	gitter.Checkout(testDir, testBranch)
 	stableVersion.Version = "1.0.1"

--- a/pkg/collector/git_collector.go
+++ b/pkg/collector/git_collector.go
@@ -106,7 +106,7 @@ func (c *GitCollector) CollectFiles(patterns []string, outputPath string, basedi
 		log.Logger().Errorf("%s", err)
 		return urls, err
 	}
-	err = gitClient.Push(ghPagesDir)
+	err = gitClient.Push(ghPagesDir, "origin", false, false, "HEAD")
 	return urls, err
 }
 
@@ -154,7 +154,7 @@ func (c *GitCollector) CollectData(data []byte, outputPath string) (string, erro
 	if err != nil {
 		return u, err
 	}
-	err = gitClient.Push(ghPagesDir)
+	err = gitClient.Push(ghPagesDir, "origin", false, false, "HEAD")
 	return u, err
 }
 

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -335,23 +335,28 @@ func (g *GitCLI) WriteOperation(dir string, args ...string) error {
 }
 
 // Push pushes the changes from the repository at the given directory
-func (g *GitCLI) Push(dir string) error {
-	return g.WriteOperation(dir, "push", "origin", "HEAD")
+func (g *GitCLI) Push(dir string, remote string, force bool, setUpstream bool, refspec ...string) error {
+	args := []string{"push", remote}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, refspec...)
+	return g.WriteOperation(dir, args...)
 }
 
 // ForcePushBranch does a force push of the local branch into the remote branch of the repository at the given directory
 func (g *GitCLI) ForcePushBranch(dir string, localBranch string, remoteBranch string) error {
-	return g.WriteOperation(dir, "push", "-f", "origin", localBranch+":"+remoteBranch)
+	return g.Push(dir, "origin", true, false, fmt.Sprintf("%s:%s", localBranch, remoteBranch))
 }
 
-// PushMaster pushes the master branch into the origin
+// PushMaster pushes the master branch into the origin, setting the upstream
 func (g *GitCLI) PushMaster(dir string) error {
-	return g.WriteOperation(dir, "push", "-u", "origin", "master")
+	return g.Push(dir, "origin", false, true, "master")
 }
 
 // Pushtag pushes the given tag into the origin
 func (g *GitCLI) PushTag(dir string, tag string) error {
-	return g.WriteOperation(dir, "push", "origin", tag)
+	return g.Push(dir, "origin", false, false, tag)
 }
 
 // Add does a git add for all the given arguments

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -144,7 +144,7 @@ func (g *GitFake) ShallowClone(dir string, url string, commitish string, pullReq
 }
 
 // Push performs a git push
-func (g *GitFake) Push(dir string) error {
+func (g *GitFake) Push(dir string, remote string, force bool, setUpstream bool, refspec ...string) error {
 	return nil
 }
 

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -152,8 +152,8 @@ func (g *GitLocal) Branch(dir string) (string, error) {
 
 // Push pushes the changes from the repository at the given directory
 // Faked out
-func (g *GitLocal) Push(dir string) error {
-	return g.GitFake.Push(dir)
+func (g *GitLocal) Push(dir string, remote string, force bool, setUpstream bool, refspec ...string) error {
+	return g.GitFake.Push(dir, "origin", false, false)
 }
 
 // ForcePushBranch does a force push of the local branch into the remote branch of the repository at the given directory

--- a/pkg/gits/helpers_test.go
+++ b/pkg/gits/helpers_test.go
@@ -482,7 +482,7 @@ func TestForkAndPullRepo(t *testing.T) {
 					assert.NoError(t, err)
 					err = args.gitter.CommitDir(dir, "Second commit")
 					assert.NoError(t, err)
-					err = args.gitter.Push(dir)
+					err = args.gitter.Push(dir, "origin", false, false, "HEAD")
 					assert.NoError(t, err)
 
 					// Set the provider username to wile in order to use the fork
@@ -578,7 +578,7 @@ func TestForkAndPullRepo(t *testing.T) {
 					assert.NoError(t, err)
 					err = args.gitter.CommitDir(dir, "Second commit")
 					assert.NoError(t, err)
-					err = args.gitter.Push(dir)
+					err = args.gitter.Push(dir, "origin", false, false, "HEAD")
 					assert.NoError(t, err)
 
 					// Set the provider username to wile in order to use the fork
@@ -672,7 +672,7 @@ func TestForkAndPullRepo(t *testing.T) {
 					assert.NoError(t, err)
 					err = args.gitter.CommitDir(dir, "Second commit")
 					assert.NoError(t, err)
-					err = args.gitter.Push(dir)
+					err = args.gitter.Push(dir, "origin", false, false, "HEAD")
 					assert.NoError(t, err)
 
 					// Set the provider username to wile in order to use the fork
@@ -870,7 +870,7 @@ func TestForkAndPullRepo(t *testing.T) {
 					assert.NoError(t, err)
 					err = args.gitter.CommitDir(dir, "Second commit")
 					assert.NoError(t, err)
-					err = args.gitter.Push(dir)
+					err = args.gitter.Push(dir, "origin", false, false, "HEAD")
 					assert.NoError(t, err)
 
 					// Set the provider username to wile in order to use the fork
@@ -973,7 +973,7 @@ func TestForkAndPullRepo(t *testing.T) {
 					assert.NoError(t, err)
 					err = args.gitter.CommitDir(dir, "Second commit")
 					assert.NoError(t, err)
-					err = args.gitter.Push(dir)
+					err = args.gitter.Push(dir, "origin", false, false, "HEAD")
 					assert.NoError(t, err)
 
 					// Set the provider username to wile in order to use the fork
@@ -1118,7 +1118,7 @@ func TestDuplicateGitRepoFromCommitsh(t *testing.T) {
 	err = gitter.CommitDir(dir, "add license")
 	assert.NoError(t, err)
 
-	err = gitter.Push(dir)
+	err = gitter.Push(dir, "origin", false, false, "HEAD")
 	assert.NoError(t, err)
 
 	err = gitter.CreateBranch(dir, "release")
@@ -1139,7 +1139,7 @@ func TestDuplicateGitRepoFromCommitsh(t *testing.T) {
 	err = gitter.CreateTag(dir, "v1.0.0", "1.0.0")
 	assert.NoError(t, err)
 
-	err = gitter.Push(dir)
+	err = gitter.Push(dir, "origin", false, false, "HEAD")
 	assert.NoError(t, err)
 
 	err = gitter.PushTag(dir, "v1.0.0")

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -196,7 +196,7 @@ type Gitter interface {
 	ShallowClone(dir string, url string, commitish string, pullRequest string) error
 	FetchUnshallow(dir string) error
 	IsShallow(dir string) (bool, error)
-	Push(dir string) error
+	Push(dir string, remote string, force bool, setUpstream bool, refspec ...string) error
 	PushMaster(dir string) error
 	PushTag(dir string, tag string) error
 	CreatePushURL(cloneURL string, userAuth *auth.UserAuth) (string, error)

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -947,11 +947,14 @@ func (mock *MockGitter) PullUpstream(_param0 string) error {
 	return ret0
 }
 
-func (mock *MockGitter) Push(_param0 string) error {
+func (mock *MockGitter) Push(_param0 string, _param1 string, _param2 bool, _param3 bool, _param4 ...string) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
 	}
-	params := []pegomock.Param{_param0}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
+	for _, param := range _param4 {
+		params = append(params, param)
+	}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("Push", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
@@ -3113,8 +3116,11 @@ func (c *MockGitter_PullUpstream_OngoingVerification) GetAllCapturedArguments() 
 	return
 }
 
-func (verifier *VerifierMockGitter) Push(_param0 string) *MockGitter_Push_OngoingVerification {
-	params := []pegomock.Param{_param0}
+func (verifier *VerifierMockGitter) Push(_param0 string, _param1 string, _param2 bool, _param3 bool, _param4 ...string) *MockGitter_Push_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
+	for _, param := range _param4 {
+		params = append(params, param)
+	}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Push", params, verifier.timeout)
 	return &MockGitter_Push_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -3124,17 +3130,38 @@ type MockGitter_Push_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockGitter_Push_OngoingVerification) GetCapturedArguments() string {
-	_param0 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1]
+func (c *MockGitter_Push_OngoingVerification) GetCapturedArguments() (string, string, bool, bool, []string) {
+	_param0, _param1, _param2, _param3, _param4 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1]
 }
 
-func (c *MockGitter_Push_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
+func (c *MockGitter_Push_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []bool, _param3 []bool, _param4 [][]string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(params[0]))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(params[1]))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
+		}
+		_param2 = make([]bool, len(params[2]))
+		for u, param := range params[2] {
+			_param2[u] = param.(bool)
+		}
+		_param3 = make([]bool, len(params[3]))
+		for u, param := range params[3] {
+			_param3[u] = param.(bool)
+		}
+		_param4 = make([][]string, len(params[4]))
+		for u := range params[0] {
+			_param4[u] = make([]string, len(params)-4)
+			for x := 4; x < len(params); x++ {
+				if params[x][u] != nil {
+					_param4[u][x-4] = params[x][u].(string)
+				}
+			}
 		}
 	}
 	return

--- a/pkg/kube/env.go
+++ b/pkg/kube/env.go
@@ -456,7 +456,7 @@ func DoCreateEnvironmentGitRepo(batchMode bool, authConfigSvc auth.ConfigService
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "adding helm values to the forked environment repo")
 				}
-				err = git.Push(dir)
+				err = git.Push(dir, "origin", false, false, "HEAD")
 				if err != nil {
 					return nil, nil, errors.Wrapf(err, "pushing forked environment dir %q", dir)
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Previously the code would use the push url as the remote url. This is fine when run in a pipeline but less than ideal when run locally (as in `jx boot`.

With this change we set the remote to the clone URL and use the push URL directly when we do pushes.

#### Special notes for the reviewer(s)
No tests yet - will add shortly

#### Which issue this PR fixes

contributes to #4789 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
