### PR TITLE
fix: Don't include successful metapipeline in logs

### DIFF
--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -723,7 +723,7 @@ func (o *ControllerBuildOptions) updatePipelineActivityForRun(kubeClient kuberne
 		}
 
 		// Only complete the job if it's failed, or if it's finished and the PRI we're looking at is _not_ the metapipeline
-		if spec.Status == v1.ActivityStatusTypeFailed || (spec.Status.IsTerminated() && pri.Type != tekton.MetaPipeline) {
+		if spec.Status == v1.ActivityStatusTypeFailed || (spec.Status.IsTerminated() && pri.Type != tekton.MetaPipeline.String()) {
 			if !biggestFinishedAt.IsZero() {
 				spec.CompletedTimestamp = &biggestFinishedAt
 			}
@@ -1396,7 +1396,7 @@ func logJobCompletedState(activity *v1.PipelineActivity, pri *tekton.PipelineRun
 	}
 	if pri != nil {
 		fields["pipelineRunInfo"] = pri.Name
-		fields["pipelineRunType"] = pri.Type.String()
+		fields["pipelineRunType"] = pri.Type
 	}
 	log.Logger().WithFields(fields).Infof("Build %s %s", activity.Name, activity.Spec.Status)
 }

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelineruns.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelineruns.yml
@@ -10,6 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1
@@ -97,6 +98,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: build
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: cb-kubecd-bdd-spring-1568135191-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelineruns.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelineruns.yml
@@ -10,7 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1
@@ -98,7 +98,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: build
+      jenkins.io/pipelineType: build
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: cb-kubecd-bdd-spring-1568135191-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelines.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelines.yml
@@ -10,6 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: meta-cb-kubecd-bdd-spring-15681-1
@@ -44,6 +45,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: build
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: cb-kubecd-bdd-spring-1568135191-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelines.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pipelines.yml
@@ -10,7 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: meta-cb-kubecd-bdd-spring-15681-1
@@ -45,7 +45,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: build
+      jenkins.io/pipelineType: build
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: cb-kubecd-bdd-spring-1568135191-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pods.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pods.yml
@@ -12,7 +12,7 @@ items:
       created-by-prow: "true"
       jenkins.io/task-stage-name: meta-pipeline
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1
@@ -745,7 +745,7 @@ items:
       created-by-prow: "true"
       jenkins.io/task-stage-name: from-build-pack
       owner: cb-kubecd
-      pipelineType: build
+      jenkins.io/pipelineType: build
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: cb-kubecd-bdd-spring-1568135191-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pods.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/pods.yml
@@ -12,6 +12,7 @@ items:
       created-by-prow: "true"
       jenkins.io/task-stage-name: meta-pipeline
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1
@@ -744,6 +745,7 @@ items:
       created-by-prow: "true"
       jenkins.io/task-stage-name: from-build-pack
       owner: cb-kubecd
+      pipelineType: build
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: cb-kubecd-bdd-spring-1568135191-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/structures.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/structures.yml
@@ -10,7 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: meta-cb-kubecd-bdd-spring-15681-1
@@ -39,7 +39,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: build
+      jenkins.io/pipelineType: build
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: cb-kubecd-bdd-spring-1568135191-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/structures.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/cluster_state/structures.yml
@@ -10,6 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: meta-cb-kubecd-bdd-spring-15681-1
@@ -38,6 +39,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: build
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: cb-kubecd-bdd-spring-1568135191-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelineruns.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelineruns.yml
@@ -10,6 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelineruns.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelineruns.yml
@@ -10,7 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelines.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelines.yml
@@ -10,7 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelines.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pipelines.yml
@@ -10,6 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pods.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pods.yml
@@ -12,7 +12,7 @@ items:
       created-by-prow: "true"
       jenkins.io/task-stage-name: meta-pipeline
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pods.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/pods.yml
@@ -12,6 +12,7 @@ items:
       created-by-prow: "true"
       jenkins.io/task-stage-name: meta-pipeline
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/structures.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/structures.yml
@@ -10,7 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/structures.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/cluster_state/structures.yml
@@ -10,6 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelineruns.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelineruns.yml
@@ -10,6 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelineruns.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelineruns.yml
@@ -10,7 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelines.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelines.yml
@@ -10,7 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelines.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelines.yml
@@ -10,6 +10,7 @@ items:
       build: "1"
       created-by-prow: "true"
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
     name: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pods.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pods.yml
@@ -12,7 +12,7 @@ items:
       created-by-prow: "true"
       jenkins.io/task-stage-name: meta-pipeline
       owner: cb-kubecd
-      pipelineType: meta
+      jenkins.io/pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pods.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pods.yml
@@ -12,6 +12,7 @@ items:
       created-by-prow: "true"
       jenkins.io/task-stage-name: meta-pipeline
       owner: cb-kubecd
+      pipelineType: meta
       prowJobName: 6bae4c2b-d3ed-11e9-b0c6-72256f93bb5c
       repository: bdd-spring-1568135191
       tekton.dev/pipeline: meta-cb-kubecd-bdd-spring-15681-1

--- a/pkg/cmd/get/get_build_logs_test.go
+++ b/pkg/cmd/get/get_build_logs_test.go
@@ -345,7 +345,7 @@ func TestWithMetapipeline(t *testing.T) {
 	outBytes, _ := ioutil.ReadAll(r)
 	r.Close()
 	output := stripansi.Strip(string(outBytes))
-	assert.Contains(t, output, "stage app-extension")
+	assert.NotContains(t, output, "stage app-extension")
 	assert.Contains(t, output, "stage from-build-pack")
 }
 

--- a/pkg/cmd/get/test_data/get_build_logs/multiple_stages/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/multiple_stages/pipelinerun.yml
@@ -7,6 +7,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
     tekton.dev/pipeline: abayer-js-test-repo-master-1
   name: abayer-js-test-repo-master-1

--- a/pkg/cmd/get/test_data/get_build_logs/multiple_stages/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/multiple_stages/pipelinerun.yml
@@ -7,7 +7,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
     tekton.dev/pipeline: abayer-js-test-repo-master-1
   name: abayer-js-test-repo-master-1

--- a/pkg/cmd/get/test_data/get_build_logs/multiple_stages/pods.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/multiple_stages/pods.yml
@@ -11,7 +11,7 @@ items:
       build-number: "1"
       jenkins.io/task-stage-name: build
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
       tekton.dev/pipeline: abayer-js-test-repo-master
       tekton.dev/pipelineRun: abayer-js-test-repo-master-1

--- a/pkg/cmd/get/test_data/get_build_logs/multiple_stages/pods.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/multiple_stages/pods.yml
@@ -11,6 +11,7 @@ items:
       build-number: "1"
       jenkins.io/task-stage-name: build
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
       tekton.dev/pipeline: abayer-js-test-repo-master
       tekton.dev/pipelineRun: abayer-js-test-repo-master-1

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pipelinerun.yml
@@ -7,7 +7,7 @@ metadata:
     build: "1"
     created-by-prow: "true"
     owner: fakeowner
-    pipelineType: build
+    jenkins.io/pipelineType: build
     prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
     repository: fakerepo
     tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pipelinerun.yml
@@ -7,6 +7,7 @@ metadata:
     build: "1"
     created-by-prow: "true"
     owner: fakeowner
+    pipelineType: build
     prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
     repository: fakerepo
     tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pod.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pod.yml
@@ -9,6 +9,7 @@ metadata:
     build: "1"
     jenkins.io/task-stage-name: from-build-pack
     owner: fakeowner
+    pipelineType: build
     repository: fakerepo
     tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
     tekton.dev/pipelineRun: fakeowner-fakerepo-fakebranch-1

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pod.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs/pod.yml
@@ -9,7 +9,7 @@ metadata:
     build: "1"
     jenkins.io/task-stage-name: from-build-pack
     owner: fakeowner
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: fakerepo
     tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
     tekton.dev/pipelineRun: fakeowner-fakerepo-fakebranch-1

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pipelinerun.yml
@@ -7,7 +7,7 @@ metadata:
     build: "1"
     created-by-prow: "true"
     owner: fakeowner
-    pipelineType: build
+    jenkins.io/pipelineType: build
     prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
     repository: fakerepo
     tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pipelinerun.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pipelinerun.yml
@@ -7,6 +7,7 @@ metadata:
     build: "1"
     created-by-prow: "true"
     owner: fakeowner
+    pipelineType: build
     prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
     repository: fakerepo
     tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pod.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pod.yml
@@ -9,6 +9,7 @@ metadata:
     build: "1"
     jenkins.io/task-stage-name: app-extension
     owner: fakeowner
+    pipelineType: build
     repository: fakerepo
     tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
     tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1

--- a/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pod.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/tekton_build_logs_pending/pod.yml
@@ -9,7 +9,7 @@ metadata:
     build: "1"
     jenkins.io/task-stage-name: app-extension
     owner: fakeowner
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: fakerepo
     tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
     tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelineruns.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelineruns.yml
@@ -6,11 +6,11 @@ items:
       creationTimestamp: "2019-07-02T12:34:56Z"
       generation: 1
       labels:
-        tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
         branch: fakebranch
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
+        pipelineType: build
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
         repo: fakerepo
         tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
@@ -158,12 +158,8 @@ items:
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
+        pipelineType: meta
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
-        repo: fakerepo
-        tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
-        branch: fakebranch
-        build: "1"
-        owner: fakeowner
         repo: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
       name: meta-fakeowner-fakerepo-build-1

--- a/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelineruns.yml
+++ b/pkg/cmd/get/test_data/get_build_logs/with-metapipeline/pipelineruns.yml
@@ -10,7 +10,7 @@ items:
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
-        pipelineType: build
+        jenkins.io/pipelineType: build
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
         repo: fakerepo
         tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
@@ -158,7 +158,7 @@ items:
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
-        pipelineType: meta
+        jenkins.io/pipelineType: meta
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
         repo: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -303,8 +303,8 @@ func (o *StepCreateTaskOptions) Run() error {
 	}
 
 	// resourceName is shared across all builds of a branch, while the pipelineName is unique for each build.
-	resourceName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline, nil, "")
-	pipelineName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline, tektonClient, ns)
+	resourceName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline.String(), nil, "")
+	pipelineName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline.String(), tektonClient, ns)
 
 	exists, err = o.effectiveProjectConfigExists()
 	if err != nil {
@@ -823,6 +823,7 @@ func (o *StepCreateTaskOptions) setBuildValues() error {
 		labels[tekton.LabelContext] = o.Context
 	}
 	labels[tekton.LabelBuild] = o.BuildNumber
+	labels[tekton.LabelType] = tekton.BuildPipeline.String()
 	return o.combineLabels(labels)
 }
 

