### PR TITLE
fix: Report error for nil pipeline for expected kind

### DIFF
--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -344,7 +344,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			organization:          "abayer",
 			branch:                "really-long",
 			kind:                  "release",
-			effectiveProjectError: fmt.Errorf("%s", "no pipeline defined for kind release"),
+			effectiveProjectError: errors.New("no pipeline defined for kind release"),
 		},
 	}
 

--- a/pkg/cmd/step/create/test_data/step_create_task/no_pipeline_for_kind/jenkins-x.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/no_pipeline_for_kind/jenkins-x.yml
@@ -1,0 +1,42 @@
+buildPack: none
+pipelineConfig:
+  env:
+    - name: FRUIT
+      value: BANANA
+  pipelines:
+    pullRequest:
+      pipeline:
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: somebodyelse
+        options:
+          containerOptions:
+            resources:
+              requests:
+                cpu: 0.1
+                memory: 64Mi
+        agent:
+          image: nodejs
+        stages:
+          - name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+            steps:
+              - command: echo
+                args:
+                  - hello world
+              - command: ls
+                args:
+                  - -la
+                env:
+                  - name: ANOTHER_VAR
+                    value: Another value
+          - name: Second
+            steps:
+              - command: echo
+                args:
+                  - hi ${FRUIT}
+            options:
+              containerOptions:
+                resources:
+                  limits:
+                    cpu: 0.4
+                    memory: 256Mi

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-pipeline-from-jenkins-x-yml/jenkins-x.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-pipeline-from-jenkins-x-yml/jenkins-x.yml
@@ -1,3 +1,4 @@
+buildPack: none
 pipelineConfig:
   env:
     - name: FRUIT

--- a/pkg/cmd/step/syntax/step_syntax_effective.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective.go
@@ -388,6 +388,11 @@ func (o *StepSyntaxEffectiveOptions) createPipelineForKind(kind string, lifecycl
 		if projectConfig.BuildPack == "" || projectConfig.BuildPack == "none" {
 			for _, override := range pipelines.Overrides {
 				if override.MatchesPipeline(kind) {
+					// If no step/steps, other overrides, or stage is specified, just remove the whole pipeline.
+					// TODO: This is probably pointless functionality.
+					if override.Step == nil && len(override.Steps) == 0 && !override.HasNonStepOverrides() && override.Stage == "" {
+						return nil, nil
+					}
 					parsed = syntax.ApplyStepOverridesToPipeline(parsed, override)
 				}
 			}

--- a/pkg/config/project_config.go
+++ b/pkg/config/project_config.go
@@ -159,11 +159,11 @@ func (c *ProjectConfig) GetPipeline(kind string) (*syntax.ParsedPipeline, error)
 			parsed = c.PipelineConfig.Pipelines.Feature.Pipeline
 		}
 	default:
-		return nil, fmt.Errorf("unknown pipeline kind %s", kind)
+		return nil, errors.Errorf("unknown pipeline kind %s", kind)
 	}
 
 	if parsed == nil {
-		return nil, fmt.Errorf("no pipeline defined for kind %s", kind)
+		return nil, errors.Errorf("no pipeline defined for kind %s", kind)
 	}
 	return parsed, nil
 }

--- a/pkg/config/project_config.go
+++ b/pkg/config/project_config.go
@@ -161,5 +161,9 @@ func (c *ProjectConfig) GetPipeline(kind string) (*syntax.ParsedPipeline, error)
 	default:
 		return nil, fmt.Errorf("unknown pipeline kind %s", kind)
 	}
+
+	if parsed == nil {
+		return nil, fmt.Errorf("no pipeline defined for kind %s", kind)
+	}
 	return parsed, nil
 }

--- a/pkg/config/project_config_test.go
+++ b/pkg/config/project_config_test.go
@@ -93,12 +93,12 @@ func TestGetPipeline(t *testing.T) {
 	assert.NotNil(t, releasePipeline)
 
 	pullRequestPipeline, err := testProjectConfigMaven.GetPipeline(jenkinsfile.PipelineKindPullRequest)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "no pipeline defined for kind pullrequest")
 	assert.Nil(t, pullRequestPipeline)
 
 	featurePipeline, err := testProjectConfigMaven.GetPipeline(jenkinsfile.PipelineKindFeature)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "no pipeline defined for kind feature")
 	assert.Nil(t, featurePipeline)
 }

--- a/pkg/config/project_config_test.go
+++ b/pkg/config/project_config_test.go
@@ -93,10 +93,12 @@ func TestGetPipeline(t *testing.T) {
 	assert.NotNil(t, releasePipeline)
 
 	pullRequestPipeline, err := testProjectConfigMaven.GetPipeline(jenkinsfile.PipelineKindPullRequest)
-	assert.NoError(t, err)
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "no pipeline defined for kind pullrequest")
 	assert.Nil(t, pullRequestPipeline)
 
 	featurePipeline, err := testProjectConfigMaven.GetPipeline(jenkinsfile.PipelineKindFeature)
-	assert.NoError(t, err)
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "no pipeline defined for kind feature")
 	assert.Nil(t, featurePipeline)
 }

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -1884,7 +1884,7 @@ func (p *PipelineOverride) AsStepsSlice() []*Step {
 
 // MatchesPipeline returns true if the pipeline name is specified in the override or no pipeline is specified at all in the override
 func (p *PipelineOverride) MatchesPipeline(name string) bool {
-	if p.Pipeline == "" || p.Pipeline == name {
+	if p.Pipeline == "" || strings.EqualFold(p.Pipeline, name) {
 		return true
 	}
 	return false


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Previously, we'd just end up with a nil pointer, and that's...never helpful. This will instead report an error for when there is no pipeline of a given kind in the effective config.

Also, I reworked how we check for expected errors in the test, and made `override.MatchesPipeline` case-insensitive, since we've got `pullrequest` in some places and `pullRequest` in others. Sigh.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

fixes #5183
