### PR TITLE
fix: fix the jx changelog for now

### DIFF
--- a/pkg/cmd/step/git/step_git_merge_test.go
+++ b/pkg/cmd/step/git/step_git_merge_test.go
@@ -2,15 +2,16 @@ package git
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/cmd/opts"
-	"github.com/jenkins-x/jx/pkg/gits"
-	"github.com/jenkins-x/jx/pkg/log"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/gits/testhelpers"
+	"github.com/jenkins-x/jx/pkg/log"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func TestStepGitMerge(t *testing.T) {
@@ -47,28 +48,28 @@ var _ = Describe("step git merge", func() {
 		repoDir, err = ioutil.TempDir("", "jenkins-x-git-test-repo-")
 		By(fmt.Sprintf("creating a test repository in '%s'", repoDir))
 		Expect(err).NotTo(HaveOccurred())
-		gits.GitCmd(Fail, repoDir, "init")
+		testhelpers.GitCmd(Fail, repoDir, "init")
 
 		By("adding single commit on master branch")
-		gits.WriteFile(Fail, repoDir, "a.txt", "a")
-		gits.Add(Fail, repoDir)
-		masterSha = gits.Commit(Fail, repoDir, "a commit")
+		testhelpers.WriteFile(Fail, repoDir, "a.txt", "a")
+		testhelpers.Add(Fail, repoDir)
+		masterSha = testhelpers.Commit(Fail, repoDir, "a commit")
 
 		By("creating branch 'b' and adding a commit")
-		gits.Branch(Fail, repoDir, "b")
-		gits.WriteFile(Fail, repoDir, "b.txt", "b")
-		gits.Add(Fail, repoDir)
-		branchBSha = gits.Commit(Fail, repoDir, "b commit")
+		testhelpers.Branch(Fail, repoDir, "b")
+		testhelpers.WriteFile(Fail, repoDir, "b.txt", "b")
+		testhelpers.Add(Fail, repoDir)
+		branchBSha = testhelpers.Commit(Fail, repoDir, "b commit")
 
 		By("creating branch 'c' and adding a commit")
-		gits.Checkout(Fail, repoDir, "master")
-		gits.Branch(Fail, repoDir, "c")
-		gits.WriteFile(Fail, repoDir, "c.txt", "c")
-		gits.Add(Fail, repoDir)
-		branchCSha = gits.Commit(Fail, repoDir, "c commit")
+		testhelpers.Checkout(Fail, repoDir, "master")
+		testhelpers.Branch(Fail, repoDir, "c")
+		testhelpers.WriteFile(Fail, repoDir, "c.txt", "c")
+		testhelpers.Add(Fail, repoDir)
+		branchCSha = testhelpers.Commit(Fail, repoDir, "c commit")
 
 		By("checking out master")
-		gits.Checkout(Fail, repoDir, "master")
+		testhelpers.Checkout(Fail, repoDir, "master")
 	})
 
 	AfterEach(func() {
@@ -85,7 +86,7 @@ var _ = Describe("step git merge", func() {
 
 	Context("with command line options", func() {
 		It("succeeds", func() {
-			currentHeadSha := gits.HeadSha(Fail, repoDir)
+			currentHeadSha := testhelpers.HeadSha(Fail, repoDir)
 			Expect(currentHeadSha).Should(Equal(masterSha))
 
 			options := StepGitMergeOptions{
@@ -101,7 +102,7 @@ var _ = Describe("step git merge", func() {
 			err := options.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			currentHeadSha = gits.HeadSha(Fail, repoDir)
+			currentHeadSha = testhelpers.HeadSha(Fail, repoDir)
 			Expect(currentHeadSha).Should(Equal(branchBSha))
 		})
 	})
@@ -118,7 +119,7 @@ var _ = Describe("step git merge", func() {
 		})
 
 		It("succeeds", func() {
-			currentHeadSha := gits.HeadSha(Fail, repoDir)
+			currentHeadSha := testhelpers.HeadSha(Fail, repoDir)
 			Expect(currentHeadSha).Should(Equal(masterSha))
 
 			options := StepGitMergeOptions{
@@ -131,7 +132,7 @@ var _ = Describe("step git merge", func() {
 			err := options.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			currentHeadSha = gits.HeadSha(Fail, repoDir)
+			currentHeadSha = testhelpers.HeadSha(Fail, repoDir)
 			Expect(currentHeadSha).Should(Equal(branchBSha))
 		})
 	})
@@ -149,7 +150,7 @@ var _ = Describe("step git merge", func() {
 		})
 
 		It("merges all shas and creates a merge commit", func() {
-			currentHeadSha := gits.HeadSha(Fail, repoDir)
+			currentHeadSha := testhelpers.HeadSha(Fail, repoDir)
 			Expect(currentHeadSha).Should(Equal(masterSha))
 
 			options := StepGitMergeOptions{
@@ -188,7 +189,7 @@ var _ = Describe("step git merge", func() {
 				err := options.Run()
 				Expect(err).NotTo(HaveOccurred())
 
-				currentHeadSha := gits.HeadSha(Fail, repoDir)
+				currentHeadSha := testhelpers.HeadSha(Fail, repoDir)
 				Expect(currentHeadSha).Should(Equal(masterSha))
 			})
 

--- a/pkg/cmd/step/step_changelog.go
+++ b/pkg/cmd/step/step_changelog.go
@@ -246,7 +246,7 @@ func (o *StepChangelogOptions) Run() error {
 		}
 	}
 	if previousRev == "" {
-		previousRev, _, err = o.Git().GetPreviousGitTagSHA(dir)
+		previousRev, _, err = o.Git().GetCommitPointedToByPreviousTag(dir)
 		if err != nil {
 			return err
 		}
@@ -257,7 +257,7 @@ func (o *StepChangelogOptions) Run() error {
 	}
 	currentRev := o.CurrentRevision
 	if currentRev == "" {
-		currentRev, _, err = o.Git().GetCurrentGitTagSHA(dir)
+		currentRev, _, err = o.Git().GetCommitPointedToByLatestTag(dir)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/step/step_next_version.go
+++ b/pkg/cmd/step/step_next_version.go
@@ -106,7 +106,7 @@ func (o *StepNextVersionOptions) Run() error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		rev, tag, err := o.Git().GetCurrentGitTagSHA(o.Dir)
+		rev, tag, err := o.Git().GetCommitPointedToByLatestTag(o.Dir)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -431,8 +431,8 @@ func (g *GitFake) HasChanges(dir string) (bool, error) {
 	return g.Changes, nil
 }
 
-// GetPreviousGitTagSHA returns the previous git tag SHA
-func (g *GitFake) GetPreviousGitTagSHA(dir string) (string, string, error) {
+// GetCommitPointedToByPreviousTag returns the previous git tag SHA
+func (g *GitFake) GetCommitPointedToByPreviousTag(dir string) (string, string, error) {
 	len := len(g.Commits)
 	if len < 2 {
 		return "", "", errors.New("no previous commit found")
@@ -440,8 +440,8 @@ func (g *GitFake) GetPreviousGitTagSHA(dir string) (string, string, error) {
 	return g.Commits[len-2].SHA, "", nil
 }
 
-// GetCurrentGitTagSHA returns the current git tag sha
-func (g *GitFake) GetCurrentGitTagSHA(dir string) (string, string, error) {
+// GetCommitPointedToByLatestTag returns the current git tag sha
+func (g *GitFake) GetCommitPointedToByLatestTag(dir string) (string, string, error) {
 	len := len(g.Commits)
 	if len < 1 {
 		return "", "", errors.New("no current commit found")

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -273,9 +273,9 @@ func (g *GitLocal) RemoteBranchNames(dir string, prefix string) ([]string, error
 	return g.GitCLI.RemoteBranchNames(dir, prefix)
 }
 
-// GetPreviousGitTagSHA returns the previous git tag from the repository at the given directory
-func (g *GitLocal) GetPreviousGitTagSHA(dir string) (string, string, error) {
-	return g.GitCLI.GetPreviousGitTagSHA(dir)
+// GetCommitPointedToByPreviousTag returns the previous git tag from the repository at the given directory
+func (g *GitLocal) GetCommitPointedToByPreviousTag(dir string) (string, string, error) {
+	return g.GitCLI.GetCommitPointedToByPreviousTag(dir)
 }
 
 // GetRevisionBeforeDate returns the revision before the given date
@@ -288,9 +288,9 @@ func (g *GitLocal) GetRevisionBeforeDateText(dir string, dateText string) (strin
 	return g.GitCLI.GetRevisionBeforeDateText(dir, dateText)
 }
 
-// GetCurrentGitTagSHA return the SHA of the current git tag from the repository at the given directory
-func (g *GitLocal) GetCurrentGitTagSHA(dir string) (string, string, error) {
-	return g.GitCLI.GetCurrentGitTagSHA(dir)
+// GetCommitPointedToByLatestTag return the SHA of the current git tag from the repository at the given directory
+func (g *GitLocal) GetCommitPointedToByLatestTag(dir string) (string, string, error) {
+	return g.GitCLI.GetCommitPointedToByLatestTag(dir)
 }
 
 // GetLatestCommitMessage returns the latest git commit message

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -253,8 +253,8 @@ type Gitter interface {
 	LoadFileFromBranch(dir string, branch string, file string) (string, error)
 
 	GetLatestCommitMessage(dir string) (string, error)
-	GetPreviousGitTagSHA(dir string) (string, string, error)
-	GetCurrentGitTagSHA(dir string) (string, string, error)
+	GetCommitPointedToByPreviousTag(dir string) (string, string, error)
+	GetCommitPointedToByLatestTag(dir string) (string, string, error)
 	FetchTags(dir string) error
 	Tags(dir string) ([]string, error)
 	FilterTags(dir string, filter string) ([]string, error)

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -560,6 +560,52 @@ func (mock *MockGitter) GetAuthorEmailForCommit(_param0 string, _param1 string) 
 	return ret0, ret1
 }
 
+func (mock *MockGitter) GetCommitPointedToByLatestTag(_param0 string) (string, string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("GetCommitPointedToByLatestTag", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 string
+	var ret2 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(string)
+		}
+		if result[2] != nil {
+			ret2 = result[2].(error)
+		}
+	}
+	return ret0, ret1, ret2
+}
+
+func (mock *MockGitter) GetCommitPointedToByPreviousTag(_param0 string) (string, string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("GetCommitPointedToByPreviousTag", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 string
+	var ret2 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(string)
+		}
+		if result[2] != nil {
+			ret2 = result[2].(error)
+		}
+	}
+	return ret0, ret1, ret2
+}
+
 func (mock *MockGitter) GetCommits(_param0 string, _param1 string, _param2 string) ([]gits.GitCommit, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -577,29 +623,6 @@ func (mock *MockGitter) GetCommits(_param0 string, _param1 string, _param2 strin
 		}
 	}
 	return ret0, ret1
-}
-
-func (mock *MockGitter) GetCurrentGitTagSHA(_param0 string) (string, string, error) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockGitter().")
-	}
-	params := []pegomock.Param{_param0}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("GetCurrentGitTagSHA", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 string
-	var ret1 string
-	var ret2 error
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(string)
-		}
-		if result[1] != nil {
-			ret1 = result[1].(string)
-		}
-		if result[2] != nil {
-			ret2 = result[2].(error)
-		}
-	}
-	return ret0, ret1, ret2
 }
 
 func (mock *MockGitter) GetLatestCommitMessage(_param0 string) (string, error) {
@@ -638,29 +661,6 @@ func (mock *MockGitter) GetLatestCommitSha(_param0 string) (string, error) {
 		}
 	}
 	return ret0, ret1
-}
-
-func (mock *MockGitter) GetPreviousGitTagSHA(_param0 string) (string, string, error) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockGitter().")
-	}
-	params := []pegomock.Param{_param0}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("GetPreviousGitTagSHA", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 string
-	var ret1 string
-	var ret2 error
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(string)
-		}
-		if result[1] != nil {
-			ret1 = result[1].(string)
-		}
-		if result[2] != nil {
-			ret2 = result[2].(error)
-		}
-	}
-	return ret0, ret1, ret2
 }
 
 func (mock *MockGitter) GetRemoteUrl(_param0 *config.Config, _param1 string) string {
@@ -2474,6 +2474,60 @@ func (c *MockGitter_GetAuthorEmailForCommit_OngoingVerification) GetAllCapturedA
 	return
 }
 
+func (verifier *VerifierMockGitter) GetCommitPointedToByLatestTag(_param0 string) *MockGitter_GetCommitPointedToByLatestTag_OngoingVerification {
+	params := []pegomock.Param{_param0}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetCommitPointedToByLatestTag", params, verifier.timeout)
+	return &MockGitter_GetCommitPointedToByLatestTag_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_GetCommitPointedToByLatestTag_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_GetCommitPointedToByLatestTag_OngoingVerification) GetCapturedArguments() string {
+	_param0 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1]
+}
+
+func (c *MockGitter_GetCommitPointedToByLatestTag_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(params[0]))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) GetCommitPointedToByPreviousTag(_param0 string) *MockGitter_GetCommitPointedToByPreviousTag_OngoingVerification {
+	params := []pegomock.Param{_param0}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetCommitPointedToByPreviousTag", params, verifier.timeout)
+	return &MockGitter_GetCommitPointedToByPreviousTag_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_GetCommitPointedToByPreviousTag_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_GetCommitPointedToByPreviousTag_OngoingVerification) GetCapturedArguments() string {
+	_param0 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1]
+}
+
+func (c *MockGitter_GetCommitPointedToByPreviousTag_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(params[0]))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+	}
+	return
+}
+
 func (verifier *VerifierMockGitter) GetCommits(_param0 string, _param1 string, _param2 string) *MockGitter_GetCommits_OngoingVerification {
 	params := []pegomock.Param{_param0, _param1, _param2}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetCommits", params, verifier.timeout)
@@ -2504,33 +2558,6 @@ func (c *MockGitter_GetCommits_OngoingVerification) GetAllCapturedArguments() (_
 		_param2 = make([]string, len(params[2]))
 		for u, param := range params[2] {
 			_param2[u] = param.(string)
-		}
-	}
-	return
-}
-
-func (verifier *VerifierMockGitter) GetCurrentGitTagSHA(_param0 string) *MockGitter_GetCurrentGitTagSHA_OngoingVerification {
-	params := []pegomock.Param{_param0}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetCurrentGitTagSHA", params, verifier.timeout)
-	return &MockGitter_GetCurrentGitTagSHA_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockGitter_GetCurrentGitTagSHA_OngoingVerification struct {
-	mock              *MockGitter
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockGitter_GetCurrentGitTagSHA_OngoingVerification) GetCapturedArguments() string {
-	_param0 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1]
-}
-
-func (c *MockGitter_GetCurrentGitTagSHA_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
-	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
-	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
-		for u, param := range params[0] {
-			_param0[u] = param.(string)
 		}
 	}
 	return
@@ -2580,33 +2607,6 @@ func (c *MockGitter_GetLatestCommitSha_OngoingVerification) GetCapturedArguments
 }
 
 func (c *MockGitter_GetLatestCommitSha_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
-	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
-	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
-		for u, param := range params[0] {
-			_param0[u] = param.(string)
-		}
-	}
-	return
-}
-
-func (verifier *VerifierMockGitter) GetPreviousGitTagSHA(_param0 string) *MockGitter_GetPreviousGitTagSHA_OngoingVerification {
-	params := []pegomock.Param{_param0}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetPreviousGitTagSHA", params, verifier.timeout)
-	return &MockGitter_GetPreviousGitTagSHA_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockGitter_GetPreviousGitTagSHA_OngoingVerification struct {
-	mock              *MockGitter
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockGitter_GetPreviousGitTagSHA_OngoingVerification) GetCapturedArguments() string {
-	_param0 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1]
-}
-
-func (c *MockGitter_GetPreviousGitTagSHA_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(params[0]))

--- a/pkg/jenkinsfile/gitresolver/buildpack_test.go
+++ b/pkg/jenkinsfile/gitresolver/buildpack_test.go
@@ -1,15 +1,17 @@
 package gitresolver
 
 import (
-	"github.com/google/uuid"
-	"github.com/jenkins-x/jx/pkg/gits"
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/jenkins-x/jx/pkg/util"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/gits/testhelpers"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildPackInitClone(t *testing.T) {
@@ -63,11 +65,11 @@ func TestBuildPackInitClone(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Removing the remote tracking information, after executing InitBuildPack, it should have not failed and it should've set a remote tracking branch
-	gits.GitCmd(func(s string, i ...int) {}, gitDir, "branch", "--unset-upstream")
+	testhelpers.GitCmd(func(s string, i ...int) {}, gitDir, "branch", "--unset-upstream")
 
 	_, err = InitBuildPack(gitter, "", "master")
 
-	gits.GitCmd(func(s string, i ...int) {}, gitDir, "status", "-sb")
+	testhelpers.GitCmd(func(s string, i ...int) {}, gitDir, "status", "-sb")
 
 	args := []string{"status", "-sb"}
 	cmd := util.Command{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)
This at least restores the broken release notes as covered in #4867. @hferentschik when you are back you should pick this up and see how you think it should be fixed properly. 

We should also think about how we actually test this - it was certainly returning a nonexistent SHA.

#### Which issue this PR fixes


<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
