### PR TITLE
feat: adding Jenkins-x[bot] user

### DIFF
--- a/pkg/cmd/step/verify/step_verify_git.go
+++ b/pkg/cmd/step/verify/step_verify_git.go
@@ -106,6 +106,11 @@ func (o *StepVerifyGitOptions) Run() error {
 				return errors.Wrapf(err, "failed to create GitProvider for %s at git server %s", userAuth.Username, server.URL)
 			}
 
+			if provider.CurrentUsername() == "jenkins-x[bot]" {
+				pipeUserValid = true
+				continue
+			}
+
 			orgs, err := provider.ListOrganisations()
 			if err != nil {
 				return errors.Wrapf(err, "failed to list the organisations for %s at git server %s", userAuth.Username, server.URL)

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -1368,7 +1368,7 @@ func (p *GitHubProvider) AcceptInvitation(ID int64) (*github.Response, error) {
 // ShouldForkForPullRequest returns true if we should create a personal fork of this repository
 // before creating a pull request
 func (p *GitHubProvider) ShouldForkForPullRequest(originalOwner string, repoName string, username string) bool {
-	if originalOwner == username {
+	if username == "jenkins-x[bot]" || originalOwner == username {
 		return false
 	}
 


### PR DESCRIPTION
Add special handling for the Jenkins-x[bot] user. This is the Github app bot.

Signed-off-by: warrenbailey <warren@warrenbailey.net>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
