### PR TITLE
fix: build controller should restart if it fails to list/watch pods

### DIFF
--- a/pkg/kube/watcher/pods.go
+++ b/pkg/kube/watcher/pods.go
@@ -1,0 +1,47 @@
+package watcher
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+type podListWatch struct {
+	client kubernetes.Interface
+}
+
+// NewPodWatcher creates a new pod watcher
+func NewPodWatcher(client kubernetes.Interface, ns string, listOptions metav1.ListOptions, handlerFuncs HandlerFuncs) Watcher {
+	listWatch := NewPodListWatch(client)
+	return Watcher{
+		Namespace:    ns,
+		ListOptions:  listOptions,
+		HandlerFuncs: handlerFuncs,
+		ListWatch:    listWatch,
+	}
+}
+
+// NewPodListWatch creates a new pod list watch
+func NewPodListWatch(client kubernetes.Interface) ListWatch {
+	return &podListWatch{client: client}
+}
+
+// List lists the resources in the namespace
+func (w *podListWatch) List(ns string, listOptions metav1.ListOptions) ([]runtime.Object, error) {
+	resourceList, err := w.client.CoreV1().Pods(ns).List(listOptions)
+	var answer []runtime.Object
+	if resourceList != nil {
+		for _, resource := range resourceList.Items {
+			copy := resource
+			answer = append(answer, &copy)
+		}
+	}
+	return answer, err
+}
+
+// Watch creates a watcher of the resources in the namespace
+func (w *podListWatch) Watch(ns string, listOptions metav1.ListOptions) (watch.Interface, error) {
+	resources := w.client.CoreV1().Pods(ns)
+	return resources.Watch(listOptions)
+}

--- a/pkg/kube/watcher/watcher.go
+++ b/pkg/kube/watcher/watcher.go
@@ -1,0 +1,94 @@
+package watcher
+
+import (
+	"fmt"
+
+	"github.com/jenkins-x/jx/pkg/log"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// Watcher lists and watches resources
+type Watcher struct {
+	Namespace    string
+	ListOptions  metav1.ListOptions
+	HandlerFuncs HandlerFuncs
+	ListWatch    ListWatch
+}
+
+// HandlerFuncs is an adaptor to let you easily specify as many or
+// as few of the notification functions as you want
+type HandlerFuncs struct {
+	AddFunc    func(obj runtime.Object)
+	ModifyFunc func(obj runtime.Object)
+	DeleteFunc func(obj runtime.Object)
+}
+
+// ListWatch an interface for something that can list and watch resources
+type ListWatch interface {
+	List(ns string, listOptions metav1.ListOptions) ([]runtime.Object, error)
+	Watch(ns string, listOptions metav1.ListOptions) (watch.Interface, error)
+}
+
+// Run watches the resources until the connection is lost
+func (w *Watcher) Run() error {
+	log.Logger().Infof("watching and listing resources in namespace %s", w.Namespace)
+
+	watcher, err := w.ListWatch.Watch(w.Namespace, w.ListOptions)
+	if err != nil {
+		log.Logger().Fatalf("failed to watch resources in namespace %s due to %s", w.Namespace, err.Error())
+	}
+
+	resources, err := w.ListWatch.List(w.Namespace, w.ListOptions)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Logger().Fatalf("failed to list resources in namespace %s due to %s", w.Namespace, err.Error())
+		}
+	}
+
+	for _, resource := range resources {
+		w.onAdd(resource)
+	}
+
+	// TODO we could ensure that watch events are always newer than the first list just in case?
+	ch := watcher.ResultChan()
+	for event := range ch {
+		switch event.Type {
+		case watch.Added:
+			w.onAdd(event.Object)
+		case watch.Modified:
+			w.onModified(event.Object)
+		case watch.Deleted:
+			w.onDeleted(event.Object)
+		case watch.Error:
+			log.Logger().Fatalf("watcher is closed in namespace %s", w.Namespace)
+			watcher.Stop()
+			return fmt.Errorf("watch channel disconnected")
+		}
+	}
+	return nil
+}
+
+func (w *Watcher) onAdd(object runtime.Object) {
+	if w.HandlerFuncs.AddFunc != nil {
+		w.HandlerFuncs.AddFunc(object)
+	}
+}
+
+func (w *Watcher) onModified(object runtime.Object) {
+	if w.HandlerFuncs.ModifyFunc != nil {
+		w.HandlerFuncs.ModifyFunc(object)
+	}
+}
+
+func (w *Watcher) onDeleted(object runtime.Object) {
+	if w.HandlerFuncs.DeleteFunc != nil {
+		w.HandlerFuncs.DeleteFunc(object)
+	}
+}
+
+func (w *Watcher) onError() {
+	log.Logger().Fatalf("watcher is closed in namespace %s", w.Namespace)
+}


### PR DESCRIPTION
fix up a simpler and nicer retry logic for watching resources like pods so
we can handle losing a watch; we try to rerun things if a watch fails
otherwise we restart the pod

fixes #5395