### PR TITLE
feat: correctly gather boot requirements for EKS

### DIFF
--- a/pkg/cloud/amazon/common.go
+++ b/pkg/cloud/amazon/common.go
@@ -4,8 +4,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pkg/errors"
 	"os"
 	"path"
+	"regexp"
 	"runtime"
 )
 
@@ -59,6 +61,16 @@ func ResolveRegion(profileOption string, regionOption string) (string, error) {
 
 func ResolveRegionWithoutOptions() (string, error) {
 	return ResolveRegion("", "")
+}
+
+// ParseContext parses the EKS cluster context to extract the cluster name and the region
+func ParseContext(context string) (string, string, error) {
+	reg := regexp.MustCompile(`([a-zA-Z][-a-zA-Z0-9]*)\.((us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d)\.*`)
+	result := reg.FindStringSubmatch(context)
+	if len(result) < 3 {
+		return "", "", errors.Errorf("unable to parse %s as <cluster_name>.<region>.*", context)
+	}
+	return result[1], result[2], nil
 }
 
 // UserHomeDir returns the home directory for the user the process is running under.

--- a/pkg/cloud/amazon/common_test.go
+++ b/pkg/cloud/amazon/common_test.go
@@ -110,3 +110,37 @@ func TestReadingRegionFromEnvProfile(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "qux", *session.Config.Region)
 }
+
+func TestParseContext(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		context string
+		cluster string
+		region  string
+	}{
+		"full cluster name from eksctl": {
+			context: "cluster-name-jx.us-east-1.eksctl.io",
+			cluster: "cluster-name-jx",
+			region:  "us-east-1",
+		},
+		"full cluster name no eksctl": {
+			context: "cluster-name-jx.us-east-1",
+			cluster: "cluster-name-jx",
+			region:  "us-east-1",
+		},
+		"full cluster name other region": {
+			context: "cluster-name-jx.eu-north-4",
+			cluster: "cluster-name-jx",
+			region:  "eu-north-4",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cluster, region, err := amazon.ParseContext(tc.context)
+			assert.NoErrorf(t, err, "there shouldn't be an error parsing context %s", tc.context)
+			assert.Equal(t, tc.cluster, cluster)
+			assert.Equal(t, tc.region, region)
+		})
+	}
+}


### PR DESCRIPTION
chore: formatting and comment
Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Added code to gather boot requirements when using EKS and add the `Region` to the `jx-install-config` ConfigMap.

Also fixed an issue where we would panic when asking for feedback and the user answered no.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #5441 
fixed #5370 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
