### PR TITLE
feat: add the requirements file to a ConfigMap on every pipeline run so it can be obtained in other contexts

### DIFF
--- a/pkg/cmd/step/verify/step_verify_preinstall_test.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall_test.go
@@ -3,14 +3,22 @@ package verify
 import (
 	"fmt"
 	"github.com/acarl005/stripansi"
+	"github.com/jenkins-x/jx/pkg/cmd/clients/fake"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
+	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
 	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/tests"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/sanathkr/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
+	v12 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
+	"path"
 	"testing"
 	"time"
 )
@@ -211,4 +219,101 @@ func Test_abort_private_repos_with_github_provider(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Equal(t, "cannot continue without completed git requirements", err.Error())
+}
+
+func TestStepVerifyPreInstallOptions_VerifyRequirementsConfigMap(t *testing.T) {
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	options := &commonOpts
+	testhelpers.ConfigureTestOptions(options, options.Git(), options.Helm())
+
+	kubeClient, err := options.KubeClient()
+	assert.NoError(t, err, "There shouldn't be any error getting the fake Kube Client")
+
+	testOptions := &StepVerifyPreInstallOptions{
+		StepVerifyOptions: StepVerifyOptions{
+			StepOptions: step.StepOptions{
+				CommonOptions: options,
+			},
+		},
+	}
+
+	requirementsYamlFile := path.Join("test_data", "preinstall", "no_tls", "jx-requirements.yml")
+	exists, err := util.FileExists(requirementsYamlFile)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	bytes, err := ioutil.ReadFile(requirementsYamlFile)
+	assert.NoError(t, err)
+	requirements := &config.RequirementsConfig{}
+	err = yaml.Unmarshal(bytes, requirements)
+	assert.NoError(t, err)
+
+	err = testOptions.VerifyRequirementsConfigMap(kubeClient, "jx", requirements)
+	assert.NoError(t, err, "there shouldn't be any error creating the ConfigMap")
+
+	requirementsCm, err := kubeClient.CoreV1().ConfigMaps("jx").Get(kube.ConfigMapNameRequirementsYaml, v1.GetOptions{})
+	assert.NoError(t, err, "the jx-requirements-config ConfigMap should be present")
+
+	mapRequirements := &config.RequirementsConfig{}
+	err = yaml.Unmarshal([]byte(requirementsCm.Data["requirementsFile"]), mapRequirements)
+	assert.NoError(t, err)
+
+	assert.Equal(t, requirements, mapRequirements)
+}
+
+func TestStepVerifyPreInstallOptions_VerifyRequirementsConfigMapWithModification(t *testing.T) {
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	options := &commonOpts
+	testhelpers.ConfigureTestOptions(options, options.Git(), options.Helm())
+
+	requirementsYamlFile := path.Join("test_data", "preinstall", "no_tls", "jx-requirements.yml")
+	exists, err := util.FileExists(requirementsYamlFile)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	bytes, err := ioutil.ReadFile(requirementsYamlFile)
+	assert.NoError(t, err)
+	requirements := &config.RequirementsConfig{}
+	err = yaml.Unmarshal(bytes, requirements)
+	assert.NoError(t, err)
+
+	kubeClient, err := options.KubeClient()
+	assert.NoError(t, err, "There shouldn't be any error getting the fake Kube Client")
+
+	_, err = kubeClient.CoreV1().ConfigMaps("jx").Create(&v12.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name: kube.ConfigMapNameRequirementsYaml,
+		},
+		Data: map[string]string{
+			"requirementsFile": string(bytes),
+		},
+	})
+	assert.NoError(t, err)
+
+	// We make a modification to the requirements and we should see it when we retrieve the ConfigMap later
+	requirements.Storage.Logs = config.StorageEntryConfig{
+		Enabled: true,
+		URL:     "gs://randombucket",
+	}
+
+	testOptions := &StepVerifyPreInstallOptions{
+		StepVerifyOptions: StepVerifyOptions{
+			StepOptions: step.StepOptions{
+				CommonOptions: options,
+			},
+		},
+	}
+
+	err = testOptions.VerifyRequirementsConfigMap(kubeClient, "jx", requirements)
+	assert.NoError(t, err, "there shouldn't be any error creating the ConfigMap")
+
+	requirementsCm, err := kubeClient.CoreV1().ConfigMaps("jx").Get(kube.ConfigMapNameRequirementsYaml, v1.GetOptions{})
+	assert.NoError(t, err, "the jx-requirements-config ConfigMap should be present")
+
+	mapRequirements := &config.RequirementsConfig{}
+	err = yaml.Unmarshal([]byte(requirementsCm.Data["requirementsFile"]), mapRequirements)
+	assert.NoError(t, err)
+
+	assert.Equal(t, requirements.Storage.Logs, mapRequirements.Storage.Logs, "the change done before calling"+
+		"VerifyRequirementsConfigMap should be present in the retrieved configuration")
 }

--- a/pkg/kube/constants.go
+++ b/pkg/kube/constants.go
@@ -139,6 +139,9 @@ const (
 	// ConfigMapNameJXInstallConfig is the ConfigMap containing the jx installation's CA and server url. Used by jx login
 	ConfigMapNameJXInstallConfig = "jx-install-config"
 
+	// ConfigMapNameRequirementsYaml is the ConfigMap containing the marshalled and encoded requirements.yaml file for Boot installs
+	ConfigMapNameRequirementsYaml = "jx-requirements-config"
+
 	// LocalHelmRepoName is the default name of the local chart repository where CI/CD releases go to
 	LocalHelmRepoName = "releases"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
When using AWS, you need to provide the AWS_REGION variable in multiple parts of the code (among others).

I needed a way to reliably get this from the cluster configuration so we may as well save the current state of the requirements yaml in a config map so we can access it from everywhere in the code.

This allows for some utility code that can be used to return an implementation based on cloud provider. 

#### Which issue this PR fixes

part of #5432 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