--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -434,8 +434,8 @@ func TestGenerateTektonCRDs(t *testing.T) {
 					assert.NoError(t, err)
 				}
 
-				resourceName := tekton.PipelineResourceNameFromGitInfo(createTask.GitInfo, createTask.Branch, createTask.Context, tekton.BuildPipeline, nil, "")
-				pipelineName := tekton.PipelineResourceNameFromGitInfo(createTask.GitInfo, createTask.Branch, createTask.Context, tekton.BuildPipeline, tektonClient, ns)
+				resourceName := tekton.PipelineResourceNameFromGitInfo(createTask.GitInfo, createTask.Branch, createTask.Context, tekton.BuildPipeline.String(), nil, "")
+				pipelineName := tekton.PipelineResourceNameFromGitInfo(createTask.GitInfo, createTask.Branch, createTask.Context, tekton.BuildPipeline.String(), tektonClient, ns)
 				crds, err := createTask.generateTektonCRDs(effectiveProjectConfig, ns, pipelineName, resourceName)
 				if tt.generateError != nil {
 					if err == nil {

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-golang-qs-test-master
-    retries: 0
     taskRef:
       name: abayer-golang-qs-test-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-golang-qs-test-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: golang-qs-test
     name: abayer-golang-qs-test-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: golang-qs-test
     name: abayer-golang-qs-test-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx
@@ -30,7 +31,6 @@ spec:
       outputs:
       - name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
   - name: second
@@ -43,7 +43,6 @@ spec:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -20,11 +21,13 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     outputs:
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: ""
         type: git
     steps:
@@ -230,6 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx
@@ -242,6 +246,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -233,7 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-jx-demo-qs-master
-    retries: 0
     taskRef:
       name: abayer-jx-demo-qs-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-jx-demo-qs-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx
@@ -43,7 +44,6 @@ spec:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -20,11 +21,13 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     outputs:
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: ""
         type: git
     steps:
@@ -166,6 +169,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx
@@ -178,6 +182,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -169,7 +169,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-jx-demo-qs-master
-    retries: 0
     taskRef:
       name: abayer-jx-demo-qs-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-jx-demo-qs-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-jx-demo-qs-master
-    retries: 0
     taskRef:
       name: abayer-jx-demo-qs-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-jx-demo-qs-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx
@@ -30,7 +31,6 @@ spec:
       outputs:
       - name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
   - name: second
@@ -43,7 +43,6 @@ spec:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -20,11 +21,13 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     outputs:
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: ""
         type: git
     steps:
@@ -230,6 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx
@@ -242,6 +246,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -233,7 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-golang-qs-test-master
-    retries: 0
     taskRef:
       name: abayer-golang-qs-test-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-golang-qs-test-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: golang-qs-test
     name: abayer-golang-qs-test-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: golang-qs-test
     name: abayer-golang-qs-test-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx
@@ -30,7 +31,6 @@ spec:
       outputs:
       - name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
   - name: second
@@ -43,7 +43,6 @@ spec:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -20,11 +21,13 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     outputs:
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: ""
         type: git
     steps:
@@ -230,6 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx
@@ -242,6 +246,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -233,7 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx
@@ -30,7 +31,6 @@ spec:
       outputs:
       - name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
   - name: second
@@ -43,7 +43,6 @@ spec:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelinerun.yml
@@ -6,18 +6,19 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
+      - podAffinityTerm:
           labelSelector:
             matchLabels:
               tekton.dev/pipelineRun: abayer-js-test-repo-really-long-1
           topologyKey: failure-domain.beta.kubernetes.io/zone
+        weight: 100
   params:
   - name: version
     value: 0.0.1
@@ -31,6 +32,4 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -20,11 +21,13 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     outputs:
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: ""
         type: git
     steps:
@@ -230,6 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx
@@ -242,6 +246,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -233,7 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx
@@ -30,7 +31,6 @@ spec:
       outputs:
       - name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
   - name: second
@@ -43,7 +43,6 @@ spec:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -20,11 +21,13 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     outputs:
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: ""
         type: git
     steps:
@@ -230,6 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx
@@ -242,6 +246,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -233,7 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: build-pack
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-build-pack-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-js-test-repo-build-pack
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-build-pack-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: build-pack
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-build-pack-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: build-pack
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-build-pack-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-build-pack
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: build-pack
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-build-pack-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: build-pack
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-build-pack-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: build-pack
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-build-pack-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-build-pack-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-build-pack-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: fix-kaniko-special-casing
     build: "1"
     owner: jenkins-x
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx
   name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: fix-kaniko-special-casing
     build: "1"
     owner: jenkins-x
+    pipelineType: build
     repository: jx
   name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: jenkins-x-jx-fix-kaniko-special
-    retries: 0
     taskRef:
       name: jenkins-x-jx-fix-kaniko-special-9l9zj-ci-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: fix-kaniko-special-casing
     build: "1"
     owner: jenkins-x
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx
   name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: fix-kaniko-special-casing
     build: "1"
     owner: jenkins-x
+    pipelineType: build
     repository: jx
   name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: jenkins-x-jx-fix-kaniko-special
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: fix-kaniko-special-casing
     build: "1"
     owner: jenkins-x
+    pipelineType: build
     repository: jx
   name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: fix-kaniko-special-casing
     build: "1"
     owner: jenkins-x
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx
   name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: ci
       owner: jenkins-x
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: jx
     name: jenkins-x-jx-fix-kaniko-special-9l9zj-ci-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: ci
       owner: jenkins-x
+      pipelineType: build
       repository: jx
     name: jenkins-x-jx-fix-kaniko-special-9l9zj-ci-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-jx-demo-qs-master
-    retries: 0
     taskRef:
       name: abayer-jx-demo-qs-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-jx-demo-qs-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-jx-demo-qs-master
-    retries: 0
     taskRef:
       name: abayer-jx-demo-qs-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-jx-demo-qs-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: override-default-agent
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-override-de-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-js-test-repo-override-de
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-override-de-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: override-default-agent
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-override-de-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: override-default-agent
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-override-de-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: override-default-agent
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-override-de-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-override-de
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: override-default-agent
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-override-de-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: override-default-agent
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-override-de-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-override-de-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-override-de-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-golang-qs-test-master
-    retries: 0
     taskRef:
       name: abayer-golang-qs-test-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-golang-qs-test-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: golang-qs-test
     name: abayer-golang-qs-test-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: golang-qs-test
     name: abayer-golang-qs-test-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx
@@ -30,7 +31,6 @@ spec:
       outputs:
       - name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
   - name: second
@@ -43,7 +43,6 @@ spec:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -20,11 +21,13 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     outputs:
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: ""
         type: git
     steps:
@@ -230,6 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx
@@ -242,6 +246,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -233,7 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-jx-demo-qs-master
-    retries: 0
     taskRef:
       name: abayer-jx-demo-qs-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-jx-demo-qs-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-golang-qs-test-master
-    retries: 0
     taskRef:
       name: abayer-golang-qs-test-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-golang-qs-test-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: golang-qs-test
     name: abayer-golang-qs-test-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: golang-qs-test
     name: abayer-golang-qs-test-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-golang-qs-test-master
-    retries: 0
     taskRef:
       name: abayer-golang-qs-test-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-golang-qs-test-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: golang-qs-test
   name: abayer-golang-qs-test-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: golang-qs-test
     name: abayer-golang-qs-test-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: golang-qs-test
     name: abayer-golang-qs-test-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx
@@ -30,7 +31,6 @@ spec:
       outputs:
       - name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
   - name: second
@@ -43,7 +43,6 @@ spec:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 10h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -20,11 +21,13 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     outputs:
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: ""
         type: git
     steps:
@@ -230,6 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx
@@ -242,6 +246,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -233,7 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-jx-demo-qs-master
-    retries: 0
     taskRef:
       name: abayer-jx-demo-qs-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-jx-demo-qs-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx
@@ -30,7 +31,6 @@ spec:
       outputs:
       - name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
   - name: second
@@ -43,7 +43,6 @@ spec:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
         resource: abayer-js-test-repo-really-long
-    retries: 0
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: really-long
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -20,11 +21,13 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     outputs:
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: ""
         type: git
     steps:
@@ -230,6 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx
@@ -242,6 +246,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
     namespace: jx
@@ -233,7 +233,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: second
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-really-long-second-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-jx-demo-qs-master
-    retries: 0
     taskRef:
       name: abayer-jx-demo-qs-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-jx-demo-qs-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: no-default-agent
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-no-default-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: no-default-agent
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-no-default-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-js-test-repo-no-default
-    retries: 0
     taskRef:
       name: abayer-js-test-repo-no-default-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: no-default-agent
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-no-default-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: no-default-agent
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-no-default-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-js-test-repo-no-default
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: no-default-agent
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-no-default-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: no-default-agent
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: js-test-repo
   name: abayer-js-test-repo-no-default-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-no-default-from-build-pack-1
     namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: js-test-repo
     name: abayer-js-test-repo-no-default-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipeline.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipeline.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
   namespace: jx
@@ -27,7 +28,6 @@ spec:
       inputs:
       - name: workspace
         resource: abayer-jx-demo-qs-master
-    retries: 0
     taskRef:
       name: abayer-jx-demo-qs-master-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelinerun.yml
@@ -6,6 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:
@@ -22,6 +23,4 @@ spec:
       name: abayer-jx-demo-qs-master
   serviceAccount: tekton-bot
   timeout: 240h0m0s
-  trigger:
-    type: manual
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelinerun.yml
@@ -6,7 +6,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/structure.yml
@@ -4,6 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
+    pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/structure.yml
@@ -4,7 +4,7 @@ metadata:
     branch: master
     build: "1"
     owner: abayer
-    pipelineType: build
+    jenkins.io/pipelineType: build
     repository: jx-demo-qs
   name: abayer-jx-demo-qs-master-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
@@ -8,6 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
+      pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx
@@ -20,6 +21,7 @@ items:
         name: version
       resources:
       - name: workspace
+        outputImageDir: ""
         targetPath: source
         type: git
     steps:

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
@@ -8,7 +8,7 @@ items:
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      pipelineType: build
+      jenkins.io/pipelineType: build
       repository: jx-demo-qs
     name: abayer-jx-demo-qs-master-from-build-pack-1
     namespace: jx

--- a/pkg/logs/test_data/metapipeline_failure/pipelineruns.yml
+++ b/pkg/logs/test_data/metapipeline_failure/pipelineruns.yml
@@ -9,7 +9,7 @@ items:
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
-        pipelineType: meta
+        jenkins.io/pipelineType: meta
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
         repository: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1

--- a/pkg/logs/test_data/metapipeline_failure/pipelineruns.yml
+++ b/pkg/logs/test_data/metapipeline_failure/pipelineruns.yml
@@ -41,45 +41,8 @@ items:
       completionTime: "2019-09-10T17:08:23Z"
       conditions:
         - lastTransitionTime: "2019-09-10T17:08:23Z"
-          message: All Tasks have completed executing
-          reason: Succeeded
-          status: "True"
+          message: TaskRun meta-fakeowner-fakerepo-build-1-app-extension-kvvp6 has failed
+          reason: Failed
+          status: "False"
           type: Succeeded
       startTime: "2019-09-10T17:07:08Z"
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineRun
-    metadata:
-      generation: 1
-      labels:
-        branch: fakebranch
-        build: "1"
-        created-by-prow: "true"
-        owner: fakeowner
-        pipelineType: build
-        prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
-        repository: fakerepo
-        tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
-      name: fakeowner-fakerepo-fakebranch-1
-      namespace: jx
-      ownerReferences:
-        - apiVersion: tekton.dev/v1alpha1
-          kind: pipeline
-          name: fakeowner-fakerepo-fakebranch-1
-          uid: 3fe9c5ff-9da8-11e9-8283-42010a840060
-      selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/fakeowner-fakerepo-fakebranch-1
-    spec:
-      params:
-        - name: version
-          value: 0.0.1
-        - name: build_id
-          value: "1"
-      pipelineRef:
-        apiVersion: tekton.dev/v1alpha1
-        name: fakeowner-fakerepo-fakebranch-1
-      resources:
-        - name: fakeowner-fakerepo-fakebranch
-          resourceRef:
-            apiVersion: tekton.dev/v1alpha1
-            name: fakeowner-fakerepo-fakebranch
-      serviceAccount: tekton-bot
-      timeout: 240h0m0s

--- a/pkg/logs/test_data/metapipeline_failure/pods.yml
+++ b/pkg/logs/test_data/metapipeline_failure/pods.yml
@@ -11,7 +11,7 @@ items:
         build: "1"
         jenkins.io/task-stage-name: app-extension
         owner: fakeowner
-        pipelineType: meta
+        jenkins.io/pipelineType: meta
         repository: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
         tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1

--- a/pkg/logs/test_data/metapipeline_failure/pods.yml
+++ b/pkg/logs/test_data/metapipeline_failure/pods.yml
@@ -1,0 +1,504 @@
+apiVersion: v1
+items:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      creationTimestamp: "2019-07-02T12:34:45Z"
+      labels:
+        branch: fakebranch
+        build: "1"
+        jenkins.io/task-stage-name: app-extension
+        owner: fakeowner
+        pipelineType: meta
+        repository: fakerepo
+        tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
+        tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1
+        tekton.dev/task: meta-fakeowner-fakerepo-build-app-extension-8
+        tekton.dev/taskRun: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6
+      name: meta-fakewoenr-fakerepo-build-1-app-extension-kvvp6-pod-fcf1fe
+      namespace: jx
+      ownerReferences:
+        - apiVersion: tekton.dev/v1alpha1
+          blockOwnerDeletion: true
+          controller: true
+          kind: TaskRun
+          name: meta-fakeowner-fakerepo-build-1-app-extension-kvvp6
+          uid: c5c20379-9cc5-11e9-aa2e-42010a8a00fe
+      resourceVersion: "235888"
+      selfLink: /api/v1/namespaces/jx/pods/meta-fakeowner-fakerepo-build-1-app-extension-kvvp6-pod-fcf1fe
+      uid: c5c6d6f9-9cc5-11e9-aa2e-42010a8a00fe
+    spec:
+      containers:
+        - args:
+            - -wait_file
+            - ""
+            - -post_file
+            - /builder/tools/0
+            - -entrypoint
+            - /ko-app/git-init
+            - --
+            - -url
+            - https://github.com/fakeowner/fakerepo
+            - -revision
+            - fakebranch
+            - -path
+            - /workspace/source
+          command:
+            - /builder/tools/entrypoint
+          env:
+            - name: HOME
+              value: /builder/home
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.4.0
+          imagePullPolicy: IfNotPresent
+          name: build-step-git-source-meta-fakeowner-fakerepo-build-v7hvv
+          resources:
+            requests:
+              cpu: "0"
+              ephemeral-storage: "0"
+              memory: "0"
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /builder/tools
+              name: tools
+            - mountPath: /workspace
+              name: workspace
+            - mountPath: /builder/home
+              name: home
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: tekton-bot-token-kbbrz
+              readOnly: true
+          workingDir: /workspace
+        - args:
+            - -wait_file
+            - /builder/tools/0
+            - -post_file
+            - /builder/tools/1
+            - -entrypoint
+            - jx
+            - --
+            - step
+            - git
+            - merge
+            - --verbose
+          command:
+            - /builder/tools/entrypoint
+          env:
+            - name: HOME
+              value: /builder/home
+            - name: APP_NAME
+              value: fakerepo
+            - name: BRANCH_NAME
+              value: fakebranch
+            - name: BUILD_NUMBER
+              value: "1"
+            - name: JOB_NAME
+              value: fakeowner/fakerepo/fakebranch
+            - name: JX_LOG_FORMAT
+              value: json
+            - name: PIPELINE_KIND
+              value: release
+            - name: REPO_NAME
+              value: fakerepo
+            - name: REPO_OWNER
+              value: fakeowner
+          image: gcr.io/jenkinsxio/builder-maven:0.1.542
+          imagePullPolicy: IfNotPresent
+          name: build-step-git-merge
+          resources:
+            requests:
+              cpu: "0"
+              ephemeral-storage: "0"
+              memory: "0"
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /builder/tools
+              name: tools
+            - mountPath: /workspace
+              name: workspace
+            - mountPath: /builder/home
+              name: home
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: tekton-bot-token-kbbrz
+              readOnly: true
+          workingDir: /workspace/source
+        - args:
+            - -wait_file
+            - /builder/tools/1
+            - -post_file
+            - /builder/tools/2
+            - -entrypoint
+            - /bin/sh
+            - --
+            - -c
+            - jx step syntax effective --output-dir .
+          command:
+            - /builder/tools/entrypoint
+          env:
+            - name: HOME
+              value: /builder/home
+            - name: APP_NAME
+              value: fakerepo
+            - name: BRANCH_NAME
+              value: fakebranch
+            - name: BUILD_NUMBER
+              value: "1"
+            - name: JOB_NAME
+              value: fakeowner/fakerepo/fakebranch
+            - name: JX_LOG_FORMAT
+              value: json
+            - name: PIPELINE_KIND
+              value: release
+            - name: REPO_NAME
+              value: fakerepo
+            - name: REPO_OWNER
+              value: fakeowner
+          image: gcr.io/jenkinsxio/builder-maven:0.1.542
+          imagePullPolicy: IfNotPresent
+          name: build-step-create-effective-pipeline
+          resources:
+            requests:
+              cpu: "0"
+              ephemeral-storage: "0"
+              memory: "0"
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /builder/tools
+              name: tools
+            - mountPath: /workspace
+              name: workspace
+            - mountPath: /builder/home
+              name: home
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: tekton-bot-token-kbbrz
+              readOnly: true
+          workingDir: /workspace/source
+        - args:
+            - -wait_file
+            - /builder/tools/2
+            - -post_file
+            - /builder/tools/3
+            - -entrypoint
+            - /bin/sh
+            - --
+            - -c
+            - jx step create task --clone-dir /workspace/source --build-number 8 --trigger
+              manual --service-account tekton-bot --source source --branch fakebranch
+          command:
+            - /builder/tools/entrypoint
+          env:
+            - name: HOME
+              value: /builder/home
+            - name: APP_NAME
+              value: fakerepo
+            - name: BRANCH_NAME
+              value: fakebranch
+            - name: BUILD_NUMBER
+              value: "1"
+            - name: JOB_NAME
+              value: fakeowner/fakerepo/fakebranch
+            - name: JX_LOG_FORMAT
+              value: json
+            - name: PIPELINE_KIND
+              value: release
+            - name: REPO_NAME
+              value: fakerepo
+            - name: REPO_OWNER
+              value: fakeowner
+          image: gcr.io/jenkinsxio/builder-maven:0.1.542
+          imagePullPolicy: IfNotPresent
+          name: build-step-create-tekton-crds
+          resources:
+            requests:
+              cpu: "0"
+              ephemeral-storage: "0"
+              memory: "0"
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /builder/tools
+              name: tools
+            - mountPath: /workspace
+              name: workspace
+            - mountPath: /builder/home
+              name: home
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: tekton-bot-token-kbbrz
+              readOnly: true
+          workingDir: /workspace/source
+        - args:
+            - -wait_file
+            - /builder/tools/3
+            - -post_file
+            - /builder/tools/4
+            - -entrypoint
+            - /ko-app/nop
+            - --
+          command:
+            - /builder/tools/entrypoint
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.4.0
+          imagePullPolicy: IfNotPresent
+          name: nop
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /builder/tools
+              name: tools
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: tekton-bot-token-kbbrz
+              readOnly: true
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - args:
+            - -basic-git=knative-git-user-pass=https://github.com
+          command:
+            - /ko-app/creds-init
+          env:
+            - name: HOME
+              value: /builder/home
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.4.0
+          imagePullPolicy: IfNotPresent
+          name: build-step-credential-initializer-xht92
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /workspace
+              name: workspace
+            - mountPath: /builder/home
+              name: home
+            - mountPath: /var/build-secrets/knative-git-user-pass
+              name: secret-volume-knative-git-user-pass-6zhjb
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: tekton-bot-token-kbbrz
+              readOnly: true
+          workingDir: /workspace
+        - args:
+            - -args
+            - mkdir -p /workspace/source
+          command:
+            - /ko-app/bash
+          env:
+            - name: HOME
+              value: /builder/home
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
+          imagePullPolicy: IfNotPresent
+          name: build-step-working-dir-initializer-8c9w5
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /workspace
+              name: workspace
+            - mountPath: /builder/home
+              name: home
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: tekton-bot-token-kbbrz
+              readOnly: true
+          workingDir: /workspace
+        - args:
+            - -c
+            - cp /ko-app/entrypoint /builder/tools/entrypoint
+          command:
+            - /bin/sh
+          env:
+            - name: HOME
+              value: /builder/home
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.4.0
+          imagePullPolicy: IfNotPresent
+          name: build-step-place-tools
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /builder/tools
+              name: tools
+            - mountPath: /workspace
+              name: workspace
+            - mountPath: /builder/home
+              name: home
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: tekton-bot-token-kbbrz
+              readOnly: true
+          workingDir: /workspace
+      nodeName: gke-fakeowner-test-cluster-default-pool-666b1aa4-k4xk
+      priority: 0
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: tekton-bot
+      serviceAccountName: tekton-bot
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 300
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 300
+      volumes:
+        - emptyDir: {}
+          name: tools
+        - emptyDir: {}
+          name: workspace
+        - emptyDir: {}
+          name: home
+        - name: secret-volume-knative-git-user-pass-6zhjb
+          secret:
+            defaultMode: 420
+            secretName: knative-git-user-pass
+        - name: tekton-bot-token-kbbrz
+          secret:
+            defaultMode: 420
+            secretName: tekton-bot-token-kbbrz
+    status:
+      conditions:
+        - lastProbeTime: null
+          lastTransitionTime: "2019-07-02T12:34:49Z"
+          reason: PodCompleted
+          status: "True"
+          type: Initialized
+        - lastProbeTime: null
+          lastTransitionTime: "2019-07-02T12:34:45Z"
+          reason: PodCompleted
+          status: "False"
+          type: Ready
+        - lastProbeTime: null
+          lastTransitionTime: "2019-07-02T12:34:45Z"
+          reason: PodCompleted
+          status: "False"
+          type: ContainersReady
+        - lastProbeTime: null
+          lastTransitionTime: "2019-07-02T12:34:45Z"
+          status: "True"
+          type: PodScheduled
+      containerStatuses:
+        - containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+          image: gcr.io/jenkinsxio/builder-maven:0.1.542
+          imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+          lastState: {}
+          name: build-step-create-effective-pipeline
+          ready: false
+          restartCount: 0
+          state:
+            terminated:
+              containerID: docker://1e02e8305372c87d7ae119dc8674550a11357292bfabdf4dad2d71b9b9933d07
+              exitCode: 1
+              finishedAt: "2019-07-02T12:34:52Z"
+              reason: Error
+              startedAt: "2019-07-02T12:34:49Z"
+        - containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+          image: gcr.io/jenkinsxio/builder-maven:0.1.542
+          imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+          lastState: {}
+          name: build-step-create-tekton-crds
+          ready: false
+          restartCount: 0
+          state:
+            terminated:
+              containerID: docker://52d9bb435df3c1205ac0c4f236a254b3492e00476870661c7c10738517ae29b5
+              exitCode: 0
+              finishedAt: "2019-07-02T12:34:56Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:34:49Z"
+        - containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+          image: gcr.io/jenkinsxio/builder-maven:0.1.542
+          imageID: docker-pullable://gcr.io/jenkinsxio/builder-maven@sha256:3d9e0c647efb7fcee74ac7181fdda79bf5d6313f1a5f35792bcc699c7405d281
+          lastState: {}
+          name: build-step-git-merge
+          ready: false
+          restartCount: 0
+          state:
+            terminated:
+              containerID: docker://d57909b6e267152b4278f0cdb57eb611a80157abfd723003f07d3e6d38d3a719
+              exitCode: 0
+              finishedAt: "2019-07-02T12:34:50Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:34:49Z"
+        - containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.4.0
+          imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:4b91c31560f18a8f09c68d5288f2261797b6df31522a57a9d7350bc0060a1284
+          lastState: {}
+          name: build-step-git-source-meta-fakeowner-fakerepo-build-v7hvv
+          ready: false
+          restartCount: 0
+          state:
+            terminated:
+              containerID: docker://9bd11fefa342196453f05e458e72bc0b9dfb756bdd3ce86098cba4c23df8d902
+              exitCode: 0
+              finishedAt: "2019-07-02T12:34:49Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:34:49Z"
+        - containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.4.0
+          imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop@sha256:9160ed41b20b2822d06e907d89f6398ea866c86a971f83371efb9e147fba079f
+          lastState: {}
+          name: nop
+          ready: false
+          restartCount: 0
+          state:
+            terminated:
+              containerID: docker://f20141db591e676595149dd8c27bad4f4a0e94f734023a0d64de6b6153167756
+              exitCode: 0
+              finishedAt: "2019-07-02T12:34:57Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:34:50Z"
+      hostIP: 10.138.0.56
+      initContainerStatuses:
+        - containerID: docker://5e897a5dfaf1687cad1692d9c8c6261108735e595ed37e03b43bcf51f86a7330
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.4.0
+          imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:b4877c99d928fad3cf26c995d171674b34d206178d6f9f0efb337ebff01bb34b
+          lastState: {}
+          name: build-step-credential-initializer-xht92
+          ready: true
+          restartCount: 0
+          state:
+            terminated:
+              containerID: docker://5e897a5dfaf1687cad1692d9c8c6261108735e595ed37e03b43bcf51f86a7330
+              exitCode: 0
+              finishedAt: "2019-07-02T12:34:46Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:34:46Z"
+        - containerID: docker://1e68c4fcfc19db3c695ff5ac3cbd7b4f2cf8c5a92637267fd2745a97eaf21150
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash:v0.4.0
+          imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash@sha256:0355a9b21a7c0cc9466bf75071648e266de07b5e13fbfd271ec791c45a818bdb
+          lastState: {}
+          name: build-step-working-dir-initializer-8c9w5
+          ready: true
+          restartCount: 0
+          state:
+            terminated:
+              containerID: docker://1e68c4fcfc19db3c695ff5ac3cbd7b4f2cf8c5a92637267fd2745a97eaf21150
+              exitCode: 0
+              finishedAt: "2019-07-02T12:34:47Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:34:47Z"
+        - containerID: docker://4109f59817a239085ce4084ae87cec62297ada549cb42e247160cd41f7479426
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.4.0
+          imageID: docker-pullable://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:4d1fe990ca06ecc671370dfeab31d857efa8ccf81d632a672561c60482fd9aae
+          lastState: {}
+          name: build-step-place-tools
+          ready: true
+          restartCount: 0
+          state:
+            terminated:
+              containerID: docker://4109f59817a239085ce4084ae87cec62297ada549cb42e247160cd41f7479426
+              exitCode: 0
+              finishedAt: "2019-07-02T12:34:48Z"
+              reason: Completed
+              startedAt: "2019-07-02T12:34:48Z"
+      phase: Failed
+      podIP: 10.28.0.32
+      qosClass: BestEffort
+      startTime: "2019-07-02T12:34:45Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/logs/test_data/metapipeline_failure/structures.yml
+++ b/pkg/logs/test_data/metapipeline_failure/structures.yml
@@ -1,0 +1,27 @@
+apiVersion: jenkins.io/v1
+items:
+  - apiVersion: jenkins.io/v1
+    kind: PipelineStructure
+    metadata:
+      creationTimestamp: 2019-03-05T20:06:13Z
+      generation: 1
+      name: meta-fakeowner-fakerepo-build-1
+      namespace: jx
+      ownerReferences:
+        - apiVersion: tekton.dev/v1alpha1
+          kind: Pipeline
+          name: meta-fakeowner-fakerepo-build-1
+          uid: 208e0fad-3f82-11e9-bd41-42010a8a00a2
+      resourceVersion: "1421155"
+      selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelinestructures/meta-fakeowner-fakerepo-build-1
+      uid: 20c58bd5-3f82-11e9-bd41-42010a8a00a2
+    pipelineRef: meta-fakeowner-fakerepo-build-1
+    pipelineRunRef: meta-fakeowner-fakerepo-build-1
+    stages:
+      - depth: 0
+        name: App Extension
+        taskRef: meta-fakeowner-fakerepo-build-app-extension-8
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/pkg/logs/test_data/pipelineruns.yml
+++ b/pkg/logs/test_data/pipelineruns.yml
@@ -9,7 +9,7 @@ items:
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
-        pipelineType: meta
+        jenkins.io/pipelineType: meta
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
         repository: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
@@ -55,7 +55,7 @@ items:
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
-        pipelineType: build
+        jenkins.io/pipelineType: build
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
         repository: fakerepo
         tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1

--- a/pkg/logs/test_data/pipelineruns.yml
+++ b/pkg/logs/test_data/pipelineruns.yml
@@ -9,6 +9,7 @@ items:
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
+        pipelineType: meta
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
         repository: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
@@ -36,6 +37,15 @@ items:
             name: fakeowner-fakerepo-fakebranch
       serviceAccount: tekton-bot
       timeout: 240h0m0s
+    status:
+      completionTime: "2019-09-10T17:08:23Z"
+      conditions:
+        - lastTransitionTime: "2019-09-10T17:08:23Z"
+          message: All Tasks have completed executing
+          reason: Succeeded
+          status: "True"
+          type: Succeeded
+      startTime: "2019-09-10T17:07:08Z"
   - apiVersion: tekton.dev/v1alpha1
     kind: PipelineRun
     metadata:
@@ -45,6 +55,7 @@ items:
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
+        pipelineType: build
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
         repository: fakerepo
         tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
@@ -72,3 +83,12 @@ items:
             name: fakeowner-fakerepo-fakebranch
       serviceAccount: tekton-bot
       timeout: 240h0m0s
+    status:
+      completionTime: "2019-09-10T17:08:23Z"
+      conditions:
+        - lastTransitionTime: "2019-09-10T17:08:23Z"
+          message: All Tasks have completed executing
+          reason: Succeeded
+          status: "True"
+          type: Succeeded
+      startTime: "2019-09-10T17:07:08Z"

--- a/pkg/logs/test_data/pod_with_failure/pipelineruns.yml
+++ b/pkg/logs/test_data/pod_with_failure/pipelineruns.yml
@@ -9,7 +9,7 @@ items:
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
-        pipelineType: meta
+        jenkins.io/pipelineType: meta
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
         repository: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
@@ -55,7 +55,7 @@ items:
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
-        pipelineType: build
+        jenkins.io/pipelineType: build
         prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001122
         repository: fakerepo
         tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1

--- a/pkg/logs/test_data/pod_with_failure/pods.yml
+++ b/pkg/logs/test_data/pod_with_failure/pods.yml
@@ -11,7 +11,7 @@ items:
         build: "1"
         jenkins.io/task-stage-name: app-extension
         owner: fakeowner
-        pipelineType: meta
+        jenkins.io/pipelineType: meta
         repository: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
         tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1
@@ -506,7 +506,7 @@ items:
       creationTimestamp: "2019-07-02T12:34:56Z"
       labels:
         jenkins.io/task-stage-name: from-fakebranch
-        pipelineType: build
+        jenkins.io/pipelineType: build
         tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
         tekton.dev/pipelineRun: fakeowner-fakerepo-fakebranch-1
         tekton.dev/task: fakeowner-fakerepo-fakebranch-from-fakebranch-1

--- a/pkg/logs/test_data/pod_with_failure/pods.yml
+++ b/pkg/logs/test_data/pod_with_failure/pods.yml
@@ -11,6 +11,7 @@ items:
         build: "1"
         jenkins.io/task-stage-name: app-extension
         owner: fakeowner
+        pipelineType: meta
         repository: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
         tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1
@@ -505,6 +506,7 @@ items:
       creationTimestamp: "2019-07-02T12:34:56Z"
       labels:
         jenkins.io/task-stage-name: from-fakebranch
+        pipelineType: build
         tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
         tekton.dev/pipelineRun: fakeowner-fakerepo-fakebranch-1
         tekton.dev/task: fakeowner-fakerepo-fakebranch-from-fakebranch-1

--- a/pkg/logs/test_data/pods.yml
+++ b/pkg/logs/test_data/pods.yml
@@ -11,7 +11,7 @@ items:
         build: "1"
         jenkins.io/task-stage-name: app-extension
         owner: fakeowner
-        pipelineType: meta
+        jenkins.io/pipelineType: meta
         repository: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
         tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1
@@ -506,7 +506,7 @@ items:
       creationTimestamp: "2019-07-02T12:34:56Z"
       labels:
         jenkins.io/task-stage-name: from-fakebranch
-        pipelineType: build
+        jenkins.io/pipelineType: build
         tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
         tekton.dev/pipelineRun: fakeowner-fakerepo-fakebranch-1
         tekton.dev/task: fakeowner-fakerepo-fakebranch-from-fakebranch-1

--- a/pkg/logs/test_data/pods.yml
+++ b/pkg/logs/test_data/pods.yml
@@ -11,6 +11,7 @@ items:
         build: "1"
         jenkins.io/task-stage-name: app-extension
         owner: fakeowner
+        pipelineType: meta
         repository: fakerepo
         tekton.dev/pipeline: meta-fakeowner-fakerepo-build-1
         tekton.dev/pipelineRun: meta-fakeowner-fakerepo-build-1
@@ -505,6 +506,7 @@ items:
       creationTimestamp: "2019-07-02T12:34:56Z"
       labels:
         jenkins.io/task-stage-name: from-fakebranch
+        pipelineType: build
         tekton.dev/pipeline: fakeowner-fakerepo-fakebranch-1
         tekton.dev/pipelineRun: fakeowner-fakerepo-fakebranch-1
         tekton.dev/task: fakeowner-fakerepo-fakebranch-from-fakebranch-1

--- a/pkg/tekton/constants.go
+++ b/pkg/tekton/constants.go
@@ -24,5 +24,5 @@ const (
 	LabelContext = "context"
 
 	// LabelType is the label added to Tekton CRDs for the type of pipeline.
-	LabelType = "pipelineType"
+	LabelType = "jenkins.io/pipelineType"
 )

--- a/pkg/tekton/constants.go
+++ b/pkg/tekton/constants.go
@@ -22,4 +22,7 @@ const (
 
 	// LabelContext is the label added to Tekton CRDs for the context being built.
 	LabelContext = "context"
+
+	// LabelType is the label added to Tekton CRDs for the type of pipeline.
+	LabelType = "pipelineType"
 )

--- a/pkg/tekton/metapipeline/clientfactory.go
+++ b/pkg/tekton/metapipeline/clientfactory.go
@@ -106,8 +106,8 @@ func (c *clientFactory) Create(param PipelineCreateParam) (kube.PromoteStepActiv
 	}
 
 	// resourceName is shared across all builds of a branch, while the pipelineName is unique for each build.
-	resourceName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline, nil, "")
-	pipelineName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline, c.tektonClient, c.ns)
+	resourceName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String(), nil, "")
+	pipelineName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String(), c.tektonClient, c.ns)
 	buildNumber, err := tekton.GenerateNextBuildNumber(c.tektonClient, c.jxClient, c.ns, gitInfo, branchIdentifier, retryDuration, param.Context)
 	if err != nil {
 		return kube.PromoteStepActivityKey{}, tekton.CRDWrapper{}, errors.Wrap(err, "unable to determine next build number")

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -356,6 +356,7 @@ func buildLabels(params CRDCreationParameters) (map[string]string, error) {
 		labels[tekton.LabelContext] = params.Context
 	}
 	labels[tekton.LabelBuild] = params.BuildNumber
+	labels[tekton.LabelType] = tekton.MetaPipeline.String()
 
 	return util.MergeMaps(labels, params.Labels), nil
 }

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -39,7 +39,7 @@ type PipelineRunInfo struct {
 	GitURL            string
 	GitInfo           *gits.GitRepository
 	Stages            []*StageInfo
-	Type              PipelineType
+	Type              string
 	CreatedTime       time.Time
 }
 
