### PR TITLE
chore: Increase cpu limit for release builds to 4

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -43,7 +43,7 @@ pipelineConfig:
               containerOptions:
                 resources:
                   limits:
-                    cpu: 3
+                    cpu: 4
                     memory: 8Gi
                   requests:
                     cpu: 1


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

While watching a release build, I saw it spiking to its cpu limit of 3 a few times, so let's bump it to 4 and speed things up ever so slightly.

#### Special notes for the reviewer(s)

/assign @pmuir 
/assign @rawlingsj 

#### Which issue this PR fixes

n/a