### PR TITLE
fix: jx delete preview returns error

### DIFF
--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -865,10 +865,11 @@ func (o *PreviewOptions) DefaultValues(ns string, warnMissingName bool) error {
 			}
 		}
 	}
-	o.Name = naming.ToValidName(o.Name)
 	if o.Name == "" {
 		return fmt.Errorf("No name could be defaulted for the Preview Environment. Please supply one!")
 	}
+	o.Name = naming.ToValidName(o.Name)
+
 	if o.Namespace == "" {
 		prefix := ns + "-"
 		if len(prefix) > 63 {

--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -865,11 +865,10 @@ func (o *PreviewOptions) DefaultValues(ns string, warnMissingName bool) error {
 			}
 		}
 	}
+	o.Name = naming.ToValidName(o.Name)
 	if o.Name == "" {
 		return fmt.Errorf("No name could be defaulted for the Preview Environment. Please supply one!")
 	}
-	o.Name = naming.ToValidName(o.Name)
-
 	if o.Namespace == "" {
 		prefix := ns + "-"
 		if len(prefix) > 63 {

--- a/pkg/kube/naming/names.go
+++ b/pkg/kube/naming/names.go
@@ -35,6 +35,9 @@ func ToValidNameTruncated(name string, maxLength int) string {
 }
 
 func toValidName(name string, allowDots bool, maxLength int) string {
+	if name == "" {
+		return ""
+	}
 	var buffer bytes.Buffer
 	first := true
 	lastCharDash := false

--- a/pkg/kube/naming/names_valid_test.go
+++ b/pkg/kube/naming/names_valid_test.go
@@ -15,6 +15,7 @@ func TestToValidName(t *testing.T) {
 	assertToValidName(t, "foo-bar-0.1.0", "foo-bar-0-1-0")
 	assertToValidName(t, "---foo-bar-", "foo-bar")
 	assertToValidName(t, "foo/bar_*123", "foo-bar-123")
+	assertToValidName(t, "", "")
 }
 
 func TestToValidNameWithDots(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)

The `jx delete preview` cmd is returning the error `error: no environment with name 'x' found` since this PR https://github.com/jenkins-x/jx/pull/4382.