### PR TITLE
fix: added optional git reporting of pipelines for lighthouse

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.2.0
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
-	github.com/google/go-cmp v0.2.0
+	github.com/google/go-cmp v0.3.0
 	github.com/google/go-containerregistry v0.0.0-20190317040536-ebbba8469d06 // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
@@ -66,6 +66,7 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jbrukh/bayesian v0.0.0-20161210175230-bf3f261f9a9c // indirect
 	github.com/jenkins-x/draft-repo v0.0.0-20180417100212-2f66cc518135
+	github.com/jenkins-x/go-scm v1.5.21
 	github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314
 	github.com/jetstack/cert-manager v0.5.2
 	github.com/kevinburke/ssh_config v0.0.0-20180317175531-9fc7bb800b55 // indirect
@@ -120,7 +121,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.1.0
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	gocloud.dev v0.9.0
-	golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f
 	golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 // indirect
@@ -134,7 +135,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190126160303-ccdd560a045f
 	k8s.io/apiextensions-apiserver v0.0.0-20190308081736-3a66ae4d2f93
-	k8s.io/apimachinery v0.0.0-20190122181752-bebe27e40fb7
+	k8s.io/apimachinery v0.0.0-20190703205208-4cfb76a8bf76
 	k8s.io/client-go v9.0.0+incompatible
 	k8s.io/helm v2.7.2+incompatible
 	k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCy
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-containerregistry v0.0.0-20190317040536-ebbba8469d06 h1:NpQB+kIohBPM3cbY/XTyNlLls6I9n5XELX7/TEFa4iI=
 github.com/google/go-containerregistry v0.0.0-20190317040536-ebbba8469d06/go.mod h1:yZAFP63pRshzrEYLXLGPmUt0Ay+2zdjmMN1loCnRLUk=
 github.com/google/go-github v0.0.0-20170604030111-7a51fb928f52/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -347,6 +349,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.4.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpg
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/grpc-ecosystem/grpc-gateway v1.5.1 h1:3scN4iuXkNOyP98jF55Lv8a9j1o/IwvnDIZ0LHJK1nk=
 github.com/grpc-ecosystem/grpc-gateway v1.5.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
+github.com/h2non/gock v1.0.9/go.mod h1:CZMcB0Lg5IWnr9bF79pPMg9WeV6WumxQiUJ1UvdO1iE=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce h1:prjrVgOk2Yg6w+PflHoszQNLTUh4kaByUcEWM/9uin4=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -408,6 +411,10 @@ github.com/jbrukh/bayesian v0.0.0-20161210175230-bf3f261f9a9c h1:jqLMOnuwp+ac6nI
 github.com/jbrukh/bayesian v0.0.0-20161210175230-bf3f261f9a9c/go.mod h1:SELxwZQq/mPnfPCR2mchLmT4TQaPJvYtLcCtDWSM7vM=
 github.com/jenkins-x/draft-repo v0.0.0-20180417100212-2f66cc518135 h1:3zy/Nvdi9V95Jfu6+W4NAJrHDeypB58FSLyzI3XfO/4=
 github.com/jenkins-x/draft-repo v0.0.0-20180417100212-2f66cc518135/go.mod h1:K/L25ViEpDx196rOZyjn433tAM5zr2F/IouK+3g+DkE=
+github.com/jenkins-x/go-scm v1.5.20 h1:PDv9WNgZsG/sPwCdVkHJKBHE2jouLDFL2e5P5LyoQyU=
+github.com/jenkins-x/go-scm v1.5.20/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
+github.com/jenkins-x/go-scm v1.5.21 h1:xAbVDPBPoZUk5ntI72rt2rXeUx/tsDELj4ohdJgFBIQ=
+github.com/jenkins-x/go-scm v1.5.21/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/ucSV92S+umX/V6DDaPNynlFFOM9MGJWApltoU=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314/go.mod h1:C6j5HgwlHGjRU27W4XCs6jXksqYFo8OdBu+p44jqQeM=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767 h1:lKtC9uHyWi8wd+EUch3Pfzk3/8XSJvYRJhvk9dK4YKY=
@@ -775,6 +782,7 @@ golang.org/x/net v0.0.0-20181201002055-351d144fa1fc h1:a3CU5tJYVj92DY2LaA1kUkrsq
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc h1:a3CU5tJYVj92DY2LaA1kUkrsqD5/3mLDhx2NcNqyW+0=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -786,6 +794,8 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890 h1:uESlIz09WIHT2I+pasSXcpLYqYK8wHcdCetU3VuMBJE=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
@@ -839,6 +849,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.3.0 h1:FBSsiFRMz3LBeXIomRnVzrQwSDj4ibvcRexLG0LZGQk=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180601223552-81158efcc9f2/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180608181217-32ee49c4dd80/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/pkg/cmd/controller/controller_build_test.go
+++ b/pkg/cmd/controller/controller_build_test.go
@@ -131,6 +131,18 @@ func TestUpdateForStage(t *testing.T) {
 	}
 }
 
