### PR TITLE
test: add an option in the makefile to disable the test caching only when is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,9 @@ else
 GOTEST += -p 4
 endif
 
-
+ifdef DISABLE_TEST_CACHING
+GOTEST += -count=1
+endif
 
 # support for building a covered jx binary (one with the coverage instrumentation compiled in). The `build-covered`
 # target also builds the covered binary explicitly
@@ -124,10 +126,10 @@ make-reports-dir:
 	mkdir -p $(REPORTS_DIR)
 
 test: make-reports-dir ## Run ONLY the tests that have no build flags (and example of a build tag is the "integration" build tag)
-	CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -count=1 $(COVERFLAGS) -failfast -short ./...
+	CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) $(COVERFLAGS) -failfast -short ./...
 
 test-cloud-gke: make-reports-dir ## Run ONLY the tests that have no build flags (and example of a build tag is the "integration" build tag)
-	CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -count=1 -coverprofile=$(COVER_OUT) --covermode=count --coverpkg=./pkg/cloud/gke -failfast -short ./pkg/cloud/gke
+	CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -coverprofile=$(COVER_OUT) --covermode=count --coverpkg=./pkg/cloud/gke -failfast -short ./pkg/cloud/gke
 
 test-report: make-reports-dir get-test-deps test ## Create the test report
 	@gocov convert $(COVER_OUT) | gocov report
@@ -142,19 +144,19 @@ test-slow-report: get-test-deps test-slow make-reports-dir
 	@gocov convert $(COVER_OUT) | gocov report
 
 test-slow: make-reports-dir ## Run unit tests sequentially
-	@CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -count=1 $(COVERFLAGS) ./...
+	@CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) $(COVERFLAGS) ./...
 
 test-slow-report-html: make-reports-dir get-test-deps test-slow
 	@gocov convert $(COVER_OUT) | gocov-html > $(REPORTS_DIR)/cover.html && open $(REPORTS_DIR)/cover.html
 
 test-integration: get-test-deps## Run the integration tests
-	@CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -count=1 -tags=integration  -short ./...
+	@CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -tags=integration  -short ./...
 
 test-integration1: make-reports-dir
-	@CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -count=1 -tags=integration $(COVERFLAGS) -short ./... -test.v -run $(TEST)
+	@CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -tags=integration $(COVERFLAGS) -short ./... -test.v -run $(TEST)
 
 test-rich-integration1: make-reports-dir
-	@CGO_ENABLED=$(CGO_ENABLED) richgo test -count=1 -tags=integration $(COVERFLAGS) -short -test.v $(TEST_PACKAGE) -run $(TEST)
+	@CGO_ENABLED=$(CGO_ENABLED) richgo test -tags=integration $(COVERFLAGS) -short -test.v $(TEST_PACKAGE) -run $(TEST)
 
 test-integration-report: make-reports-dir get-test-deps test-integration ## Create the integration tests report
 	@gocov convert $(COVER_OUT) | gocov report
@@ -163,7 +165,7 @@ test-integration-report-html: make-reports-dir get-test-deps test-integration
 	@gocov convert $(COVER_OUT) | gocov-html > $(REPORTS_DIR)/cover.html && open $(REPORTS_DIR)/cover.html
 
 test-slow-integration: make-reports-dir ## Run the any tests without a build tag as well as those that have the "integration" build tag. This target is run during CI.
-	@CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -count=1 -tags=integration $(COVERFLAGS) ./...
+	@CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -tags=integration $(COVERFLAGS) ./...
 
 test-slow-integration-report: make-reports-dir get-test-deps test-slow-integration
 	@gocov convert $(COVER_OUT) | gocov report
@@ -172,7 +174,7 @@ test-slow-integration-report-html: make-reports-dir get-test-deps test-slow-inte
 	@gocov convert $(COVER_OUT) | gocov-html > $(REPORTS_DIR)/cover.html && open $(REPORTS_DIR)/cover.html
 
 test-soak: make-reports-dir get-test-deps
-	@CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -count=1 -tags soak $(COVERFLAGS) ./...
+	@CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -tags soak $(COVERFLAGS) ./...
 
 test1: get-test-deps make-reports-dir ## Runs single test specified by test name, eg 'make test1 TEST=TestFoo'
 	CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) ./... -test.v -run $(TEST)

--- a/jenkins-x-integration.yml
+++ b/jenkins-x-integration.yml
@@ -25,7 +25,7 @@ pipelineConfig:
               - name: PARALLEL_BUILDS
                 value: "2"
               - name: DISABLE_TEST_CACHING
-                value: "ture"
+                value: "true"
             options:
               containerOptions:
                 resources:

--- a/jenkins-x-integration.yml
+++ b/jenkins-x-integration.yml
@@ -24,6 +24,8 @@ pipelineConfig:
                 value: "true"
               - name: PARALLEL_BUILDS
                 value: "2"
+              - name: DISABLE_TEST_CACHING
+                value: "ture"
             options:
               containerOptions:
                 resources:

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -33,6 +33,8 @@ pipelineConfig:
                 value: "2"
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /builder/home/kaniko-secret.json
+              - name: DISABLE_TEST_CACHING
+                value: "ture"
 
             steps:
               - image: gcr.io/jenkinsxio/builder-jx:0.1.639

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -34,7 +34,7 @@ pipelineConfig:
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /builder/home/kaniko-secret.json
               - name: DISABLE_TEST_CACHING
-                value: "ture"
+                value: "true"
 
             steps:
               - image: gcr.io/jenkinsxio/builder-jx:0.1.639

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -38,7 +38,7 @@ pipelineConfig:
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /builder/home/kaniko-secret.json
               - name: DISABLE_TEST_CACHING
-                value: "ture"
+                value: "true"
             options:
               containerOptions:
                 resources:

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -37,6 +37,8 @@ pipelineConfig:
                 value: "2"
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /builder/home/kaniko-secret.json
+              - name: DISABLE_TEST_CACHING
+                value: "ture"
             options:
               containerOptions:
                 resources:


### PR DESCRIPTION
The test caching seems to be disable by default in all test without any option to
turn it on when test are executed locally. This option will allow to keep the
test caching on and disable it explicitly only when required.

This will speed up the test execution at least when run locally.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->