### PR TITLE
fix: lets avoid failing to promote if we cannot add labels

### DIFF
--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -1149,7 +1149,8 @@ func (b *BitbucketServerProvider) ListCommits(owner, repo string, opt *ListCommi
 
 // AddLabelsToIssue adds labels to issues or pullrequests
 func (b *BitbucketServerProvider) AddLabelsToIssue(owner, repo string, number int, labels []string) error {
-	return fmt.Errorf("Getting content not supported on bitbucket")
+	log.Logger().Warnf("Adding labels not supported on bitbucket server yet for repo %s/%s issue %d labels %v", owner, repo, number, labels)
+	return nil
 }
 
 // GetLatestRelease fetches the latest release from the git provider for org and name

--- a/pkg/gits/gitlab.go
+++ b/pkg/gits/gitlab.go
@@ -834,7 +834,8 @@ func (g *GitlabProvider) ListCommits(owner, repo string, opt *ListCommitsArgumen
 
 // AddLabelsToIssue adds labels to issues or pullrequests
 func (g *GitlabProvider) AddLabelsToIssue(owner, repo string, number int, labels []string) error {
-	return fmt.Errorf("Getting content not supported on gitlab yet")
+	log.Logger().Warnf("Adding labels not supported on gitlab yet for repo %s/%s issue %d labels %v", owner, repo, number, labels)
+	return nil
 }
 
 // GetLatestRelease fetches the latest release from the git provider for org and name

--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -359,7 +359,7 @@ func PushRepoAndCreatePullRequest(dir string, upstreamRepo *GitRepository, forkR
 		}
 		log.Logger().Infof("Created Pull Request: %s", util.ColorInfo(pr.URL))
 	}
-	if labels != nil {
+	if len(labels) > 0 {
 		number := *pr.Number
 		var err error
 		err = provider.AddLabelsToIssue(pr.Owner, pr.Repo, number, labels)


### PR DESCRIPTION
for bitbucket server / gitlab - they are not vital and usually we use them for updatebot type logic anyway