### PR TITLE
fix: warn the user if TLS is not enabled

### DIFF
--- a/pkg/cmd/step/verify/step_verify_preinstall_integration_test.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall_integration_test.go
@@ -3,13 +3,14 @@
 package verify_test
 
 import (
-	"github.com/jenkins-x/jx/pkg/cmd/step/create"
-	"github.com/jenkins-x/jx/pkg/config"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/cmd/step/create"
+	"github.com/jenkins-x/jx/pkg/config"
 
 	"github.com/jenkins-x/jx/pkg/cmd/clients"
 	"github.com/jenkins-x/jx/pkg/cmd/namespace"
@@ -69,6 +70,18 @@ func TestStepVerifyPreInstallNoKanikoLazyCreate(t *testing.T) {
 	// we default to lazy create if not using terraform
 	err = options.Run()
 	assert.NoErrorf(t, err, "the command should not have failed as we should have lazily created the deploy namespace")
+}
+
+func TestStepVerifyPreInstallNoTLS(t *testing.T) {
+	options := createTestStepVerifyPreInstallOptions(filepath.Join("test_data", "preinstall", "no_tls"))
+
+	_, origNamespace, err := options.KubeClientAndDevNamespace()
+	assert.NoError(t, err)
+	defer resetNamespace(t, origNamespace)
+
+	// we default to lazy create if not using terraform
+	err = options.Run()
+	assert.Error(t, err, "the command should have failed as we are running in batch mode with no tls")
 }
 
 func TestStepVerifyPreInstallSetClusterRequirementsViaEnvars(t *testing.T) {

--- a/pkg/cmd/step/verify/test_data/preinstall/no_tls/jx-requirements.yml
+++ b/pkg/cmd/step/verify/test_data/preinstall/no_tls/jx-requirements.yml
@@ -14,7 +14,7 @@ ingress:
   namespaceSubDomain: -jx.
   tls:
     email: ""
-    enabled: true
+    enabled: false
     production: false
 secretStorage: local
 storage:


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Warn the user that continuing without TLS is not
recommended if they are using vault or web hooks.

Note that right now you can’t not use web hooks.

We present a confirmation dialog to continue, with
`N` being the default after logging warnings.



#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #5044 fixes #5048

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
