### PR TITLE
fix: use the version stream to find the latest jx version

### DIFF
--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -423,7 +423,7 @@ func (o *CreateDevPodOptions) Run() error {
 			// disable input for replacing the version stream git repo
 			batch := o.BatchMode
 			o.BatchMode = true
-			resolver, err := o.CreateVersionResolver("", "")
+			resolver, err := o.GetVersionResolver()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/opts/common.go
+++ b/pkg/cmd/opts/common.go
@@ -11,6 +11,7 @@ import (
 	gojenkins "github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	"github.com/jenkins-x/jx/pkg/prow"
+	"github.com/jenkins-x/jx/pkg/versionstream"
 	"github.com/spf13/viper"
 
 	"github.com/jenkins-x/jx/pkg/secreturl"
@@ -41,7 +42,7 @@ import (
 	kserve "github.com/knative/serving/pkg/client/clientset/versioned"
 	"github.com/spf13/cobra"
 	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	survey "gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	gitcfg "gopkg.in/src-d/go-git.v4/config"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -101,9 +102,11 @@ type ModifyEnvironmentFn func(name string, callback func(env *jenkinsv1.Environm
 type CommonOptions struct {
 	prow.Prow
 
+	AdvancedMode           bool
 	Args                   []string
 	BatchMode              bool
 	Cmd                    *cobra.Command
+	ConfigFile             string
 	Domain                 string
 	Err                    io.Writer
 	ExternalJenkinsBaseURL string
@@ -111,6 +114,7 @@ type CommonOptions struct {
 	InstallDependencies    bool
 	ModifyDevEnvironmentFn ModifyDevEnvironmentFn
 	ModifyEnvironmentFn    ModifyEnvironmentFn
+	NameServers            []string
 	NoBrew                 bool
 	RemoteCluster          bool
 	Out                    terminal.FileWriter
@@ -139,15 +143,13 @@ type CommonOptions struct {
 	kuber                  kube.Kuber
 	modifyDevEnvironmentFn ModifyDevEnvironmentFn
 	modifyEnvironmentFn    ModifyEnvironmentFn
-	NameServers            []string
 	resourcesInstaller     resources.Installer
 	systemVaultClient      vault.Client
 	tektonClient           tektonclient.Interface
 	vaultClient            vault.Client
 	secretURLClient        secreturl.Client
 	vaultOperatorClient    vaultoperatorclient.Interface
-	AdvancedMode           bool
-	ConfigFile             string
+	versionResolver        *versionstream.VersionResolver
 }
 
 type ServerFlags struct {

--- a/pkg/cmd/opts/version.go
+++ b/pkg/cmd/opts/version.go
@@ -22,6 +22,20 @@ func (o *CommonOptions) CreateVersionResolver(repo string, gitRef string) (*vers
 	}, nil
 }
 
+// GetVersionResolver gets a VersionResolver, lazy creating one if required so we can reuse it later
+func (o *CommonOptions) GetVersionResolver() (*versionstream.VersionResolver, error) {
+	var err error
+	if o.versionResolver == nil {
+		o.versionResolver, err = o.CreateVersionResolver("", "")
+	}
+	return o.versionResolver, err
+}
+
+// SetVersionResolver gets a VersionResolver, lazy creating one if required
+func (o *CommonOptions) SetVersionResolver(resolver *versionstream.VersionResolver) {
+	o.versionResolver = resolver
+}
+
 // GetPackageVersions returns the package versions and a table if they need to be rendered
 func (o *CommonOptions) GetPackageVersions(ns string, helmTLS bool) (map[string]string, table.Table) {
 	info := util.ColorInfo

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -238,7 +238,7 @@ func (o *StepCreateTaskOptions) Run() error {
 	}
 
 	if o.VersionResolver == nil {
-		o.VersionResolver, err = o.CreateVersionResolver("", "")
+		o.VersionResolver, err = o.GetVersionResolver()
 		if err != nil {
 			return errors.Wrap(err, "Unable to create version resolver")
 		}

--- a/pkg/cmd/step/syntax/step_syntax_effective.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective.go
@@ -144,7 +144,7 @@ func (o *StepSyntaxEffectiveOptions) Run() error {
 		o.DefaultImage = syntax.DefaultContainerImage
 	}
 	if o.VersionResolver == nil {
-		o.VersionResolver, err = o.CreateVersionResolver("", "")
+		o.VersionResolver, err = o.GetVersionResolver()
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/step/verify/step_verify_packages.go
+++ b/pkg/cmd/step/verify/step_verify_packages.go
@@ -132,7 +132,7 @@ func (o *StepVerifyPackagesOptions) verifyJXVersion(resolver *versionstream.Vers
 	versionText := newVersion.String()
 
 	if currentVersion.EQ(newVersion) {
-		log.Logger().Infof("already using version %s of %s", info(versionText), info("jx"))
+		log.Logger().Infof("using version %s of %s", info(versionText), info("jx"))
 		return nil
 	}
 

--- a/pkg/cmd/upgrade/upgrade_cli.go
+++ b/pkg/cmd/upgrade/upgrade_cli.go
@@ -16,7 +16,9 @@ import (
 
 var (
 	upgradeCLILong = templates.LongDesc(`
-		Upgrades the Jenkins X command line tools if there is a new version available in the version stream
+		Upgrades the Jenkins X command line tools if there is a different version stored in the version stream.
+
+		The exact version used for the version stream is stored in the Team Settings on the 'dev' Environment CRD.
 
 		For more information on Version Streams see: [https://jenkins-x.io/architecture/version-stream/](https://jenkins-x.io/architecture/version-stream/)
 `)

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -113,7 +113,7 @@ func (o *VersionOptions) upgradeCliIfNeeded(resolver *versionstream.VersionResol
 	if currentVersion.LT(newVersion) {
 		app := util.ColorInfo("jx")
 		log.Logger().Info("\n")
-		log.Logger().Warnf("A different %s version %s is available in the version stream. We highly recommend you upgrade to it.", app, util.ColorInfo(newVersion.String()))
+		log.Logger().Warnf("%s version %s is available in the version stream. We highly recommend you upgrade to it.", app, util.ColorInfo(newVersion.String()))
 		if o.BatchMode {
 			log.Logger().Warnf("To upgrade to this new version use: %s", util.ColorInfo("jx upgrade cli"))
 		} else {

--- a/pkg/dependencymatrix/matrix.go
+++ b/pkg/dependencymatrix/matrix.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
+	"github.com/jenkins-x/jx/pkg/util"
 
 	"github.com/jenkins-x/jx/pkg/log"
 
@@ -118,6 +119,27 @@ type DependencyDetails struct {
 // KeyEquals validates that the key (Host, Owner, Repo and Component) are all the same
 func (d *DependencyDetails) KeyEquals(o v1.DependencyUpdateDetails) bool {
 	return d.Host == o.Host && d.Owner == o.Owner && d.Repo == o.Repo && d.Component == o.Component
+}
+
+// LoadDependencyMatrix loads the dependency matrix file from the given project directory
+func LoadDependencyMatrix(dir string) (*DependencyMatrix, error) {
+	dependencyMatrix := &DependencyMatrix{}
+	path := filepath.Join(dir, DependencyMatrixDirName, "matrix.yaml")
+	exists, err := util.FileExists(path)
+	if err != nil {
+		return dependencyMatrix, errors.Wrapf(err, "checking %s exists", path)
+	}
+	if exists {
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return dependencyMatrix, errors.Wrapf(err, "reading %s", path)
+		}
+		err = yaml.Unmarshal(data, &dependencyMatrix)
+		if err != nil {
+			return dependencyMatrix, errors.Wrapf(err, "unmarshaling %s", path)
+		}
+	}
+	return dependencyMatrix, nil
 }
 
 // UpdateDependencyMatrix updates the dependency matrix in dir/dependency-matrix using update


### PR DESCRIPTION
rather than using whatever is on github, lets use the version in the version stream dependency matrix.

This means that `jx version` and `jx upgrade cli` will now use the version stream instead

also added `o.GetVersionResolver()` as a helper method to lazily create and cache the creation of the version resolver to avoid multiple git clones + filling the log with duplicate clone text

fixes #5276

Signed-off-by: James Strachan <james.strachan@gmail.com>