### PR TITLE
feat: added a way to read logs from HTTP/HTTPS URLs back

### DIFF
--- a/pkg/cmd/get/get_build_logs.go
+++ b/pkg/cmd/get/get_build_logs.go
@@ -431,7 +431,8 @@ func (o *GetBuildLogsOptions) getTektonLogs(kubeClient kubernetes.Interface, tek
 	}
 
 	if pa.Spec.BuildLogsURL != "" {
-		return false, logs.StreamPipelinePersistentLogs(logWriter, pa.Spec.BuildLogsURL)
+		_ = logWriter.WriteLog(fmt.Sprintf("Obtaining stored build logs for %s", util.ColorInfo(name)))
+		return false, logs.StreamPipelinePersistentLogs(logWriter, pa.Spec.BuildLogsURL, o.CommonOptions)
 	}
 
 	_ = logWriter.WriteLog(fmt.Sprintf("Build logs for %s", util.ColorInfo(name)))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Added support for downloading stored logs from a HTTP(S) endpoint back. This will allow us to get logs back from GitHub pages as a fallback.
