### PR TITLE
fix: allow .git to appear in dep update messages

### DIFF
--- a/pkg/cmd/opts/releases_test.go
+++ b/pkg/cmd/opts/releases_test.go
@@ -51,6 +51,19 @@ update BRIE_VERSION to 1.2.4`, v1.DependencyUpdate{
 			},
 		}, &commonOpts)
 	})
+	t.Run("with-dot", func(t *testing.T) {
+		assertParseDependencyUpdateMessage(t, `chore(dependencies): update https://github.com/pmuir/brie.git from 1.2.3 to 1.2.4
+
+update BRIE_VERSION to 1.2.4`, v1.DependencyUpdate{
+			DependencyUpdateDetails: v1.DependencyUpdateDetails{
+				Owner:       "pmuir",
+				Repo:        "brie",
+				ToVersion:   "1.2.4",
+				FromVersion: "1.2.3",
+				Host:        "github.com",
+			},
+		}, &commonOpts)
+	})
 	t.Run("simple", func(t *testing.T) {
 		assertParseDependencyUpdateMessage(t, `chore(dependencies): update pmuir/brie from 1.2.3 to 1.2.4
 

--- a/pkg/dependencymatrix/commits.go
+++ b/pkg/dependencymatrix/commits.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	dependencyUpdateRegex = regexp.MustCompile(`^(?m:chore\((?:deps|dependencies)\): (?:bump|update) (.*) from ([\w\.]*) to ([\w\.]*)$)`)
-	slugLinkRegex         = regexp.MustCompile(`^(?:([\w-]*?)?\/?([\w-]+)|(https?):\/\/([\w\.]*)\/([\w-]*)\/([\w-]*))(?::([\w-]*))?$`)
+	slugLinkRegex         = regexp.MustCompile(`^(?:([\w-]*?)?\/?([\w-]+)|(https?):\/\/([\w\.]*)\/([\w-]*)\/([\w-]*)(?:\.git)?)(?::([\w-]*))?$`)
 	//slugLinkRegex = regexp.MustCompile(``)
 	slugRegex = regexp.MustCompile(`^(\w*)?\/(\w*)$`)
 )


### PR DESCRIPTION
Signed-off-by: Pete Muir <pmuir@bleepbleep.org.uk>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Regex didn't allow the .git suffix to be on the url

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
