### PR TITLE
feat: avoid passing arguments down the chain with create cluster

### DIFF
--- a/pkg/cmd/create/create_cluster_eks.go
+++ b/pkg/cmd/create/create_cluster_eks.go
@@ -124,6 +124,11 @@ func (o *CreateClusterEKSOptions) Run() error {
 		os.Exit(-1)
 	}
 
+	// We don't want to pass any args that were introduced by mistake because they are passed to all other commands down the chain
+	if len(o.Args) > 0 {
+		log.Logger().Warn("We detected arguments being passed to the command, these arguments will be ignored and only flags will be considered")
+		o.Args = []string{}
+	}
 	flags := &o.Flags
 
 	zones := flags.Zones


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [] Change is covered by existing or new tests.

#### Description
Neither `jx create cluster eks` nor `jx install` receive any arguments as part of its execution and every data needed is passed by flags.

Introducing a flag the wrong way: 
`--static-jenkins true` was causing the value to be passed as an argument instead of being the part of the flag like `--static-jenkins=true`.

This was being passed down the commands calls as an argument and ended up calling `jx create jenkins token "true"` which was causing errors when loging into the Jenkins server.


#### Which issue this PR fixes

fixes #5000 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
