### PR TITLE
fix(tekton): Metapipeline resource name should be consistent.

### DIFF
--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -80,7 +80,7 @@ func CreateMetaPipelineCRDs(params CRDCreationParameters) (*tekton.CRDWrapper, e
 	if revision == "" {
 		revision = params.PullRef.BaseBranch
 	}
-	resources := []*pipelineapi.PipelineResource{tekton.GenerateSourceRepoResource(params.PipelineName, &params.GitInfo, revision)}
+	resources := []*pipelineapi.PipelineResource{tekton.GenerateSourceRepoResource(params.ResourceName, &params.GitInfo, revision)}
 	run := tekton.CreatePipelineRun(resources, pipeline.Name, pipeline.APIVersion, labels, params.ServiceAccount, nil, nil)
 
 	tektonCRDs, err := tekton.NewCRDWrapper(pipeline, tasks, resources, structure, run)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

It should be the same in the `PipelineRun` as in the `Pipeline`, generated in the same way as in the generated pipeline. This means we should be passing the resource name to `GenerateSourceRepoResource` here as we do in `generateTektonCRDs`.

#### Special notes for the reviewer(s)

/assign @wbrefvem 
/assign @jstrachan 
/assign @hferentschik 

Replaces #4989 

#### Which issue this PR fixes

n/a