### PR TITLE
fix(pipeline): Pass pull refs for metapipeline to PipelineActivity

### DIFF
--- a/pkg/tekton/metapipeline/clientfactory.go
+++ b/pkg/tekton/metapipeline/clientfactory.go
@@ -144,7 +144,8 @@ func (c *clientFactory) Create(param PipelineCreateParam) (kube.PromoteStepActiv
 		return kube.PromoteStepActivityKey{}, tekton.CRDWrapper{}, errors.Wrap(err, "failed to generate Tekton CRDs for meta pipeline")
 	}
 
-	pipelineActivity := tekton.GeneratePipelineActivity(buildNumber, branchIdentifier, gitInfo, param.Context, &tekton.PullRefs{})
+	pr, _ := tekton.ParsePullRefs(param.PullRef.String())
+	pipelineActivity := tekton.GeneratePipelineActivity(buildNumber, branchIdentifier, gitInfo, param.Context, pr)
 
 	return *pipelineActivity, *tektonCRDs, nil
 }


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We're not passing the pull refs to the `PipelineActivity` for metapipelines, which causes things like batch reconciliation not to be performed. This was surfaced in the process of investigating #5539.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

fixes #5552 