### PR TITLE
feat(cloud): create buckets for AWS

### DIFF
--- a/pkg/cloud/amazon/storage/bucket_provider.go
+++ b/pkg/cloud/amazon/storage/bucket_provider.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/jenkins-x/jx/pkg/cloud/amazon"
+	"github.com/jenkins-x/jx/pkg/cloud/buckets"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
+)
+
+// AmazonBucketProvider the bucket provider for AWS
+type AmazonBucketProvider struct {
+	Requirements *config.RequirementsConfig
+	api          s3iface.S3API
+}
+
+func (b *AmazonBucketProvider) s3() (s3iface.S3API, error) {
+	if b.api != nil {
+		return b.api, nil
+	}
+	region := b.Requirements.Cluster.Region
+	if region == "" {
+		return nil, errors.New("requirements do not specify a cluster region")
+	}
+	sess, err := amazon.NewAwsSession("", region)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create AWS session")
+	}
+	b.api = s3.New(sess)
+
+	return b.api, nil
+}
+
+// CreateNewBucketForCluster creates a new dynamic bucket
+func (b *AmazonBucketProvider) CreateNewBucketForCluster(clusterName string, bucketKind string) (string, error) {
+	uuid4, _ := uuid.NewV4()
+	bucketName := fmt.Sprintf("%s-%s-%s", clusterName, bucketKind, uuid4.String())
+
+	// Max length is 63, https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+	if len(bucketName) > 63 {
+		bucketName = bucketName[:63]
+	}
+	bucketName = strings.TrimRight(bucketName, "-")
+	bucketURL := "s3://" + bucketName
+	err := b.EnsureBucketIsCreated(bucketURL)
+	if err != nil {
+		return bucketURL, errors.Wrapf(err, "failed to create bucket %s", bucketURL)
+	}
+
+	return bucketURL, nil
+}
+
+// EnsureBucketIsCreated ensures the bucket URL is created
+func (b *AmazonBucketProvider) EnsureBucketIsCreated(bucketURL string) error {
+	svc, err := b.s3()
+	if err != nil {
+		return err
+	}
+
+	u, err := url.Parse(bucketURL)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse bucket name from %s", bucketURL)
+	}
+	bucketName := u.Host
+
+	// Check if bucket exists already
+	_, err = svc.HeadBucket(&s3.HeadBucketInput{Bucket: aws.String(bucketName)})
+	if err == nil {
+		return nil // bucket already exists
+	}
+	aerr, ok := err.(awserr.Error)
+	if !ok || aerr.Code() != s3.ErrCodeNoSuchBucket {
+		return errors.Wrapf(err, "failed to check if %s bucket exists already", bucketName)
+	}
+
+	infoBucketURL := util.ColorInfo(bucketURL)
+	log.Logger().Infof("The bucket %s does not exist so lets create it", infoBucketURL)
+	_, err = svc.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+		CreateBucketConfiguration: &s3.CreateBucketConfiguration{
+			LocationConstraint: aws.String(b.Requirements.Cluster.Region),
+		},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "there was a problem creating the bucket %s in the AWS", bucketName)
+	}
+	return nil
+}
+
+// NewAmazonBucketProvider create a new provider for AWS
+func NewAmazonBucketProvider(requirements *config.RequirementsConfig) buckets.Provider {
+	return &AmazonBucketProvider{
+		Requirements: requirements,
+	}
+}

