### PR TITLE
fix: only skip the commit for the versions pr

### DIFF
--- a/pkg/cmd/step/create/pr/step_create_pr.go
+++ b/pkg/cmd/step/create/pr/step_create_pr.go
@@ -27,6 +27,7 @@ type StepCreatePrOptions struct {
 	Component  string
 	Version    string
 	DryRun     bool
+	SkipCommit bool
 }
 
 // NewCmdStepCreatePr Steps a command object for the "step" command
@@ -136,5 +137,6 @@ func (o *StepCreatePrOptions) createPullRequestOperation() operations.PullReques
 		Version:       o.Version,
 		Component:     o.Component,
 		DryRun:        o.DryRun,
+		SkipCommit:    o.SkipCommit,
 	}
 }

--- a/pkg/cmd/step/create/pr/step_create_pr_versions.go
+++ b/pkg/cmd/step/create/pr/step_create_pr_versions.go
@@ -175,7 +175,8 @@ func (o *StepCreatePullRequestVersionsOptions) Run() error {
 		modifyFns = append(modifyFns, pro.WrapChangeFilesWithCommitFn("versions", operations.CreateChartChangeFilesFn(o.Name, o.Version, o.Kind, &pro, o.Helm(), vaultClient, o.In, o.Out, o.Err)))
 	}
 
-	o.SrcGitURL = "" // there is no src url for the overall PR
+	o.SrcGitURL = ""    // there is no src url for the overall PR
+	o.SkipCommit = true // As we've done all the commits already
 	return o.CreatePullRequest("versionstream", func(dir string, gitInfo *gits.GitRepository) ([]string, error) {
 		if versionstream.VersionKind(o.Kind) == versionstream.KindChart {
 			_, err := o.HelmInitDependency(dir, o.DefaultReleaseCharts())

--- a/pkg/gits/operations/pull_request_op.go
+++ b/pkg/gits/operations/pull_request_op.go
@@ -45,6 +45,7 @@ type PullRequestOperation struct {
 	BranchName string
 	Version    string
 	DryRun     bool
+	SkipCommit bool
 }
 
 // ChangeFilesFn is the function called to create the pull request
@@ -82,7 +83,7 @@ func (o *PullRequestOperation) CreatePullRequest(kind string, update ChangeFiles
 		filter := &gits.PullRequestFilter{
 			Labels: labels,
 		}
-		result, err = gits.PushRepoAndCreatePullRequest(dir, upstreamInfo, forkInfo, o.Base, details, filter, false, commitMessage, true, o.DryRun, o.Git(), provider, labels)
+		result, err = gits.PushRepoAndCreatePullRequest(dir, upstreamInfo, forkInfo, o.Base, details, filter, !o.SkipCommit, commitMessage, true, o.DryRun, o.Git(), provider, labels)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create PR for base %s and head branch %s from temp dir %s", o.Base, details.BranchName, dir)
 		}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
I had mistakenly skipped the commit for all of
`jx step create pr` which broke updatebot


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
