### PR TITLE
feat: improve synchronization on logging so we don't lose or mix trac…

### DIFF
--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -65,8 +65,8 @@ type LongTermStorageLogWriter struct {
 }
 
 // WriteLog will receive a logs.LogLine value and append its bytes to the LongTermStorageLogWriter stored bytes
-func (w *LongTermStorageLogWriter) WriteLog(logLine logs.LogLine) error {
-	w.data = append(w.data, logLine.Line...)
+func (w *LongTermStorageLogWriter) WriteLog(logLine logs.LogLine, lch chan<- logs.LogLine) error {
+	lch <- logLine
 	return nil
 }
 

--- a/pkg/cmd/get/get_build_logs.go
+++ b/pkg/cmd/get/get_build_logs.go
@@ -443,9 +443,7 @@ func (o *GetBuildLogsOptions) getTektonLogs(kubeClient kubernetes.Interface, tek
 		return false, o.TektonLogger.StreamPipelinePersistentLogs(pa.Spec.BuildLogsURL, o.CommonOptions)
 	}
 
-	_ = o.TektonLogger.LogWriter.WriteLog(logs.LogLine{
-		Line: fmt.Sprintf("Build logs for %s", util.ColorInfo(name)),
-	})
+	log.Logger().Infof("Build logs for %s", util.ColorInfo(name))
 	name = strings.TrimSuffix(name, " ")
 	return false, o.TektonLogger.GetRunningBuildLogs(pa, name)
 }
@@ -466,8 +464,8 @@ func (o *CLILogWriter) StreamLog(lch <-chan logs.LogLine, ech <-chan error) erro
 }
 
 // WriteLog implementation of LogWriter.WriteLog for CLILogWriter, this implementation will write the provided log line through the defined logger
-func (o *CLILogWriter) WriteLog(logLine logs.LogLine) error {
-	log.Logger().Info(logLine.Line)
+func (o *CLILogWriter) WriteLog(logLine logs.LogLine, lch chan<- logs.LogLine) error {
+	lch <- logLine
 	return nil
 }
 

--- a/pkg/cmd/get/get_build_logs_test.go
+++ b/pkg/cmd/get/get_build_logs_test.go
@@ -412,9 +412,9 @@ func LogsProvider(pod *v1.Pod, container *v1.Container) (io.Reader, func(), erro
 	}, nil
 }
 
