### PR TITLE
feat: added a flag to skip the jx install for terraform clusters

### DIFF
--- a/pkg/cmd/create/create_terraform.go
+++ b/pkg/cmd/create/create_terraform.go
@@ -41,7 +41,7 @@ type Flags struct {
 	SkipLogin                   bool
 	ForkOrganisationGitRepo     string
 	SkipTerraformApply          bool
-	SkipJxInstall               bool
+	SkipInstallation            bool
 	NoActiveCluster             bool
 	IgnoreTerraformWarnings     bool
 	JxEnvironment               string
@@ -128,7 +128,7 @@ func (options *CreateTerraformOptions) addFlags(cmd *cobra.Command, addSharedFla
 	cmd.Flags().StringVarP(&options.Flags.ClusterName, optionClusterName, "", "", "The name of a single cluster to create - cannot be used in conjunction with --"+optionCluster)
 	cmd.Flags().StringVarP(&options.Flags.CloudProvider, optionCloudProvider, "", "", "The cloud provider (currently gke only) - cannot be used in conjunction with --"+optionCluster)
 	cmd.Flags().BoolVarP(&options.Flags.SkipTerraformApply, "skip-terraform-apply", "", false, "Skip applying the generated Terraform plans")
-	cmd.Flags().BoolVarP(&options.Flags.SkipJxInstall, "skip-jx-install", "", false, "Skip installing Jenkins X into the generated cluster")
+	cmd.Flags().BoolVarP(&options.Flags.SkipInstallation, "skip-installation", "", false, "Provision cluster(s) only, don't install Jenkins X into it")
 	cmd.Flags().BoolVarP(&options.Flags.IgnoreTerraformWarnings, "ignore-terraform-warnings", "", false, "Ignore any warnings about the Terraform plan being potentially destructive")
 	cmd.Flags().StringVarP(&options.Flags.JxEnvironment, "jx-environment", "", "dev", "The cluster name to install jx inside")
 	cmd.Flags().StringVarP(&options.Flags.LocalOrganisationRepository, "local-organisation-repository", "", "", "Rather than cloning from a remote Git server, the local directory to use for the organisational folder")
@@ -446,7 +446,7 @@ func (options *CreateTerraformOptions) createOrganisationGitRepo() error {
 		if err != nil {
 			log.Logger().Infof("Skipping jx install")
 		} else {
-			if !options.Flags.SkipJxInstall {
+			if !options.Flags.SkipInstallation {
 				err = options.installJx(devCluster, clusterDefinitions)
 				if err != nil {
 					return err

--- a/pkg/cmd/create/create_terraform.go
+++ b/pkg/cmd/create/create_terraform.go
@@ -41,6 +41,7 @@ type Flags struct {
 	SkipLogin                   bool
 	ForkOrganisationGitRepo     string
 	SkipTerraformApply          bool
+	SkipJxInstall               bool
 	NoActiveCluster             bool
 	IgnoreTerraformWarnings     bool
 	JxEnvironment               string
@@ -127,6 +128,7 @@ func (options *CreateTerraformOptions) addFlags(cmd *cobra.Command, addSharedFla
 	cmd.Flags().StringVarP(&options.Flags.ClusterName, optionClusterName, "", "", "The name of a single cluster to create - cannot be used in conjunction with --"+optionCluster)
 	cmd.Flags().StringVarP(&options.Flags.CloudProvider, optionCloudProvider, "", "", "The cloud provider (currently gke only) - cannot be used in conjunction with --"+optionCluster)
 	cmd.Flags().BoolVarP(&options.Flags.SkipTerraformApply, "skip-terraform-apply", "", false, "Skip applying the generated Terraform plans")
+	cmd.Flags().BoolVarP(&options.Flags.SkipJxInstall, "skip-jx-install", "", false, "Skip installing Jenkins X into the generated cluster")
 	cmd.Flags().BoolVarP(&options.Flags.IgnoreTerraformWarnings, "ignore-terraform-warnings", "", false, "Ignore any warnings about the Terraform plan being potentially destructive")
 	cmd.Flags().StringVarP(&options.Flags.JxEnvironment, "jx-environment", "", "dev", "The cluster name to install jx inside")
 	cmd.Flags().StringVarP(&options.Flags.LocalOrganisationRepository, "local-organisation-repository", "", "", "Rather than cloning from a remote Git server, the local directory to use for the organisational folder")
@@ -444,9 +446,13 @@ func (options *CreateTerraformOptions) createOrganisationGitRepo() error {
 		if err != nil {
 			log.Logger().Infof("Skipping jx install")
 		} else {
-			err = options.installJx(devCluster, clusterDefinitions)
-			if err != nil {
-				return err
+			if !options.Flags.SkipJxInstall {
+				err = options.installJx(devCluster, clusterDefinitions)
+				if err != nil {
+					return err
+				}
+			} else {
+				log.Logger().Infof("Skipping jx install")
 			}
 		}
 	} else {

--- a/pkg/cmd/create/create_terraform_gke.go
+++ b/pkg/cmd/create/create_terraform_gke.go
@@ -211,7 +211,7 @@ type TerraformGKEFlags struct {
 	SkipLogin                   bool
 	ForkOrganisationGitRepo     string
 	SkipTerraformApply          bool
-	SkipJxInstall               bool
+	SkipInstallation            bool
 	NoActiveCluster             bool
 	IgnoreTerraformWarnings     bool
 	JxEnvironment               string
@@ -310,7 +310,7 @@ func (options *TerraformGKEOptions) addFlags(cmd *cobra.Command, addSharedFlags 
 	cmd.Flags().StringVarP(&options.Flags.ClusterName, optionClusterName, "", "", "The name of a single cluster to create - cannot be used in conjunction with --"+optionCluster)
 	cmd.Flags().StringVarP(&options.Flags.CloudProvider, optionCloudProvider, "", "", "The cloud provider (currently gke only) - cannot be used in conjunction with --"+optionCluster)
 	cmd.Flags().BoolVarP(&options.Flags.SkipTerraformApply, "skip-terraform-apply", "", false, "Skip applying the generated Terraform plans")
-	cmd.Flags().BoolVarP(&options.Flags.SkipJxInstall, "skip-jx-install", "", false, "Skip installing Jenkins X into the generated cluster")
+	cmd.Flags().BoolVarP(&options.Flags.SkipInstallation, "skip-installation", "", false, "Provision cluster only, don't install Jenkins X into it")
 	cmd.Flags().BoolVarP(&options.Flags.IgnoreTerraformWarnings, "ignore-terraform-warnings", "", false, "Ignore any warnings about the Terraform plan being potentially destructive")
 	cmd.Flags().StringVarP(&options.Flags.JxEnvironment, "jx-environment", "", "dev", "The cluster name to install jx inside")
 	cmd.Flags().StringVarP(&options.Flags.LocalOrganisationRepository, "local-organisation-repository", "", "", "Rather than cloning from a remote Git server, the local directory to use for the organisational folder")
@@ -572,7 +572,7 @@ func (options *TerraformGKEOptions) createOrganisationGitRepo() error {
 		if err != nil {
 			log.Logger().Infof("Skipping jx install")
 		} else {
-			if !options.Flags.SkipJxInstall {
+			if !options.Flags.SkipInstallation {
 				err = options.installJx(devCluster, clusterDefinitions)
 				if err != nil {
 					return err

--- a/pkg/cmd/create/create_terraform_gke.go
+++ b/pkg/cmd/create/create_terraform_gke.go
@@ -211,6 +211,7 @@ type TerraformGKEFlags struct {
 	SkipLogin                   bool
 	ForkOrganisationGitRepo     string
 	SkipTerraformApply          bool
+	SkipJxInstall               bool
 	NoActiveCluster             bool
 	IgnoreTerraformWarnings     bool
 	JxEnvironment               string
@@ -309,6 +310,7 @@ func (options *TerraformGKEOptions) addFlags(cmd *cobra.Command, addSharedFlags 
 	cmd.Flags().StringVarP(&options.Flags.ClusterName, optionClusterName, "", "", "The name of a single cluster to create - cannot be used in conjunction with --"+optionCluster)
 	cmd.Flags().StringVarP(&options.Flags.CloudProvider, optionCloudProvider, "", "", "The cloud provider (currently gke only) - cannot be used in conjunction with --"+optionCluster)
 	cmd.Flags().BoolVarP(&options.Flags.SkipTerraformApply, "skip-terraform-apply", "", false, "Skip applying the generated Terraform plans")
+	cmd.Flags().BoolVarP(&options.Flags.SkipJxInstall, "skip-jx-install", "", false, "Skip installing Jenkins X into the generated cluster")
 	cmd.Flags().BoolVarP(&options.Flags.IgnoreTerraformWarnings, "ignore-terraform-warnings", "", false, "Ignore any warnings about the Terraform plan being potentially destructive")
 	cmd.Flags().StringVarP(&options.Flags.JxEnvironment, "jx-environment", "", "dev", "The cluster name to install jx inside")
 	cmd.Flags().StringVarP(&options.Flags.LocalOrganisationRepository, "local-organisation-repository", "", "", "Rather than cloning from a remote Git server, the local directory to use for the organisational folder")
@@ -570,9 +572,13 @@ func (options *TerraformGKEOptions) createOrganisationGitRepo() error {
 		if err != nil {
 			log.Logger().Infof("Skipping jx install")
 		} else {
-			err = options.installJx(devCluster, clusterDefinitions)
-			if err != nil {
-				return err
+			if !options.Flags.SkipJxInstall {
+				err = options.installJx(devCluster, clusterDefinitions)
+				if err != nil {
+					return err
+				}
+			} else {
+				log.Logger().Infof("Skipping jx install")
 			}
 		}
 	} else {


### PR DESCRIPTION
--skip-jx-install can be used to stop the jx install into the dev cluster.  The generated cluster can then be used with jx boot