### PR TITLE
fix: explicitly specify the secrets location when creating the vault URL client based on value specified in requirements file

### DIFF
--- a/pkg/cmd/step/create/step_create_values.go
+++ b/pkg/cmd/step/create/step_create_values.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
+	"github.com/jenkins-x/jx/pkg/io/secrets"
 
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/helm"
@@ -181,7 +182,7 @@ func (o *StepCreateValuesOptions) CreateValuesFile() error {
 	if err != nil {
 		return errors.Wrapf(err, "getting team name")
 	}
-	secretURLClient, err := o.GetSecretURLClient()
+	secretURLClient, err := o.GetSecretURLClient(secrets.ToSecretsLocation(o.SecretsScheme))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -250,13 +250,14 @@ func (o *StepHelmApplyOptions) Run() error {
 		}()
 	}
 
-	secretURLClient, err := o.GetSecretURLClient()
-	if err != nil {
-		return errors.Wrap(err, "failed to create a Secret RL client")
-	}
 	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir)
 	if err != nil {
 		return err
+	}
+
+	secretURLClient, err := o.GetSecretURLClient(secrets.ToSecretsLocation(string(requirements.SecretStorage)))
+	if err != nil {
+		return errors.Wrap(err, "failed to create a Secret RL client")
 	}
 
 	DefaultEnvironments(requirements, devGitInfo)

--- a/pkg/cmd/step/helm/step_helm_build.go
+++ b/pkg/cmd/step/helm/step_helm_build.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/helm"
+	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/pkg/errors"
 
@@ -90,15 +91,14 @@ func (o *StepHelmBuildOptions) Run() error {
 	}
 
 	if o.Boot {
-
-		secretURLClient, err := o.GetSecretURLClient()
-		if err != nil {
-			return errors.Wrap(err, "failed to create a Secret RL client")
-		}
-
 		requirements, requirementsFileName, err := config.LoadRequirementsConfig(dir)
 		if err != nil {
 			return err
+		}
+
+		secretURLClient, err := o.GetSecretURLClient(secrets.ToSecretsLocation(string(requirements.SecretStorage)))
+		if err != nil {
+			return errors.Wrap(err, "creating a Secret URL client")
 		}
 
 		devGitInfo, err := o.FindGitInfo(dir)

--- a/pkg/io/secrets/secret_locations.go
+++ b/pkg/io/secrets/secret_locations.go
@@ -3,7 +3,7 @@ package secrets
 import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -17,11 +17,13 @@ type SecretsLocationKind string
 
 const (
 	// FileSystemLocationKind indicates that secrets location is the file system
-	FileSystemLocationKind SecretsLocationKind = "fileSystem"
+	FileSystemLocationKind SecretsLocationKind = "local"
 	// VaultLocationKind indicates that secrets location is vault
 	VaultLocationKind SecretsLocationKind = "vault"
 	// KubeLocationKind inidcates that secrets location is in Kuberntes
 	KubeLocationKind SecretsLocationKind = "kube"
+	// KubeLocationKind indicates that secrets location needs to be dynamically determine
+	AutoLocationKind SecretsLocationKind = "auto"
 )
 
 // SecretLocation interfaces to identify where is the secrets location
@@ -85,4 +87,18 @@ func getInstallConfigMapData(kubeClient kubernetes.Interface, namespace string) 
 		return nil, errors.Wrapf(err, "getting configmap %s", kube.ConfigMapNameJXInstallConfig)
 	}
 	return configMap, nil
+}
+
+// ToSecretsLocation converts a string to a SecretsLocationKind
+func ToSecretsLocation(location string) SecretsLocationKind {
+	switch location {
+	case "local":
+		return FileSystemLocationKind
+	case "vault":
+		return VaultLocationKind
+	case "kube":
+		return KubeLocationKind
+	default:
+		return AutoLocationKind
+	}
 }

--- a/pkg/io/secrets/secret_locations.go
+++ b/pkg/io/secrets/secret_locations.go
@@ -22,7 +22,7 @@ const (
 	VaultLocationKind SecretsLocationKind = "vault"
 	// KubeLocationKind inidcates that secrets location is in Kuberntes
 	KubeLocationKind SecretsLocationKind = "kube"
-	// KubeLocationKind indicates that secrets location needs to be dynamically determine
+	// AutoLocationKind indicates that secrets location needs to be dynamically determine
 	AutoLocationKind SecretsLocationKind = "auto"
 )
 

--- a/pkg/kube/vault/vault_factory.go
+++ b/pkg/kube/vault/vault_factory.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -24,7 +24,7 @@ const (
 	maxRetries = 2
 
 	// healthReadyTimeout define the maximum duration to wait for vault to become initialized and unsealed
-	healthhRetyTimeout = 2 * time.Minute
+	healthhRetyTimeout = 5 * time.Minute
 
 	// healthInitialRetryDelay define the initial delay before starting the retries
 	healthInitialRetryDelay = 10 * time.Second
@@ -39,7 +39,7 @@ const (
 	kvEngineInitialRetyDelay = 1 * time.Second
 
 	// kvEngineRetryTimeout define the maximum duration to wait for KV engine to be properly configured
-	kvEngineRetryTimeout = 1 * time.Minute
+	kvEngineRetryTimeout = 3 * time.Minute
 )
 
 // OptionsInterface is an interface to allow passing around of a CommonOptions object without dependencies on the whole of the cmd package


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

In the current implementation the `step create values` is falling silently back on local secrets URL client when the vault
is not ready. This could happen during the boot sequence when vault is starting off. This results in secrets being locally stored,
but in the following steps vault becomes ready and `step helm apply` tries to fetch the secrets from vault. Unfortunately the secrets
aren't stored in vault but locally.

This is not what the user expects since he configured `secretsStorage: vault` in the `jx-requirements.yaml` file. It is better to fail
explicitly instead of mixing the secrets location in unexpected way.

I increased also some timeouts used during vault client creation. It seems that sometimes it takes longer with external DNS + TLS until
the vault becomes reachable.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->