### PR TITLE
fix(tekton): topologyKey needs to be specified in affinity policy

### DIFF
--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelinerun.yml
@@ -17,6 +17,7 @@ spec:
           labelSelector:
             matchLabels:
               tekton.dev/pipelineRun: abayer-js-test-repo-really-long-1
+          topologyKey: failure-domain.beta.kubernetes.io/zone
   params:
   - name: version
     value: 0.0.1

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -992,6 +992,7 @@ func (j *ParsedPipeline) GetPossibleAffinityPolicy(name string) *corev1.Affinity
 								pipeline.GroupName + pipeline.PipelineRunLabelKey: name,
 							},
 						},
+						TopologyKey: "failure-domain.beta.kubernetes.io/zone",
 					},
 				}},
 			},


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

See https://github.com/jenkins-x/jenkins-x-builders/pull/659 for me trying to use the new `distributeParallelAcrossNodes: true` option and discovering that I was missing something rather important. Whoops.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

n/a