### PR TITLE
fix(init): enable both http and https for NLB ingress

### DIFF
--- a/pkg/cmd/initcmd/init.go
+++ b/pkg/cmd/initcmd/init.go
@@ -516,20 +516,6 @@ func (o *InitOptions) InitIngress() error {
 			return errors.Wrap(err, "failed to append the myvalues file")
 		}
 		if o.Flags.Provider == cloud.AWS || o.Flags.Provider == cloud.EKS {
-			// For EKS enable both ports for NLBs to be able to use TLS on Nginx ingresses
-			// Fix for https://github.com/jenkins-x/jx/issues/3079
-			enableHTTP := "true"
-			enableHTTPS := "true"
-
-			// For AWS we can only enable one port for NLBs right now?
-			if o.Flags.Provider == cloud.AWS {
-				enableHTTP = "false"
-				enableHTTPS = "true"
-				if o.Flags.Http {
-					enableHTTP = "true"
-					enableHTTPS = "false"
-				}
-			}
 			yamlText := `---
 rbac:
  create: true
@@ -538,8 +524,8 @@ controller:
  service:
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-type: nlb
-   enableHttp: ` + enableHTTP + `
-   enableHttps: ` + enableHTTPS + `
+   enableHttp: true
+   enableHttps: true
 `
 
 			f, err := ioutil.TempFile("", "ing-values-")


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

When using kops or EKS, NLB appears to now support handling both HTTP and HTTPS traffic.  Also, if you look at the example NLB, it has both ports: https://github.com/kubernetes/ingress-nginx/blob/master/deploy/static/provider/aws/service-nlb.yaml

#### Special notes for the reviewer(s)

The way I tested this was by creating a YAML file with:

```yaml
rbac:
 create: true

controller:
 service:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
   enableHttp: true
   enableHttps: true
```

And then running:

```bash
helm repo update
helm upgrade jxing stable/nginx-ingress --values jxing-values.yaml
```

And that setup `443` on the existing NLB.  This did install `nginx-ingress` version `1.17.0` which I think is ahead of what is distributed with JX.

#### Which issue this PR fixes

fixes #3079 but existing installs need to do the workaround still, this only fixes newly installed ingresses.