### PR TITLE
fix: Handling of completion of metapipeline in build controller was flawed

### DIFF
--- a/myvalues.yaml.tekton.template
+++ b/myvalues.yaml.tekton.template
@@ -32,3 +32,8 @@ pipelinerunner:
     XDG_CONFIG_HOME: "/home/jenkins"
     MAVEN_OPTS: "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
     CODECOV_TOKEN: $CODECOV_TOKEN
+
+controllerbuild:
+  image:
+    repository: gcr.io/jenkinsxio/builder-go
+    tag: $VERSION

--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -10,13 +10,13 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/jenkins-x/jx/pkg/cmd/step/git"
-	"github.com/jenkins-x/jx/pkg/kube/watcher"
-	"github.com/jenkins-x/jx/pkg/logs"
 	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/step/git"
 	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/kube/watcher"
+	"github.com/jenkins-x/jx/pkg/logs"
 
 	"github.com/jenkins-x/jx/pkg/collector"
 	"github.com/jenkins-x/jx/pkg/helm"
@@ -37,7 +37,7 @@ import (
 	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -711,7 +711,8 @@ func (o *ControllerBuildOptions) updatePipelineActivityForRun(kubeClient kuberne
 			spec.Status = v1.ActivityStatusTypeSucceeded
 		}
 
-		if spec.Status != v1.ActivityStatusTypeRunning {
+		// Only complete the job if it's failed, or if it's finished and the PRI we're looking at is _not_ the metapipeline
+		if spec.Status == v1.ActivityStatusTypeFailed || (spec.Status.IsTerminated() && pri.Type != tekton.MetaPipeline) {
 			if !biggestFinishedAt.IsZero() {
 				spec.CompletedTimestamp = &biggestFinishedAt
 			}

--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"fmt"
 	"os"
-
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -51,6 +50,8 @@ type ControllerBuildOptions struct {
 	TargetURLTemplate  string
 
 	EnvironmentCache *kube.EnvironmentNamespaceCache
+
+	DryRun bool
 
 	// private fields added for easier testing
 	gitHubProvider gits.GitProvider
@@ -641,7 +642,7 @@ func (o *ControllerBuildOptions) updatePipelineActivity(kubeClient kubernetes.In
 		}
 	}
 
-	if spec.Author == "" {
+	if spec.Author == "" && !o.DryRun {
 		err := o.completeBuildSourceInfo(activity)
 		if err != nil {
 			log.Logger().Warnf("Error completing build information: %s", err)
@@ -722,7 +723,7 @@ func (o *ControllerBuildOptions) updatePipelineActivityForRun(kubeClient kuberne
 
 			// TODO: This will need to be reworked for per-step logs, so leaving alone as part of metapipeline work
 			// lets ensure we overwrite any canonical jenkins build URL thats generated automatically
-			if spec.BuildLogsURL == "" {
+			if spec.BuildLogsURL == "" && !o.DryRun {
 				podInterface := kubeClient.CoreV1().Pods(ns)
 
 				envName := kube.LabelValueDevEnvironment
@@ -763,7 +764,7 @@ func (o *ControllerBuildOptions) updatePipelineActivityForRun(kubeClient kuberne
 		}
 	}
 
-	if spec.Author == "" {
+	if spec.Author == "" && !o.DryRun {
 		err := o.completeBuildSourceInfo(activity)
 		if err != nil {
 			log.Logger().Warnf("Error completing build information: %s", err)

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/activity.yml
@@ -1,0 +1,72 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  creationTimestamp: "2019-09-10T17:43:36Z"
+  generation: 29
+  labels:
+    branch: master
+    build: "1"
+    owner: cb-kubecd
+    provider: github
+    repository: bdd-spring-1568135191
+    sourcerepository: cb-kubecd-bdd-spring-1568135191
+  name: cb-kubecd-bdd-spring-1568135191-master-1
+  namespace: jx
+  resourceVersion: "4954"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
+  uid: 8461830a-d3f2-11e9-82fc-42010a840132
+spec:
+  batchPipelineActivity: {}
+  build: "1"
+  gitBranch: master
+  gitOwner: cb-kubecd
+  gitRepository: bdd-spring-1568135191
+  gitUrl: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+  lastCommitSHA: 7307e06426062dc31f76fd95abecbb8f93af5b54
+  pipeline: cb-kubecd/bdd-spring-1568135191/master
+  startedTimestamp: "2019-09-10T17:43:41Z"
+  status: Running
+  steps:
+  - kind: Stage
+    stage:
+      completedTimestamp: "2019-09-10T17:08:20Z"
+      name: meta pipeline
+      startedTimestamp: "2019-09-10T17:07:13Z"
+      status: Succeeded
+      steps:
+      - completedTimestamp: "2019-09-10T17:07:13Z"
+        name: Credential Initializer V7srb
+        startedTimestamp: "2019-09-10T17:07:13Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:15Z"
+        name: Working Dir Initializer Lnjrj
+        startedTimestamp: "2019-09-10T17:07:13Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:17Z"
+        name: Place Tools
+        startedTimestamp: "2019-09-10T17:07:15Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        description: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+        name: Git Source Meta Cb Kubecd Bdd Spring 15681 D925z
+        startedTimestamp: "2019-09-10T17:07:17Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        name: Git Merge
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        name: Merge Pull Refs
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:35Z"
+        name: Create Effective Pipeline
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:08:20Z"
+        name: Create Tekton Crds
+        startedTimestamp: "2019-09-10T17:07:35Z"
+        status: Succeeded
+  version: 0.0.1
+  workflowStatus: Running
+status: {}

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelineruns.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelineruns.yml
@@ -1,0 +1,220 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineRun
+  metadata:
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+      tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1
+    name: meta-cb-kubecd-bdd-spring-15681-1
+    namespace: jx
+    resourceVersion: "3572"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/meta-cb-kubecd-bdd-spring-15681-1
+    uid: 6c44d166-d3ed-11e9-8142-42010a840094
+  spec:
+    pipelineRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: meta-cb-kubecd-bdd-spring-15681-1
+    resources:
+    - name: meta-cb-kubecd-bdd-spring-15681
+      resourceRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: meta-cb-kubecd-bdd-spring-15681
+    serviceAccount: tekton-bot
+    timeout: 240h0m0s
+  status:
+    completionTime: "2019-09-10T17:08:23Z"
+    conditions:
+    - lastTransitionTime: "2019-09-10T17:08:23Z"
+      message: All Tasks have completed executing
+      reason: Succeeded
+      status: "True"
+      type: Succeeded
+    startTime: "2019-09-10T17:07:08Z"
+    taskRuns:
+      meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55:
+        pipelineTaskName: meta-pipeline
+        status:
+          completionTime: "2019-09-10T17:08:21Z"
+          conditions:
+          - lastTransitionTime: "2019-09-10T17:08:21Z"
+            message: All Steps have completed executing
+            reason: Succeeded
+            status: "True"
+            type: Succeeded
+          podName: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55-pod-e44008
+          startTime: "2019-09-10T17:07:08Z"
+          steps:
+          - name: git-merge
+            terminated:
+              containerID: docker://2f94880db188f839b490cecf829c5552f9bc656330f4385ca3c1fcb029989b17
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:30Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:26Z"
+          - name: merge-pull-refs
+            terminated:
+              containerID: docker://ae5aff984092e048febc28df550c7f795ef07f701f6c48a160b08808332e3f94
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:30Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:26Z"
+          - name: create-effective-pipeline
+            terminated:
+              containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:35Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:26Z"
+          - name: create-tekton-crds
+            terminated:
+              containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
+              exitCode: 0
+              finishedAt: "2019-09-10T17:08:20Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:27Z"
+          - name: git-source-meta-cb-kubecd-bdd-spring-15681-d925z
+            terminated:
+              containerID: docker://911ee8a7611dc4e3f158e9d2d6269c4476bbaa603c04f0a72ee770e8b5d30a52
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:30Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:19Z"
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineRun
+  metadata:
+    creationTimestamp: "2019-09-10T17:08:20Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+      tekton.dev/pipeline: cb-kubecd-bdd-spring-1568135191-1
+    name: cb-kubecd-bdd-spring-1568135191-1
+    namespace: jx
+    resourceVersion: "4551"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/cb-kubecd-bdd-spring-1568135191-1
+    uid: 97276610-d3ed-11e9-8142-42010a840094
+  spec:
+    params:
+    - name: version
+      value: 0.0.1
+    - name: build_id
+      value: "1"
+    pipelineRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: cb-kubecd-bdd-spring-1568135191-1
+    resources:
+    - name: cb-kubecd-bdd-spring-1568135191
+      resourceRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: cb-kubecd-bdd-spring-1568135191
+    serviceAccount: tekton-bot
+    timeout: 240h0m0s
+  status:
+    completionTime: "2019-09-10T17:11:31Z"
+    conditions:
+    - lastTransitionTime: "2019-09-10T17:11:31Z"
+      message: All Tasks have completed executing
+      reason: Succeeded
+      status: "True"
+      type: Succeeded
+    startTime: "2019-09-10T17:08:20Z"
+    taskRuns:
+      cb-kubecd-bdd-spring-1568135191-1-from-build-pack-mrz2r:
+        pipelineTaskName: from-build-pack
+        status:
+          completionTime: "2019-09-10T17:11:31Z"
+          conditions:
+          - lastTransitionTime: "2019-09-10T17:11:31Z"
+            message: All Steps have completed executing
+            reason: Succeeded
+            status: "True"
+            type: Succeeded
+          podName: cb-kubecd-bdd-spring-1568135191-1-from-build-pack-mrz2r-pod-8d000a
+          startTime: "2019-09-10T17:08:20Z"
+          steps:
+          - name: git-merge
+            terminated:
+              containerID: docker://053dbc7462bb411ade35bd2e3edb06f6304a5090b81a7200e581666257de605b
+              exitCode: 0
+              finishedAt: "2019-09-10T17:09:00Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:08:32Z"
+          - name: setup-jx-git-credentials
+            terminated:
+              containerID: docker://831134be7a23adbef100d8e1f1eefc8a588a2e8ed1cee349090d2122c7c2c5be
+              exitCode: 0
+              finishedAt: "2019-09-10T17:09:01Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:08:52Z"
+          - name: build-mvn-deploy
+            terminated:
+              containerID: docker://bc879af1e79aa4d9028408c3da08433c51213e1839c4faf83a33de131b2383c8
+              exitCode: 0
+              finishedAt: "2019-09-10T17:09:51Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:08:52Z"
+          - name: build-skaffold-version
+            terminated:
+              containerID: docker://4de444fdd205efd0d9dc2b24bb0913e185556d53447fc5b3ca08c0b81e654531
+              exitCode: 0
+              finishedAt: "2019-09-10T17:09:51Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:08:52Z"
+          - name: build-container-build
+            terminated:
+              containerID: docker://9417b1519ea1307ff112050edf7642894994ec6ba3f78d99a8d6aad3d8ef6c55
+              exitCode: 0
+              finishedAt: "2019-09-10T17:10:01Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:08:55Z"
+          - name: build-post-build
+            terminated:
+              containerID: docker://19c6882478feb28259f26a9e0d1d85a3ba15f8e161b591535cfc9f410de52a9d
+              exitCode: 0
+              finishedAt: "2019-09-10T17:10:02Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:08:55Z"
+          - name: promote-changelog
+            terminated:
+              containerID: docker://97cb4d3d588d4decff0bcc2b279312d33044d7bb7a5f63bb27b5ba8182c47232
+              exitCode: 0
+              finishedAt: "2019-09-10T17:10:04Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:08:56Z"
+          - name: promote-helm-release
+            terminated:
+              containerID: docker://0185c5e21ef22da68133c07c48fbee57396c6bc06d981359550b7e578e8c4e5a
+              exitCode: 0
+              finishedAt: "2019-09-10T17:10:09Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:08:56Z"
+          - name: promote-jx-promote
+            terminated:
+              containerID: docker://863aaccefc672eb10284e165ded50ff2d3755219627956307c3d4db29fa0a076
+              exitCode: 0
+              finishedAt: "2019-09-10T17:11:30Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:08:56Z"
+          - name: git-source-cb-kubecd-bdd-spring-1568135191-7zl6b
+            terminated:
+              containerID: docker://7c08c3035e166ceb9fa3ac7692235ae8c023e7651776b84709c96353353475fe
+              exitCode: 0
+              finishedAt: "2019-09-10T17:09:00Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:08:32Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelines.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelines.yml
@@ -1,0 +1,87 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Pipeline
+  metadata:
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+    name: meta-cb-kubecd-bdd-spring-15681-1
+    namespace: jx
+    ownerReferences:
+    - apiVersion: jenkins.io/v1
+      kind: PipelineActivity
+      name: cb-kubecd-bdd-spring-1568135191-master-1
+      uid: 6c3963df-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3188"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/meta-cb-kubecd-bdd-spring-15681-1
+    uid: 6c431e3c-d3ed-11e9-8142-42010a840094
+  spec:
+    resources:
+    - name: meta-cb-kubecd-bdd-spring-15681
+      type: git
+    tasks:
+    - name: meta-pipeline
+      resources:
+        inputs:
+        - name: workspace
+          resource: meta-cb-kubecd-bdd-spring-15681
+      taskRef:
+        name: meta-cb-kubecd-bdd-spring-15681-meta-pipeline-1
+- apiVersion: tekton.dev/v1alpha1
+  kind: Pipeline
+  metadata:
+    creationTimestamp: "2019-09-10T17:08:20Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+    name: cb-kubecd-bdd-spring-1568135191-1
+    namespace: jx
+    ownerReferences:
+    - apiVersion: jenkins.io/v1
+      kind: PipelineActivity
+      name: cb-kubecd-bdd-spring-1568135191-master-1
+      uid: 6c3963df-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3543"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/cb-kubecd-bdd-spring-1568135191-1
+    uid: 9725fd7c-d3ed-11e9-8142-42010a840094
+  spec:
+    params:
+    - default: 0.0.1
+      description: the version number for this pipeline which is used as a tag on docker
+        images and helm charts
+      name: version
+    - default: "1"
+      description: the PipelineRun build number
+      name: build_id
+    resources:
+    - name: cb-kubecd-bdd-spring-1568135191
+      type: git
+    tasks:
+    - name: from-build-pack
+      params:
+      - name: version
+        value: ${params.version}
+      - name: build_id
+        value: ${params.build_id}
+      resources:
+        inputs:
+        - name: workspace
+          resource: cb-kubecd-bdd-spring-1568135191
+      taskRef:
+        name: cb-kubecd-bdd-spring-1568135191-from-build-pack-1
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pods.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pods.yml
@@ -1,0 +1,2173 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      tekton.dev/ready: READY
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      jenkins.io/task-stage-name: meta-pipeline
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+      tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1
+      tekton.dev/pipelineRun: meta-cb-kubecd-bdd-spring-15681-1
+      tekton.dev/pipelineTask: meta-pipeline
+      tekton.dev/task: meta-cb-kubecd-bdd-spring-15681-meta-pipeline-1
+      tekton.dev/taskRun: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55
+    name: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55-pod-e44008
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: TaskRun
+      name: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55
+      uid: 6c4b0a44-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3555"
+    selfLink: /api/v1/namespaces/jx/pods/meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55-pod-e44008
+    uid: 6c5192c3-d3ed-11e9-8142-42010a840094
+  spec:
+    containers:
+    - args:
+      - -wait_file
+      - /builder/downward/ready
+      - -post_file
+      - /builder/tools/0
+      - -wait_file_content
+      - -entrypoint
+      - /ko-app/git-init
+      - --
+      - -url
+      - https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - -revision
+      - 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - -path
+      - /workspace/source
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-git-source-meta-cb-kubecd-bdd-spring-15681-d925z
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /builder/downward
+        name: downward
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -wait_file
+      - /builder/tools/0
+      - -post_file
+      - /builder/tools/1
+      - -entrypoint
+      - jx
+      - --
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      image: gcr.io/jenkinsxio/builder-jx:0.1.747
+      imagePullPolicy: IfNotPresent
+      name: step-git-merge
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/1
+      - -post_file
+      - /builder/tools/2
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - 'echo ''SKIP merge-pull-refs: Nothing to merge'''
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JENKINS_URL
+        value: http://jenkins:8080
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-merge-pull-refs
+      resources:
+        requests:
+          cpu: 400m
+          ephemeral-storage: "0"
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/2
+      - -post_file
+      - /builder/tools/3
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step syntax effective --output-dir . --env BUILD_NUMBER=1 --env PIPELINE_KIND=release
+        --env PULL_REFS=master:0708469b9e463bfd8df21af92dc4afe82ac0b581 --env SOURCE_URL=https://github.com/cb-kubecd/bdd-spring-1568135191.git
+        --env REPO_OWNER=cb-kubecd --env REPO_NAME=bdd-spring-1568135191 --env APP_NAME=bdd-spring-1568135191
+        --env BRANCH_NAME=master --env JOB_NAME=cb-kubecd/bdd-spring-1568135191/master
+        --env PULL_BASE_REF=master --env BUILD_ID= --env PROW_JOB_ID= --env JOB_TYPE=postsubmit
+        --env JOB_SPEC={"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}
+        --env PULL_BASE_SHA=0708469b9e463bfd8df21af92dc4afe82ac0b581
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JENKINS_URL
+        value: http://jenkins:8080
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-create-effective-pipeline
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/3
+      - -post_file
+      - /builder/tools/4
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step create task --clone-dir /workspace/source --kind release --service-account
+        tekton-bot --source source --branch master --build-number 1 --label prowJobName=6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+        --label created-by-prow=true
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JENKINS_URL
+        value: http://jenkins:8080
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-create-tekton-crds
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    dnsPolicy: ClusterFirst
+    enableServiceLinks: true
+    initContainers:
+    - args:
+      - -basic-git=knative-git-user-pass=https://github.com
+      command:
+      - /ko-app/creds-init
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-credential-initializer-v7srb
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/build-secrets/knative-git-user-pass
+        name: secret-volume-knative-git-user-pass-hnnfg
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -args
+      - mkdir -p /workspace/source
+      command:
+      - /ko-app/bash
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-working-dir-initializer-lnjrj
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -c
+      - cp /ko-app/entrypoint /builder/tools/entrypoint
+      command:
+      - /bin/sh
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-place-tools
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    nodeName: gke-pr-5411-40-tekton-gk-default-pool-85b243e8-45r2
+    priority: 0
+    restartPolicy: Never
+    schedulerName: default-scheduler
+    securityContext: {}
+    serviceAccount: tekton-bot
+    serviceAccountName: tekton-bot
+    terminationGracePeriodSeconds: 30
+    tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+        type: ""
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        defaultMode: 420
+        secretName: jenkins-maven-settings
+    - name: volume-1
+      secret:
+        defaultMode: 420
+        secretName: jenkins-docker-cfg
+    - name: volume-2
+      secret:
+        defaultMode: 420
+        secretName: jenkins-release-gpg
+    - emptyDir: {}
+      name: workspace-volume
+    - emptyDir: {}
+      name: tools
+    - downwardAPI:
+        defaultMode: 420
+        items:
+        - fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.annotations['tekton.dev/ready']
+          path: ready
+      name: downward
+    - emptyDir: {}
+      name: workspace
+    - emptyDir: {}
+      name: home
+    - name: secret-volume-knative-git-user-pass-hnnfg
+      secret:
+        defaultMode: 420
+        secretName: knative-git-user-pass
+    - name: tekton-bot-token-snk54
+      secret:
+        defaultMode: 420
+        secretName: tekton-bot-token-snk54
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:18Z"
+      reason: PodCompleted
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:31Z"
+      reason: PodCompleted
+      status: "False"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:31Z"
+      reason: PodCompleted
+      status: "False"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:08Z"
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-create-effective-pipeline
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:35Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:26Z"
+    - containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-create-tekton-crds
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
+          exitCode: 0
+          finishedAt: "2019-09-10T17:08:20Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:27Z"
+    - containerID: docker://2f94880db188f839b490cecf829c5552f9bc656330f4385ca3c1fcb029989b17
+      image: gcr.io/jenkinsxio/builder-jx:0.1.747
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-jx@sha256:1e231548ca73780c760a0790a9e80ce16218998080126b6cb53d631208e96661
+      lastState: {}
+      name: step-git-merge
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://2f94880db188f839b490cecf829c5552f9bc656330f4385ca3c1fcb029989b17
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:30Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:26Z"
+    - containerID: docker://911ee8a7611dc4e3f158e9d2d6269c4476bbaa603c04f0a72ee770e8b5d30a52
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:7bb771b0f12a6c5495a3ae750e28330dcf01124ea29d628cabeb2b371ead8d2b
+      lastState: {}
+      name: step-git-source-meta-cb-kubecd-bdd-spring-15681-d925z
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://911ee8a7611dc4e3f158e9d2d6269c4476bbaa603c04f0a72ee770e8b5d30a52
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:30Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:19Z"
+    - containerID: docker://ae5aff984092e048febc28df550c7f795ef07f701f6c48a160b08808332e3f94
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-merge-pull-refs
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://ae5aff984092e048febc28df550c7f795ef07f701f6c48a160b08808332e3f94
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:30Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:26Z"
+    hostIP: 10.132.0.35
+    initContainerStatuses:
+    - containerID: docker://413d99d1a74fa66ecb0c13b4deae0a5514b42204030284e56d4dce5be7a2a67d
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:17119dde117437d7109622fc38ec046ec05757b336b223777761b841f5e49d8d
+      lastState: {}
+      name: step-credential-initializer-v7srb
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://413d99d1a74fa66ecb0c13b4deae0a5514b42204030284e56d4dce5be7a2a67d
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:13Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:13Z"
+    - containerID: docker://efd3798bae17bb2c1d4bb51747f2fa1c3a746c6114dac5f2eb898d031dc7833d
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash@sha256:16e89d13b266947239e89057d4541e79e4f65211fc215bdbfe4ea8c2c48552aa
+      lastState: {}
+      name: step-working-dir-initializer-lnjrj
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://efd3798bae17bb2c1d4bb51747f2fa1c3a746c6114dac5f2eb898d031dc7833d
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:15Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:15Z"
+    - containerID: docker://e6386097aa54897f86c136de234b6f325a414c5d25df91a830ba95a7f6b32086
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:1b7f9a621e7a1344fad071f63551b5991e9e9aa6e40ac59557e34e7c2a17bcdf
+      lastState: {}
+      name: step-place-tools
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://e6386097aa54897f86c136de234b6f325a414c5d25df91a830ba95a7f6b32086
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:17Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:17Z"
+    phase: Succeeded
+    podIP: 10.44.0.12
+    qosClass: Burstable
+    startTime: "2019-09-10T17:07:09Z"
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      tekton.dev/ready: READY
+    creationTimestamp: "2019-09-10T17:08:20Z"
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      jenkins.io/task-stage-name: from-build-pack
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+      tekton.dev/pipeline: cb-kubecd-bdd-spring-1568135191-1
+      tekton.dev/pipelineRun: cb-kubecd-bdd-spring-1568135191-1
+      tekton.dev/pipelineTask: from-build-pack
+      tekton.dev/task: cb-kubecd-bdd-spring-1568135191-from-build-pack-1
+      tekton.dev/taskRun: cb-kubecd-bdd-spring-1568135191-1-from-build-pack-mrz2r
+    name: cb-kubecd-bdd-spring-1568135191-1-from-build-pack-mrz2r-pod-8d000a
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: TaskRun
+      name: cb-kubecd-bdd-spring-1568135191-1-from-build-pack-mrz2r
+      uid: 972cee23-d3ed-11e9-8142-42010a840094
+    resourceVersion: "4547"
+    selfLink: /api/v1/namespaces/jx/pods/cb-kubecd-bdd-spring-1568135191-1-from-build-pack-mrz2r-pod-8d000a
+    uid: 97320056-d3ed-11e9-8142-42010a840094
+  spec:
+    containers:
+    - args:
+      - -wait_file
+      - /builder/downward/ready
+      - -post_file
+      - /builder/tools/0
+      - -wait_file_content
+      - -entrypoint
+      - /ko-app/git-init
+      - --
+      - -url
+      - https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - -revision
+      - v0.0.1
+      - -path
+      - /workspace/source
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-git-source-cb-kubecd-bdd-spring-1568135191-7zl6b
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /builder/downward
+        name: downward
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -wait_file
+      - /builder/tools/0
+      - -post_file
+      - /builder/tools/1
+      - -entrypoint
+      - jx
+      - --
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: type:postsubmit
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.1
+      - name: PREVIEW_VERSION
+        value: 0.0.1
+      image: gcr.io/jenkinsxio/builder-jx:0.1.747
+      imagePullPolicy: IfNotPresent
+      name: step-git-merge
+      resources:
+        requests:
+          cpu: 400m
+          ephemeral-storage: "0"
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/1
+      - -post_file
+      - /builder/tools/2
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step git credentials
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: type:postsubmit
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.1
+      - name: PREVIEW_VERSION
+        value: 0.0.1
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-setup-jx-git-credentials
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/2
+      - -post_file
+      - /builder/tools/3
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - mvn clean deploy
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: type:postsubmit
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.1
+      - name: PREVIEW_VERSION
+        value: 0.0.1
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-build-mvn-deploy
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/3
+      - -post_file
+      - /builder/tools/4
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - skaffold version
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: type:postsubmit
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.1
+      - name: PREVIEW_VERSION
+        value: 0.0.1
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-build-skaffold-version
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/4
+      - -post_file
+      - /builder/tools/5
+      - -entrypoint
+      - /kaniko/executor
+      - --
+      - --cache=true
+      - --cache-dir=/workspace
+      - --context=/workspace/source
+      - --dockerfile=/workspace/source/Dockerfile
+      - --destination=gcr.io/jenkins-x-bdd2/bdd-spring-1568135191:0.0.1
+      - --cache-repo=gcr.io/jenkins-x-bdd2/cache
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: type:postsubmit
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /kaniko-secret/secret.json
+      - name: PREVIEW_VERSION
+        value: 0.0.1
+      image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+      imagePullPolicy: IfNotPresent
+      name: step-build-container-build
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /kaniko-secret
+        name: kaniko-secret
+        readOnly: true
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/5
+      - -post_file
+      - /builder/tools/6
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:${VERSION}
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: type:postsubmit
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.1
+      - name: PREVIEW_VERSION
+        value: 0.0.1
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-build-post-build
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/6
+      - -post_file
+      - /builder/tools/7
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step changelog --version v${VERSION}
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: type:postsubmit
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.1
+      - name: PREVIEW_VERSION
+        value: 0.0.1
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-promote-changelog
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source/charts/bdd-spring-1568135191
+    - args:
+      - -wait_file
+      - /builder/tools/7
+      - -post_file
+      - /builder/tools/8
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step helm release
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: type:postsubmit
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.1
+      - name: PREVIEW_VERSION
+        value: 0.0.1
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-promote-helm-release
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source/charts/bdd-spring-1568135191
+    - args:
+      - -wait_file
+      - /builder/tools/8
+      - -post_file
+      - /builder/tools/9
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx promote -b --all-auto --timeout 1h --version ${VERSION}
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: type:postsubmit
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: 0.0.1
+      - name: PREVIEW_VERSION
+        value: 0.0.1
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-promote-jx-promote
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source/charts/bdd-spring-1568135191
+    dnsPolicy: ClusterFirst
+    enableServiceLinks: true
+    initContainers:
+    - args:
+      - -basic-git=knative-git-user-pass=https://github.com
+      command:
+      - /ko-app/creds-init
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-credential-initializer-dtwbl
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/build-secrets/knative-git-user-pass
+        name: secret-volume-knative-git-user-pass-wsc4m
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -args
+      - mkdir -p /workspace/source /workspace/source/charts/bdd-spring-1568135191
+      command:
+      - /ko-app/bash
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-working-dir-initializer-d5rgx
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -c
+      - cp /ko-app/entrypoint /builder/tools/entrypoint
+      command:
+      - /bin/sh
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-place-tools
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    nodeName: gke-pr-5411-40-tekton-gk-default-pool-85b243e8-2xqd
+    priority: 0
+    restartPolicy: Never
+    schedulerName: default-scheduler
+    securityContext: {}
+    serviceAccount: tekton-bot
+    serviceAccountName: tekton-bot
+    terminationGracePeriodSeconds: 30
+    tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+        type: ""
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        defaultMode: 420
+        secretName: jenkins-maven-settings
+    - name: volume-1
+      secret:
+        defaultMode: 420
+        secretName: jenkins-docker-cfg
+    - name: volume-2
+      secret:
+        defaultMode: 420
+        secretName: jenkins-release-gpg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        defaultMode: 420
+        items:
+        - fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+    - name: kaniko-secret
+      secret:
+        defaultMode: 420
+        items:
+        - key: kaniko-secret
+          path: secret.json
+        secretName: kaniko-secret
+    - emptyDir: {}
+      name: tools
+    - downwardAPI:
+        defaultMode: 420
+        items:
+        - fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.annotations['tekton.dev/ready']
+          path: ready
+      name: downward
+    - emptyDir: {}
+      name: workspace
+    - emptyDir: {}
+      name: home
+    - name: secret-volume-knative-git-user-pass-wsc4m
+      secret:
+        defaultMode: 420
+        secretName: knative-git-user-pass
+    - name: tekton-bot-token-snk54
+      secret:
+        defaultMode: 420
+        secretName: tekton-bot-token-snk54
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:08:30Z"
+      reason: PodCompleted
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:09:01Z"
+      reason: PodCompleted
+      status: "False"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:09:01Z"
+      reason: PodCompleted
+      status: "False"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:08:20Z"
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://9417b1519ea1307ff112050edf7642894994ec6ba3f78d99a8d6aad3d8ef6c55
+      image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+      imageID: docker-pullable://gcr.io/kaniko-project/executor@sha256:94c69a4be5eccf88070e640bc682c969a53996c8a4490e39776c9411b974d8fa
+      lastState: {}
+      name: step-build-container-build
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://9417b1519ea1307ff112050edf7642894994ec6ba3f78d99a8d6aad3d8ef6c55
+          exitCode: 0
+          finishedAt: "2019-09-10T17:10:01Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:55Z"
+    - containerID: docker://bc879af1e79aa4d9028408c3da08433c51213e1839c4faf83a33de131b2383c8
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-build-mvn-deploy
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://bc879af1e79aa4d9028408c3da08433c51213e1839c4faf83a33de131b2383c8
+          exitCode: 0
+          finishedAt: "2019-09-10T17:09:51Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:52Z"
+    - containerID: docker://19c6882478feb28259f26a9e0d1d85a3ba15f8e161b591535cfc9f410de52a9d
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-build-post-build
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://19c6882478feb28259f26a9e0d1d85a3ba15f8e161b591535cfc9f410de52a9d
+          exitCode: 0
+          finishedAt: "2019-09-10T17:10:02Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:55Z"
+    - containerID: docker://4de444fdd205efd0d9dc2b24bb0913e185556d53447fc5b3ca08c0b81e654531
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-build-skaffold-version
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://4de444fdd205efd0d9dc2b24bb0913e185556d53447fc5b3ca08c0b81e654531
+          exitCode: 0
+          finishedAt: "2019-09-10T17:09:51Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:52Z"
+    - containerID: docker://053dbc7462bb411ade35bd2e3edb06f6304a5090b81a7200e581666257de605b
+      image: gcr.io/jenkinsxio/builder-jx:0.1.747
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-jx@sha256:1e231548ca73780c760a0790a9e80ce16218998080126b6cb53d631208e96661
+      lastState: {}
+      name: step-git-merge
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://053dbc7462bb411ade35bd2e3edb06f6304a5090b81a7200e581666257de605b
+          exitCode: 0
+          finishedAt: "2019-09-10T17:09:00Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:32Z"
+    - containerID: docker://7c08c3035e166ceb9fa3ac7692235ae8c023e7651776b84709c96353353475fe
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:7bb771b0f12a6c5495a3ae750e28330dcf01124ea29d628cabeb2b371ead8d2b
+      lastState: {}
+      name: step-git-source-cb-kubecd-bdd-spring-1568135191-7zl6b
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://7c08c3035e166ceb9fa3ac7692235ae8c023e7651776b84709c96353353475fe
+          exitCode: 0
+          finishedAt: "2019-09-10T17:09:00Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:32Z"
+    - containerID: docker://97cb4d3d588d4decff0bcc2b279312d33044d7bb7a5f63bb27b5ba8182c47232
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-promote-changelog
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://97cb4d3d588d4decff0bcc2b279312d33044d7bb7a5f63bb27b5ba8182c47232
+          exitCode: 0
+          finishedAt: "2019-09-10T17:10:04Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:56Z"
+    - containerID: docker://0185c5e21ef22da68133c07c48fbee57396c6bc06d981359550b7e578e8c4e5a
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-promote-helm-release
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://0185c5e21ef22da68133c07c48fbee57396c6bc06d981359550b7e578e8c4e5a
+          exitCode: 0
+          finishedAt: "2019-09-10T17:10:09Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:56Z"
+    - containerID: docker://863aaccefc672eb10284e165ded50ff2d3755219627956307c3d4db29fa0a076
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-promote-jx-promote
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://863aaccefc672eb10284e165ded50ff2d3755219627956307c3d4db29fa0a076
+          exitCode: 0
+          finishedAt: "2019-09-10T17:11:30Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:56Z"
+    - containerID: docker://831134be7a23adbef100d8e1f1eefc8a588a2e8ed1cee349090d2122c7c2c5be
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-setup-jx-git-credentials
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://831134be7a23adbef100d8e1f1eefc8a588a2e8ed1cee349090d2122c7c2c5be
+          exitCode: 0
+          finishedAt: "2019-09-10T17:09:01Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:52Z"
+    hostIP: 10.132.0.36
+    initContainerStatuses:
+    - containerID: docker://f2cda50711c5112cc418c0fc4ebefb50600b74b065acfd4ca7753fb0fe4565be
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:17119dde117437d7109622fc38ec046ec05757b336b223777761b841f5e49d8d
+      lastState: {}
+      name: step-credential-initializer-dtwbl
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://f2cda50711c5112cc418c0fc4ebefb50600b74b065acfd4ca7753fb0fe4565be
+          exitCode: 0
+          finishedAt: "2019-09-10T17:08:25Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:25Z"
+    - containerID: docker://fc37972d271e2898110146c08bf0ba81eb199638964277fea80ee5c163e599be
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash@sha256:16e89d13b266947239e89057d4541e79e4f65211fc215bdbfe4ea8c2c48552aa
+      lastState: {}
+      name: step-working-dir-initializer-d5rgx
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://fc37972d271e2898110146c08bf0ba81eb199638964277fea80ee5c163e599be
+          exitCode: 0
+          finishedAt: "2019-09-10T17:08:28Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:28Z"
+    - containerID: docker://100f474367eca09708cdc33d7a68445604a6270600e1218aba2e12756dc1a150
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:1b7f9a621e7a1344fad071f63551b5991e9e9aa6e40ac59557e34e7c2a17bcdf
+      lastState: {}
+      name: step-place-tools
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://100f474367eca09708cdc33d7a68445604a6270600e1218aba2e12756dc1a150
+          exitCode: 0
+          finishedAt: "2019-09-10T17:08:29Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:08:29Z"
+    phase: Succeeded
+    podIP: 10.44.1.16
+    qosClass: Burstable
+    startTime: "2019-09-10T17:08:21Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/structures.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/structures.yml
@@ -1,0 +1,62 @@
+apiVersion: jenkins.io/v1
+items:
+- apiVersion: jenkins.io/v1
+  kind: PipelineStructure
+  metadata:
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+    name: meta-cb-kubecd-bdd-spring-15681-1
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: pipeline
+      name: meta-cb-kubecd-bdd-spring-15681-1
+      uid: 6c431e3c-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3199"
+    selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/meta-cb-kubecd-bdd-spring-15681-1
+    uid: 6c58e971-d3ed-11e9-8142-42010a840094
+  pipelineRef: meta-cb-kubecd-bdd-spring-15681-1
+  pipelineRunRef: meta-cb-kubecd-bdd-spring-15681-1
+  stages:
+  - depth: 0
+    name: meta-pipeline
+    taskRef: meta-cb-kubecd-bdd-spring-15681-meta-pipeline-1
+- apiVersion: jenkins.io/v1
+  kind: PipelineStructure
+  metadata:
+    creationTimestamp: "2019-09-10T17:08:20Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+    name: cb-kubecd-bdd-spring-1568135191-1
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: pipeline
+      name: cb-kubecd-bdd-spring-1568135191-1
+      uid: 9725fd7c-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3545"
+    selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/cb-kubecd-bdd-spring-1568135191-1
+    uid: 97288a33-d3ed-11e9-8142-42010a840094
+  pipelineRef: cb-kubecd-bdd-spring-1568135191-1
+  pipelineRunRef: cb-kubecd-bdd-spring-1568135191-1
+  stages:
+  - depth: 0
+    name: from-build-pack
+    taskRef: cb-kubecd-bdd-spring-1568135191-from-build-pack-1
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/expected/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/expected/activity.yml
@@ -1,0 +1,133 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  creationTimestamp: "2019-09-10T17:43:36Z"
+  generation: 29
+  labels:
+    branch: master
+    build: "1"
+    owner: cb-kubecd
+    provider: github
+    repository: bdd-spring-1568135191
+    sourcerepository: cb-kubecd-bdd-spring-1568135191
+  name: cb-kubecd-bdd-spring-1568135191-master-1
+  namespace: jx
+  resourceVersion: "4954"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
+  uid: 8461830a-d3f2-11e9-82fc-42010a840132
+spec:
+  batchPipelineActivity: {}
+  build: "1"
+  completedTimestamp: "2019-09-10T17:11:30Z"
+  gitBranch: master
+  gitOwner: cb-kubecd
+  gitRepository: bdd-spring-1568135191
+  gitUrl: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+  lastCommitSHA: 7307e06426062dc31f76fd95abecbb8f93af5b54
+  pipeline: cb-kubecd/bdd-spring-1568135191/master
+  startedTimestamp: "2019-09-10T17:43:41Z"
+  status: Succeeded
+  steps:
+  - kind: Stage
+    stage:
+      completedTimestamp: "2019-09-10T17:08:20Z"
+      name: meta pipeline
+      startedTimestamp: "2019-09-10T17:07:13Z"
+      status: Succeeded
+      steps:
+      - completedTimestamp: "2019-09-10T17:07:13Z"
+        name: Credential Initializer V7srb
+        startedTimestamp: "2019-09-10T17:07:13Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:15Z"
+        name: Working Dir Initializer Lnjrj
+        startedTimestamp: "2019-09-10T17:07:13Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:17Z"
+        name: Place Tools
+        startedTimestamp: "2019-09-10T17:07:15Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        description: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+        name: Git Source Meta Cb Kubecd Bdd Spring 15681 D925z
+        startedTimestamp: "2019-09-10T17:07:17Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        name: Git Merge
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        name: Merge Pull Refs
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:35Z"
+        name: Create Effective Pipeline
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:08:20Z"
+        name: Create Tekton Crds
+        startedTimestamp: "2019-09-10T17:07:35Z"
+        status: Succeeded
+  - kind: Stage
+    stage:
+      completedTimestamp: "2019-09-10T17:11:30Z"
+      name: from build pack
+      startedTimestamp: "2019-09-10T17:08:25Z"
+      status: Succeeded
+      steps:
+      - completedTimestamp: "2019-09-10T17:08:25Z"
+        name: Credential Initializer Dtwbl
+        startedTimestamp: "2019-09-10T17:08:25Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:08:28Z"
+        name: Working Dir Initializer D5rgx
+        startedTimestamp: "2019-09-10T17:08:25Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:08:29Z"
+        name: Place Tools
+        startedTimestamp: "2019-09-10T17:08:28Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:09:00Z"
+        description: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+        name: Git Source Cb Kubecd Bdd Spring 1568135191 7zl6b
+        startedTimestamp: "2019-09-10T17:08:29Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:09:00Z"
+        name: Git Merge
+        startedTimestamp: "2019-09-10T17:09:00Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:09:01Z"
+        name: Setup Jx Git Credentials
+        startedTimestamp: "2019-09-10T17:09:00Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:09:51Z"
+        name: Build Mvn Deploy
+        startedTimestamp: "2019-09-10T17:09:01Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:09:51Z"
+        name: Build Skaffold Version
+        startedTimestamp: "2019-09-10T17:09:51Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:10:01Z"
+        name: Build Container Build
+        startedTimestamp: "2019-09-10T17:09:51Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:10:02Z"
+        name: Build Post Build
+        startedTimestamp: "2019-09-10T17:10:01Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:10:04Z"
+        name: Promote Changelog
+        startedTimestamp: "2019-09-10T17:10:02Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:10:09Z"
+        name: Promote Helm Release
+        startedTimestamp: "2019-09-10T17:10:04Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:11:30Z"
+        name: Promote Jx Promote
+        startedTimestamp: "2019-09-10T17:10:09Z"
+        status: Succeeded
+  version: 0.0.1
+  workflowStatus: Running
+status: {}

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/activity.yml
@@ -1,0 +1,32 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  creationTimestamp: "2019-09-10T17:43:36Z"
+  generation: 29
+  labels:
+    branch: master
+    build: "1"
+    owner: cb-kubecd
+    provider: github
+    repository: bdd-spring-1568135191
+    sourcerepository: cb-kubecd-bdd-spring-1568135191
+  name: cb-kubecd-bdd-spring-1568135191-master-1
+  namespace: jx
+  resourceVersion: "4954"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
+  uid: 8461830a-d3f2-11e9-82fc-42010a840132
+spec:
+  batchPipelineActivity: {}
+  build: "1"
+  gitBranch: master
+  gitOwner: cb-kubecd
+  gitRepository: bdd-spring-1568135191
+  gitUrl: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+  lastCommitSHA: 7307e06426062dc31f76fd95abecbb8f93af5b54
+  pipeline: cb-kubecd/bdd-spring-1568135191/master
+  startedTimestamp: "2019-09-10T17:43:41Z"
+  status: Running
+  steps: []
+  version: 0.0.1
+  workflowStatus: Running
+status: {}

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelineruns.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelineruns.yml
@@ -1,0 +1,93 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineRun
+  metadata:
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+      tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1
+    name: meta-cb-kubecd-bdd-spring-15681-1
+    namespace: jx
+    resourceVersion: "3572"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/meta-cb-kubecd-bdd-spring-15681-1
+    uid: 6c44d166-d3ed-11e9-8142-42010a840094
+  spec:
+    pipelineRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: meta-cb-kubecd-bdd-spring-15681-1
+    resources:
+    - name: meta-cb-kubecd-bdd-spring-15681
+      resourceRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: meta-cb-kubecd-bdd-spring-15681
+    serviceAccount: tekton-bot
+    timeout: 240h0m0s
+  status:
+    completionTime: "2019-09-10T17:08:23Z"
+    conditions:
+    - lastTransitionTime: "2019-09-10T17:08:23Z"
+      message: All Tasks have completed executing
+      reason: Succeeded
+      status: "True"
+      type: Succeeded
+    startTime: "2019-09-10T17:07:08Z"
+    taskRuns:
+      meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55:
+        pipelineTaskName: meta-pipeline
+        status:
+          completionTime: "2019-09-10T17:08:21Z"
+          conditions:
+          - lastTransitionTime: "2019-09-10T17:08:21Z"
+            message: All Steps have completed executing
+            reason: Succeeded
+            status: "True"
+            type: Succeeded
+          podName: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55-pod-e44008
+          startTime: "2019-09-10T17:07:08Z"
+          steps:
+          - name: git-merge
+            terminated:
+              containerID: docker://2f94880db188f839b490cecf829c5552f9bc656330f4385ca3c1fcb029989b17
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:30Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:26Z"
+          - name: merge-pull-refs
+            terminated:
+              containerID: docker://ae5aff984092e048febc28df550c7f795ef07f701f6c48a160b08808332e3f94
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:30Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:26Z"
+          - name: create-effective-pipeline
+            terminated:
+              containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:35Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:26Z"
+          - name: create-tekton-crds
+            terminated:
+              containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
+              exitCode: 0
+              finishedAt: "2019-09-10T17:08:20Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:27Z"
+          - name: git-source-meta-cb-kubecd-bdd-spring-15681-d925z
+            terminated:
+              containerID: docker://911ee8a7611dc4e3f158e9d2d6269c4476bbaa603c04f0a72ee770e8b5d30a52
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:30Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:19Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelines.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelines.yml
@@ -1,0 +1,40 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Pipeline
+  metadata:
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+    name: meta-cb-kubecd-bdd-spring-15681-1
+    namespace: jx
+    ownerReferences:
+    - apiVersion: jenkins.io/v1
+      kind: PipelineActivity
+      name: cb-kubecd-bdd-spring-1568135191-master-1
+      uid: 6c3963df-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3188"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/meta-cb-kubecd-bdd-spring-15681-1
+    uid: 6c431e3c-d3ed-11e9-8142-42010a840094
+  spec:
+    resources:
+    - name: meta-cb-kubecd-bdd-spring-15681
+      type: git
+    tasks:
+    - name: meta-pipeline
+      resources:
+        inputs:
+        - name: workspace
+          resource: meta-cb-kubecd-bdd-spring-15681
+      taskRef:
+        name: meta-cb-kubecd-bdd-spring-15681-meta-pipeline-1
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pods.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pods.yml
@@ -1,0 +1,738 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      tekton.dev/ready: READY
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      jenkins.io/task-stage-name: meta-pipeline
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+      tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1
+      tekton.dev/pipelineRun: meta-cb-kubecd-bdd-spring-15681-1
+      tekton.dev/pipelineTask: meta-pipeline
+      tekton.dev/task: meta-cb-kubecd-bdd-spring-15681-meta-pipeline-1
+      tekton.dev/taskRun: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55
+    name: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55-pod-e44008
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: TaskRun
+      name: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55
+      uid: 6c4b0a44-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3555"
+    selfLink: /api/v1/namespaces/jx/pods/meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55-pod-e44008
+    uid: 6c5192c3-d3ed-11e9-8142-42010a840094
+  spec:
+    containers:
+    - args:
+      - -wait_file
+      - /builder/downward/ready
+      - -post_file
+      - /builder/tools/0
+      - -wait_file_content
+      - -entrypoint
+      - /ko-app/git-init
+      - --
+      - -url
+      - https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - -revision
+      - 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - -path
+      - /workspace/source
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-git-source-meta-cb-kubecd-bdd-spring-15681-d925z
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /builder/downward
+        name: downward
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -wait_file
+      - /builder/tools/0
+      - -post_file
+      - /builder/tools/1
+      - -entrypoint
+      - jx
+      - --
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      image: gcr.io/jenkinsxio/builder-jx:0.1.747
+      imagePullPolicy: IfNotPresent
+      name: step-git-merge
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/1
+      - -post_file
+      - /builder/tools/2
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - 'echo ''SKIP merge-pull-refs: Nothing to merge'''
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JENKINS_URL
+        value: http://jenkins:8080
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-merge-pull-refs
+      resources:
+        requests:
+          cpu: 400m
+          ephemeral-storage: "0"
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/2
+      - -post_file
+      - /builder/tools/3
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step syntax effective --output-dir . --env BUILD_NUMBER=1 --env PIPELINE_KIND=release
+        --env PULL_REFS=master:0708469b9e463bfd8df21af92dc4afe82ac0b581 --env SOURCE_URL=https://github.com/cb-kubecd/bdd-spring-1568135191.git
+        --env REPO_OWNER=cb-kubecd --env REPO_NAME=bdd-spring-1568135191 --env APP_NAME=bdd-spring-1568135191
+        --env BRANCH_NAME=master --env JOB_NAME=cb-kubecd/bdd-spring-1568135191/master
+        --env PULL_BASE_REF=master --env BUILD_ID= --env PROW_JOB_ID= --env JOB_TYPE=postsubmit
+        --env JOB_SPEC={"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}
+        --env PULL_BASE_SHA=0708469b9e463bfd8df21af92dc4afe82ac0b581
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JENKINS_URL
+        value: http://jenkins:8080
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-create-effective-pipeline
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/3
+      - -post_file
+      - /builder/tools/4
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step create task --clone-dir /workspace/source --kind release --service-account
+        tekton-bot --source source --branch master --build-number 1 --label prowJobName=6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+        --label created-by-prow=true
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JENKINS_URL
+        value: http://jenkins:8080
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-create-tekton-crds
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    dnsPolicy: ClusterFirst
+    enableServiceLinks: true
+    initContainers:
+    - args:
+      - -basic-git=knative-git-user-pass=https://github.com
+      command:
+      - /ko-app/creds-init
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-credential-initializer-v7srb
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/build-secrets/knative-git-user-pass
+        name: secret-volume-knative-git-user-pass-hnnfg
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -args
+      - mkdir -p /workspace/source
+      command:
+      - /ko-app/bash
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-working-dir-initializer-lnjrj
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -c
+      - cp /ko-app/entrypoint /builder/tools/entrypoint
+      command:
+      - /bin/sh
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-place-tools
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    nodeName: gke-pr-5411-40-tekton-gk-default-pool-85b243e8-45r2
+    priority: 0
+    restartPolicy: Never
+    schedulerName: default-scheduler
+    securityContext: {}
+    serviceAccount: tekton-bot
+    serviceAccountName: tekton-bot
+    terminationGracePeriodSeconds: 30
+    tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+        type: ""
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        defaultMode: 420
+        secretName: jenkins-maven-settings
+    - name: volume-1
+      secret:
+        defaultMode: 420
+        secretName: jenkins-docker-cfg
+    - name: volume-2
+      secret:
+        defaultMode: 420
+        secretName: jenkins-release-gpg
+    - emptyDir: {}
+      name: workspace-volume
+    - emptyDir: {}
+      name: tools
+    - downwardAPI:
+        defaultMode: 420
+        items:
+        - fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.annotations['tekton.dev/ready']
+          path: ready
+      name: downward
+    - emptyDir: {}
+      name: workspace
+    - emptyDir: {}
+      name: home
+    - name: secret-volume-knative-git-user-pass-hnnfg
+      secret:
+        defaultMode: 420
+        secretName: knative-git-user-pass
+    - name: tekton-bot-token-snk54
+      secret:
+        defaultMode: 420
+        secretName: tekton-bot-token-snk54
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:18Z"
+      reason: PodCompleted
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:31Z"
+      reason: PodCompleted
+      status: "False"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:31Z"
+      reason: PodCompleted
+      status: "False"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:08Z"
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-create-effective-pipeline
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:35Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:26Z"
+    - containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-create-tekton-crds
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
+          exitCode: 0
+          finishedAt: "2019-09-10T17:08:20Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:27Z"
+    - containerID: docker://2f94880db188f839b490cecf829c5552f9bc656330f4385ca3c1fcb029989b17
+      image: gcr.io/jenkinsxio/builder-jx:0.1.747
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-jx@sha256:1e231548ca73780c760a0790a9e80ce16218998080126b6cb53d631208e96661
+      lastState: {}
+      name: step-git-merge
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://2f94880db188f839b490cecf829c5552f9bc656330f4385ca3c1fcb029989b17
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:30Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:26Z"
+    - containerID: docker://911ee8a7611dc4e3f158e9d2d6269c4476bbaa603c04f0a72ee770e8b5d30a52
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:7bb771b0f12a6c5495a3ae750e28330dcf01124ea29d628cabeb2b371ead8d2b
+      lastState: {}
+      name: step-git-source-meta-cb-kubecd-bdd-spring-15681-d925z
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://911ee8a7611dc4e3f158e9d2d6269c4476bbaa603c04f0a72ee770e8b5d30a52
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:30Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:19Z"
+    - containerID: docker://ae5aff984092e048febc28df550c7f795ef07f701f6c48a160b08808332e3f94
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-merge-pull-refs
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://ae5aff984092e048febc28df550c7f795ef07f701f6c48a160b08808332e3f94
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:30Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:26Z"
+    hostIP: 10.132.0.35
+    initContainerStatuses:
+    - containerID: docker://413d99d1a74fa66ecb0c13b4deae0a5514b42204030284e56d4dce5be7a2a67d
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:17119dde117437d7109622fc38ec046ec05757b336b223777761b841f5e49d8d
+      lastState: {}
+      name: step-credential-initializer-v7srb
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://413d99d1a74fa66ecb0c13b4deae0a5514b42204030284e56d4dce5be7a2a67d
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:13Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:13Z"
+    - containerID: docker://efd3798bae17bb2c1d4bb51747f2fa1c3a746c6114dac5f2eb898d031dc7833d
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash@sha256:16e89d13b266947239e89057d4541e79e4f65211fc215bdbfe4ea8c2c48552aa
+      lastState: {}
+      name: step-working-dir-initializer-lnjrj
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://efd3798bae17bb2c1d4bb51747f2fa1c3a746c6114dac5f2eb898d031dc7833d
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:15Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:15Z"
+    - containerID: docker://e6386097aa54897f86c136de234b6f325a414c5d25df91a830ba95a7f6b32086
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:1b7f9a621e7a1344fad071f63551b5991e9e9aa6e40ac59557e34e7c2a17bcdf
+      lastState: {}
+      name: step-place-tools
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://e6386097aa54897f86c136de234b6f325a414c5d25df91a830ba95a7f6b32086
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:17Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:17Z"
+    phase: Succeeded
+    podIP: 10.44.0.12
+    qosClass: Burstable
+    startTime: "2019-09-10T17:07:09Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/structures.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/structures.yml
@@ -1,0 +1,34 @@
+apiVersion: jenkins.io/v1
+items:
+- apiVersion: jenkins.io/v1
+  kind: PipelineStructure
+  metadata:
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+    name: meta-cb-kubecd-bdd-spring-15681-1
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: pipeline
+      name: meta-cb-kubecd-bdd-spring-15681-1
+      uid: 6c431e3c-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3199"
+    selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/meta-cb-kubecd-bdd-spring-15681-1
+    uid: 6c58e971-d3ed-11e9-8142-42010a840094
+  pipelineRef: meta-cb-kubecd-bdd-spring-15681-1
+  pipelineRunRef: meta-cb-kubecd-bdd-spring-15681-1
+  stages:
+  - depth: 0
+    name: meta-pipeline
+    taskRef: meta-cb-kubecd-bdd-spring-15681-meta-pipeline-1
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/expected/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/expected/activity.yml
@@ -1,0 +1,72 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  creationTimestamp: "2019-09-10T17:43:36Z"
+  generation: 29
+  labels:
+    branch: master
+    build: "1"
+    owner: cb-kubecd
+    provider: github
+    repository: bdd-spring-1568135191
+    sourcerepository: cb-kubecd-bdd-spring-1568135191
+  name: cb-kubecd-bdd-spring-1568135191-master-1
+  namespace: jx
+  resourceVersion: "4954"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
+  uid: 8461830a-d3f2-11e9-82fc-42010a840132
+spec:
+  batchPipelineActivity: {}
+  build: "1"
+  gitBranch: master
+  gitOwner: cb-kubecd
+  gitRepository: bdd-spring-1568135191
+  gitUrl: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+  lastCommitSHA: 7307e06426062dc31f76fd95abecbb8f93af5b54
+  pipeline: cb-kubecd/bdd-spring-1568135191/master
+  startedTimestamp: "2019-09-10T17:43:41Z"
+  status: Running
+  steps:
+  - kind: Stage
+    stage:
+      completedTimestamp: "2019-09-10T17:08:20Z"
+      name: meta pipeline
+      startedTimestamp: "2019-09-10T17:07:13Z"
+      status: Succeeded
+      steps:
+      - completedTimestamp: "2019-09-10T17:07:13Z"
+        name: Credential Initializer V7srb
+        startedTimestamp: "2019-09-10T17:07:13Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:15Z"
+        name: Working Dir Initializer Lnjrj
+        startedTimestamp: "2019-09-10T17:07:13Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:17Z"
+        name: Place Tools
+        startedTimestamp: "2019-09-10T17:07:15Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        description: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+        name: Git Source Meta Cb Kubecd Bdd Spring 15681 D925z
+        startedTimestamp: "2019-09-10T17:07:17Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        name: Git Merge
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        name: Merge Pull Refs
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:35Z"
+        name: Create Effective Pipeline
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:08:20Z"
+        name: Create Tekton Crds
+        startedTimestamp: "2019-09-10T17:07:35Z"
+        status: Succeeded
+  version: 0.0.1
+  workflowStatus: Running
+status: {}

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/activity.yml
@@ -1,0 +1,32 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  creationTimestamp: "2019-09-10T17:43:36Z"
+  generation: 29
+  labels:
+    branch: master
+    build: "1"
+    owner: cb-kubecd
+    provider: github
+    repository: bdd-spring-1568135191
+    sourcerepository: cb-kubecd-bdd-spring-1568135191
+  name: cb-kubecd-bdd-spring-1568135191-master-1
+  namespace: jx
+  resourceVersion: "4954"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
+  uid: 8461830a-d3f2-11e9-82fc-42010a840132
+spec:
+  batchPipelineActivity: {}
+  build: "1"
+  gitBranch: master
+  gitOwner: cb-kubecd
+  gitRepository: bdd-spring-1568135191
+  gitUrl: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+  lastCommitSHA: 7307e06426062dc31f76fd95abecbb8f93af5b54
+  pipeline: cb-kubecd/bdd-spring-1568135191/master
+  startedTimestamp: "2019-09-10T17:43:41Z"
+  status: Running
+  steps: []
+  version: 0.0.1
+  workflowStatus: Running
+status: {}

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelineruns.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelineruns.yml
@@ -1,0 +1,92 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineRun
+  metadata:
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+      tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1
+    name: meta-cb-kubecd-bdd-spring-15681-1
+    namespace: jx
+    resourceVersion: "3572"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/meta-cb-kubecd-bdd-spring-15681-1
+    uid: 6c44d166-d3ed-11e9-8142-42010a840094
+  spec:
+    pipelineRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: meta-cb-kubecd-bdd-spring-15681-1
+    resources:
+    - name: meta-cb-kubecd-bdd-spring-15681
+      resourceRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: meta-cb-kubecd-bdd-spring-15681
+    serviceAccount: tekton-bot
+    timeout: 240h0m0s
+  status:
+    completionTime: "2019-09-10T17:08:23Z"
+    conditions:
+    - lastTransitionTime: "2019-09-10T17:08:23Z"
+      message: TaskRun meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55 has failed
+      reason: Failed
+      status: "False"
+      type: Succeeded
+    startTime: "2019-09-10T17:07:08Z"
+    taskRuns:
+      meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55:
+        pipelineTaskName: meta-pipeline
+        status:
+          completionTime: "2019-09-10T17:08:21Z"
+          conditions:
+          - lastTransitionTime: "2019-09-10T17:08:21Z"
+            message: Something broke
+            status: "False"
+            type: Succeeded
+          podName: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55-pod-e44008
+          startTime: "2019-09-10T17:07:08Z"
+          steps:
+          - name: git-merge
+            terminated:
+              containerID: docker://2f94880db188f839b490cecf829c5552f9bc656330f4385ca3c1fcb029989b17
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:30Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:26Z"
+          - name: merge-pull-refs
+            terminated:
+              containerID: docker://ae5aff984092e048febc28df550c7f795ef07f701f6c48a160b08808332e3f94
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:30Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:26Z"
+          - name: create-effective-pipeline
+            terminated:
+              containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:35Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:26Z"
+          - name: create-tekton-crds
+            terminated:
+              containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
+              exitCode: 1
+              finishedAt: "2019-09-10T17:08:20Z"
+              reason: Error
+              startedAt: "2019-09-10T17:07:27Z"
+          - name: git-source-meta-cb-kubecd-bdd-spring-15681-d925z
+            terminated:
+              containerID: docker://911ee8a7611dc4e3f158e9d2d6269c4476bbaa603c04f0a72ee770e8b5d30a52
+              exitCode: 0
+              finishedAt: "2019-09-10T17:07:30Z"
+              reason: Completed
+              startedAt: "2019-09-10T17:07:19Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelines.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelines.yml
@@ -1,0 +1,40 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Pipeline
+  metadata:
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+    name: meta-cb-kubecd-bdd-spring-15681-1
+    namespace: jx
+    ownerReferences:
+    - apiVersion: jenkins.io/v1
+      kind: PipelineActivity
+      name: cb-kubecd-bdd-spring-1568135191-master-1
+      uid: 6c3963df-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3188"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelines/meta-cb-kubecd-bdd-spring-15681-1
+    uid: 6c431e3c-d3ed-11e9-8142-42010a840094
+  spec:
+    resources:
+    - name: meta-cb-kubecd-bdd-spring-15681
+      type: git
+    tasks:
+    - name: meta-pipeline
+      resources:
+        inputs:
+        - name: workspace
+          resource: meta-cb-kubecd-bdd-spring-15681
+      taskRef:
+        name: meta-cb-kubecd-bdd-spring-15681-meta-pipeline-1
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pods.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pods.yml
@@ -1,0 +1,738 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      tekton.dev/ready: READY
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      jenkins.io/task-stage-name: meta-pipeline
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+      tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1
+      tekton.dev/pipelineRun: meta-cb-kubecd-bdd-spring-15681-1
+      tekton.dev/pipelineTask: meta-pipeline
+      tekton.dev/task: meta-cb-kubecd-bdd-spring-15681-meta-pipeline-1
+      tekton.dev/taskRun: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55
+    name: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55-pod-e44008
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: TaskRun
+      name: meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55
+      uid: 6c4b0a44-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3555"
+    selfLink: /api/v1/namespaces/jx/pods/meta-cb-kubecd-bdd-spring-15681-1-meta-pipeline-rwb55-pod-e44008
+    uid: 6c5192c3-d3ed-11e9-8142-42010a840094
+  spec:
+    containers:
+    - args:
+      - -wait_file
+      - /builder/downward/ready
+      - -post_file
+      - /builder/tools/0
+      - -wait_file_content
+      - -entrypoint
+      - /ko-app/git-init
+      - --
+      - -url
+      - https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - -revision
+      - 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - -path
+      - /workspace/source
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-git-source-meta-cb-kubecd-bdd-spring-15681-d925z
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /builder/downward
+        name: downward
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -wait_file
+      - /builder/tools/0
+      - -post_file
+      - /builder/tools/1
+      - -entrypoint
+      - jx
+      - --
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      image: gcr.io/jenkinsxio/builder-jx:0.1.747
+      imagePullPolicy: IfNotPresent
+      name: step-git-merge
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/1
+      - -post_file
+      - /builder/tools/2
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - 'echo ''SKIP merge-pull-refs: Nothing to merge'''
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JENKINS_URL
+        value: http://jenkins:8080
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-merge-pull-refs
+      resources:
+        requests:
+          cpu: 400m
+          ephemeral-storage: "0"
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/2
+      - -post_file
+      - /builder/tools/3
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step syntax effective --output-dir . --env BUILD_NUMBER=1 --env PIPELINE_KIND=release
+        --env PULL_REFS=master:0708469b9e463bfd8df21af92dc4afe82ac0b581 --env SOURCE_URL=https://github.com/cb-kubecd/bdd-spring-1568135191.git
+        --env REPO_OWNER=cb-kubecd --env REPO_NAME=bdd-spring-1568135191 --env APP_NAME=bdd-spring-1568135191
+        --env BRANCH_NAME=master --env JOB_NAME=cb-kubecd/bdd-spring-1568135191/master
+        --env PULL_BASE_REF=master --env BUILD_ID= --env PROW_JOB_ID= --env JOB_TYPE=postsubmit
+        --env JOB_SPEC={"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}
+        --env PULL_BASE_SHA=0708469b9e463bfd8df21af92dc4afe82ac0b581
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JENKINS_URL
+        value: http://jenkins:8080
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-create-effective-pipeline
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - -wait_file
+      - /builder/tools/3
+      - -post_file
+      - /builder/tools/4
+      - -entrypoint
+      - /bin/sh
+      - --
+      - -c
+      - jx step create task --clone-dir /workspace/source --kind release --service-account
+        tekton-bot --source source --branch master --build-number 1 --label prowJobName=6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+        --label created-by-prow=true
+      command:
+      - /builder/tools/entrypoint
+      env:
+      - name: HOME
+        value: /builder/home
+      - name: APP_NAME
+        value: bdd-spring-1568135191
+      - name: BRANCH_NAME
+        value: master
+      - name: BUILD_ID
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: JENKINS_URL
+        value: http://jenkins:8080
+      - name: JOB_NAME
+        value: cb-kubecd/bdd-spring-1568135191/master
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","refs":{"org":"cb-kubecd","repo":"bdd-spring-1568135191","base_ref":"master","base_sha":"0708469b9e463bfd8df21af92dc4afe82ac0b581"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: MAVEN_OPTS
+        value: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: PIPELINE_KIND
+        value: release
+      - name: PROW_JOB_ID
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: PULL_REFS
+        value: master:0708469b9e463bfd8df21af92dc4afe82ac0b581
+      - name: REPO_NAME
+        value: bdd-spring-1568135191
+      - name: REPO_OWNER
+        value: cb-kubecd
+      - name: SOURCE_URL
+        value: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /home/jenkins
+      - name: _JAVA_OPTIONS
+        value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true
+          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imagePullPolicy: IfNotPresent
+      name: step-create-tekton-crds
+      resources:
+        requests:
+          cpu: "0"
+          ephemeral-storage: "0"
+          memory: "0"
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /root/.m2/
+        name: volume-0
+      - mountPath: /home/jenkins/.docker
+        name: volume-1
+      - mountPath: /home/jenkins/.gnupg
+        name: volume-2
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace/source
+    dnsPolicy: ClusterFirst
+    enableServiceLinks: true
+    initContainers:
+    - args:
+      - -basic-git=knative-git-user-pass=https://github.com
+      command:
+      - /ko-app/creds-init
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-credential-initializer-v7srb
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/build-secrets/knative-git-user-pass
+        name: secret-volume-knative-git-user-pass-hnnfg
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -args
+      - mkdir -p /workspace/source
+      command:
+      - /ko-app/bash
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-working-dir-initializer-lnjrj
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    - args:
+      - -c
+      - cp /ko-app/entrypoint /builder/tools/entrypoint
+      command:
+      - /bin/sh
+      env:
+      - name: HOME
+        value: /builder/home
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.5.1
+      imagePullPolicy: IfNotPresent
+      name: step-place-tools
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /builder/tools
+        name: tools
+      - mountPath: /workspace
+        name: workspace
+      - mountPath: /builder/home
+        name: home
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: tekton-bot-token-snk54
+        readOnly: true
+      workingDir: /workspace
+    nodeName: gke-pr-5411-40-tekton-gk-default-pool-85b243e8-45r2
+    priority: 0
+    restartPolicy: Never
+    schedulerName: default-scheduler
+    securityContext: {}
+    serviceAccount: tekton-bot
+    serviceAccountName: tekton-bot
+    terminationGracePeriodSeconds: 30
+    tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+        type: ""
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        defaultMode: 420
+        secretName: jenkins-maven-settings
+    - name: volume-1
+      secret:
+        defaultMode: 420
+        secretName: jenkins-docker-cfg
+    - name: volume-2
+      secret:
+        defaultMode: 420
+        secretName: jenkins-release-gpg
+    - emptyDir: {}
+      name: workspace-volume
+    - emptyDir: {}
+      name: tools
+    - downwardAPI:
+        defaultMode: 420
+        items:
+        - fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.annotations['tekton.dev/ready']
+          path: ready
+      name: downward
+    - emptyDir: {}
+      name: workspace
+    - emptyDir: {}
+      name: home
+    - name: secret-volume-knative-git-user-pass-hnnfg
+      secret:
+        defaultMode: 420
+        secretName: knative-git-user-pass
+    - name: tekton-bot-token-snk54
+      secret:
+        defaultMode: 420
+        secretName: tekton-bot-token-snk54
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:18Z"
+      reason: PodCompleted
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:31Z"
+      reason: PodCompleted
+      status: "False"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:31Z"
+      reason: PodCompleted
+      status: "False"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2019-09-10T17:07:08Z"
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-create-effective-pipeline
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:35Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:26Z"
+    - containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-create-tekton-crds
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
+          exitCode: 1
+          finishedAt: "2019-09-10T17:08:20Z"
+          reason: Error
+          startedAt: "2019-09-10T17:07:27Z"
+    - containerID: docker://2f94880db188f839b490cecf829c5552f9bc656330f4385ca3c1fcb029989b17
+      image: gcr.io/jenkinsxio/builder-jx:0.1.747
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-jx@sha256:1e231548ca73780c760a0790a9e80ce16218998080126b6cb53d631208e96661
+      lastState: {}
+      name: step-git-merge
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://2f94880db188f839b490cecf829c5552f9bc656330f4385ca3c1fcb029989b17
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:30Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:26Z"
+    - containerID: docker://911ee8a7611dc4e3f158e9d2d6269c4476bbaa603c04f0a72ee770e8b5d30a52
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:7bb771b0f12a6c5495a3ae750e28330dcf01124ea29d628cabeb2b371ead8d2b
+      lastState: {}
+      name: step-git-source-meta-cb-kubecd-bdd-spring-15681-d925z
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://911ee8a7611dc4e3f158e9d2d6269c4476bbaa603c04f0a72ee770e8b5d30a52
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:30Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:19Z"
+    - containerID: docker://ae5aff984092e048febc28df550c7f795ef07f701f6c48a160b08808332e3f94
+      image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
+      imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:82ec6020f4f43683a80fbc327c2c9fb80c65a9dbc86d097e2a507183048b8265
+      lastState: {}
+      name: step-merge-pull-refs
+      ready: false
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://ae5aff984092e048febc28df550c7f795ef07f701f6c48a160b08808332e3f94
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:30Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:26Z"
+    hostIP: 10.132.0.35
+    initContainerStatuses:
+    - containerID: docker://413d99d1a74fa66ecb0c13b4deae0a5514b42204030284e56d4dce5be7a2a67d
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:17119dde117437d7109622fc38ec046ec05757b336b223777761b841f5e49d8d
+      lastState: {}
+      name: step-credential-initializer-v7srb
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://413d99d1a74fa66ecb0c13b4deae0a5514b42204030284e56d4dce5be7a2a67d
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:13Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:13Z"
+    - containerID: docker://efd3798bae17bb2c1d4bb51747f2fa1c3a746c6114dac5f2eb898d031dc7833d
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash@sha256:16e89d13b266947239e89057d4541e79e4f65211fc215bdbfe4ea8c2c48552aa
+      lastState: {}
+      name: step-working-dir-initializer-lnjrj
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://efd3798bae17bb2c1d4bb51747f2fa1c3a746c6114dac5f2eb898d031dc7833d
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:15Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:15Z"
+    - containerID: docker://e6386097aa54897f86c136de234b6f325a414c5d25df91a830ba95a7f6b32086
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.5.1
+      imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:1b7f9a621e7a1344fad071f63551b5991e9e9aa6e40ac59557e34e7c2a17bcdf
+      lastState: {}
+      name: step-place-tools
+      ready: true
+      restartCount: 0
+      state:
+        terminated:
+          containerID: docker://e6386097aa54897f86c136de234b6f325a414c5d25df91a830ba95a7f6b32086
+          exitCode: 0
+          finishedAt: "2019-09-10T17:07:17Z"
+          reason: Completed
+          startedAt: "2019-09-10T17:07:17Z"
+    phase: Succeeded
+    podIP: 10.44.0.12
+    qosClass: Burstable
+    startTime: "2019-09-10T17:07:09Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/structures.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/structures.yml
@@ -1,0 +1,34 @@
+apiVersion: jenkins.io/v1
+items:
+- apiVersion: jenkins.io/v1
+  kind: PipelineStructure
+  metadata:
+    creationTimestamp: "2019-09-10T17:07:08Z"
+    generation: 1
+    labels:
+      branch: master
+      build: "1"
+      created-by-prow: "true"
+      owner: cb-kubecd
+      prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
+      repository: bdd-spring-1568135191
+    name: meta-cb-kubecd-bdd-spring-15681-1
+    namespace: jx
+    ownerReferences:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: pipeline
+      name: meta-cb-kubecd-bdd-spring-15681-1
+      uid: 6c431e3c-d3ed-11e9-8142-42010a840094
+    resourceVersion: "3199"
+    selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/meta-cb-kubecd-bdd-spring-15681-1
+    uid: 6c58e971-d3ed-11e9-8142-42010a840094
+  pipelineRef: meta-cb-kubecd-bdd-spring-15681-1
+  pipelineRunRef: meta-cb-kubecd-bdd-spring-15681-1
+  stages:
+  - depth: 0
+    name: meta-pipeline
+    taskRef: meta-cb-kubecd-bdd-spring-15681-meta-pipeline-1
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/expected/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/expected/activity.yml
@@ -1,0 +1,73 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  creationTimestamp: "2019-09-10T17:43:36Z"
+  generation: 29
+  labels:
+    branch: master
+    build: "1"
+    owner: cb-kubecd
+    provider: github
+    repository: bdd-spring-1568135191
+    sourcerepository: cb-kubecd-bdd-spring-1568135191
+  name: cb-kubecd-bdd-spring-1568135191-master-1
+  namespace: jx
+  resourceVersion: "4954"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
+  uid: 8461830a-d3f2-11e9-82fc-42010a840132
+spec:
+  batchPipelineActivity: {}
+  build: "1"
+  completedTimestamp: "2019-09-10T17:08:20Z"
+  gitBranch: master
+  gitOwner: cb-kubecd
+  gitRepository: bdd-spring-1568135191
+  gitUrl: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+  lastCommitSHA: 7307e06426062dc31f76fd95abecbb8f93af5b54
+  pipeline: cb-kubecd/bdd-spring-1568135191/master
+  startedTimestamp: "2019-09-10T17:43:41Z"
+  status: Failed
+  steps:
+  - kind: Stage
+    stage:
+      completedTimestamp: "2019-09-10T17:08:20Z"
+      name: meta pipeline
+      startedTimestamp: "2019-09-10T17:07:13Z"
+      status: Failed
+      steps:
+      - completedTimestamp: "2019-09-10T17:07:13Z"
+        name: Credential Initializer V7srb
+        startedTimestamp: "2019-09-10T17:07:13Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:15Z"
+        name: Working Dir Initializer Lnjrj
+        startedTimestamp: "2019-09-10T17:07:13Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:17Z"
+        name: Place Tools
+        startedTimestamp: "2019-09-10T17:07:15Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        description: https://github.com/cb-kubecd/bdd-spring-1568135191.git
+        name: Git Source Meta Cb Kubecd Bdd Spring 15681 D925z
+        startedTimestamp: "2019-09-10T17:07:17Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        name: Git Merge
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:30Z"
+        name: Merge Pull Refs
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:07:35Z"
+        name: Create Effective Pipeline
+        startedTimestamp: "2019-09-10T17:07:30Z"
+        status: Succeeded
+      - completedTimestamp: "2019-09-10T17:08:20Z"
+        name: Create Tekton Crds
+        startedTimestamp: "2019-09-10T17:07:35Z"
+        status: Failed
+  version: 0.0.1
+  workflowStatus: Running
+status: {}

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	metaPipelineStageName = "meta-pipeline"
+	// MetaPipelineStageName is the name used for the single stage used within a metapipeline
+	MetaPipelineStageName = "meta-pipeline"
 
 	// mergePullRefsStepName is the meta pipeline step name for merging all pull refs into the workspace
 	mergePullRefsStepName = "merge-pull-refs"
@@ -111,7 +112,7 @@ func createPipeline(params CRDCreationParameters) (*syntax.ParsedPipeline, error
 	}
 
 	stage := syntax.Stage{
-		Name:  metaPipelineStageName,
+		Name:  MetaPipelineStageName,
 		Steps: steps,
 		Agent: &syntax.Agent{
 			Image: determineDefaultStepImage(params.DefaultImage),

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -153,7 +153,7 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 		Name:        PipelineResourceName(pr.Labels[LabelOwner], pr.Labels[LabelRepo], pr.Labels[LabelBranch], pr.Labels[LabelContext], pipelineType, nil, "") + "-" + pr.Labels[LabelBuild],
 		PipelineRun: pr.Name,
 		Pipeline:    pr.Spec.PipelineRef.Name,
-		Type:        BuildPipeline,
+		Type:        pipelineType,
 		CreatedTime: pr.CreationTimestamp.Time,
 	}
 

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -151,7 +151,7 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 		CreatedTime: pr.CreationTimestamp.Time,
 	}
 
-	if strings.HasPrefix(pr.Name, "metapipeline-") {
+	if strings.HasPrefix(pr.Name, MetaPipeline.String() + "-") {
 		pri.Type = MetaPipeline
 	}
 

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -143,16 +143,18 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 		return nil, errors.New(fmt.Sprintf("PipelineRun %s cannot be found", prName))
 	}
 
+	pipelineType := BuildPipeline
+
+	if strings.HasPrefix(pr.Name, MetaPipeline.String()+"-") {
+		pipelineType = MetaPipeline
+	}
+
 	pri := &PipelineRunInfo{
-		Name:        PipelineResourceName(pr.Labels[LabelOwner], pr.Labels[LabelRepo], pr.Labels[LabelBranch], pr.Labels[LabelContext], BuildPipeline, nil, "") + "-" + pr.Labels[LabelBuild],
+		Name:        PipelineResourceName(pr.Labels[LabelOwner], pr.Labels[LabelRepo], pr.Labels[LabelBranch], pr.Labels[LabelContext], pipelineType, nil, "") + "-" + pr.Labels[LabelBuild],
 		PipelineRun: pr.Name,
 		Pipeline:    pr.Spec.PipelineRef.Name,
 		Type:        BuildPipeline,
 		CreatedTime: pr.CreationTimestamp.Time,
-	}
-
-	if strings.HasPrefix(pr.Name, MetaPipeline.String() + "-") {
-		pri.Type = MetaPipeline
 	}
 
 	var pod *corev1.Pod


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This fixes a number of inconsistencies/shoddy logic/odd behavior around how metapipelines are handled in `controller_build`. First, we weren't properly detecting the `PipelineRun` type due to using the wrong prefix, which was dumb on my part. =) That on its own led to us assuming the `PipelineActivity` was complete as soon as the metapipeline finished, which led us down code paths that result in #5395. Additionally, we weren't consistent with our `PipelineRunInfo` names, which may not have been a functional bug, but was definitely a logging bug that made it hard for me to figure out what was going on.

Along the way, I realized that even with those things dealt with, we still ended up processing the metapipeline's pod, albeit after the completion of the generated pipeline, so it didn't actually do anything, but that's still annoying, so I've fixed the logic for deciding whether to call `logJobCompleteState` and try to populate the long-term storage logs URL, etc to be smarter about how to handle metapipeline.

Oh, and we weren't actually using the image we just built in the `jenkins-x-controllerbuild` pod in the Tekton BDD tests, which took me a couple runs to realize, so let's do that.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #5395 