### PR TITLE
feat: fix ordering of metapipeline logs

### DIFF
--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -173,6 +173,11 @@ func getPipelineRunNamesForActivity(pa *v1.PipelineActivity, tektonClient tekton
 			return nil, err
 		}
 	}
+
+	sort.Slice(tektonPRs.Items, func(i, j int) bool {
+		return tektonPRs.Items[i].CreationTimestamp.Before(&tektonPRs.Items[j].CreationTimestamp)
+	})
+
 	var names []string
 	for _, pr := range tektonPRs.Items {
 		buildNumber := pr.Labels[tekton.LabelBuild]
@@ -214,8 +219,9 @@ func (t TektonLogger) GetRunningBuildLogs(pa *v1.PipelineActivity, buildName str
 					if err != nil {
 						return errors.Wrapf(err, "failed to get pods for pipeline run %s in namespace %s", prName, pa.Namespace)
 					}
+
 					sort.Slice(pods, func(i, j int) bool {
-						return pods[j].CreationTimestamp.Before(&pods[i].CreationTimestamp)
+						return pods[i].CreationTimestamp.Before(&pods[j].CreationTimestamp)
 					})
 
 					for _, pod := range pods {


### PR DESCRIPTION


Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Fixed the ordering of pipeline runs so we always get the metapipeline stage(s) first.

Also reversed the ordering of pods in a certain pipeline so we show the logs of stages in order.

#### Which issue this PR fixes

fixes #5207 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