@@ -151,10 +151,10 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 	}
 
 	pri := &PipelineRunInfo{
-		Name:        PipelineResourceName(pr.Labels[LabelOwner], pr.Labels[LabelRepo], pr.Labels[LabelBranch], pr.Labels[LabelContext], pipelineType, nil, "") + "-" + pr.Labels[LabelBuild],
+		Name:        PipelineResourceName(pr.Labels[LabelOwner], pr.Labels[LabelRepo], pr.Labels[LabelBranch], pr.Labels[LabelContext], pr.Labels[LabelType], nil, "") + "-" + pr.Labels[LabelBuild],
 		PipelineRun: pr.Name,
 		Pipeline:    pr.Spec.PipelineRef.Name,
-		Type:        pipelineType,
+		Type:        pipelineType.String(),
 		CreatedTime: pr.CreationTimestamp.Time,
 	}
 

--- a/pkg/tekton/pipeline_info_test.go
+++ b/pkg/tekton/pipeline_info_test.go
@@ -55,7 +55,7 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 				TaskRun:        "cb-kubecd-bdd-spring-1567745634-s92nd-1-from-build-pack-x8hsc",
 				Parents:        []string{},
 			}},
-			Type:        tekton.BuildPipeline,
+			Type:        tekton.BuildPipeline.String(),
 			CreatedTime: *parseTime(t, "2019-09-06T05:24:17Z"),
 		},
 		prName: "cb-kubecd-bdd-spring-1567745634-s92nd-1",