-func (w *BuildLogsTestWriter) WriteLog(logLine logs.LogLine) error {
-	log.Logger().Info(logLine.Line)
+func (w *BuildLogsTestWriter) WriteLog(logLine logs.LogLine, lch chan<- logs.LogLine) error {
 	w.SingleLinesLogged = append(w.SingleLinesLogged, logLine.Line)
+	lch <- logLine
 	return nil
 }
 

--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -40,7 +40,7 @@ type TektonLogger struct {
 	KubeClient        kubernetes.Interface
 	LogWriter         LogWriter
 	Namespace         string
-	logsRetrieverFunc retrieverFunc
+	LogsRetrieverFunc retrieverFunc
 	logsChannel       chan LogLine
 	errorsChannel     chan error
 	wg                *sync.WaitGroup
@@ -298,11 +298,11 @@ func (t *TektonLogger) syncStreamLog() {
 
 func (t *TektonLogger) fetchLogsToChannel(ns string, pod *corev1.Pod, container *corev1.Container) error {
 
-	if t.logsRetrieverFunc == nil {
-		t.logsRetrieverFunc = t.retrieveLogsFromPod
+	if t.LogsRetrieverFunc == nil {
+		t.LogsRetrieverFunc = t.retrieveLogsFromPod
 	}
 
-	reader, cleanFN, err := t.logsRetrieverFunc(pod, container)
+	reader, cleanFN, err := t.LogsRetrieverFunc(pod, container)
 	if err != nil {
 		t.errorsChannel <- err
 		return err

--- a/pkg/logs/tekton_logging_test.go
+++ b/pkg/logs/tekton_logging_test.go
@@ -52,7 +52,7 @@ func TestGetTektonPipelinesWithActivePipelineActivityNoData(t *testing.T) {
 			StreamLinesLogged: make([]string, 0),
 			SingleLinesLogged: make([]string, 0),
 		},
-		logsRetrieverFunc: LogsProvider,
+		LogsRetrieverFunc: LogsProvider,
 	}
 	names, paNames, err := tl.GetTektonPipelinesWithActivePipelineActivity([]string{}, "")
 
@@ -72,7 +72,7 @@ func TestGetTektonPipelinesWithActivePipelineActivitySingleBuild(t *testing.T) {
 			StreamLinesLogged: make([]string, 0),
 			SingleLinesLogged: make([]string, 0),
 		},
-		logsRetrieverFunc: LogsProvider,
+		LogsRetrieverFunc: LogsProvider,
 	}
 
 	_, err := jxClient.JenkinsV1().PipelineActivities(ns).Create(&v1.PipelineActivity{
@@ -162,7 +162,7 @@ func TestGetTektonPipelinesWithActivePipelineActivityOnlyWaitingStep(t *testing.
 			StreamLinesLogged: make([]string, 0),
 			SingleLinesLogged: make([]string, 0),
 		},
-		logsRetrieverFunc: LogsProvider,
+		LogsRetrieverFunc: LogsProvider,
 	}
 
 	_, err := jxClient.JenkinsV1().PipelineActivities(ns).Create(&v1.PipelineActivity{
@@ -253,7 +253,7 @@ func TestGetRunningBuildLogsNoBuildPods(t *testing.T) {
 			StreamLinesLogged: make([]string, 0),
 			SingleLinesLogged: make([]string, 0),
 		},
-		logsRetrieverFunc: LogsProvider,
+		LogsRetrieverFunc: LogsProvider,
 	}
 	pa := &v1.PipelineActivity{
 		ObjectMeta: v12.ObjectMeta{
@@ -296,7 +296,7 @@ func TestGetRunningBuildLogsWithPipelineRunButNoBuildPods(t *testing.T) {
 			StreamLinesLogged: make([]string, 0),
 			SingleLinesLogged: make([]string, 0),
 		},
-		logsRetrieverFunc: LogsProvider,
+		LogsRetrieverFunc: LogsProvider,
 	}
 
 	pa := &v1.PipelineActivity{
@@ -338,7 +338,7 @@ func TestGetRunningBuildLogsNoMatchingBuildPods(t *testing.T) {
 			StreamLinesLogged: make([]string, 0),
 			SingleLinesLogged: make([]string, 0),
 		},
-		logsRetrieverFunc: LogsProvider,
+		LogsRetrieverFunc: LogsProvider,
 	}
 
 	pa := &v1.PipelineActivity{
@@ -385,7 +385,7 @@ func TestGetRunningBuildLogsWithMatchingBuildPods(t *testing.T) {
 			StreamLinesLogged: make([]string, 0),
 			SingleLinesLogged: make([]string, 0),
 		},
-		logsRetrieverFunc: LogsProvider,
+		LogsRetrieverFunc: LogsProvider,
 	}
 
 	pa := &v1.PipelineActivity{
@@ -451,7 +451,7 @@ func TestGetRunningBuildLogsWithMatchingBuildPodsWithFailedContainerInTheMiddle(
 			StreamLinesLogged: make([]string, 0),
 			SingleLinesLogged: make([]string, 0),
 		},
-		logsRetrieverFunc: LogsProvider,
+		LogsRetrieverFunc: LogsProvider,
 	}
 
 	pa := &v1.PipelineActivity{
@@ -517,7 +517,7 @@ func TestGetRunningBuildLogsForLegacyPipelineRunWithMatchingBuildPods(t *testing
 			StreamLinesLogged: make([]string, 0),
 			SingleLinesLogged: make([]string, 0),
 		},
-		logsRetrieverFunc: LogsProvider,
+		LogsRetrieverFunc: LogsProvider,
 	}
 
 	pa := &v1.PipelineActivity{
@@ -614,7 +614,7 @@ func TestGetRunningBuildLogsWithMultipleStages(t *testing.T) {
 			StreamLinesLogged: make([]string, 0),
 			SingleLinesLogged: make([]string, 0),
 		},
-		logsRetrieverFunc: LogsProvider,
+		LogsRetrieverFunc: LogsProvider,
 	}
 
 	pa := &v1.PipelineActivity{

--- a/pkg/logs/test_data/legacy_pipeline_run/pods.yml
+++ b/pkg/logs/test_data/legacy_pipeline_run/pods.yml
@@ -1784,9 +1784,9 @@ items:
           state:
             terminated:
               containerID: docker://d4abd70d8942c22bcd1d9fa1ec8a9440fa65ef4143c15b0286e0589f1dbb2a22
-              exitCode: 1
+              exitCode: 0
               finishedAt: "2019-07-02T12:36:46Z"
-              reason: Error
+              reason: Completed
               startedAt: "2019-07-02T12:35:03Z"
         - containerID: docker://8ef0a0090393a926ac59b0ed792d9e4fa32ed93443a2da251d0f8913688d1c10
           image: gcr.io/jenkinsxio/builder-nodejs:0.1.542

--- a/pkg/logs/test_data/pod_with_failure/pipelineruns.yml
+++ b/pkg/logs/test_data/pod_with_failure/pipelineruns.yml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+  - apiVersion: tekton.dev/v1alpha1
+    kind: PipelineRun
+    metadata:
+      generation: 1
+      labels:
+        branch: fakebranch
+        build: "1"
+        created-by-prow: "true"
+        owner: fakeowner
+        prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
+        repository: fakerepo
+        tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
+      name: meta-fakeowner-fakerepo-build-1
+      namespace: jx
+      ownerReferences:
+        - apiVersion: tekton.dev/v1alpha1
+          kind: pipeline
+          name: meta-fakeowner-fakerepo-build-1
+          uid: 3fe9c5ff-9da8-11e9-8283-42010a840060
+      selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/meta-fakeowner-fakerepo-build-1
+    spec:
+      params:
+        - name: version
+          value: 0.0.1
+        - name: build_id
+          value: "1"
+      pipelineRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: meta-fakeowner-fakerepo-build-1
+      resources:
+        - name: fakeowner-fakerepo-fakebranch
+          resourceRef:
+            apiVersion: tekton.dev/v1alpha1
+            name: fakeowner-fakerepo-fakebranch
+      serviceAccount: tekton-bot
+      timeout: 240h0m0s
+  - apiVersion: tekton.dev/v1alpha1
+    kind: PipelineRun
+    metadata:
+      generation: 1
+      labels:
+        branch: fakebranch
+        build: "1"
+        created-by-prow: "true"
+        owner: fakeowner
+        prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
+        repository: fakerepo
+        tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
+      name: fakeowner-fakerepo-fakebranch-1
+      namespace: jx
+      ownerReferences:
+        - apiVersion: tekton.dev/v1alpha1
+          kind: pipeline
+          name: fakeowner-fakerepo-fakebranch-1
+          uid: 3fe9c5ff-9da8-11e9-8283-42010a840060
+      selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/fakeowner-fakerepo-fakebranch-1
+    spec:
+      params:
+        - name: version
+          value: 0.0.1
+        - name: build_id
+          value: "1"
+      pipelineRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: fakeowner-fakerepo-fakebranch-1
+      resources:
+        - name: fakeowner-fakerepo-fakebranch
+          resourceRef:
+            apiVersion: tekton.dev/v1alpha1
+            name: fakeowner-fakerepo-fakebranch
+      serviceAccount: tekton-bot
+      timeout: 240h0m0s

--- a/pkg/logs/test_data/pod_with_failure/pods.yml
+++ b/pkg/logs/test_data/pod_with_failure/pods.yml
@@ -1742,9 +1742,9 @@ items:
           state:
             terminated:
               containerID: docker://087e23e897b77226706cf686a074a942ce9d4a50fc651d3bf9a54b2b1aeb8b40
-              exitCode: 0
+              exitCode: 1
               finishedAt: "2019-07-02T12:35:02Z"
-              reason: Completed
+              reason: Error
               startedAt: "2019-07-02T12:35:00Z"
         - containerID: docker://5780df05616c5f396b108d2549359061fc79d7eec5fc062c237f70472fa2f95d
           image: gcr.io/jenkinsxio/builder-nodejs:0.1.542

--- a/pkg/logs/test_data/pod_with_failure/structures.yml
+++ b/pkg/logs/test_data/pod_with_failure/structures.yml
@@ -1,0 +1,48 @@
+apiVersion: jenkins.io/v1
+items:
+  - apiVersion: jenkins.io/v1
+    kind: PipelineStructure
+    metadata:
+      creationTimestamp: 2019-03-05T20:06:13Z
+      generation: 1
+      name: fakeowner-fakerepo-fakebranch-1
+      namespace: jx
+      ownerReferences:
+      - apiVersion: tekton.dev/v1alpha1
+        kind: Pipeline
+        name: fakeowner-fakerepo-fakebranch-1
+        uid: 208e0fad-3f82-11e9-bd41-42010a8a00a2
+      resourceVersion: "1421155"
+      selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/fakeowner-fakerepo-fakebranch-1
+      uid: 20c58bd5-3f82-11e9-bd41-42010a8a00a2
+    pipelineRef: fakeowner-fakerepo-fakebranch-1
+    pipelineRunRef: fakeowner-fakerepo-fakebranch-1
+    stages:
+    - depth: 0
+      name: From Fakebranch
+      taskRef: fakeowner-fakerepo-fakebranch-from-fakebranch-1
+  - apiVersion: jenkins.io/v1
+    kind: PipelineStructure
+    metadata:
+      creationTimestamp: 2019-03-05T20:06:13Z
+      generation: 1
+      name: meta-fakeowner-fakerepo-build-1
+      namespace: jx
+      ownerReferences:
+        - apiVersion: tekton.dev/v1alpha1
+          kind: Pipeline
+          name: meta-fakeowner-fakerepo-build-1
+          uid: 208e0fad-3f82-11e9-bd41-42010a8a00a2
+      resourceVersion: "1421155"
+      selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/meta-fakeowner-fakerepo-build-1
+      uid: 20c58bd5-3f82-11e9-bd41-42010a8a00a2
+    pipelineRef: meta-fakeowner-fakerepo-build-1
+    pipelineRunRef: meta-fakeowner-fakerepo-build-1
+    stages:
+      - depth: 0
+        name: App Extension
+        taskRef: meta-fakeowner-fakerepo-build-app-extension-8
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""


### PR DESCRIPTION
…es (like headers)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
There was a problem with logging where we could lose the last few traces when logging through the CLI.

This was due to miss synchronization between channels.
We could also mix headers and traces in certain situations.

I've added synchronization via WaitGroup so we always wait for the printing goroutine to finish before leaving the logging functions.

Also, the func `LogWriter.WriteLog` should now put the line in the given channel instead of writing it itself, this means it will be in order when printing the log.

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
