### PR TITLE
fix: fixed a bug that made boot fail when a generated bucket name ends with '-'

### DIFF
--- a/pkg/cloud/gke/storage/bucket_provider.go
+++ b/pkg/cloud/gke/storage/bucket_provider.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/jenkins-x/jx/pkg/cloud/buckets"
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
@@ -25,6 +26,9 @@ func (b *GKEBucketProvider) CreateNewBucketForCluster(clusterName string, bucket
 	bucketURL := fmt.Sprintf("gs://%s-%s-%s", clusterName, bucketKind, uuid4.String())
 	if len(bucketURL) > 60 {
 		bucketURL = bucketURL[:60]
+	}
+	if strings.HasSuffix(bucketURL, "-") {
+		bucketURL = bucketURL[:59]
 	}
 	err := b.EnsureBucketIsCreated(bucketURL)
 	if err != nil {

--- a/pkg/cloud/gke/storage/bucket_provider_test.go
+++ b/pkg/cloud/gke/storage/bucket_provider_test.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"github.com/jenkins-x/jx/pkg/cloud/gke/mocks"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/petergtz/pegomock"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestCreateNewBucketForClusterWithLongClusterNameAndDashAtCharacterSixty(t *testing.T) {
+	p := GKEBucketProvider{
+		gcloud: gke_test.NewMockGClouder(),
+		Requirements: &config.RequirementsConfig{
+			Cluster: config.ClusterConfig{
+				ProjectID: "project",
+			},
+		},
+	}
+
+	pegomock.When(p.gcloud.BucketExists(pegomock.AnyString(), pegomock.AnyString())).ThenReturn(true, nil)
+
+	bucketName, err := p.CreateNewBucketForCluster("rrehhhhhhhhhhhhhhhhhhhhhhhhhj3j3k2kwkdkjdbiwabduwabduoawbdb-dbwdbwaoud", "logs")
+	assert.NoError(t, err)
+	assert.NotNil(t, bucketName, "it should always generate a name")
+	assert.False(t, strings.HasSuffix(bucketName, "-"), "the bucket can't end with a dash")
+}
+
+func TestCreateNewBucketForClusterWithSmallClusterName(t *testing.T) {
+	p := GKEBucketProvider{
+		gcloud: gke_test.NewMockGClouder(),
+		Requirements: &config.RequirementsConfig{
+			Cluster: config.ClusterConfig{
+				ProjectID: "project",
+			},
+		},
+	}
+
+	pegomock.When(p.gcloud.BucketExists(pegomock.AnyString(), pegomock.AnyString())).ThenReturn(true, nil)
+
+	bucketName := createUniqueBucketNameForCluster("cluster")
+	assert.NotNil(t, bucketName, "it should always generate a name")
+	assert.False(t, strings.HasSuffix(bucketName, "-"), "the bucket can't end with a dash")
+}

--- a/pkg/cloud/gke/storage/long_term_storage.go
+++ b/pkg/cloud/gke/storage/long_term_storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	"github.com/jenkins-x/jx/pkg/kube"
@@ -54,6 +55,9 @@ func createUniqueBucketNameForCluster(clusterName string) string {
 	bucketName := fmt.Sprintf("%s-lts-%s", clusterName, uuid4.String())
 	if len(bucketName) > 60 {
 		bucketName = bucketName[:60]
+	}
+	if strings.HasSuffix(bucketName, "-") {
+		bucketName = bucketName[:59]
 	}
 	return bucketName
 }

--- a/pkg/cloud/gke/storage/long_term_storage_test.go
+++ b/pkg/cloud/gke/storage/long_term_storage_test.go
@@ -1,0 +1,19 @@
+package storage
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestCreateAValidBucketNameWithLongClusterNameAndDashAtCharacterSixty(t *testing.T) {
+	bucketName := createUniqueBucketNameForCluster("rrehhhhhhhhhhhhhhhhhhhhhhhhhj3j3k2kwkdkjdbiwabduwabduoawbdb-dbwdbwaoud")
+	assert.NotNil(t, bucketName, "it should always generate a name")
+	assert.False(t, strings.HasSuffix(bucketName, "-"), "the bucket can't end with a dash")
+}
+
+func TestCreateAValidBucketNameWithSmallClusterName(t *testing.T) {
+	bucketName := createUniqueBucketNameForCluster("cluster")
+	assert.NotNil(t, bucketName, "it should always generate a name")
+	assert.False(t, strings.HasSuffix(bucketName, "-"), "the bucket can't end with a dash")
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Added a control for an edge case that was making boot install to fail when creating a long term storage bucket


fixes #4895 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