@@ -88,7 +88,7 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 				TaskRun:        "abayer-jx-demo-qs-master-1-build-vhz8d",
 				Parents:        []string{},
 			}},
-			Type:        tekton.BuildPipeline,
+			Type:        tekton.BuildPipeline.String(),
 			CreatedTime: *parseTime(t, "2019-02-21T17:10:48-05:00"),
 		},
 		prName: "abayer-jx-demo-qs-master-1",
@@ -129,7 +129,7 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 				TaskRun:        "abayer-js-test-repo-master-1-second-9czt5",
 				Parents:        []string{},
 			}},
-			Type:        tekton.BuildPipeline,
+			Type:        tekton.BuildPipeline.String(),
 			CreatedTime: *parseTime(t, "2019-02-21T17:02:43-05:00"),
 		},
 		prName: "abayer-js-test-repo-master-1",
@@ -174,7 +174,7 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 					Parents:        []string{"Parent"},
 				}},
 			}},
-			Type:        tekton.BuildPipeline,
+			Type:        tekton.BuildPipeline.String(),
 			CreatedTime: *parseTime(t, "2019-02-21T17:07:36-05:00"),
 		},
 		prName: "abayer-js-test-repo-nested-1",
@@ -215,7 +215,7 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 				TaskRun:        "abayer-js-test-repo-master-1-second-wglk8",
 				Parents:        []string{},
 			}},
