### PR TITLE
fix: Stop updating jenkins-x-platform and prow charts from jx directly

### DIFF
--- a/jx/scripts/update-bot.sh
+++ b/jx/scripts/update-bot.sh
@@ -5,7 +5,5 @@ set -o nounset
 set -o pipefail
 
 ./build/linux/jx step create pr docker --name JX_VERSION --version $VERSION --repo https://github.com/jenkins-x/jenkins-x-builders.git --repo https://github.com/jenkins-x/jenkins-x-serverless.git --repo https://github.com/jenkins-x/jenkins-x-builders-ml.git
-./build/linux/jx step create pr chart --name jx --version $VERSION  --repo https://github.com/jenkins-x/jenkins-x-platform.git
-./build/linux/jx step create pr regex --regex "\s*jxTag:\s*(.*)" --version $VERSION --files prow/values.yaml --repo https://github.com/jenkins-x-charts/prow.git
 ./build/linux/jx step create pr go --name github.com/jenkins-x/jx --version $VERSION --build "make mod" --repo https://github.com/jenkins-x/lighthouse.git
 ./build/linux/jx step create pr go --name github.com/jenkins-x/jx --version $VERSION --build "make build" --repo https://github.com/cloudbees/jxui-backend.git


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Once https://github.com/jenkins-x/jenkins-x-builders/pull/823 is merged, it will handle updating the jx version in `jenkins-x-platform` and `prow`, keeping them more cleanly in sync.

#### Special notes for the reviewer(s)

/assign @cagiti 

#### Which issue this PR fixes

fixes #5596 
