### PR TITLE
fix: specify version stream for vault operator

### DIFF
--- a/pkg/cmd/step/boot/step_boot_vault.go
+++ b/pkg/cmd/step/boot/step_boot_vault.go
@@ -174,7 +174,7 @@ func (o *StepBootVaultOptions) Run() error {
 		}
 	}
 
-	tag, err := o.vaultOperatorImageTag()
+	tag, err := o.vaultOperatorImageTag(&requirements.VersionStream)
 	if err != nil {
 		return err
 	}
@@ -276,8 +276,8 @@ func (o *StepBootVaultOptions) verifyVaultIngress(requirements *config.Requireme
 }
 
 // vaultOperatorImageTag lookups the vault operator image tag in the version stream
-func (o *StepBootVaultOptions) vaultOperatorImageTag() (string, error) {
-	resolver, err := o.CreateVersionResolver(config.DefaultVersionsURL, "")
+func (o *StepBootVaultOptions) vaultOperatorImageTag(versionStream *config.VersionStreamConfig) (string, error) {
+	resolver, err := o.CreateVersionResolver(versionStream.URL, versionStream.Ref)
 	if err != nil {
 		return "", errors.Wrap(err, "creating the vault-operator docker image version resolver")
 	}


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The vault operator is currently always using the default version stream to lookup its image tag.  This can lead to the incorrect one being used (or a failure occurring as the ref of the incorrect version stream being doesn't exist)
