### PR TITLE
feat: allow dev environment repo creation when in batch mode

### DIFF
--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -278,7 +278,7 @@ func (o *StepVerifyEnvironmentsOptions) createEnvGitRepository(name string, requ
 	}
 
 	if name == kube.LabelValueDevEnvironment || environment.Spec.Kind == v1.EnvironmentKindTypeDevelopment {
-		if !o.InCluster() {
+		if !o.InCluster() || o.InCluster() && batchMode {
 			err := o.prDevEnvironment(gitInfo.Name, gitInfo.Organisation, privateRepo, userAuth, requirements, server)
 			if err != nil {
 				return errors.Wrapf(err, "creating dev environment for %s", gitInfo.Name)


### PR DESCRIPTION
Signed-off-by: Cai Cooper <caicooper82@gmail.com>

Allow the creation of the dev environment repository when in cluster and `jx boot` is executing in batch mode