### PR TITLE
fix: correct and add storage overrides for boot override step

### DIFF
--- a/pkg/cmd/step/step_override_requirements.go
+++ b/pkg/cmd/step/step_override_requirements.go
@@ -132,7 +132,13 @@ func (o *StepOverrideRequirementsOptions) overrideRequirements(requirements *con
 		webhookString := os.Getenv(config.RequirementWebhook)
 		requirements.Webhook = config.WebhookType(webhookString)
 	}
-
+	if "" != os.Getenv(config.RequirementStorageBackupEnabled) {
+		storageBackup := os.Getenv(config.RequirementStorageBackupEnabled)
+		if storageBackup == "true" && "" != os.Getenv(config.RequirementStorageBackupURL) {
+			requirements.Storage.Backup.Enabled = true
+			requirements.Storage.Backup.URL = os.Getenv(config.RequirementStorageBackupURL)
+		}
+	}
 	if "" != os.Getenv(config.RequirementStorageLogsEnabled) {
 		storageLogs := os.Getenv(config.RequirementStorageLogsEnabled)
 		if storageLogs == "true" && "" != os.Getenv(config.RequirementStorageLogsURL) {

--- a/pkg/cmd/step/step_override_requirements.go
+++ b/pkg/cmd/step/step_override_requirements.go
@@ -134,30 +134,24 @@ func (o *StepOverrideRequirementsOptions) overrideRequirements(requirements *con
 	}
 
 	if "" != os.Getenv(config.RequirementStorageLogsEnabled) {
-		storageLogs := config.RequirementStorageLogsEnabled
-		if storageLogs == "true" {
+		storageLogs := os.Getenv(config.RequirementStorageLogsEnabled)
+		if storageLogs == "true" && "" != os.Getenv(config.RequirementStorageLogsURL) {
 			requirements.Storage.Logs.Enabled = true
-			if "" != os.Getenv(config.RequirementStorageLogsURL) {
-				requirements.Storage.Logs.URL = os.Getenv(config.RequirementStorageLogsURL)
-			}
+			requirements.Storage.Logs.URL = os.Getenv(config.RequirementStorageLogsURL)
 		}
 	}
 	if "" != os.Getenv(config.RequirementStorageReportsEnabled) {
-		storageReports := config.RequirementStorageReportsEnabled
-		if storageReports == "true" {
+		storageReports := os.Getenv(config.RequirementStorageReportsEnabled)
+		if storageReports == "true" && "" != os.Getenv(config.RequirementStorageReportsURL) {
 			requirements.Storage.Reports.Enabled = true
-			if "" != os.Getenv(config.RequirementStorageReportsURL) {
-				requirements.Storage.Reports.URL = os.Getenv(config.RequirementStorageReportsURL)
-			}
+			requirements.Storage.Reports.URL = os.Getenv(config.RequirementStorageReportsURL)
 		}
 	}
 	if "" != os.Getenv(config.RequirementStorageRepositoryEnabled) {
-		storageRepository := config.RequirementStorageRepositoryEnabled
-		if storageRepository == "true" {
+		storageRepository := os.Getenv(config.RequirementStorageRepositoryEnabled)
+		if storageRepository == "true" && "" != os.Getenv(config.RequirementStorageRepositoryURL) {
 			requirements.Storage.Repository.Enabled = true
-			if "" != os.Getenv(config.RequirementStorageRepositoryURL) {
-				requirements.Storage.Repository.URL = os.Getenv(config.RequirementStorageRepositoryURL)
-			}
+			requirements.Storage.Repository.URL = os.Getenv(config.RequirementStorageRepositoryURL)
 		}
 	}
 	log.Logger().Debugf("saving %s", requirementsFileName)

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -73,6 +73,10 @@ const (
 	RequirementIngressTLSProduction = "JX_REQUIREMENT_INGRESS_TLS_PRODUCTION"
 	// RequirementWebhook the webhook handler for jx
 	RequirementWebhook = "JX_REQUIREMENT_WEBHOOK"
+	// RequirementStorageBackupEnabled if backup storage is required
+	RequirementStorageBackupEnabled = "JX_REQUIREMENT_STORAGE_BACKUP_ENABLED"
+	// RequirementStorageBackupURL backup storage url
+	RequirementStorageBackupURL = "JX_REQUIREMENT_STORAGE_BACKUP_URL"
 	// RequirementStorageLogsEnabled if log storage is required
 	RequirementStorageLogsEnabled = "JX_REQUIREMENT_STORAGE_LOGS_ENABLED"
 	// RequirementStorageLogsURL logs storage url


### PR DESCRIPTION
The storage enabled check for each storage was not being populated correctly during the override step, this should now populate the local field correctly so that it can determine whether it's enabled or not.

The backup storage enabled and url can now also be overridden using an environment variable.