### PR TITLE
feat: remove git diff check from environment repo and get vault name differently

### DIFF
--- a/pkg/cmd/step/boot/step_boot_vault.go
+++ b/pkg/cmd/step/boot/step_boot_vault.go
@@ -94,11 +94,7 @@ func (o *StepBootVaultOptions) Run() error {
 	}
 
 	if requirements.Cluster.VaultName == "" {
-		systemVaultName, err := kubevault.SystemVaultName(o.Kube())
-		if err != nil {
-			return errors.Wrap(err, "building the system vault name from cluster name")
-		}
-		requirements.Cluster.VaultName = systemVaultName
+		requirements.Cluster.VaultName = kubevault.SystemVaultNameForCluster(requirements.Cluster.ClusterName)
 	}
 
 	noExposeVault, err := o.verifyVaultIngress(requirements, kubeClient, ns, requirements.Cluster.VaultName)

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -278,16 +278,7 @@ func (o *StepVerifyEnvironmentsOptions) createEnvGitRepository(name string, requ
 	}
 
 	if name == kube.LabelValueDevEnvironment || environment.Spec.Kind == v1.EnvironmentKindTypeDevelopment {
-		if o.InCDPipeline() && o.InCluster() {
-			// Fail if there are local changes
-			diff, err := o.Git().Diff(o.Dir)
-			if err != nil {
-				return errors.Wrapf(err, "running git diff")
-			}
-			if diff != "" {
-				return errors.Errorf("There are local changes to the dev env:\n\n%s", diff)
-			}
-		} else {
+		if !o.InCDPipeline() && !o.InCluster() {
 			err := o.prDevEnvironment(gitInfo.Name, gitInfo.Organisation, privateRepo, userAuth, requirements, server)
 			if err != nil {
 				return errors.Wrapf(err, "creating dev environment for %s", gitInfo.Name)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [] Change is covered by existing or new tests.

#### Description
There were a few issues with the master pipeline on a new GitOps cluster's dev environment repo.

We are now getting the cluster name from the `requirements.yaml` file instead of trying to get it from the cluster. We are also removing the git diff check on the dev environment repo before continuing with the master pipeline.
