### PR TITLE
fix: Upgrade Prow in GitOps cluster

### DIFF
--- a/pkg/cmd/create/create_addon_prow.go
+++ b/pkg/cmd/create/create_addon_prow.go
@@ -103,7 +103,7 @@ func (o *CreateAddonProwOptions) Run() error {
 		pipelineUserName = pipelineUser.Username
 	}
 
-	err = o.InstallProw(o.Tekton, o.ExternalDNS, isGitOps, "", "", pipelineUserName, nil)
+	err = o.InstallProw(o.Tekton, o.ExternalDNS, isGitOps, "", pipelineUserName, nil)
 	if err != nil {
 		return fmt.Errorf("failed to install Prow: %v", err)
 	}

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -709,7 +709,7 @@ func (options *InstallOptions) Run() error {
 		return errors.Wrap(err, "configuring Prow in team settings")
 	}
 
-	err = options.configureAndInstallProw(ns, gitOpsDir, gitOpsEnvDir, valuesFiles)
+	err = options.configureAndInstallProw(ns, gitOpsEnvDir, valuesFiles)
 	if err != nil {
 		return errors.Wrap(err, "configuring and installing Prow")
 	}
@@ -1125,7 +1125,7 @@ func (options *InstallOptions) installPlatformGitOpsMode(gitOpsEnvDir string, gi
 	return nil
 }
 
