### PR TITLE
fix: allow ingress to be used to discover a service url

### DIFF
--- a/pkg/kube/services/services.go
+++ b/pkg/kube/services/services.go
@@ -100,10 +100,15 @@ func FindServiceURL(client kubernetes.Interface, namespace string, name string) 
 		log.Logger().Debugf("found service url %s", answer)
 		return answer, nil
 	}
-
 	log.Logger().Debugf("couldn't find service url, attempting to look up via ingress")
 
-	// lets try find the service via Ingress
+	return FindIngressURL(client, namespace, name)
+}
+
+// FindIngressURL returns the url of an Ingress using the Ingress name
+func FindIngressURL(client kubernetes.Interface, namespace string, name string) (string, error) {
+	log.Logger().Debugf("finding ingress url for %s in namespace %s", name, namespace)
+
 	ing, err := client.ExtensionsV1beta1().Ingresses(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		log.Logger().Errorf("error finding ingress for %s in namespace %s - err %s", name, namespace, err)
@@ -112,7 +117,7 @@ func FindServiceURL(client kubernetes.Interface, namespace string, name string) 
 
 	url := IngressURL(ing)
 	if url == "" {
-		log.Logger().Debugf("unable to find service url via ingress for %s in namespace %s", name, namespace)
+		log.Logger().Debugf("unable to find url via ingress for %s in namespace %s", name, namespace)
 	}
 	return url, nil
 }

--- a/pkg/kube/vault/vault.go
+++ b/pkg/kube/vault/vault.go
@@ -434,6 +434,14 @@ func GetVaults(client kubernetes.Interface, vaultOperatorClient versioned.Interf
 			log.Logger().Warnf("error finding vault service url setting to empty string, err: %s", err)
 			vaultURL = ""
 		}
+		if vaultURL == "" {
+			log.Logger().Infof("Looking for %s ingress in the %s namespace to retrieve the service URL for Vault", vaultName, ns)
+			vaultURL, err = services.FindIngressURL(client, ns, vaultName)
+			if err != nil {
+				log.Logger().Warnf("error finding vault ingress url setting to empty string, err: %s", err)
+				vaultURL = ""
+			}
+		}
 		vault := Vault{
 			Name:                   vaultName,
 			Namespace:              ns,


### PR DESCRIPTION
Signed-off-by: Cai Cooper <caicooper82@gmail.com>

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
When checking the vault health during the installation of the vault-operator using `jx boot`. If the vault service URL cannot be located using its service then it should try and discover the URL via the Ingress.
**NOTE: this assumes that the service name and ingress name are the same!**

Fixes #5133 