### PR TITLE
feat: allow vault to be configured in cluster

### DIFF
--- a/pkg/cmd/create/create_vault.go
+++ b/pkg/cmd/create/create_vault.go
@@ -2,6 +2,7 @@ package create
 
 import (
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts/upgrade"
@@ -62,6 +63,7 @@ type CreateVaultOptions struct {
 
 	GKECreateVaultOptions
 	kubevault.AWSConfig
+	ClusterName         string
 	Namespace           string
 	SecretsPathPrefix   string
 	RecreateVaultBucket bool
@@ -107,13 +109,14 @@ func NewCmdCreateVault(commonOpts *opts.CommonOptions) *cobra.Command {
 
 	awsCreateVaultOptions(cmd, &options.AWSConfig)
 
+	cmd.Flags().StringVarP(&options.ClusterName, "cluster-name", "", "", "Name of the cluster to install vault")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "Namespace where the Vault is created")
 	cmd.Flags().StringVarP(&options.SecretsPathPrefix, "secrets-path-prefix", "p", vault.DefaultSecretsPathPrefix, "Path prefix for secrets used for access control config")
 	cmd.Flags().BoolVarP(&options.RecreateVaultBucket, "recreate", "", true, "If the bucket already exists delete it so its created empty for the vault")
 	cmd.Flags().BoolVarP(&options.NoExposeVault, "no-expose", "", false, "If enabled disable the exposing of the vault")
 	cmd.Flags().StringVarP(&options.BucketName, "bucket-name", "", "", "Specify the bucket name. If empty then the bucket name will be based on the vault name")
-	cmd.Flags().StringVarP(&options.BucketName, "keyring-name", "", "", "Specify the KMS Keyring name. If empty then tehe keyring name will be based on the vault name")
-	cmd.Flags().StringVarP(&options.BucketName, "service-account-name", "", "", "Specify Service Account name used. If empty then the service account name will be based on the vault name")
+	cmd.Flags().StringVarP(&options.KeyringName, "keyring-name", "", "", "Specify the KMS Keyring name. If empty then tehe keyring name will be based on the vault name")
+	cmd.Flags().StringVarP(&options.ServiceAccountName, "service-account-name", "", "", "Specify Service Account name used. If empty then the service account name will be based on the vault name")
 
 	return cmd
 }
@@ -189,10 +192,21 @@ func (o *CreateVaultOptions) CreateVault(vaultOperatorClient versioned.Interface
 	if err != nil {
 		return err
 	}
-	clusterName, err := cluster.ShortName(o.Kube())
-	if err != nil {
-		return err
+
+	var clusterName string
+	if o.ClusterName == "" {
+		clusterName, err = cluster.ShortName(o.Kube())
+		if err != nil {
+			return err
+		}
+	} else {
+		clusterName = naming.ToValidNameTruncated(o.ClusterName, 16)
 	}
+
+	if clusterName == "" {
+		return errors.Wrap(err, "unable to determine the cluster name")
+	}
+
 	log.Logger().Debugf("cluster short name for vault naming: %s", util.ColorInfo(clusterName))
 	vaultAuthServiceAccount, err := CreateAuthServiceAccount(kubeClient, vaultName, o.ServiceAccountName, o.Namespace, clusterName)
 	if err != nil {

--- a/pkg/cmd/step/boot/step_boot_vault.go
+++ b/pkg/cmd/step/boot/step_boot_vault.go
@@ -97,6 +97,8 @@ func (o *StepBootVaultOptions) Run() error {
 		requirements.Vault.Name = kubevault.SystemVaultNameForCluster(requirements.Cluster.ClusterName)
 	}
 
+	log.Logger().Debugf("Using vault name '%s'", requirements.Vault.Name)
+
 	noExposeVault, err := o.verifyVaultIngress(requirements, kubeClient, ns, requirements.Vault.Name)
 	if err != nil {
 		return err
@@ -126,6 +128,7 @@ func (o *StepBootVaultOptions) Run() error {
 		BucketName:          requirements.Vault.Bucket,
 		KeyringName:         requirements.Vault.Keyring,
 		ServiceAccountName:  requirements.Vault.ServiceAccount,
+		ClusterName:         requirements.Cluster.ClusterName,
 		// TODO - load from a local yaml file if available?
 		// AWSConfig:           o.AWSConfig,
 	}


### PR DESCRIPTION
PR allows clusterName & vaultServiceAccount name to be configured from the 
jx-requirements.yml when installing from `jx boot`