-func (options *InstallOptions) configureAndInstallProw(namespace string, gitOpsDir string, gitOpsEnvDir string, valuesFiles []string) error {
+func (options *InstallOptions) configureAndInstallProw(namespace string, gitOpsEnvDir string, valuesFiles []string) error {
 	options.SetCurrentNamespace(namespace)
 	if options.Flags.Prow {
 		_, pipelineUser, err := options.GetPipelineGitAuth()
@@ -1133,7 +1133,7 @@ func (options *InstallOptions) configureAndInstallProw(namespace string, gitOpsD
 			return errors.Wrap(err, "retrieving the pipeline Git Auth")
 		}
 		options.OAUTHToken = pipelineUser.ApiToken
-		err = options.InstallProw(options.Flags.Tekton, options.InitOptions.Flags.ExternalDNS, options.Flags.GitOpsMode, gitOpsDir, gitOpsEnvDir, pipelineUser.Username, valuesFiles)
+		err = options.InstallProw(options.Flags.Tekton, options.InitOptions.Flags.ExternalDNS, options.Flags.GitOpsMode, gitOpsEnvDir, pipelineUser.Username, valuesFiles)
 		if err != nil {
 			return errors.Wrap(err, "installing Prow")
 		}

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -304,7 +304,7 @@ func (o *CommonOptions) AddHelmBinaryRepoIfMissing(url, repoName, username, pass
 }
 
 // InstallChartOrGitOps if using gitOps lets write files otherwise lets use helm
-func (o *CommonOptions) InstallChartOrGitOps(isGitOps bool, gitOpsDir string, gitOpsEnvDir string, releaseName string, chart string, alias string, version string, ns string, helmUpdate bool,
+func (o *CommonOptions) InstallChartOrGitOps(isGitOps bool, gitOpsEnvDir string, releaseName string, chart string, alias string, version string, ns string, helmUpdate bool,
 	setValues []string, setSecrets []string, valueFiles []string, repo string) error {
 
 	if !isGitOps {

--- a/pkg/cmd/opts/install.go
+++ b/pkg/cmd/opts/install.go
@@ -1658,7 +1658,7 @@ func (o *CommonOptions) AddDummyApplication(client kubernetes.Interface, devName
 }
 
 // InstallProw installs prow
-func (o *CommonOptions) InstallProw(useTekton bool, useExternalDNS bool, isGitOps bool, gitOpsDir string, gitOpsEnvDir string, gitUsername string, valuesFiles []string) error {
+func (o *CommonOptions) InstallProw(useTekton bool, useExternalDNS bool, isGitOps bool, gitOpsEnvDir string, gitUsername string, valuesFiles []string) error {
 	if o.ReleaseName == "" {
 		o.ReleaseName = kube.DefaultProwReleaseName
 	}
@@ -1744,7 +1744,7 @@ func (o *CommonOptions) InstallProw(useTekton bool, useExternalDNS bool, isGitOp
 			"auth.git.password="+o.OAUTHToken)
 
 		err = o.Retry(2, time.Second, func() (err error) {
-			return o.InstallChartOrGitOps(isGitOps, gitOpsDir, gitOpsEnvDir, kube.DefaultTektonReleaseName,
+			return o.InstallChartOrGitOps(isGitOps, gitOpsEnvDir, kube.DefaultTektonReleaseName,
 				kube.ChartTekton, "tekton", "", devNamespace, true, setValues, ksecretValues, valuesFiles, "")
 		})
 		if err != nil {
@@ -1761,7 +1761,7 @@ func (o *CommonOptions) InstallProw(useTekton bool, useExternalDNS bool, isGitOp
 		setValues = append(setValues, "build.auth.git.username="+gitUsername)
 		ksecretValues = append(ksecretValues, "build.auth.git.username="+gitUsername, "build.auth.git.password="+o.OAUTHToken)
 		err = o.Retry(2, time.Second, func() (err error) {
-			return o.InstallChartOrGitOps(isGitOps, gitOpsDir, gitOpsEnvDir, kube.DefaultKnativeBuildReleaseName,
+			return o.InstallChartOrGitOps(isGitOps, gitOpsEnvDir, kube.DefaultKnativeBuildReleaseName,
 				kube.ChartKnativeBuild, "knativebuild", "", devNamespace, true, setValues, ksecretValues, valuesFiles, "")
 		})
 		if err != nil {
@@ -1798,7 +1798,7 @@ func (o *CommonOptions) InstallProw(useTekton bool, useExternalDNS bool, isGitOp
 
 	secretValues := []string{"user=" + gitUsername, "oauthToken=" + o.OAUTHToken, "hmacToken=" + o.HMACToken}
 	err = o.Retry(2, time.Second, func() (err error) {
-		return o.InstallChartOrGitOps(isGitOps, gitOpsDir, gitOpsEnvDir, o.ReleaseName,
+		return o.InstallChartOrGitOps(isGitOps, gitOpsEnvDir, o.ReleaseName,
 			o.Chart, "prow", prowVersion, devNamespace, true, setValues, secretValues, valuesFiles, "")
 	})
 	if err != nil {
@@ -1808,7 +1808,7 @@ func (o *CommonOptions) InstallProw(useTekton bool, useExternalDNS bool, isGitOp
 	if !useTekton {
 		log.Logger().Infof("\nInstalling BuildTemplates into namespace %s", util.ColorInfo(devNamespace))
 		err = o.Retry(2, time.Second, func() (err error) {
-			return o.InstallChartOrGitOps(isGitOps, gitOpsDir, gitOpsEnvDir, kube.DefaultBuildTemplatesReleaseName,
+			return o.InstallChartOrGitOps(isGitOps, gitOpsEnvDir, kube.DefaultBuildTemplatesReleaseName,
 				kube.ChartBuildTemplates, "jxbuildtemplates", "", devNamespace, true, nil, nil, nil, "")
 		})
 		if err != nil {
@@ -1952,7 +1952,7 @@ func (o *CommonOptions) installExternalDNSGKE() error {
 
 	log.Logger().Infof("\nInstalling External DNS into namespace %s", util.ColorInfo(devNamespace))
 	err = o.Retry(2, time.Second, func() (err error) {
-		return o.InstallChartOrGitOps(false, "", "", kube.DefaultExternalDNSReleaseName, kube.ChartExternalDNS,
+		return o.InstallChartOrGitOps(false, "", kube.DefaultExternalDNSReleaseName, kube.ChartExternalDNS,
 			kube.ChartExternalDNS, "", devNamespace, true, values, nil, nil, "")
 	})
 	if err != nil {

--- a/pkg/helm/helm_helpers.go
+++ b/pkg/helm/helm_helpers.go
@@ -125,9 +125,15 @@ func (r *Requirements) SetAppVersion(app string, version string, repository stri
 	}
 	for _, dep := range r.Dependencies {
 		if dep != nil && dep.Name == app {
-			dep.Version = version
-			dep.Repository = repository
-			dep.Alias = alias
+			if version != dep.Version {
+				dep.Version = version
+			}
+			if repository != "" {
+				dep.Repository = repository
+			}
+			if alias != "" {
+				dep.Alias = alias
+			}
 			return
 		}
 	}


### PR DESCRIPTION
When running jx upgrade add on prow on a gitops enabled cluster, upgrade prow and tekton via a PR to the dev repository

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #4870
<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
