### PR TITLE
fix(version): set namespace for jx version command

### DIFF
--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -49,11 +49,20 @@ func NewCmdVersion(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.HelmTLS, "helm-tls", "", false, "Whether to use TLS with helm")
 	cmd.Flags().BoolVarP(&options.NoVersionCheck, "no-version-check", "n", false, "Disable checking of version upgrade checks")
 	cmd.Flags().BoolVarP(&options.NoVerify, "no-verify", "", false, "Disable verification of package versions")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "", "", "The namespace to use to look for currently installed platform version")
 	return cmd
 }
 
 func (o *VersionOptions) Run() error {
-	packages, table := o.GetPackageVersions(o.Namespace, o.HelmTLS)
+	ns := o.Namespace
+	if ns == "" {
+		var err error
+		_, ns, err = o.JXClientAndDevNamespace()
+		if err != nil {
+			return err
+		}
+	}
+	packages, table := o.GetPackageVersions(ns, o.HelmTLS)
 
 	// os version
 	osVersion, err := o.GetOsVersion()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The namespace for jx version is empty and it cannot be set.  In addition and if you have multiple teams installed on a cluster, then it reports the incorrect version because it processes releases in the whole cluster instead of the team namespace.