### PR TITLE
feat: allow annotations on ServiceAccount

### DIFF
--- a/charts/jx/templates/serviceaccount.yaml
+++ b/charts/jx/templates/serviceaccount.yaml
@@ -12,4 +12,8 @@ metadata:
     chart: {{ template "jx.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.serviceaccount.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
For example, IAM permissions via service accounts require
eks.amazonaws.com/role-arn annotations for ServiceAccount.

https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/

Please note that I have not been able to test this on a live cluster - I've not been able to work out how to patch in the changes.