### PR TITLE
fix: Don't use pointers for getPipelineRunsForActivity return

### DIFF
--- a/pkg/logs/test_data/metapipeline_failure/pipelineruns.yml
+++ b/pkg/logs/test_data/metapipeline_failure/pipelineruns.yml
@@ -6,6 +6,52 @@ items:
       generation: 1
       labels:
         branch: fakebranch
+        build: "3"
+        created-by-prow: "true"
+        owner: fakeowner
+        jenkins.io/pipelineType: meta
+        prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001123
+        repository: fakerepo
+        tekton.dev/pipeline: meta-fakeowner-fakerepo-build-3
+      name: meta-fakeowner-fakerepo-build-3
+      namespace: jx
+      ownerReferences:
+        - apiVersion: tekton.dev/v1alpha1
+          kind: pipeline
+          name: meta-fakeowner-fakerepo-build-3
+          uid: 3fe9c5ff-9da8-11e9-8283-42010a840061
+      selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/meta-fakeowner-fakerepo-build-3
+    spec:
+      params:
+        - name: version
+          value: 0.0.3
+        - name: build_id
+          value: "3"
+      pipelineRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: meta-fakeowner-fakerepo-build-3
+      resources:
+        - name: fakeowner-fakerepo-fakebranch
+          resourceRef:
+            apiVersion: tekton.dev/v1alpha1
+            name: fakeowner-fakerepo-fakebranch
+      serviceAccount: tekton-bot
+      timeout: 240h0m0s
+    status:
+      completionTime: "2019-09-10T17:12:23Z"
+      conditions:
+        - lastTransitionTime: "2019-09-10T17:12:23Z"
+          message: TaskRun meta-fakeowner-fakerepo-build-3-app-extension-kvvp6 has failed
+          reason: Failed
+          status: "False"
+          type: Succeeded
+      startTime: "2019-09-10T17:11:08Z"
+  - apiVersion: tekton.dev/v1alpha1
+    kind: PipelineRun
+    metadata:
+      generation: 1
+      labels:
+        branch: fakebranch
         build: "1"
         created-by-prow: "true"
         owner: fakeowner
@@ -46,3 +92,49 @@ items:
           status: "False"
           type: Succeeded
       startTime: "2019-09-10T17:07:08Z"
+  - apiVersion: tekton.dev/v1alpha1
+    kind: PipelineRun
+    metadata:
+      generation: 1
+      labels:
+        branch: fakebranch
+        build: "2"
+        created-by-prow: "true"
+        owner: fakeowner
+        jenkins.io/pipelineType: meta
+        prowJobName: 3930a5ce-9da8-11e9-9b3d-acde48001124
+        repository: fakerepo
+        tekton.dev/pipeline: meta-fakeowner-fakerepo-build-2
+      name: meta-fakeowner-fakerepo-build-2
+      namespace: jx
+      ownerReferences:
+        - apiVersion: tekton.dev/v1alpha1
+          kind: pipeline
+          name: meta-fakeowner-fakerepo-build-2
+          uid: 3fe9c5ff-9da8-11e9-8283-42010a840062
+      selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/meta-fakeowner-fakerepo-build-2
+    spec:
+      params:
+        - name: version
+          value: 0.0.2
+        - name: build_id
+          value: "2"
+      pipelineRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: meta-fakeowner-fakerepo-build-2
+      resources:
+        - name: fakeowner-fakerepo-fakebranch
+          resourceRef:
+            apiVersion: tekton.dev/v1alpha1
+            name: fakeowner-fakerepo-fakebranch
+      serviceAccount: tekton-bot
+      timeout: 240h0m0s
+    status:
+      completionTime: "2019-09-10T17:10:23Z"
+      conditions:
+        - lastTransitionTime: "2019-09-10T17:10:23Z"
+          message: TaskRun meta-fakeowner-fakerepo-build-1-app-extension-kvvp6 has failed
+          reason: Failed
+          status: "False"
+          type: Succeeded
+      startTime: "2019-09-10T17:09:08Z"


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

I'm not good with pointers, basically. If there are multiple runs for an owner/repo/branch, without this, the pointers returned by `getPipelineRunsForActivity` end up pointing to the last run we looked at, not the one that actually matched. Sigh. I modified an existing test to fail without this fix.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

fixes #5652 
