### PR TITLE
fix: avoid duplicating env vars during verify env

### DIFF
--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -156,8 +156,6 @@ func (o *StepVerifyEnvironmentsOptions) prDevEnvironment(gitRepoName string, env
 		return errors.Wrapf(err, "duplicating %s to %s/%s", fromGitURL, environmentsOrg, gitRepoName)
 	}
 
-	log.Logger().Debugf("got duplicate info: %s", duplicateInfo)
-
 	if createPr {
 		_, baseRef, upstreamInfo, forkInfo, err := gits.ForkAndPullRepo(duplicateInfo.CloneURL, dir, "master", "master", provider, o.Git(), gitRepoName)
 		if err != nil {


### PR DESCRIPTION
GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL should not be added if they already exist.

Fixes #5574