### PR TITLE
fix: move activity_integration_test.go into dedicated package

### DIFF
--- a/pkg/kube/test_integration/activity_integration_test.go
+++ b/pkg/kube/test_integration/activity_integration_test.go
@@ -1,6 +1,6 @@
 // +build integration
 
-package kube_test
+package test_integration_test
 
 import (
 	"fmt"
@@ -53,8 +53,6 @@ var _ = Describe("PipelineActivity", func() {
 
 			err = createNamespace(kubeClient, testNamespace)
 			Expect(err).Should(BeNil())
-
-			testPipelineActivities = nil
 		})
 
 		BeforeEach(func() {

--- a/pkg/kube/test_integration/doc.go
+++ b/pkg/kube/test_integration/doc.go
@@ -1,0 +1,3 @@
+package test_integration
+
+// Integration tests for PipelineActivity


### PR DESCRIPTION
fixes #5556

