### PR TITLE
fix: Revert update to latest cert-manager

### DIFF
--- a/jx/bdd/tekton/ci.sh
+++ b/jx/bdd/tekton/ci.sh
@@ -33,4 +33,19 @@ git config --global --add user.name JenkinsXBot
 git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
-jx step bdd --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/tekton/cluster.yaml --gopath /tmp  --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_ACCESS_TOKEN --default-admin-password $JENKINS_PASSWORD --no-delete-app --no-delete-repo --tekton --tests install --tests test-create-spring --tests test-quickstart-golang-http --tests test-import-golang-http-from-jenkins-x-yml
+jx step bdd --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+  --config jx/bdd/tekton/cluster.yaml \
+  --gopath /tmp  \
+  --git-provider=github \
+  --git-username $GH_USERNAME \
+  --git-owner $GH_OWNER \
+  --git-api-token $GH_ACCESS_TOKEN \
+  --default-admin-password $JENKINS_PASSWORD \
+  --no-delete-app \
+  --no-delete-repo \
+  --tekton \
+  --tests install \
+  --tests test-upgrade-ingress \
+  --tests test-create-spring \
+  --tests test-quickstart-golang-http \
+  --tests test-import-golang-http-from-jenkins-x-yml

--- a/pkg/cmd/opts/cert_manager.go
+++ b/pkg/cmd/opts/cert_manager.go
@@ -37,13 +37,6 @@ func (o *CommonOptions) EnsureCertManager() error {
 			}
 			log.Logger().Info(output)
 
-			log.Logger().Infof("Ensuring helm repo %q at %q for cert-manager chart is configured", pki.CertManagerChartOwner,
-				pki.CertManagerChartURL)
-			err = o.helm.AddRepo(pki.CertManagerChartOwner, pki.CertManagerChartURL, "", "")
-			if err != nil {
-				return errors.Wrapf(err, "adding helm repo %q", pki.CertManagerChartOwner)
-			}
-
 			log.Logger().Infof("Installing the chart %q in namespace %q...", pki.CertManagerChart, pki.CertManagerNamespace)
 			values := []string{
 				"rbac.create=true",

--- a/pkg/kube/pki/cert-manager.go
+++ b/pkg/kube/pki/cert-manager.go
@@ -17,14 +17,10 @@ const (
 	CertManagerDeployment = "cert-manager"
 	// CertManagerReleaseName indicates the release name for cert-manager chart
 	CertManagerReleaseName = "cert-manager"
-	// CertManagerChartOwner is the owner of the cert-manager chart repo
-	CertManagerChartOwner = "jetstack"
-	// CertManagerChartURL is the URL for the repo containing the cert-manager chart
-	CertManagerChartURL = "https://charts.jetstack.io"
 	// CertManagerChart name of the cert-manager chart
-	CertManagerChart = "jetstack/cert-manager"
+	CertManagerChart = "stable/cert-manager"
 	// CertManagerCRDsFile files which contains the cert-manager CRDs
-	CertManagerCRDsFile = "https://raw.githubusercontent.com/jetstack/cert-manager/v0.9.1/deploy/manifests/00-crds.yaml"
+	CertManagerCRDsFile = "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml"
 
 	// CertManagerIssuerProd name of the production issuer
 	CertManagerIssuerProd       = "letsencrypt-prod"


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Something in `upgrade ingress` does not want to work with the newer cert-manager, so let's revert. Also adds the `upgrade ingress` BDD test to the Tekton context here so this can't happen again.

Reverts https://github.com/jenkins-x/jx/pull/5464 and #5508.

#### Special notes for the reviewer(s)

/assign @pmuir 
/assign @jstrachan 

#### Which issue this PR fixes

n/a
