### PR TITLE
fix: skip waitForGitOps on PR if --no-merge

### DIFF
--- a/pkg/cmd/promote/promote.go
+++ b/pkg/cmd/promote/promote.go
@@ -561,6 +561,12 @@ func (o *PromoteOptions) WaitForPromotion(ns string, env *v1.Environment, releas
 	if err != nil {
 		return errors.Wrap(err, "Getting jx client")
 	}
+
+	if o.NoMergePullRequest {
+		log.Logger().Infof("Skipping `waitForGitOpsPullRequest` due to --no-merge on promotion")
+		return nil
+	}
+
 	pullRequestInfo := releaseInfo.PullRequestInfo
 	if pullRequestInfo != nil {
 		promoteKey := o.CreatePromoteKey(env)


### PR DESCRIPTION
Signed-off-by: Wei Cheng <calvinpohwc@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Not very familiar with the whole `promote` flow. Would love to get some feedback if I am doing the correct thing to skip `waitForGitOps` if `NoMergePullRequest` is `true`.

If I am in the right direction will proceed to add in suitable test cases.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #5081

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