+func TestCreateReportTargetURL(t *testing.T) {
+	params := ReportParams{
+		Owner:      "jstrachan",
+		Repository: "myapp",
+		Branch:     "PR-5",
+		Build:      "3",
+		Context:    "jenkins-x",
+	}
+	actual := CreateReportTargetURL("https://myconsole.acme.com/{{ .Owner }}/{{ .Repository }}/{{ .Branch }}/{{ .Build }}", params)
+	assert.Equal(t, "https://myconsole.acme.com/jstrachan/myapp/PR-5/3", actual, "created git report URL for params %#v", params)
+}
+
 func TestUpdateForStagePreTekton051(t *testing.T) {
 	pod := tekton_helpers_test.AssertLoadSinglePod(t, path.Join("test_data", "controller_build", "update_stage_info_pre_tekton_0.5.1"))
 	si := &tekton.StageInfo{

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -76,7 +76,7 @@ func (g *GitCLI) ShallowCloneBranch(url string, branch string, dir string) error
 
 // ShallowClone shallow clones the repo at url from the specified commitish or pull request to a local master branch
 func (g *GitCLI) ShallowClone(dir string, url string, commitish string, pullRequest string) error {
-	return g.clone(dir, url, "", true, false, "", commitish, pullRequest)
+	return g.clone(dir, url, "", true, false, "master", commitish, pullRequest)
 }
 
 // clone is a safer implementation of the `git clone` method
@@ -142,16 +142,9 @@ func (g *GitCLI) clone(dir string, gitURL string, remoteName string, shallow boo
 			commitish = "master"
 		}
 	}
-	if commitish == localBranch {
-		err = g.ResetHard(dir, fmt.Sprintf("%s/%s", remoteName, commitish))
-		if err != nil {
-			return errors.Wrapf(err, "failed to reset hard to %s in directory %s", commitish, dir)
-		}
-	} else {
-		err = g.ResetHard(dir, commitish)
-		if err != nil {
-			return errors.Wrapf(err, "failed to reset hard to %s in directory %s", commitish, dir)
-		}
+	err = g.ResetHard(dir, fmt.Sprintf("%s/%s", remoteName, commitish))
+	if err != nil {
+		return errors.Wrapf(err, "failed to reset hard to %s in directory %s", commitish, dir)
 	}
 	if verbose {
 		log.Logger().Infof("ran git reset --hard %s in directory %s", commitish, dir)

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -142,9 +142,16 @@ func (g *GitCLI) clone(dir string, gitURL string, remoteName string, shallow boo
 			commitish = "master"
 		}
 	}
-	err = g.ResetHard(dir, fmt.Sprintf("%s/%s", remoteName, commitish))
-	if err != nil {
-		return errors.Wrapf(err, "failed to reset hard to %s in directory %s", commitish, dir)
+	if commitish == localBranch {
+		err = g.ResetHard(dir, fmt.Sprintf("%s/%s", remoteName, commitish))
+		if err != nil {
+			return errors.Wrapf(err, "failed to reset hard to %s in directory %s", commitish, dir)
+		}
+	} else {
+		err = g.ResetHard(dir, commitish)
+		if err != nil {
+			return errors.Wrapf(err, "failed to reset hard to %s in directory %s", commitish, dir)
+		}
 	}
 	if verbose {
 		log.Logger().Infof("ran git reset --hard %s in directory %s", commitish, dir)

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -76,7 +76,7 @@ func (g *GitCLI) ShallowCloneBranch(url string, branch string, dir string) error
 
 // ShallowClone shallow clones the repo at url from the specified commitish or pull request to a local master branch
 func (g *GitCLI) ShallowClone(dir string, url string, commitish string, pullRequest string) error {
-	return g.clone(dir, url, "", true, false, "master", commitish, pullRequest)
+	return g.clone(dir, url, "", true, false, "", commitish, pullRequest)
 }
 
 // clone is a safer implementation of the `git clone` method

--- a/pkg/jxfactory/factory.go
+++ b/pkg/jxfactory/factory.go
@@ -1,0 +1,191 @@
+package jxfactory
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/io/secrets"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/util"
+	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	// this is so that we load the auth plugins so we can connect to, say, GCP
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+type factory struct {
+	Batch bool
+
+	kubeConfig      kube.Kuber
+	impersonateUser string
+	bearerToken     string
+	secretLocation  secrets.SecretLocation
+	offline         bool
+}
+
+var _ Factory = (*factory)(nil)
+
+// NewFactory creates a factory with the default Kubernetes resources defined
+// if optionalClientConfig is nil, then flags will be bound to a new clientcmd.ClientConfig.
+// if optionalClientConfig is not nil, then this factory will make use of it.
+func NewFactory() Factory {
+	f := &factory{}
+	f.kubeConfig = kube.NewKubeConfig()
+	return f
+}
+
+// ImpersonateUser returns a new factory impersonating the given user
+func (f *factory) ImpersonateUser(user string) Factory {
+	copy := *f
+	copy.impersonateUser = user
+	return &copy
+}
+
+// WithBearerToken returns a new factory with bearer token
+func (f *factory) WithBearerToken(token string) Factory {
+	copy := *f
+	copy.bearerToken = token
+	return &copy
+}
+
+func (f *factory) CreateKubeClient() (kubernetes.Interface, string, error) {
+	cfg, err := f.CreateKubeConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, "", err
+	}
+	if client == nil {
+		return nil, "", fmt.Errorf("Failed to create Kubernetes Client")
+	}
+	ns := ""
+	config, _, err := f.kubeConfig.LoadConfig()
+	if err != nil {
+		return client, ns, err
+	}
+	ns = kube.CurrentNamespace(config)
+	// TODO allow namsepace to be specified as a CLI argument!
+	return client, ns, nil
+}
+
+func (f *factory) CreateKubeConfig() (*rest.Config, error) {
+	masterURL := ""
+	kubeConfigEnv := os.Getenv("KUBECONFIG")
+	if kubeConfigEnv != "" {
+		pathList := filepath.SplitList(kubeConfigEnv)
+		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{Precedence: pathList},
+			&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterURL}}).ClientConfig()
+	}
+	kubeconfig := createKubeConfig(f.offline)
+	var config *rest.Config
+	var err error
+	if kubeconfig != nil {
+		exists, err := util.FileExists(*kubeconfig)
+		if err == nil && exists {
+			// use the current context in kubeconfig
+			config, err = clientcmd.BuildConfigFromFlags(masterURL, *kubeconfig)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	if config == nil {
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if config != nil && f.bearerToken != "" {
+		config.BearerToken = f.bearerToken
+		return config, nil
+	}
+
+	user := f.getImpersonateUser()
+	if config != nil && user != "" && config.Impersonate.UserName == "" {
+		config.Impersonate.UserName = user
+	}
+
+	// for testing purposes one can enable tracing of Kube REST API calls
+	trace := os.Getenv("TRACE_KUBE_API")
+	if trace == "1" || trace == "on" {
+		config.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+			return &Tracer{rt}
+		}
+	}
+	return config, nil
+}
+
+var kubeConfigCache *string
+
+func createKubeConfig(offline bool) *string {
+	if offline {
+		panic("not supposed to be making a network connection")
+	}
+	var kubeconfig *string
+	if kubeConfigCache != nil {
+		return kubeConfigCache
+	}
+	if home := util.HomeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	kubeConfigCache = kubeconfig
+	return kubeconfig
+}
+
+func (f *factory) getImpersonateUser() string {
+	user := f.impersonateUser
+	if user == "" {
+		// this is really only used for testing really
+		user = os.Getenv("JX_IMPERSONATE_USER")
+	}
+	return user
+}
+
+func (f *factory) CreateJXClient() (versioned.Interface, string, error) {
+	config, err := f.CreateKubeConfig()
+	if err != nil {
+		return nil, "", err
+	}
+
+	kubeConfig, _, err := f.kubeConfig.LoadConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	ns := kube.CurrentNamespace(kubeConfig)
+	client, err := versioned.NewForConfig(config)
+	if err != nil {
+		return nil, ns, err
+	}
+	return client, ns, err
+}
+
+func (f *factory) CreateTektonClient() (tektonclient.Interface, string, error) {
+	config, err := f.CreateKubeConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	kubeConfig, _, err := f.kubeConfig.LoadConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	ns := kube.CurrentNamespace(kubeConfig)
+	client, err := tektonclient.NewForConfig(config)
+	if err != nil {
+		return nil, ns, err
+	}
+	return client, ns, err
+}

--- a/pkg/jxfactory/interface.go
+++ b/pkg/jxfactory/interface.go
@@ -1,0 +1,38 @@
+package jxfactory
+
+import (
+	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+
+	// this is so that we load the auth plugins so we can connect to, say, GCP
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+// Factory is the interface defined for Kubernetes, Jenkins X, and Tekton REST APIs
+//go:generate pegomock generate github.com/jenkins-x/jx/pkg/cmd/clients Factory -o mocks/factory.go
+type Factory interface {
+	//
+	// Constructors
+	//
+
+	// WithBearerToken creates a factory from a k8s bearer token
+	WithBearerToken(token string) Factory
+
+	// ImpersonateUser creates a factory with an impersonated users
+	ImpersonateUser(user string) Factory
+
+	// CreateKubeClient creates a new Kubernetes client
+	CreateKubeClient() (kubernetes.Interface, string, error)
+
+	// CreateKubeConfig creates the kubernetes configuration
+	CreateKubeConfig() (*rest.Config, error)
+
+	// CreateJXClient creates a new Kubernetes client for Jenkins X CRDs
+	CreateJXClient() (versioned.Interface, string, error)
+
+	// CreateTektonClient create a new Kubernetes client for Tekton resources
+	CreateTektonClient() (tektonclient.Interface, string, error)
+}

--- a/pkg/jxfactory/tracer.go
+++ b/pkg/jxfactory/tracer.go
@@ -1,0 +1,54 @@
+package jxfactory
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"regexp"
+)
+
+// Tracer implements http.RoundTripper.  It prints each request and
+// response/error to os.Stderr.
+type Tracer struct {
+	http.RoundTripper
+}
+
+// RoundTrip calls the nested RoundTripper while printing each request and
+// response/error to os.Stderr on either side of the nested call.
+func (t *Tracer) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Dump the request to os.Stderr.
+	b, err := httputil.DumpRequestOut(req, true)
+	if err != nil {
+		return nil, err
+	}
+	os.Stderr.Write(t.sanitize(b))
+	os.Stderr.Write([]byte{'\n'})
+
+	// Call the nested RoundTripper.
+	resp, err := t.RoundTripper.RoundTrip(req)
+
+	// If an error was returned, dump it to os.Stderr.
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return resp, err
+	}
+
+	// Dump the response to os.Stderr.
+	b, err = httputil.DumpResponse(resp, req.URL.Query().Get("watch") != "true")
+	if err != nil {
+		return nil, err
+	}
+	os.Stderr.Write(b)
+	os.Stderr.Write([]byte("---"))
+	os.Stderr.Write([]byte{'\n'})
+
+	return resp, err
+}
+
+func (t *Tracer) sanitize(raw []byte) []byte {
+	s := string(raw)
+	regExp := regexp.MustCompile("Authorization: Bearer .*\n")
+	s = regExp.ReplaceAllString(s, "Authorization: Bearer xxx\n")
+	return []byte(s)
+}

