### PR TITLE
chore: avoid duplicating the pipeline github token in a k8s secret when vault is enabled

### DIFF
--- a/pkg/cmd/opts/common.go
+++ b/pkg/cmd/opts/common.go
@@ -998,6 +998,12 @@ func (o *CommonOptions) SystemVaultClient(namespace string) (vault.Client, error
 	return o.systemVaultClient, nil
 }
 
+// connectToSystemVault tries to connect to system vault
+func (o *CommonOptions) connectToSystemVault() bool {
+	_, err := o.SystemVaultClient(o.devNamespace)
+	return err == nil
+}
+
 // VaultClient returns or creates the vault client
 func (o *CommonOptions) VaultClient(name string, namespace string) (vault.Client, error) {
 	if o.factory == nil {

--- a/pkg/cmd/opts/git.go
+++ b/pkg/cmd/opts/git.go
@@ -84,6 +84,11 @@ func (o *CommonOptions) CreateGitProvider(dir string) (*gits.GitRepository, gits
 
 // UpdatePipelineGitCredentialsSecret updates the pipeline git credentials in a kubernetes secret
 func (o *CommonOptions) UpdatePipelineGitCredentialsSecret(server *auth.AuthServer, userAuth *auth.UserAuth) (string, error) {
+	// hack to skip duplicating the git credentials in a k8s secret when vault is enabled
+	if o.connectToSystemVault() {
+		return "", nil
+	}
+
 	client, curNs, err := o.KubeClientAndNamespace()
 	if err != nil {
 		return "", err

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -420,7 +420,6 @@ func (o *CommonOptions) GetSecretURLClient() (secreturl.Client, error) {
 		var err error
 		o.secretURLClient, err = o.SystemVaultClient(o.devNamespace)
 		if err != nil {
-			log.Logger().Warnf("failed to create system vault in namespace %s due to %s\n", o.devNamespace, err.Error())
 			o.secretURLClient = nil
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Avoid duplicating the pipeline GitHub token in a k8s secret when vault is enabled. This is an effort to remove the duplicated secrets to improve the secrets management.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

part of #4196

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->