### PR TITLE
fix: boot command should not ask for confirmation when provider is not GKE

### DIFF
--- a/pkg/cmd/step/verify/step_verify_preinstall_test.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall_test.go
@@ -1,6 +1,8 @@
 package verify
 
 import (
+	"fmt"
+	"github.com/acarl005/stripansi"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
 	"github.com/jenkins-x/jx/pkg/config"
@@ -8,6 +10,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 )
@@ -68,6 +71,108 @@ func Test_confirm_private_repos_with_github_provider(t *testing.T) {
 	<-done
 
 	assert.NoError(t, err)
+}
+
+func Test_doesnt_ask_for_confirmation_when_in_gke(t *testing.T) {
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+
+	testOptions := &StepVerifyPreInstallOptions{
+		WorkloadIdentity: true,
+		StepVerifyOptions: StepVerifyOptions{
+			StepOptions: step.StepOptions{
+				CommonOptions: &opts.CommonOptions{
+					Out: fakeStdout,
+				},
+			},
+		},
+	}
+
+	testConfig := &config.RequirementsConfig{}
+	testConfig.Cluster.GitKind = "github"
+	testConfig.Cluster.Provider = "gke"
+	testConfig.Cluster.EnvironmentGitOwner = "acme"
+	testConfig.Cluster.ProjectID = "test"
+	testConfig.Cluster.Zone = "exzone"
+	testConfig.Cluster.ClusterName = "acme"
+
+	testOptions.gatherRequirements(testConfig, "")
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	output := stripansi.Strip(string(outBytes))
+	assert.NotContains(t, output, fmt.Sprintf("jx boot has only been validated on GKE"))
+}
+
+func Test_doesnt_ask_for_confirmation_when_in_batch_mode_and_with_different_provider(t *testing.T) {
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+
+	testOptions := &StepVerifyPreInstallOptions{
+		StepVerifyOptions: StepVerifyOptions{
+			StepOptions: step.StepOptions{
+				CommonOptions: &opts.CommonOptions{
+					BatchMode: true,
+					Out:       fakeStdout,
+				},
+			},
+		},
+	}
+
+	testConfig := &config.RequirementsConfig{}
+	testConfig.Cluster.GitKind = "github"
+	testConfig.Cluster.Provider = "iks"
+	testConfig.Cluster.EnvironmentGitOwner = "acme"
+	testConfig.Cluster.ProjectID = "test"
+	testConfig.Cluster.Zone = "exzone"
+	testConfig.Cluster.ClusterName = "acme"
+
+	testOptions.gatherRequirements(testConfig, "")
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	output := stripansi.Strip(string(outBytes))
+	assert.Contains(t, output, fmt.Sprintf("jx boot has only been validated on GKE"))
+}
+
+func Test_asks_for_confirmation_when_not_in_batch_mode_and_with_different_provider(t *testing.T) {
+	t.Parallel()
+	log.SetOutput(ioutil.Discard)
+
+	console := tests.NewTerminal(t, &timeout)
+	defer console.Cleanup()
+
+	testOptions := &StepVerifyPreInstallOptions{
+		StepVerifyOptions: StepVerifyOptions{
+			StepOptions: step.StepOptions{
+				CommonOptions: &opts.CommonOptions{
+					BatchMode: false,
+					In:        console.In,
+					Out:       console.Out,
+					Err:       console.Err,
+				},
+			},
+		},
+	}
+
+	testConfig := &config.RequirementsConfig{}
+	testConfig.Cluster.GitKind = "github"
+	testConfig.Cluster.Provider = "iks"
+	testConfig.Cluster.EnvironmentGitOwner = "acme"
+	testConfig.Cluster.ProjectID = "test"
+	testConfig.Cluster.Zone = "exzone"
+	testConfig.Cluster.ClusterName = "acme"
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		console.ExpectString("Continue execution anyway?")
+		console.SendLine("N")
+		console.ExpectEOF()
+	}()
+	testOptions.gatherRequirements(testConfig, "")
+	console.Close()
+	<-done
 }
 
 func Test_abort_private_repos_with_github_provider(t *testing.T) {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
At the moment, `jx boot` launched in `batch mode` with a provider different than GKE, requires the user to input a confirmation to proceed. Since batch mode should run seamlessly, this PR implements a way to skip the user's input and log the same message instead.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #5573 

