### PR TITLE
fix: Fix gh-pages for log storage in a couple ways

### DIFF
--- a/pkg/collector/git_collector.go
+++ b/pkg/collector/git_collector.go
@@ -154,7 +154,7 @@ func (c *GitCollector) CollectData(data []byte, outputPath string) (string, erro
 	if err != nil {
 		return u, err
 	}
-	err = gitClient.Push(ghPagesDir, "origin", false, false, "HEAD")
+	err = gitClient.Push(ghPagesDir, "origin", false, false, "HEAD:"+c.gitBranch)
 	return u, err
 }
 
@@ -175,6 +175,11 @@ func cloneGitHubPagesBranchToTempDir(sourceURL string, gitClient gits.Gitter, br
 
 	err = gitClient.ShallowClone(ghPagesDir, sourceURL, branchName, "")
 	if err != nil {
+		os.RemoveAll(ghPagesDir)
+		ghPagesDir, err = ioutil.TempDir("", "jenkins-x-collect")
+		if err != nil {
+			return ghPagesDir, err
+		}
 		log.Logger().Infof("error doing shallow clone of branch %s: %v", branchName, err)
 		// swallow the error
 		log.Logger().Infof("No existing %s branch so creating it", branchName)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

A few things were just completely borked in using gh-pages for log storage for a while now. If the repo didn't already have a gh-pages branch, we tried to reclone without deleting the existing attempted clone, which was bad, and then when there was a gh-pages, we tried to push `HEAD` without specifying that we actually want to push it to `gh-pages`. This fixes both of those things.

#### Special notes for the reviewer(s)

/assign @dgozalo 
/assign @pmuir 

#### Which issue this PR fixes

n/a