### PR TITLE
fix: Include versions stream URL in BDD requirements

### DIFF
--- a/pkg/cmd/step_bdd.go
+++ b/pkg/cmd/step_bdd.go
@@ -593,6 +593,8 @@ func (o *StepBDDOptions) createCluster(cluster *bdd.CreateCluster) error {
 			requirements.VersionStream.Ref = o.InstallOptions.Flags.VersionsGitRef
 			log.Logger().Infof("setting the jx-requirements.yml version stream ref to: %s\n", util.ColorInfo(requirements.VersionStream.Ref))
 		}
+		requirements.VersionStream.URL = o.InstallOptions.Flags.VersionsRepository
+
 		if cluster.Name != requirements.Cluster.ClusterName {
 			requirements.Cluster.ClusterName = cluster.Name
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Should fix failures like `there was a problem creating a version resolver from versions stream repository and ref dff43bbff485edcf7d49a21f8916bcb62a17e011` in BDD tests using boot.

#### Special notes for the reviewer(s)

/assign @garethjevans 
/assign @rawlingsj 

#### Which issue this PR fixes

n/a