### PR TITLE
fix: create devpods - check for empty tls value

### DIFF
--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -87,7 +87,7 @@ func GetIngressConfig(c kubernetes.Interface, ns string) (IngressConfig, error) 
 
 	tls, exists := data[TLS]
 
-	if exists {
+	if exists && tls != "" {
 		ic.TLS, err = strconv.ParseBool(tls)
 		if err != nil {
 			return ic, fmt.Errorf("failed to parse TLS string %s to bool from %s: %v", tls, IngressConfigConfigmap, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Check that the TLS value in the ingress config is not an empty string before attempting to parse to a bool value

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #5319

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
