### PR TITLE
feat: moved the boot configuration to step helm to be used by helm build too

### DIFF
--- a/pkg/cmd/step/helm/step_helm.go
+++ b/pkg/cmd/step/helm/step_helm.go
@@ -2,7 +2,13 @@ package helm
 
 import (
 	"fmt"
+	"github.com/ghodss/yaml"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/version"
+	"github.com/pkg/errors"
+	"k8s.io/helm/pkg/chartutil"
 	"path/filepath"
+	"text/template"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/step/git"
@@ -30,6 +36,8 @@ type StepHelmOptions struct {
 	Dir         string
 	https       bool
 	GitProvider string
+
+	versionResolver *opts.VersionResolver
 }
 
 // NewCmdStepHelm Steps a command object for the "step" command
@@ -214,4 +222,165 @@ func (o *StepHelmOptions) discoverValuesFiles(dir string) ([]string, error) {
 		}
 	}
 	return valuesFiles, nil
+}
+
+func (o *StepHelmOptions) getOrCreateVersionResolver(requirementsConfig *config.RequirementsConfig) (*opts.VersionResolver, error) {
+	if o.versionResolver == nil {
+		vs := requirementsConfig.VersionStream
+		log.Logger().Infof("verifying the helm requirements versions in dir: %s using version stream URL: %s and git ref: %s\n", o.Dir, vs.URL, vs.Ref)
+
+		var err error
+		o.versionResolver, err = o.CreateVersionResolver(vs.URL, vs.Ref)
+		if err != nil {
+			return o.versionResolver, errors.Wrapf(err, "failed to create version resolver")
+		}
+	}
+	return o.versionResolver, nil
+}
+
+func (o *StepHelmOptions) verifyRequirementsYAML(resolver *opts.VersionResolver, prefixes *opts.RepositoryPrefixes, fileName string) error {
+	req, err := helm.LoadRequirementsFile(fileName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load %s", fileName)
+	}
+
+	modified := false
+	for _, dep := range req.Dependencies {
+		if dep.Version == "" {
+			name := dep.Alias
+			if name == "" {
+				name = dep.Name
+			}
+			repo := dep.Repository
+			if repo == "" {
+				return fmt.Errorf("cannot to find a version for dependency %s in file %s as there is no 'repository'", name, fileName)
+			}
+
+			prefix := prefixes.PrefixForURL(repo)
+			if prefix == "" {
+				return fmt.Errorf("the helm repository %s does not have an associated prefix in in the 'charts/repositories.yml' file the version stream, so we cannot default the version in file %s", repo, fileName)
+			}
+			newVersion := ""
+			fullChartName := prefix + "/" + dep.Name
+			newVersion, err := resolver.StableVersionNumber(version.KindChart, fullChartName)
+			if err != nil {
+				return errors.Wrapf(err, "failed to find version of chart %s in file %s", fullChartName, fileName)
+			}
+			if newVersion == "" {
+				return fmt.Errorf("failed to find a version for dependency %s in file %s in the current version stream - please either add an explicit version to this file or add chart %s to the version stream", name, fileName, fullChartName)
+			}
+			dep.Version = newVersion
+			modified = true
+			log.Logger().Infof("adding version %s to dependency %s in file %s", newVersion, name, fileName)
+		}
+	}
+
+	if modified {
+		err = helm.SaveFile(fileName, req)
+		if err != nil {
+			return errors.Wrapf(err, "failed to save %s", fileName)
+		}
+		log.Logger().Infof("adding dependency versions to file %s", fileName)
+	}
+	return nil
+}
+
+func (o *StepHelmOptions) replaceMissingVersionsFromVersionStream(requirementsConfig *config.RequirementsConfig, dir string) error {
+	fileName := filepath.Join(dir, helm.RequirementsFileName)
+	exists, err := util.FileExists(fileName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check for file %s", fileName)
+	}
+	if !exists {
+		log.Logger().Infof("no requirements file: %s so not checking for missing versions\n", fileName)
+		return nil
+	}
+
+	vs := requirementsConfig.VersionStream
+	log.Logger().Infof("verifying the helm requirements versions in dir: %s using version stream URL: %s and git ref: %s\n", o.Dir, vs.URL, vs.Ref)
+
+	resolver, err := o.getOrCreateVersionResolver(requirementsConfig)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create version resolver")
+	}
+
+	prefixes, err := resolver.GetRepositoryPrefixes()
+	if err != nil {
+		return errors.Wrapf(err, "failed to load repository prefixes")
+	}
+
+	err = o.verifyRequirementsYAML(resolver, prefixes, fileName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to replace missing versions in file %s", fileName)
+	}
+	return nil
+}
+
+func (o *StepHelmOptions) createFuncMap(requirementsConfig *config.RequirementsConfig) (template.FuncMap, error) {
+	funcMap := helm.NewFunctionMap()
+	resolver, err := o.getOrCreateVersionResolver(requirementsConfig)
+
+	if err != nil {
+		return funcMap, err
+	}
+
+	// represents the helm template function
+	// which can be used like: `{{ versionStream "chart" "foo/bar" }}
+	funcMap["versionStream"] = func(kindString, name string) string {
+		kind := version.VersionKind(kindString)
+		version, err := resolver.StableVersionNumber(kind, name)
+		if err != nil {
+			log.Logger().Errorf("failed to find %s version for %s in the version stream due to: %s\n", kindString, name, err.Error())
+		}
+		return version
+	}
+	return funcMap, nil
+}
+
+func (o *StepHelmOptions) overwriteProviderValues(requirements *config.RequirementsConfig, requirementsFileName string, valuesData []byte, params chartutil.Values, providersValuesDir string) ([]byte, error) {
+	provider := requirements.Cluster.Provider
+	if provider == "" {
+		log.Logger().Warnf("No provider in the requirements file %s\n", requirementsFileName)
+		return valuesData, nil
+	}
+	valuesTmplYamlFile := filepath.Join(providersValuesDir, provider, "values.tmpl.yaml")
+	exists, err := util.FileExists(valuesTmplYamlFile)
+	if err != nil {
+		return valuesData, errors.Wrapf(err, "failed to check if file exists: %s", valuesTmplYamlFile)
+	}
+	log.Logger().Infof("Applying the kubernetes overrides at %s\n", util.ColorInfo(valuesTmplYamlFile))
+
+	if !exists {
+		log.Logger().Warnf("No provider specific values overrides exist in file %s\n", valuesTmplYamlFile)
+		return valuesData, nil
+
+	}
+	funcMap, err := o.createFuncMap(requirements)
+	if err != nil {
+		return valuesData, err
+	}
+
+	overrideData, err := helm.ReadValuesYamlFileTemplateOutput(valuesTmplYamlFile, params, funcMap, requirements)
+	if err != nil {
+		return valuesData, errors.Wrapf(err, "failed to load provider specific helm value overrides %s", valuesTmplYamlFile)
+	}
+	if len(overrideData) == 0 {
+		return valuesData, nil
+	}
+
+	// now lets apply the overrides
+	values, err := helm.LoadValues(valuesData)
+	if err != nil {
+		return valuesData, errors.Wrapf(err, "failed to unmarshal the default helm values")
+	}
+
+	overrides, err := helm.LoadValues(overrideData)
+	if err != nil {
+		return valuesData, errors.Wrapf(err, "failed to unmarshal the default helm values")
+	}
+
+	util.CombineMapTrees(values, overrides)
+
+	data, err := yaml.Marshal(values)
+	return data, err
 }

