### PR TITLE
feat: add ability to skip linter

### DIFF
--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -2,6 +2,11 @@
 
 set -e -o pipefail
 
+if [ $DISABLE_LINTER == "true" ]
+then
+  exit 0
+fi
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if ! [ -x "$(command -v golangci-lint)" ]; then


### PR DESCRIPTION
Signed-off-by: Cai Cooper <caicooper82@gmail.com>

Allow the ability to disable the linter check performed during the pre-commit phase by adding the following environment variable `DISABLE_LINTER="true"`