### PR TITLE
fix(tekton): PipelineResource should be reused for all builds on branch

### DIFF
--- a/pkg/cmd/step/create/step_create_meta_pipeline.go
+++ b/pkg/cmd/step/create/step_create_meta_pipeline.go
@@ -171,6 +171,8 @@ func (o *StepCreatePipelineOptions) Run() error {
 	branchIdentifier := o.determineBranchIdentifier(*pullRefs)
 	pipelineKind := o.determinePipelineKind(*pullRefs)
 
+	// resourceName is shared across all builds of a branch, while the pipelineName is unique for each build.
+	resourceName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, o.Context, tekton.MetaPipeline, nil, "")
 	pipelineName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, o.Context, tekton.MetaPipeline, tektonClient, ns)
 	buildNumber, err := tekton.GenerateNextBuildNumber(tektonClient, jxClient, ns, gitInfo, branchIdentifier, retryDuration, o.Context)
 	if err != nil {
@@ -196,6 +198,7 @@ func (o *StepCreatePipelineOptions) Run() error {
 		Namespace:        ns,
 		Context:          o.Context,
 		PipelineName:     pipelineName,
+		ResourceName:     resourceName,
 		PipelineKind:     pipelineKind,
 		BuildNumber:      buildNumber,
 		GitInfo:          *gitInfo,

--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -404,8 +404,9 @@ func TestGenerateTektonCRDs(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			resourceName := tekton.PipelineResourceNameFromGitInfo(createTask.GitInfo, createTask.Branch, createTask.Context, tekton.BuildPipeline, nil, "")
 			pipelineName := tekton.PipelineResourceNameFromGitInfo(createTask.GitInfo, createTask.Branch, createTask.Context, tekton.BuildPipeline, tektonClient, ns)
-			crds, err := createTask.generateTektonCRDs(effectiveProjectConfig, ns, pipelineName)
+			crds, err := createTask.generateTektonCRDs(effectiveProjectConfig, ns, pipelineName, resourceName)
 			if tt.expectingError {
 				if err == nil {
 					t.Fatalf("Expected an error generating CRDs")

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
@@ -16,7 +16,7 @@ spec:
       images and helm charts
     name: version
   resources:
-  - name: jenkins-x-jx-fix-kaniko-special-9l9zj
+  - name: jenkins-x-jx-fix-kaniko-special
     type: git
   tasks:
   - name: ci
@@ -26,7 +26,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: jenkins-x-jx-fix-kaniko-special-9l9zj
+        resource: jenkins-x-jx-fix-kaniko-special
     retries: 0
     taskRef:
       name: jenkins-x-jx-fix-kaniko-special-9l9zj-ci-1

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: jenkins-x-jx-fix-kaniko-special-9l9zj
+    name: jenkins-x-jx-fix-kaniko-special
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
@@ -16,10 +16,10 @@ spec:
     apiVersion: tekton.dev/v1alpha1
     name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
   resources:
-  - name: jenkins-x-jx-fix-kaniko-special-9l9zj
+  - name: jenkins-x-jx-fix-kaniko-special
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: jenkins-x-jx-fix-kaniko-special-9l9zj
+      name: jenkins-x-jx-fix-kaniko-special
   serviceAccount: tekton-bot
   timeout: 240h0m0s
   trigger:

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -40,6 +40,7 @@ type CRDCreationParameters struct {
 	Namespace        string
 	Context          string
 	PipelineName     string
+	ResourceName     string
 	PipelineKind     string
 	BuildNumber      string
 	GitInfo          gits.GitRepository
@@ -70,7 +71,7 @@ func CreateMetaPipelineCRDs(params CRDCreationParameters) (*tekton.CRDWrapper, e
 	if err != nil {
 		return nil, err
 	}
-	pipeline, tasks, structure, err := parsedPipeline.GenerateCRDs(params.PipelineName, params.BuildNumber, params.Namespace, params.PodTemplates, params.VersionsDir, nil, params.SourceDir, labels, params.DefaultImage)
+	pipeline, tasks, structure, err := parsedPipeline.GenerateCRDs(params.PipelineName, params.BuildNumber, params.ResourceName, params.Namespace, params.PodTemplates, params.VersionsDir, nil, params.SourceDir, labels, params.DefaultImage)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -1488,7 +1488,7 @@ func PipelineRunName(pipelineIdentifier string, buildIdentifier string) string {
 }
 
 // GenerateCRDs translates the Pipeline structure into the corresponding Pipeline and Task CRDs
-func (j *ParsedPipeline) GenerateCRDs(pipelineIdentifier string, buildIdentifier string, namespace string, podTemplates map[string]*corev1.Pod, versionsDir string, taskParams []tektonv1alpha1.ParamSpec, sourceDir string, labels map[string]string, defaultImage string) (*tektonv1alpha1.Pipeline, []*tektonv1alpha1.Task, *v1.PipelineStructure, error) {
+func (j *ParsedPipeline) GenerateCRDs(pipelineIdentifier string, buildIdentifier string, resourceIdentifier string, namespace string, podTemplates map[string]*corev1.Pod, versionsDir string, taskParams []tektonv1alpha1.ParamSpec, sourceDir string, labels map[string]string, defaultImage string) (*tektonv1alpha1.Pipeline, []*tektonv1alpha1.Task, *v1.PipelineStructure, error) {
 	if len(j.Post) != 0 {
 		return nil, nil, nil, errors.New("Post at top level not yet supported")
 	}
@@ -1519,7 +1519,7 @@ func (j *ParsedPipeline) GenerateCRDs(pipelineIdentifier string, buildIdentifier
 		Spec: tektonv1alpha1.PipelineSpec{
 			Resources: []tektonv1alpha1.PipelineDeclaredResource{
 				{
-					Name: pipelineIdentifier,
+					Name: resourceIdentifier,
 					Type: tektonv1alpha1.PipelineResourceTypeGit,
 				},
 			},

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -1273,7 +1273,7 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 				}
 			}
 
-			pipeline, tasks, structure, err := parsed.GenerateCRDs("somepipeline", "1", "jx", nil, testVersionsDir, nil, "source", nil, "")
+			pipeline, tasks, structure, err := parsed.GenerateCRDs("somepipeline", "1", "somepipeline", "jx", nil, testVersionsDir, nil, "source", nil, "")
 
 			if err != nil {
 				if tt.expectedErrorMsg != "" {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

While we do want unique `Pipeline`s, `PipelineRun`s, etc for each build on a given org/repo/branch, we want to use the same `PipelineResource` for all those builds. There's no reason not to reuse the `PipelineResource`s, so let's avoid CRD bloat.

#### Special notes for the reviewer(s)

/assign @hferentschik 
/assign @dgozalo 
/assign @jstrachan 

#### Which issue this PR fixes

fixes #4913
