### PR TITLE
fix: print the quickstarts that match

### DIFF
--- a/pkg/quickstarts/model.go
+++ b/pkg/quickstarts/model.go
@@ -110,7 +110,7 @@ func (model *QuickstartModel) CreateSurvey(filter *QuickstartFilter, batchMode b
 		answer = names[0]
 	} else if batchMode {
 		// should not prompt for selection in batch mode so return an error
-		return nil, fmt.Errorf("More than one quickstart matches the current filter options. Try filtering based on other criteria (eg. Owner or Text)")
+		return nil, fmt.Errorf("More than one quickstart matches the current filter options. Try filtering based on other criteria (eg. Owner or Text): %v", names)
 	} else {
 		// if no single answer after filtering and we're not in batch mode then prompt
 		prompt := &survey.Select{


### PR DESCRIPTION
When more than one does in batch mode

Signed-off-by: Carlos Sanchez <carlos@apache.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Since https://github.com/jenkins-x-quickstarts/golang-http-from-jenkins-x-yml was created now this command used in many examples fail

```
jx create quickstart \
  --language go \
  --project-name xxx \
  --batch-mode

error: More than one quickstart matches the current filter options. Try filtering based on other criteria (eg. Owner or Text)
```

With the patch it prints

```
error: More than one quickstart matches the current filter options. Try filtering based on other criteria (eg. Owner or Text): [golang-http golang-http-from-jenkins-x-yml]
```

/cc @vfarcic 

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
