### PR TITLE
fix: Get logs from pod(s) if possible if BuildLogsURL starts with http

### DIFF
--- a/pkg/cmd/get/get_build_logs.go
+++ b/pkg/cmd/get/get_build_logs.go
@@ -430,7 +430,7 @@ func (o *GetBuildLogsOptions) getTektonLogs(kubeClient kubernetes.Interface, tek
 		return true, errors.New("there are no build logs for the supplied filters")
 	}
 
-	if pa.Spec.BuildLogsURL != "" {
+	if pa.Spec.BuildLogsURL != "" && !strings.HasPrefix(pa.Spec.BuildLogsURL, "http") {
 		return false, logs.StreamPipelinePersistentLogs(logWriter, pa.Spec.BuildLogsURL)
 	}
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Right now, on prod, if you try to run `jx get build logs` on a completed run, you're out of luck: it sees `BuildLogsURL` set, but it's set to an `https` URL (or maybe an `http` URL, I didn't actually check) and so just fails out. If we're not allowing streaming of logs from non-bucket sources in the first place, let's at least just skip `http*` cases and go back to the pods.

#### Special notes for the reviewer(s)

/assign @dgozalo 

#### Which issue this PR fixes

n/a