--- a/pkg/cmd/step/helm/step_helm_build.go
+++ b/pkg/cmd/step/helm/step_helm_build.go
@@ -2,7 +2,13 @@ package helm
 
 import (
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/helm"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/pkg/errors"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
@@ -13,7 +19,9 @@ import (
 type StepHelmBuildOptions struct {
 	StepHelmOptions
 
-	recursive bool
+	recursive         bool
+	Boot              bool
+	ProviderValuesDir string
 }
 
 var (
@@ -55,7 +63,8 @@ func NewCmdStepHelmBuild(commonOpts *opts.CommonOptions) *cobra.Command {
 	options.addStepHelmFlags(cmd)
 
 	cmd.Flags().BoolVarP(&options.recursive, "recursive", "r", false, "Build recursively the dependent charts")
-
+	cmd.Flags().BoolVarP(&options.Boot, "boot", "", false, "In Boot mode we load the Version Stream from the 'jx-requirements.yml' and use that to replace any missing versions in the 'reuqirements.yaml' file from the Version Stream")
+	cmd.Flags().StringVarP(&options.ProviderValuesDir, "provider-values-dir", "", "", "The optional directory of kubernetes provider specific override values.tmpl.yaml files a kubernetes provider specific folder")
 	return cmd
 }
 
@@ -76,6 +85,58 @@ func (o *StepHelmBuildOptions) Run() error {
 	valuesFiles, err := o.discoverValuesFiles(dir)
 	if err != nil {
 		return err
+	}
+
+	if o.Boot {
+
+		secretURLClient, err := o.GetSecretURLClient()
+		if err != nil {
+			return errors.Wrap(err, "failed to create a Secret RL client")
+		}
+
+		requirements, requirementsFileName, err := config.LoadRequirementsConfig(dir)
+		if err != nil {
+			return err
+		}
+
+		devGitInfo, err := o.FindGitInfo(dir)
+		if err != nil {
+			log.Logger().Warnf("could not find a git repository in the directory %s: %s\n", dir, err.Error())
+		}
+
+		DefaultEnvironments(requirements, devGitInfo)
+
+		funcMap, err := o.createFuncMap(requirements)
+		if err != nil {
+			return err
+		}
+		chartValues, params, err := helm.GenerateValues(requirements, funcMap, dir, nil, true, secretURLClient)
+		if err != nil {
+			return errors.Wrapf(err, "generating values.yaml for tree from %s", dir)
+		}
+		if o.ProviderValuesDir != "" {
+			chartValues, err = o.overwriteProviderValues(requirements, requirementsFileName, chartValues, params, o.ProviderValuesDir)
+			if err != nil {
+				return errors.Wrapf(err, "failed to overwrite provider values in dir: %s", dir)
+			}
+		}
+
+		err = o.replaceMissingVersionsFromVersionStream(requirements, dir)
+		if err != nil {
+			return errors.Wrapf(err, "failed to replace missing versions in the requirements.yaml in dir %s", dir)
+		}
+
+		chartValuesFile := filepath.Join(dir, helm.ValuesFileName)
+		err = ioutil.WriteFile(chartValuesFile, chartValues, 0755)
+		if err != nil {
+			return errors.Wrapf(err, "writing values.yaml for tree to %s", chartValuesFile)
+		}
+		log.Logger().Infof("Wrote chart values.yaml %s generated from directory tree", chartValuesFile)
+
+		valuesFiles, err = o.discoverValuesFiles(dir)
+		if err != nil {
+			return err
+		}
 	}
 
 	if o.recursive {


### PR DESCRIPTION
Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
After the need to get versions from the version resolver was identified for `jx step helm build`, the existing code performing this functionality was present in `step_helm_apply`. 

I moved the code to `step_helm.go` as it serves as the common dependency of all helm commands, which means it should be easier to reuse this code in the future. 

`jx step helm build` should now properly resolve all versions and be able to form a values yaml file that will be needed to perform the linting of the chart.

#### Which issue this PR fixes

fixes #4940, #4909 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
