### PR TITLE
fix: use the correct identifier to refer to the PipelineResource

### DIFF
--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -1519,7 +1519,7 @@ func (j *ParsedPipeline) GenerateCRDs(pipelineIdentifier string, buildIdentifier
 		Spec: tektonv1alpha1.PipelineSpec{
 			Resources: []tektonv1alpha1.PipelineDeclaredResource{
 				{
-					Name: resourceIdentifier,
+					Name: pipelineIdentifier,
 					Type: tektonv1alpha1.PipelineResourceTypeGit,
 				},
 			},


### PR DESCRIPTION
when creating a second PR the `pipelineIdentifier != resourceIdentifier` which then breaks the creation of the pipeline for 2nd PR on the same repo.

e.g. without this fix the 2nd PullRequest fails with message

```
PipelineRun jx/meta-dev1-environment-pr-373-20-9jcwz-1 doesn''t bind
      Pipeline jx/meta-dev1-environment-pr-373-20-9jcwz-1''s PipelineResources correctly:
      PipelineRun bound resources didn''t match Pipeline: Didn''t provide required
      values: [meta-dev1-environment-pr-373-20]
```

Signed-off-by: James Strachan <james.strachan@gmail.com>