### PR TITLE
fix: Don't require ordering of env vars on command in metapipeline test

### DIFF
--- a/pkg/tekton/metapipeline/metapipeline_test.go
+++ b/pkg/tekton/metapipeline/metapipeline_test.go
@@ -89,7 +89,8 @@ var _ = Describe("Meta pipeline", func() {
 
 			It("should pass custom env variables to step syntax effective to be applied to effective project config", func() {
 				step := actualCRDs.Tasks()[0].Spec.Steps[2]
-				Expect(step.Args[0]).Should(ContainSubstring("--env SOME_VAR=SOME_VAL --env OTHER_VAR=OTHER_VAL"))
+				Expect(step.Args[0]).Should(ContainSubstring("--env SOME_VAR=SOME_VAL"))
+				Expect(step.Args[0]).Should(ContainSubstring("--env OTHER_VAR=OTHER_VAL"))
 			})
 
 			It("should have correct step create task args", func() {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Since map orders aren't guaranteed, we can't be sure that the order in which the custom env vars show up in the command line will be consistent. So stop assuming they will be in the test, and just check for each of them individually.

Saw this in the integration test run for #5051, so hey, a fix.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

n/a