--- a/pkg/kube/constants.go
+++ b/pkg/kube/constants.go
@@ -276,6 +276,8 @@ const (
 	AnnotationLocalDir = "jenkins.io/local-dir"
 	// AnnotationGitURLs the newline separated list of git URLs of the DevPods
 	AnnotationGitURLs = "jenkins.io/git-urls"
+	// AnnotationGitReportState used to annotate what state has been reported to git
+	AnnotationGitReportState = "jenkins.io/git-report-state"
 
 	// AnnotationIsDefaultStorageClass used to indicate a storageclass is default
 	AnnotationIsDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"

--- a/pkg/tekton/metapipeline/metaclient/metaclient.go
+++ b/pkg/tekton/metapipeline/metaclient/metaclient.go
@@ -1,0 +1,323 @@
+package metaclient
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/jenkins-x/jx/pkg/apps"
+	jxclient "github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/jenkinsfile"
+	"github.com/jenkins-x/jx/pkg/jxfactory"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/prow"
+	"github.com/jenkins-x/jx/pkg/tekton"
+	"github.com/jenkins-x/jx/pkg/tekton/metapipeline"
+	"github.com/jenkins-x/jx/pkg/tekton/syntax"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+)
+
+const (
+	jobOptionName       = "job"
+	pullRefOptionName   = "pull-refs"
+	sourceURLOptionName = "source-url"
+
+	retryDuration      = time.Second * 30
+	defaultCheckoutDir = "source"
+)
+
+// MetaClient contains the arguments to create the meta pipeline
+type MetaClient struct {
+	SourceURL      string
+	PullRefs       string
+	Context        string
+	Job            string
+	ServiceAccount string
+	CustomLabels   []string
+	CustomEnvs     []string
+	DefaultImage   string
+
+	Results     tekton.CRDWrapper
+	OutDir      string
+	Verbose     bool
+	NoApply     *bool
+	versionsDir string
+	git         gits.Gitter
+	factory     jxfactory.Factory
+}
+
+// Run creates the meta pipeline
+func (o *MetaClient) Run() error {
+	err := o.validateArguments()
+	if err != nil {
+		return err
+	}
+
+	gitInfo, err := gits.ParseGitURL(o.SourceURL)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to determine needed git info from the specified git url '%s'", o.SourceURL))
+	}
+
+	pullRefs, err := prow.ParsePullRefs(o.PullRefs)
+	if err != nil {
+		return errors.Wrapf(err, "unable to parse pull ref '%s'", o.PullRefs)
+	}
+
+	tektonClient, jxClient, kubeClient, ns, err := o.getClientsAndNamespace()
+	if err != nil {
+		return err
+	}
+
+	podTemplates, err := o.getPodTemplates(kubeClient, ns, apps.AppPodTemplateName)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve pod templates")
+	}
+
+	branchIdentifier := o.determineBranchIdentifier(*pullRefs)
+	pipelineKind := o.determinePipelineKind(*pullRefs)
+
+	// resourceName is shared across all builds of a branch, while the pipelineName is unique for each build.
+	resourceName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, o.Context, tekton.MetaPipeline, nil, "")
+	pipelineName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, o.Context, tekton.MetaPipeline, tektonClient, ns)
+	buildNumber, err := tekton.GenerateNextBuildNumber(tektonClient, jxClient, ns, gitInfo, branchIdentifier, retryDuration, o.Context)
+	if err != nil {
+		return errors.Wrap(err, "unable to determine next build number")
+	}
+
+	if o.Verbose {
+		log.Logger().Infof("creating meta pipeline CRDs for build %s of repository '%s/%s'", buildNumber, gitInfo.Organisation, gitInfo.Name)
+	}
+	extendingApps, err := metapipeline.GetExtendingApps(jxClient, ns)
+	if err != nil {
+		return err
+	}
+
+	if o.versionsDir == "" {
+		o.versionsDir, err = o.gitCloneVersionStream(jxClient, ns)
+		if err != nil {
+			return err
+		}
+
+		defer os.RemoveAll(o.versionsDir)
+	}
+
+	crdCreationParams := metapipeline.CRDCreationParameters{
+		Namespace:        ns,
+		Context:          o.Context,
+		PipelineName:     pipelineName,
+		ResourceName:     resourceName,
+		PipelineKind:     pipelineKind,
+		BuildNumber:      buildNumber,
+		GitInfo:          *gitInfo,
+		BranchIdentifier: branchIdentifier,
+		PullRef:          *pullRefs,
+		SourceDir:        defaultCheckoutDir,
+		PodTemplates:     podTemplates,
+		ServiceAccount:   o.ServiceAccount,
+		Labels:           o.CustomLabels,
+		EnvVars:          o.CustomEnvs,
+		DefaultImage:     o.DefaultImage,
+		Apps:             extendingApps,
+		VersionsDir:      o.versionsDir,
+	}
+	tektonCRDs, err := metapipeline.CreateMetaPipelineCRDs(crdCreationParams)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate Tekton CRDs for meta pipeline")
+	}
+	// record the results in the struct for the case this command is called programmatically (HF)
+	o.Results = *tektonCRDs
+
+	err = o.handleResult(tektonClient, jxClient, tektonCRDs, buildNumber, branchIdentifier, *pullRefs, ns, gitInfo)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *MetaClient) validateArguments() error {
+	// default values
+	if o.DefaultImage == "" {
+		o.DefaultImage = syntax.DefaultContainerImage
+	}
+	if o.ServiceAccount == "" {
+		o.ServiceAccount = "tekton-bot"
+	}
+	if o.OutDir == "" {
+		o.OutDir = "out"
+	}
+
+	if o.SourceURL == "" {
+		return util.MissingOption(sourceURLOptionName)
+	}
+	if o.Job == "" {
+		return util.MissingOption(jobOptionName)
+	}
+	if o.PullRefs == "" {
+		return util.MissingOption(pullRefOptionName)
+	}
+
+	_, err := util.ExtractKeyValuePairs(o.CustomLabels, "=")
+	if err != nil {
+		return errors.Wrap(err, "unable to parse custom labels")
+	}
+	_, err = util.ExtractKeyValuePairs(o.CustomEnvs, "=")
+	if err != nil {
+		return errors.Wrap(err, "unable to parse custom environment variables")
+	}
+	return nil
+}
+
+func (o *MetaClient) handleResult(tektonClient tektonclient.Interface,
+	jxClient jxclient.Interface,
+	tektonCRDs *tekton.CRDWrapper,
+	buildNumber string,
+	branch string,
+	pullRefs prow.PullRefs,
+	ns string,
+	gitInfo *gits.GitRepository) error {
+
+	pipelineActivity := tekton.GeneratePipelineActivity(buildNumber, branch, gitInfo, &pullRefs, tekton.MetaPipeline)
+	if *o.NoApply {
+		err := tektonCRDs.WriteToDisk(o.OutDir, pipelineActivity)
+		if err != nil {
+			return errors.Wrapf(err, "failed to output Tekton CRDs")
+		}
+	} else {
+		err := tekton.ApplyPipeline(jxClient, tektonClient, tektonCRDs, ns, gitInfo, branch, pipelineActivity)
+		if err != nil {
+			return errors.Wrapf(err, "failed to apply Tekton CRDs")
+		}
+		if o.Verbose {
+			log.Logger().Infof("applied tekton CRDs for %s", tektonCRDs.PipelineRun().Name)
+		}
+	}
+	return nil
+}
+
+func (o *MetaClient) getPodTemplates(kubeClient kubeclient.Interface, ns string, containerName string) (map[string]*corev1.Pod, error) {
+	podTemplates, err := kube.LoadPodTemplates(kubeClient, ns)
+	if err != nil {
+		return nil, err
+	}
+	return podTemplates, nil
+}
+
+func (o *MetaClient) GetFactory() jxfactory.Factory {
+	if o.factory == nil {
+		o.factory = jxfactory.NewFactory()
+	}
+	return o.factory
+}
+
+func (o *MetaClient) getClientsAndNamespace() (tektonclient.Interface, jxclient.Interface, kubeclient.Interface, string, error) {
+	f := o.GetFactory()
+
+	tektonClient, _, err := f.CreateTektonClient()
+	if err != nil {
+		return nil, nil, nil, "", errors.Wrap(err, "unable to create Tekton client")
+	}
+
+	jxClient, _, err := f.CreateJXClient()
+	if err != nil {
+		return nil, nil, nil, "", errors.Wrap(err, "unable to create JX client")
+	}
+
+	kubeClient, ns, err := f.CreateKubeClient()
+	if err != nil {
+		return nil, nil, nil, "", errors.Wrap(err, "unable to create Kube client")
+	}
+	ns, _, err = kube.GetDevNamespace(kubeClient, ns)
+	if err != nil {
+		return nil, nil, nil, "", errors.Wrap(err, "unable to find the dev namespace")
+	}
+	return tektonClient, jxClient, kubeClient, ns, nil
+}
+
+// determineBranchIdentifier finds a identifier for the branch which is build by the specified pull ref.
+// The name is either an actual git branch name (eg master) or a synthetic names  like PR-<number> for single pull requests
+// or 'batch' for Prow batch builds.
+// The method makes the decision purely based on the Prow pull ref. At this stage we don't have the full ProwJov spec
+// available.
+func (o *MetaClient) determineBranchIdentifier(pullRef prow.PullRefs) string {
+	prCount := len(pullRef.ToMerge)
+	var branch string
+	switch prCount {
+	case 0:
+		{
+			// no pull requests to merge, taking base branch name as identifier
+			branch = pullRef.BaseBranch
+		}
+	case 1:
+		{
+			// single pull request, create synthetic PR identifier
+			for k := range pullRef.ToMerge {
+				branch = fmt.Sprintf("PR-%s", k)
+				break
+			}
+		}
+	default:
+		{
+			branch = "batch"
+		}
+	}
+	log.Logger().Debugf("branch identifier for pull ref '%s' : '%s'", pullRef.String(), branch)
+	return branch
+}
+
+func (o *MetaClient) determinePipelineKind(pullRef prow.PullRefs) string {
+	var kind string
+
+	prCount := len(pullRef.ToMerge)
+	if prCount > 0 {
+		kind = jenkinsfile.PipelineKindPullRequest
+	} else {
+		kind = jenkinsfile.PipelineKindRelease
+	}
+	log.Logger().Debugf("pipeline kind for pull ref '%s' : '%s'", pullRef.String(), kind)
+	return kind
+}
+
+func (o *MetaClient) gitCloneVersionStream(jxClient jxclient.Interface, ns string) (string, error) {
+	dir, err := ioutil.TempDir("", "jx-version-repo-")
+	if err != nil {
+		return dir, err
+	}
+
+	devEnv, err := kube.GetDevEnvironment(jxClient, ns)
+	if err != nil {
+		return dir, err
+	}
+	teamSettings := devEnv.Spec.TeamSettings
+	url := teamSettings.VersionStreamURL
+	ref := teamSettings.VersionStreamRef
+	if url == "" {
+		url = config.DefaultVersionsURL
+	}
+	if ref == "" {
+		ref = config.DefaultVersionsRef
+	}
+	log.Logger().WithField("url", url).WithField("ref", ref).Infof("shallow cloning version stream")
+	err = o.Git().ShallowClone(dir, url, ref, "")
+	return dir, err
+}
+
+// Git returns the git client
+func (o *MetaClient) Git() gits.Gitter {
+	if o.git == nil {
+		o.git = gits.NewGitCLI()
+	}
+	return o.git
+}
+
+// SetGit sets the git client
+func (o *MetaClient) SetGit(git gits.Gitter) {
+	o.git = git
+}

