### PR TITLE
fix: removing sourcerepository label from PipelineActivity

### DIFF
--- a/pkg/apis/jenkins.io/v1/types_pipeline.go
+++ b/pkg/apis/jenkins.io/v1/types_pipeline.go
@@ -7,14 +7,13 @@ import (
 )
 
 const (
-	LabelSourceRepository = "sourcerepository"
-	LabelProvider         = "provider"
-	LabelOwner            = "owner"
-	LabelRepository       = "repository"
-	LabelBranch           = "branch"
-	LabelBuild            = "build"
-	LabelLastCommitSha    = "lastCommitSha"
-	LabelContext          = "context"
+	LabelProvider      = "provider"
+	LabelOwner         = "owner"
+	LabelRepository    = "repository"
+	LabelBranch        = "branch"
+	LabelBuild         = "build"
+	LabelLastCommitSha = "lastCommitSha"
+	LabelContext       = "context"
 )
 
 // +genclient

--- a/pkg/kube/activity_test.go
+++ b/pkg/kube/activity_test.go
@@ -377,10 +377,9 @@ func TestBatchReconciliationWithTwoPRBuildExecutions(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: prPAName,
 			Labels: map[string]string{
-				v1.LabelBranch:           "PR-1",
-				v1.LabelLastCommitSha:    "sha1",
-				v1.LabelBuild:            "1",
-				v1.LabelSourceRepository: fmt.Sprintf("%s-%s", expectedOrganisation, expectedName),
+				v1.LabelBranch:        "PR-1",
+				v1.LabelLastCommitSha: "sha1",
+				v1.LabelBuild:         "1",
 			},
 		},
 		Spec: v1.PipelineActivitySpec{
@@ -399,10 +398,9 @@ func TestBatchReconciliationWithTwoPRBuildExecutions(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: batchPAName,
 			Labels: map[string]string{
-				v1.LabelBranch:           "batch",
-				v1.LabelLastCommitSha:    "testSha",
-				v1.LabelBuild:            expectedBatchBuild,
-				v1.LabelSourceRepository: fmt.Sprintf("%s-%s", expectedOrganisation, expectedName),
+				v1.LabelBranch:        "batch",
+				v1.LabelLastCommitSha: "testSha",
+				v1.LabelBuild:         expectedBatchBuild,
 			},
 		},
 		Spec: v1.PipelineActivitySpec{


### PR DESCRIPTION
Since the label was a combination of repo owner and name there was a chance
it exceeded the 63 char limit of labels.
Where necessary the label were replaced with field selectors.

fixes #5515

