### PR TITLE
fix: Pull request and release age limits in gc activities are flipped

### DIFF
--- a/pkg/cmd/gc/gc_activities.go
+++ b/pkg/cmd/gc/gc_activities.go
@@ -96,8 +96,8 @@ func NewCmdGCActivities(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.DryRun, "dry-run", "d", false, "Dry run mode. If enabled just list the resources that would be removed")
 	cmd.Flags().IntVarP(&options.ReleaseHistoryLimit, "release-history-limit", "l", 5, "Maximum number of PipelineActivities and PipelineRuns to keep around per repository release")
 	cmd.Flags().IntVarP(&options.PullRequestHistoryLimit, "pr-history-limit", "", 2, "Minimum number of PipelineActivities and PipelineRuns to keep around per repository Pull Request")
-	cmd.Flags().DurationVarP(&options.ReleaseAgeLimit, "pull-request-age", "p", time.Hour*48, "Maximum age to keep PipelineActivities and PipelineRun's for Pull Requests")
-	cmd.Flags().DurationVarP(&options.PullRequestAgeLimit, "release-age", "r", time.Hour*24*30, "Maximum age to keep PipelineActivities and PipelineRun's for Releases")
+	cmd.Flags().DurationVarP(&options.PullRequestAgeLimit, "pull-request-age", "p", time.Hour*48, "Maximum age to keep PipelineActivities and PipelineRun's for Pull Requests")
+	cmd.Flags().DurationVarP(&options.ReleaseAgeLimit, "release-age", "r", time.Hour*24*30, "Maximum age to keep PipelineActivities and PipelineRun's for Releases")
 	return cmd
 }
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The argument assignment was flipped, so we were keeping pull requests for the release age, and vice versa.

#### Special notes for the reviewer(s)

/assign @ccojocar 

#### Which issue this PR fixes

fixes #5293 