--- a/pkg/cloud/amazon/storage/bucket_provider_test.go
+++ b/pkg/cloud/amazon/storage/bucket_provider_test.go
@@ -1,0 +1,114 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockedS3 struct {
+	s3iface.S3API
+}
+
+func (m mockedS3) HeadBucket(input *s3.HeadBucketInput) (*s3.HeadBucketOutput, error) {
+	if *input.Bucket == "bucket_that_exists" {
+		return &s3.HeadBucketOutput{}, nil
+	}
+	return nil, awserr.New(s3.ErrCodeNoSuchBucket, "", nil)
+}
+
+func (m mockedS3) CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+	return nil, nil
+}
+
+func TestAmazonBucketProvider_EnsureBucketIsCreated(t *testing.T) {
+	p := AmazonBucketProvider{
+		Requirements: &config.RequirementsConfig{
+			Cluster: config.ClusterConfig{
+				Region: "us-east-1",
+			},
+		},
+		api: &mockedS3{},
+	}
+
+	tests := []struct {
+		bucket  string
+		message string
+	}{
+		{
+			bucket:  "new_bucket",
+			message: "The bucket s3://new_bucket does not exist so lets create it\n",
+		},
+		{
+			bucket:  "bucket_that_exists",
+			message: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.bucket, func(t *testing.T) {
+			message := log.CaptureOutput(func() {
+				err := p.EnsureBucketIsCreated("s3://" + test.bucket)
+				assert.NoError(t, err)
+			})
+
+			assert.Equal(t, test.message, message)
+		})
+	}
+}
+
+func TestAmazonBucketProvider_CreateNewBucketForCluster(t *testing.T) {
+	p := AmazonBucketProvider{
+		Requirements: &config.RequirementsConfig{
+			Cluster: config.ClusterConfig{
+				Region: "us-east-1",
+			},
+		},
+		api: &mockedS3{},
+	}
+
+	message := log.CaptureOutput(func() {
+		url, err := p.CreateNewBucketForCluster("test-cluster", "test-kind")
+		assert.NoError(t, err)
+		assert.True(t, strings.HasPrefix(url, "s3://test-cluster-test-kind-"))
+	})
+	assert.NotEmpty(t, message)
+
+	// Test very long name and trimming of hyphens
+	message = log.CaptureOutput(func() {
+		longName := strings.Repeat("A", 62)
+		url, err := p.CreateNewBucketForCluster(longName+"-cluster", "test-kind")
+		assert.NoError(t, err)
+		assert.Equal(t, "s3://"+longName, url)
+	})
+	assert.NotEmpty(t, message)
+}
+
+func TestAmazonBucketProvider_s3(t *testing.T) {
+	p := AmazonBucketProvider{
+		Requirements: &config.RequirementsConfig{
+			Cluster: config.ClusterConfig{
+				Region: "us-east-1",
+			},
+		},
+	}
+
+	svc, err := p.s3()
+	assert.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+func TestAmazonBucketProvider_s3WithNoRegion(t *testing.T) {
+	p := AmazonBucketProvider{
+		Requirements: &config.RequirementsConfig{},
+	}
+
+	svc, err := p.s3()
+	assert.Nil(t, svc)
+	assert.Error(t, err)
+}

--- a/pkg/cloud/factory/factory.go
+++ b/pkg/cloud/factory/factory.go
@@ -2,17 +2,22 @@ package factory
 
 import (
 	"github.com/jenkins-x/jx/pkg/cloud"
+	amazonStorage "github.com/jenkins-x/jx/pkg/cloud/amazon/storage"
 	"github.com/jenkins-x/jx/pkg/cloud/buckets"
 	"github.com/jenkins-x/jx/pkg/cloud/gke/storage"
 	"github.com/jenkins-x/jx/pkg/config"
 )
 
-// NewBucketProvider creates a new provider for kubeernetes provider
+// NewBucketProvider creates a new bucket provider for a given Kubernetes provider
 func NewBucketProvider(requirements *config.RequirementsConfig) buckets.Provider {
 	switch requirements.Cluster.Provider {
 	case cloud.GKE:
 		return storage.NewGKEBucketProvider(requirements)
+	case cloud.EKS:
+	case cloud.AWS:
+		return amazonStorage.NewAmazonBucketProvider(requirements)
 	default:
 		return nil
 	}
+	return nil
 }


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description

Adding AWS support for bucket provider.  This is only called during `jx step verify preinstall` command that I think it used with `jx boot` type projects.

#### Special notes for the reviewer(s)

We are not using `jx boot` yet, so didn't actually test this beyond the automated tests.  We are using AWS though, so wanted to try to get ahead of any problems.

Open questions:

1. Unsure if BDD tests or similar could be modified to include bucket creation for in AWS?
2. Wasn't sure how to get `pegomock` to work with 3rd party interface.  Maybe doesn't matter?

#### Which issue this PR fixes

Didn't find any.