### PR TITLE
fix: Fixed boolean logic around creating dev environment repo

### DIFF
--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -278,7 +278,7 @@ func (o *StepVerifyEnvironmentsOptions) createEnvGitRepository(name string, requ
 	}
 
 	if name == kube.LabelValueDevEnvironment || environment.Spec.Kind == v1.EnvironmentKindTypeDevelopment {
-		if !o.InCDPipeline() && !o.InCluster() {
+		if !o.InCluster() {
 			err := o.prDevEnvironment(gitInfo.Name, gitInfo.Organisation, privateRepo, userAuth, requirements, server)
 			if err != nil {
 				return errors.Wrapf(err, "creating dev environment for %s", gitInfo.Name)


### PR DESCRIPTION
This was failing during jx boot cli.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description

Unless I'm missing a change in design looks like some boolean logic was incorrectly refactored a couple days ago. `jx boot` now no longer creates a dev repo because of it.

fixes #5336