### PR TITLE
fix: docker registry is the host, owner is the org

### DIFF
--- a/pkg/cmd/opts/docker.go
+++ b/pkg/cmd/opts/docker.go
@@ -37,7 +37,7 @@ func (o *CommonOptions) GetDockerRegistryOrg(projectConfig *config.ProjectConfig
 func (o *CommonOptions) GetDockerRegistry(projectConfig *config.ProjectConfig) string {
 	dockerRegistry := ""
 	if projectConfig != nil {
-		dockerRegistry = projectConfig.DockerRegistryOwner
+		dockerRegistry = projectConfig.DockerRegistryHost
 	}
 	if dockerRegistry == "" {
 		dockerRegistry = os.Getenv("DOCKER_REGISTRY")


### PR DESCRIPTION
Signed-off-by: Joost van der Griendt <joostvdg@gmail.com>

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [?] Change is covered by existing or new tests.

#### Description

Context; a docker image FQN* = `${Docker Registry}`/`${Docker Registry Organization}`/`${Application}`

If you want to override the Docker Registry or the Docker Registry Organization (owner) for a pipeline, you can use the `jenkins-x.yml` file. There are two fields in this file which can be used to override the Docker Registry information, `DockerRegistryHost` and `DockerRegistryOwner`.

Currently both configuration options - Docker Registry and Docker Registry Organization - are being read from `DockerRegistryOwner`. This does not allow you to only override the Docker Registry Organization, as it will automatically override the Docker Registry as well.

I believe the `dockerRegistry` value should be retrieved from the `DockerRegistryHost`. It resolved the above-mentioned issue.