--- a/pkg/tekton/metapipeline/metaclient/metaclient.go
+++ b/pkg/tekton/metapipeline/metaclient/metaclient.go
@@ -210,6 +210,7 @@ func (o *MetaClient) getPodTemplates(kubeClient kubeclient.Interface, ns string,
 	return podTemplates, nil
 }
 
+// GetFactory returns the factory
 func (o *MetaClient) GetFactory() jxfactory.Factory {
 	if o.factory == nil {
 		o.factory = jxfactory.NewFactory()

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -76,7 +76,11 @@ func CreateMetaPipelineCRDs(params CRDCreationParameters) (*tekton.CRDWrapper, e
 		return nil, err
 	}
 
-	resources := []*pipelineapi.PipelineResource{tekton.GenerateSourceRepoResource(params.PipelineName, &params.GitInfo, params.PullRef.BaseBranch)}
+	revision := params.PullRef.BaseSha
+	if revision == "" {
+		revision = params.PullRef.BaseBranch
+	}
+	resources := []*pipelineapi.PipelineResource{tekton.GenerateSourceRepoResource(params.PipelineName, &params.GitInfo, revision)}
 	run := tekton.CreatePipelineRun(resources, pipeline.Name, pipeline.APIVersion, labels, params.ServiceAccount, nil, nil)
 
 	tektonCRDs, err := tekton.NewCRDWrapper(pipeline, tasks, resources, structure, run)


### PR DESCRIPTION
longer term we're hoping to remove the build controller completely and replace with tekton `PullRequestResource` output reporting of git statuses. 

This PR adds a tactical workaround so we can get the version stream BDD tests going green with lighthouse - enabling a feature flag to report pipeline statuses to git in the `build controller`