### PR TITLE
fix: Use correct gitRef in boot version resolver

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -169,13 +169,13 @@ func (o *BootOptions) Run() error {
 			}
 			gitRef, err = resolver.ResolveGitVersion(gitURL)
 			if err != nil {
-				return errors.Wrapf(err, "failed to resolve version for https://github.com/jenkins-x/jenkins-x-boot-config.git")
+				return errors.Wrapf(err, fmt.Sprintf("failed to resolve version for %s", gitURL))
 			}
-			if o.GitRef == "" {
+			if gitRef == "" {
 				log.Logger().Infof("Attempting to resolve version for upstream boot config %s", util.ColorInfo(config.DefaultBootRepository))
 				gitRef, err = resolver.ResolveGitVersion(config.DefaultBootRepository)
 				if err != nil {
-					return errors.Wrapf(err, "failed to resolve version for https://github.com/jenkins-x/jenkins-x-boot-config.git")
+					return errors.Wrapf(err, fmt.Sprintf("failed to resolve version for %s", config.DefaultBootRepository))
 				}
 			}
 


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This should be a catch for `gitRef, err = resolver.ResolveGitVersion(gitURL)` returning blank, instead of checking if the flag `o.GitRef` was set