### PR TITLE
fix: amend delete preview env scope

### DIFF
--- a/pkg/cmd/deletecmd/delete_preview.go
+++ b/pkg/cmd/deletecmd/delete_preview.go
@@ -116,7 +116,15 @@ func (o *DeletePreviewOptions) DeletePreview(name string) error {
 		return err
 	}
 
-	environment, err := kube.GetEnvironment(jxClient, ns, name)
+	kubeClient, err := o.KubeClient()
+	if err != nil {
+		return err
+	}
+	devNs, _, err := kube.GetDevNamespace(kubeClient, ns)
+	if err != nil {
+		return err
+	}
+	environment, err := kube.GetEnvironment(jxClient, devNs, name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Attempting to delete a preview environment `jx delete preview` from within that preview namespace gives the error `error: no environment with name 'my-preview-env' found`

This changes the scope of the command by using the dev namespace