### PR TITLE
fix(gits): correct webhook URL for Bitbucket Server

### DIFF
--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -1017,7 +1018,7 @@ func (b *BitbucketServerProvider) Kind() string {
 
 // Exposed by Jenkins plugin; this one is for https://wiki.jenkins.io/display/JENKINS/BitBucket+Plugin
 func (b *BitbucketServerProvider) JenkinsWebHookPath(gitURL string, secret string) string {
-	return "/bitbucket-scmsource-hook/notify"
+	return "/bitbucket-scmsource-hook/notify?server_url=" + url.QueryEscape(b.Server.URL)
 }
 
 func (b *BitbucketServerProvider) Label() string {

--- a/pkg/gits/bitbucket_server_test.go
+++ b/pkg/gits/bitbucket_server_test.go
@@ -285,6 +285,11 @@ func (suite *BitbucketServerProviderTestSuite) TestMergePullRequest() {
 	suite.Require().Nil(err)
 }
 
+func (suite *BitbucketServerProviderTestSuite) TestJenkinsWebHookPath() {
+	p := suite.provider.JenkinsWebHookPath("notUsed", "notUsed")
+	suite.Require().Equal("/bitbucket-scmsource-hook/notify?server_url=http%3A%2F%2Fauth.example.com", p)
+}
+
 func (suite *BitbucketServerProviderTestSuite) TestCreateWebHook() {
 
 	data := &gits.GitWebHookArguments{


### PR DESCRIPTION

Signed-off-by: Mark Nielsen <mark.nielsen@blackboard.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description

When adding the webhook via API, it only seems to set the webhook under the repository's Webhooks setting. Under these settings, the server_url parameter is required as documented [here](https://support.cloudbees.com/hc/en-us/articles/115000053051-How-to-Trigger-Multibranch-Jobs-from-Bitbucket-Server-#configurationinbitbucketserver).

When I manually added this to the webhook, it started working again.

#### Special notes for the reviewer(s)

See also https://kubernetes.slack.com/archives/C9MBGQJRH/p1566807618281800

#### Which issue this PR fixes

None that I could find.