### PR TITLE
fix: do not log an error when an ingress is not found for a service

### DIFF
--- a/pkg/kube/services/services.go
+++ b/pkg/kube/services/services.go
@@ -94,7 +94,7 @@ func FindServiceURL(client kubernetes.Interface, namespace string, name string) 
 	log.Logger().Debugf("finding service url for %s in namespace %s", name, namespace)
 	svc, err := client.CoreV1().Services(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
-		return "", errors.Wrapf(err, "findding the service %s in namespace %s", name, namespace)
+		return "", errors.Wrapf(err, "finding the service %s in namespace %s", name, namespace)
 	}
 	answer := GetServiceURL(svc)
 	if answer != "" {

--- a/pkg/kube/services/services.go
+++ b/pkg/kube/services/services.go
@@ -3,11 +3,12 @@ package services
 import (
 	"context"
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/log"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/log"
 
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
@@ -93,7 +94,7 @@ func FindServiceURL(client kubernetes.Interface, namespace string, name string) 
 	log.Logger().Debugf("finding service url for %s in namespace %s", name, namespace)
 	svc, err := client.CoreV1().Services(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to find service %s in namespace %s", name, namespace)
+		return "", errors.Wrapf(err, "findding the service %s in namespace %s", name, namespace)
 	}
 	answer := GetServiceURL(svc)
 	if answer != "" {
@@ -106,8 +107,8 @@ func FindServiceURL(client kubernetes.Interface, namespace string, name string) 
 	// lets try find the service via Ingress
 	ing, err := client.ExtensionsV1beta1().Ingresses(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
-		log.Logger().Errorf("error finding ingress for %s in namespace %s - err %s", name, namespace, err)
-		return "", nil
+		log.Logger().Debugf("unable to finding ingress for %s in namespace %s - err %s", name, namespace, err)
+		return "", errors.Wrapf(err, "getting ingress for service %q in namespace %s", name, namespace)
 	}
 
 	url := IngressURL(ing)


### PR DESCRIPTION
This method is used by jx open/jx get urls to list the available URLs/ingress resource. It's
more appropriate to log a debug message when not ingress is found for a service instead of an error.
This will reduce the noise in case of services which are not exposed from the cluster.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #5215

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->