### PR TITLE
fix: Turn off JSON logging for metapipeline-triggered pipelines

### DIFF
--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -268,11 +268,6 @@ func buildEnvParams(params CRDCreationParameters) []corev1.EnvVar {
 	var envVars []corev1.EnvVar
 
 	envVars = append(envVars, corev1.EnvVar{
-		Name:  "JX_LOG_FORMAT",
-		Value: "json",
-	})
-
-	envVars = append(envVars, corev1.EnvVar{
 		Name:  "BUILD_NUMBER",
 		Value: params.BuildNumber,
 	})


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

`JX_LOG_FORMAT=json` breaks BDD tests parsing `jx get build logs`, and, frankly, makes the log output rather unappealing in the first place. So let's turn this off until @hferentschik has a more holistic approach that turns off the JSON unless a flag like `-o json` is passed to `jx get build logs`.

#### Special notes for the reviewer(s)

/assign @hferentschik 
/assign @dgozalo 
/assign @daveconde 

#### Which issue this PR fixes

fixes #5208 
