### PR TITLE
fix(tekton): Include logs for builds with just init containers running

### DIFF
--- a/pkg/tekton/pipelines.go
+++ b/pkg/tekton/pipelines.go
@@ -427,7 +427,7 @@ func PipelineRunIsNotPending(pr *pipelineapi.PipelineRun) bool {
 		for _, v := range pr.Status.TaskRuns {
 			if v.Status != nil {
 				for _, stepState := range v.Status.Steps {
-					if stepState.Waiting == nil {
+					if stepState.Waiting == nil || stepState.Waiting.Reason == "PodInitializing" {
 						return true
 					}
 				}

--- a/pkg/tekton/pipelines_test.go
+++ b/pkg/tekton/pipelines_test.go
@@ -116,3 +116,42 @@ func TestPipelineRunIsNotPendingWaitingSteps(t *testing.T) {
 
 	assert.False(t, tekton.PipelineRunIsNotPending(pr))
 }
+
+func TestPipelineRunIsNotPendingWaitingStepsInPodInitializing(t *testing.T) {
+	taskRunStatusMap := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
+	taskRunStatusMap["faketaskrun"] = &v1alpha1.PipelineRunTaskRunStatus{
+		Status: &v1alpha1.TaskRunStatus{
+			Steps: []v1alpha1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason: "PodInitializing",
+					},
+				},
+			}},
+		},
+	}
+
+	pr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "PR1",
+			Namespace: ns,
+			Labels: map[string]string{
+				tekton.LabelRepo:    "fakerepo",
+				tekton.LabelBranch:  "fakebranch",
+				tekton.LabelOwner:   "fakeowner",
+				tekton.LabelContext: "fakecontext",
+			},
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			Params: []v1alpha1.Param{
+				{Name: "version", Value: "v1"},
+				{Name: "build_id", Value: "1"},
+			},
+		},
+		Status: v1alpha1.PipelineRunStatus{
+			TaskRuns: taskRunStatusMap,
+		},
+	}
+
+	assert.True(t, tekton.PipelineRunIsNotPending(pr))
+}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

A bit ago, we started ignoring pipeline runs that didn't have a running step yet - so that we don't get confused by pods that are in `Pending` and think they're actually done. This meant that we ended up waiting until there was a non-init container step running, because `PipelineRun`'s status doesn't include the init containers. D'oh! So let's look for either not waiting at all or waiting but the reason is `PodInitializing` - which basically means the init containers are running or have completed and other images are being pulled.

#### Special notes for the reviewer(s)

/assign @dgozalo 

#### Which issue this PR fixes

n/a