-			Type:        tekton.BuildPipeline,
+			Type:        tekton.BuildPipeline.String(),
 			CreatedTime: *parseTime(t, "2019-03-05T15:06:13-05:00"),
 		},
 		prName: "abayer-js-test-repo-master-1",
@@ -256,7 +256,7 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 				TaskRun:        "abayer-js-test-repo-master-1-second-wglk8",
 				Parents:        []string{},
 			}},
-			Type:        tekton.BuildPipeline,
+			Type:        tekton.BuildPipeline.String(),
 			CreatedTime: *parseTime(t, "2019-03-05T15:06:13-05:00"),
 		},
 		prName: "abayer-js-test-repo-master-1",
@@ -271,9 +271,6 @@ func TestCreatePipelineRunInfo(t *testing.T) {
 	}}
 
 	for _, tt := range testCases {
-		if tt.name != "from-yaml" && tt.name != "pr-yaml" {
-			continue
-		}
 		t.Run(tt.name, func(t *testing.T) {
 			testCaseDir := path.Join("test_data", "pipeline_info", tt.name)
 

--- a/pkg/tekton/pipelines.go
+++ b/pkg/tekton/pipelines.go
@@ -303,19 +303,19 @@ func CreateOrUpdatePipeline(tektonClient tektonclient.Interface, ns string, crea
 }
 
 // PipelineResourceNameFromGitInfo returns the pipeline resource name for the given git repository, branch and context
-func PipelineResourceNameFromGitInfo(gitInfo *gits.GitRepository, branch string, context string, pipelineType PipelineType, tektonClient tektonclient.Interface, ns string) string {
+func PipelineResourceNameFromGitInfo(gitInfo *gits.GitRepository, branch string, context string, pipelineType string, tektonClient tektonclient.Interface, ns string) string {
 	return PipelineResourceName(gitInfo.Organisation, gitInfo.Name, branch, context, pipelineType, tektonClient, ns)
 }
 
 // PipelineResourceName returns the pipeline resource name for the given git org, repo name, branch and context
-func PipelineResourceName(organisation string, name string, branch string, context string, pipelineType PipelineType, tektonClient tektonclient.Interface, ns string) string {
+func PipelineResourceName(organisation string, name string, branch string, context string, pipelineType string, tektonClient tektonclient.Interface, ns string) string {
 	dirtyName := organisation + "-" + name + "-" + branch
 	if context != "" {
 		dirtyName += "-" + context
 	}
 
-	if pipelineType == MetaPipeline {
-		dirtyName = pipelineType.String() + "-" + dirtyName
+	if pipelineType == MetaPipeline.String() {
+		dirtyName = pipelineType + "-" + dirtyName
 	}
 	resourceName := naming.ToValidNameTruncated(dirtyName, 31)
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

If you start running `jx get build logs` before the metapipeline succeeds, it should still include the metapipeline steps in the logs, but if you start afterwards, the metapipeline steps shouldn't be in the logs, and they shouldn't be included in the long-term storage logs for the build.

#### Special notes for the reviewer(s)

Changes to `PipelineActivity` are still to come.
/assign @hferentschik 
/assign @dgozalo 

#### Which issue this PR fixes

fixes #5455 
