### PR TITLE
feat: let's ignore the charts that have no  file when getting apps instead of forcing them

### DIFF
--- a/pkg/apps/gitops.go
+++ b/pkg/apps/gitops.go
@@ -200,16 +200,22 @@ func (o *GitOpsOptions) GetApps(appNames map[string]bool, expandFn func([]string
 					appsList.Items = append(appsList.Items, resourcesInCRD.Items...)
 				} else {
 					appPath := filepath.Join(envDir, d.Name, "templates", "app.yaml")
-					appFile, err := ioutil.ReadFile(appPath)
+					exists, err := util.FileExists(appPath)
 					if err != nil {
-						return nil, errors.Wrapf(err, "there was a problem reading the app.yaml file of %s", d.Name)
+						return nil, errors.Wrapf(err, "there was a problem checking if %s exists", appPath)
 					}
-					app := v1.App{}
-					err = yaml.Unmarshal(appFile, &app)
-					if err != nil {
-						return nil, errors.Wrapf(err, "there was a problem unmarshalling the app.yaml file of %s", d.Name)
+					if exists {
+						appFile, err := ioutil.ReadFile(appPath)
+						if err != nil {
+							return nil, errors.Wrapf(err, "there was a problem reading the app.yaml file of %s", d.Name)
+						}
+						app := v1.App{}
+						err = yaml.Unmarshal(appFile, &app)
+						if err != nil {
+							return nil, errors.Wrapf(err, "there was a problem unmarshalling the app.yaml file of %s", d.Name)
+						}
+						appsList.Items = append(appsList.Items, app)
 					}
-					appsList.Items = append(appsList.Items, app)
 				}
 			}
 		}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
We will ignore charts without an `app.yaml` file when executing `jx get apps` instead of failing. 

In the non boot way to install the platform, we were creating an `app.yaml` file for Prow and Tekton charts as we were adding them individually. Ideally these should have their own `app.yaml` file instead of creating a fake one. 

fixes #4910 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
