### PR TITLE
fix: Ordering of dep matrix mismatched versions and handling of ML builders in create pr versions

### DIFF
--- a/pkg/dependencymatrix/matrix.go
+++ b/pkg/dependencymatrix/matrix.go
@@ -242,6 +242,7 @@ func GenerateMarkdownDependencyMatrix(path string, matrix DependencyMatrix) erro
 		for k, v := range mismatchedVersionsMap {
 			mismatchedVersions = append(mismatchedVersions, fmt.Sprintf("**%s**: %s", k, strings.Join(v, ";")))
 		}
+		sort.Strings(mismatchedVersions)
 		componentStr := ""
 		if d.Component != "" {
 			componentStr = fmt.Sprintf(":%s", d.Component)

--- a/pkg/gits/operations/pull_request_op.go
+++ b/pkg/gits/operations/pull_request_op.go
@@ -460,9 +460,20 @@ func CreatePullRequestRegexFn(version string, regex string, files ...string) (Ch
 // CreatePullRequestBuildersFn creates the ChangeFilesFn that will update the gcr.io/jenkinsxio/builder-*.yml images
 func CreatePullRequestBuildersFn(version string) ChangeFilesFn {
 	return func(dir string, gitInfo *gits.GitRepository) ([]string, error) {
-		answer, err := versionstream.UpdateStableVersionFiles(filepath.Join(dir, string(versionstream.KindDocker), "gcr.io", "jenkinsxio", "builder-*.yml"), version, "builder-base.yml")
+		answer, err := versionstream.UpdateStableVersionFiles(filepath.Join(dir, string(versionstream.KindDocker), "gcr.io", "jenkinsxio", "builder-*.yml"), version, "builder-base.yml", "builder-machine-learning.yml", "builder-machine-learning-gpu.yml")
 		if err != nil {
 			return nil, errors.Wrap(err, "modifying the builder-*.yml image versions")
+		}
+		return answer, nil
+	}
+}
+
+// CreatePullRequestMLBuildersFn creates the ChangeFilesFn that will update the gcr.io/jenkinsxio/builder-machine-learning*.yml images
+func CreatePullRequestMLBuildersFn(version string) ChangeFilesFn {
+	return func(dir string, gitInfo *gits.GitRepository) ([]string, error) {
+		answer, err := versionstream.UpdateStableVersionFiles(filepath.Join(dir, string(versionstream.KindDocker), "gcr.io", "jenkinsxio", "builder-machine-learning*.yml"), version)
+		if err != nil {
+			return nil, errors.Wrap(err, "modifying the builder-machine-learning*.yml image versions")
 		}
 		return answer, nil
 	}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

* Switch to a consistent order of `Mismatched Versions` field in dependency matrix Markdown.
* Update `machine-learning` and `machine-learning-gpu` builder images separately from `jenkins-x-builders` images.

#### Special notes for the reviewer(s)

/assign @pmuir 

#### Which issue this PR fixes

fixes #5286 
fixes #5288 
