### PR TITLE
fix: check boot cluster exists

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -2,6 +2,7 @@ package boot
 
 import (
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"path/filepath"
 
@@ -312,7 +313,11 @@ func FindBootNamespace(projectConfig *config.ProjectConfig, requirementsConfig *
 }
 
 func (o *BootOptions) verifyClusterConnection() error {
-	_, err := o.KubeClient()
+	client, err := o.KubeClient()
+	if err == nil {
+		_, err = client.CoreV1().Namespaces().List(metav1.ListOptions{})
+	}
+
 	if err != nil {
 		return fmt.Errorf("You are not currently connected to a cluster, please connect to the cluster that you intend to %s\n"+
 			"Alternatively create a new cluster using %s", util.ColorInfo("jx boot"), util.ColorInfo("jx create cluster"))


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The existing check for connected cluster would pass if a context was set in the kube config, even if it wasn't actually connected to the cluster. This extra check attempts to connect to the cluster (by retrieving namespaces).