### PR TITLE
feat: add a step command to verify if a URL returns an expected HTTP status code

### DIFF
--- a/pkg/cmd/step/verify/step_verify.go
+++ b/pkg/cmd/step/verify/step_verify.go
@@ -37,6 +37,8 @@ func NewCmdStepVerify(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.AddCommand(NewCmdStepVerifyPod(commonOpts))
 	cmd.AddCommand(NewCmdStepVerifyPreInstall(commonOpts))
 	cmd.AddCommand(NewCmdStepVerifyRequirements(commonOpts))
+	cmd.AddCommand(NewCmdStepVerifyURL(commonOpts))
+
 	return cmd
 }
 

--- a/pkg/cmd/step/verify/step_verify_url.go
+++ b/pkg/cmd/step/verify/step_verify_url.go
@@ -1,0 +1,106 @@
+package verify
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
+	"github.com/jenkins-x/jx/pkg/cmd/templates"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+const (
+	optionEndpoint = "endpoint"
+	optionCode     = "code"
+	optionTimeout  = "timeout"
+)
+
+var (
+	stepVerifyURLLong = templates.LongDesc(`
+		This step checks the status of a URL
+	`)
+
+	stepVerifyURLExample = templates.Examples(`
+        jx step verify url --endpoint https://jenkins-x.io
+	`)
+)
+
+type StepVerifyURLOptions struct {
+	step.StepOptions
+
+	Endpoint string
+	Code     int
+	Timeout  time.Duration
+}
+
+// NewCmdStepVerifyURL creates a new verify url command
+func NewCmdStepVerifyURL(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := StepVerifyURLOptions{
+		StepOptions: step.StepOptions{
+			CommonOptions: commonOpts,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "url",
+		Short:   "Verifies a URL returns an expected HTTP code",
+		Long:    stepVerifyURLLong,
+		Example: stepVerifyURLExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.Endpoint, optionEndpoint, "e", "", "The endpoint on which to wait for expected HTTP code")
+	cmd.Flags().IntVarP(&options.Code, optionCode, "c", http.StatusOK, "The HTTP code which should be returned by the endpoint")
+	cmd.Flags().DurationVarP(&options.Timeout, optionTimeout, "t", 10*time.Minute, "The default timeout for the endpoint to return the expected HTTP code")
+
+	return cmd
+}
+
+func (o *StepVerifyURLOptions) checkFlags() error {
+	if o.Endpoint == "" {
+		return util.MissingOption(optionEndpoint)
+	}
+
+	return nil
+}
+
+func (o *StepVerifyURLOptions) logError(err error) error {
+	log.Logger().Infof("Retrying due to: %s", err)
+	return err
+}
+
+// Run waits with exponential backoff for an endpoint to return an expected HTTP status code
+func (o *StepVerifyURLOptions) Run() error {
+	if err := o.checkFlags(); err != nil {
+		return errors.Wrap(err, "checking flags")
+	}
+
+	log.Logger().Infof("Waiting for %q endpoint to return %d HTTP code", o.Endpoint, o.Code)
+	err := util.Retry(o.Timeout, func() error {
+		resp, err := http.Get(o.Endpoint)
+		if err != nil {
+			return o.logError(err)
+		}
+		if resp.StatusCode != o.Code {
+			err := fmt.Errorf("invalid status code %d expecting %d", resp.StatusCode, o.Code)
+			return o.logError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "waiting for %q", o.Endpoint)
+	}
+	log.Logger().Infof("Endpoint %q returns expected status code %d", o.Endpoint, o.Code)
+	return nil
+}

--- a/pkg/cmd/step/verify/step_verify_url.go
+++ b/pkg/cmd/step/verify/step_verify_url.go
@@ -31,6 +31,7 @@ var (
 	`)
 )
 
+// StepVerifyURLOptions options for step verify url command
 type StepVerifyURLOptions struct {
 	step.StepOptions
 

--- a/pkg/cmd/step/verify/step_verify_url_test.go
+++ b/pkg/cmd/step/verify/step_verify_url_test.go
@@ -1,0 +1,70 @@
+package verify_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/step/verify"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestServer(endpoint string, fn func(http.ResponseWriter, *http.Request)) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc(endpoint, fn)
+	server := httptest.NewServer(mux)
+	return server
+}
+
+func TestStepVerifyURLSuccess(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "/test"
+	server := newTestServer(endpoint, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer server.Close()
+
+	url := server.URL + endpoint
+	options := verify.StepVerifyURLOptions{
+		Endpoint: url,
+		Code:     http.StatusOK,
+		Timeout:  10 * time.Second,
+	}
+
+	commonOpts := opts.NewCommonOptionsWithFactory(nil)
+	commonOpts.Out = os.Stdout
+	commonOpts.Err = os.Stderr
+	options.CommonOptions = &commonOpts
+
+	err := options.Run()
+	assert.NoError(t, err, "should verify an endpoint which returns the expected code without error")
+}
+
+func TestStepVerifyURLFailure(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "/test"
+	server := newTestServer(endpoint, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer server.Close()
+
+	url := server.URL + endpoint
+	options := verify.StepVerifyURLOptions{
+		Endpoint: url,
+		Code:     http.StatusOK,
+		Timeout:  5 * time.Second,
+	}
+
+	commonOpts := opts.NewCommonOptionsWithFactory(nil)
+	commonOpts.Out = os.Stdout
+	commonOpts.Err = os.Stderr
+	options.CommonOptions = &commonOpts
+
+	err := options.Run()
+	assert.Error(t, err, "should verify an endpoint which does not return the expected code with an error")
+}


### PR DESCRIPTION
This command waits with exponential backoff for a URL to return an expected status code. It will
fail when the timeout is exceeded.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Add a new command `step verify url` which waits with exponential backoff for a URL to return an expected HTTP status code. 

This is particularly useful to check when a URL configured by the external DNS is ready during the boot sequence.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->