### PR TITLE
fix: Push an updated PR before updating its title and body

### DIFF
--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -345,10 +345,6 @@ func PushRepoAndCreatePullRequest(dir string, upstreamRepo *GitRepository, forkR
 		if err != nil {
 			return nil, errors.Wrapf(err, "updating pull request %s", existingPr.URL)
 		}
-		err = gitter.Push(dir, forkPushURL, true, false, fmt.Sprintf("%s:%s", "HEAD", prDetails.BranchName))
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
 		log.Logger().Infof("Updated Pull Request: %s", util.ColorInfo(pr.URL))
 	} else {
 		gha.Head = headPrefix + prDetails.BranchName


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

~~For whatever reason, GitHub seems to get goofy when you take an existing PR, update its title and body, and _then_ immediately push a new commit to the PR. That ordering results in GitHub sending two `synchronize` events for the exact same commit, triggering two builds in Prow, etc. Which isn't ideal.~~

~~But if we flip the ordering to push first and _then_ update the title and body, only one `synchronize` is sent. So let's do that thing.~~

UPDATE: @pmuir pointed out that we actually had two pushes, which is probably the root cause here. So let's get rid of the redundant extra one instead of just moving things around.

#### Special notes for the reviewer(s)

I've tested this manually by messing around with https://github.com/jenkins-x/jenkins-x-platform/pull/5835, calling the exact same `jx step create pr chart ...` that the `jx` release does, but with bogus version numbers, and it _works_. =)

/assign @pmuir 

#### Which issue this PR fixes

fixes #4785 
