### PR TITLE
fix: make the cloud DNS secret name configurable in the jx requirements

### DIFF
--- a/pkg/cmd/step/create/step_create_install_values.go
+++ b/pkg/cmd/step/create/step_create_install_values.go
@@ -146,21 +146,24 @@ func (o *StepCreateInstallValuesOptions) Run() error {
 			return errors.Wrap(err, "creating kubernetes client")
 		}
 
-		serviceAccountName := gke.GcpServiceAccountSecretName(kube.DefaultExternalDNSReleaseName)
+		cloudDnsSecretName := requirements.Ingress.TLS.CloudDnsSecretName
+		if cloudDnsSecretName != "" {
+			cloudDnsSecretName = gke.GcpServiceAccountSecretName(kube.DefaultExternalDNSReleaseName)
+			requirements.Ingress.TLS.CloudDnsSecretName = cloudDnsSecretName
+		}
 
-		err = kube.ValidateSecret(kubeClient, serviceAccountName, externaldns.ServiceAccountSecretKey, ns)
-
+		err = kube.ValidateSecret(kubeClient, cloudDnsSecretName, externaldns.ServiceAccountSecretKey, ns)
 		if err != nil {
 			if o.LazyCreate {
-
 				log.Logger().Infof("attempting to lazily create the external-dns secret %s\n", info(ns))
 
-				_, err = externaldns.CreateExternalDNSGCPServiceAccount(o.GCloud(), kubeClient, kube.DefaultExternalDNSReleaseName, ns, requirements.Cluster.ClusterName, requirements.Cluster.ProjectID)
+				_, err = externaldns.CreateExternalDNSGCPServiceAccount(o.GCloud(), kubeClient, kube.DefaultExternalDNSReleaseName, ns,
+					requirements.Cluster.ClusterName, requirements.Cluster.ProjectID)
 				if err != nil {
 					return errors.Wrap(err, "creating the ExternalDNS GCP Service Account")
 				}
 				// lets rerun the verify step to ensure its all sorted now
-				err = kube.ValidateSecret(kubeClient, serviceAccountName, externaldns.ServiceAccountSecretKey, ns)
+				err = kube.ValidateSecret(kubeClient, cloudDnsSecretName, externaldns.ServiceAccountSecretKey, ns)
 			}
 		}
 		if err != nil {

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -148,6 +148,9 @@ type TLSConfig struct {
 	// Production false uses self-signed certificates from the LetsEncrypt staging server, true enables the production
 	// server which incurs higher rate limiting https://letsencrypt.org/docs/rate-limits/
 	Production bool `json:"production"`
+	// CloudDnsSecretName secret name which contains the service account for external-dns and cert-manager issuer to
+	// access the Cloud DNS service to resolve a DNS challenge
+	CloudDnsSecretName string `json:"cloud_dns_secret_name,omitempty"`
 }
 
 // JxInstallProfile contains the jx profile info

--- a/pkg/kube/secrets.go
+++ b/pkg/kube/secrets.go
@@ -76,7 +76,6 @@ func DefaultModifySecret(kubeClient kubernetes.Interface, ns string, name string
 
 // ValidateSecret checks a given secret and key exists in the provided namespace
 func ValidateSecret(kubeClient kubernetes.Interface, secretName, key, ns string) error {
-
 	secret, err := kubeClient.CoreV1().Secrets(ns).Get(secretName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "could not find the Secret %s in the namespace: %s", secretName, ns)


### PR DESCRIPTION
Use the default name when is not configured and update the value back into the requirements file.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

part of #5310
fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->