### PR TITLE
fix: e2e gc should check equality of cluster type between clusters

### DIFF
--- a/pkg/cmd/step/e2e/step_e2e_gc.go
+++ b/pkg/cmd/step/e2e/step_e2e_gc.go
@@ -166,7 +166,7 @@ func (o *StepE2EGCOptions) ShouldDeleteDueToNewerRun(cluster *gke.Cluster, clust
 					for _, existingCluster := range clusters {
 						// Check for same PR & Cluster type
 						if existingClusterType, ok := existingCluster.ResourceLabels["cluster"]; ok {
-							if strings.Contains(existingCluster.Name, branchLabel) && strings.Contains(existingClusterType, clusterType) {
+							if strings.Contains(existingCluster.Name, branchLabel) && existingClusterType == clusterType {
 								existingBuildNumber, err := o.GetBuildNumberFromCluster(&existingCluster)
 								if err == nil {
 									// Delete the older build


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Right now, it's checking if an existing cluster's type contains another cluster's type, but that leads to situations like `boot-lh` getting deleted because `boot-lh-ghe` is running with a higher build number. Let's change that to an equality check instead.

#### Special notes for the reviewer(s)

/assign @daveconde 

#### Which issue this PR fixes

fixes #5238
