### PR TITLE
fix: making sure verify-generation-complete fails for new untracked f…

### DIFF
--- a/Makefile.codegen
+++ b/Makefile.codegen
@@ -59,8 +59,7 @@ stash:
 
 # Verifies that generated code is in sync with implementation
 verify-generation-complete: stash generate ## Verify the generated code is up to date
-	# exclude pkg/client/openapi/k8s_io_apimachinery_intstr_unversioned/openapi_generated.go since it can differs in amount of empty lines in header
-	$(eval CHANGED = $(shell git ls-files --modified -- . ':(exclude)pkg/client/openapi/k8s_io_apimachinery_intstr_unversioned/openapi_generated.go'))
+	$(eval CHANGED = $(shell git ls-files --modified --others --exclude-standard))
 	@if [ "$(CHANGED)" == "" ]; \
       	then \
       	    echo "All generated files up to date"; \


### PR DESCRIPTION
…iles

- also removing obsolete exlucde for pkg/client/openapi/k8s_io_apimachinery_intstr_unversioned/openapi_generated.go

fix for issue #4983

