### PR TITLE
fix: Add "Signed-off-by:" to `jx step create pr` commit messages

### DIFF
--- a/pkg/cmd/step/create/pr/step_create_pr.go
+++ b/pkg/cmd/step/create/pr/step_create_pr.go
@@ -131,7 +131,7 @@ func (o *StepCreatePrOptions) CreatePullRequest(kind string, update operations.C
 }
 
 func (o *StepCreatePrOptions) createPullRequestOperation() operations.PullRequestOperation {
-	return operations.PullRequestOperation{
+	op := operations.PullRequestOperation{
 		CommonOptions: o.CommonOptions,
 		GitURLs:       o.GitURLs,
 		BranchName:    o.BranchName,
@@ -142,4 +142,10 @@ func (o *StepCreatePrOptions) createPullRequestOperation() operations.PullReques
 		DryRun:        o.DryRun,
 		SkipCommit:    o.SkipCommit,
 	}
+	authorName, authorEmail, err := gits.EnsureUserAndEmailSetup(o.Git())
+	if err != nil {
+		op.AuthorName = authorName
+		op.AuthorEmail = authorEmail
+	}
+	return op
 }

--- a/pkg/cmd/step/create/pr/step_create_pr_quickstarts.go
+++ b/pkg/cmd/step/create/pr/step_create_pr_quickstarts.go
@@ -133,6 +133,11 @@ func (o *StepCreatePullRequestQuickStartsOptions) Run() error {
 			DryRun:        o.DryRun,
 		}
 
+		authorName, authorEmail, err := gits.EnsureUserAndEmailSetup(o.Git())
+		if err != nil {
+			pro.AuthorName = authorName
+			pro.AuthorEmail = authorEmail
+		}
 		callback := func(from *quickstarts.Quickstart, dir string, gitInfo *gits.GitRepository) ([]string, error) {
 			quickstarts, err := versionstream.GetQuickStarts(dir)
 			if err != nil {

--- a/pkg/cmd/step/create/pr/step_create_pr_versions.go
+++ b/pkg/cmd/step/create/pr/step_create_pr_versions.go
@@ -148,6 +148,11 @@ func (o *StepCreatePullRequestVersionsOptions) Run() error {
 			Version:       builderImageVersion,
 			DryRun:        o.DryRun,
 		}
+		authorName, authorEmail, _ := gits.EnsureUserAndEmailSetup(o.Git())
+		if authorName != "" && authorEmail != "" {
+			pro.AuthorName = authorName
+			pro.AuthorEmail = authorEmail
+		}
 		fn, err := operations.CreatePullRequestRegexFn(builderImageVersion, "gcr.io/jenkinsxio/builder-(?:maven|go|terraform):(?P<versions>.+)", "jenkins-x*.yml")
 		if err != nil {
 			return errors.WithStack(err)
@@ -177,6 +182,10 @@ func (o *StepCreatePullRequestVersionsOptions) Run() error {
 			Version:       mlBuilderImageVersion,
 			DryRun:        o.DryRun,
 		}
+		if authorName != "" && authorEmail != "" {
+			pro.AuthorName = authorName
+			pro.AuthorEmail = authorEmail
+		}
 		modifyFns = append(modifyFns, mlPro.WrapChangeFilesWithCommitFn("versions", operations.CreatePullRequestMLBuildersFn(mlBuilderImageVersion)))
 	}
 	if len(o.Includes) > 0 {
@@ -191,6 +200,11 @@ func (o *StepCreatePullRequestVersionsOptions) Run() error {
 			BranchName:    o.BranchName,
 			Version:       o.Version,
 			DryRun:        o.DryRun,
+		}
+		authorName, authorEmail, _ := gits.EnsureUserAndEmailSetup(o.Git())
+		if authorName != "" && authorEmail != "" {
+			pro.AuthorName = authorName
+			pro.AuthorEmail = authorEmail
 		}
 		vaultClient, err := o.SystemVaultClient("")
 		if err != nil {
@@ -286,6 +300,11 @@ func (o *StepCreatePullRequestVersionsOptions) CreatePullRequestUpdateVersionFil
 					Base:          o.Base,
 					BranchName:    o.BranchName,
 					DryRun:        o.DryRun,
+				}
+				authorName, authorEmail, err := gits.EnsureUserAndEmailSetup(o.Git())
+				if err != nil {
+					pro.AuthorName = authorName
+					pro.AuthorEmail = authorEmail
 				}
 				var cff operations.ChangeFilesFn
 				switch kindStr {

--- a/pkg/gits/operations/pull_request_op.go
+++ b/pkg/gits/operations/pull_request_op.go
@@ -38,14 +38,16 @@ import (
 // PullRequestOperation provides a way to execute a PullRequest operation using Git
 type PullRequestOperation struct {
 	*opts.CommonOptions
-	GitURLs    []string
-	SrcGitURL  string
-	Base       string
-	Component  string
-	BranchName string
-	Version    string
-	DryRun     bool
-	SkipCommit bool
+	GitURLs     []string
+	SrcGitURL   string
+	Base        string
+	Component   string
+	BranchName  string
+	Version     string
+	DryRun      bool
+	SkipCommit  bool
+	AuthorName  string
+	AuthorEmail string
 }
 
 // ChangeFilesFn is the function called to create the pull request
@@ -376,6 +378,9 @@ func (o PullRequestOperation) CreateDependencyUpdatePRDetails(kind string, srcRe
 	}
 	message.WriteString(fmt.Sprintf("\n\nCommand run was `%s`", strings.Join(os.Args, " ")))
 	commitMessage.WriteString(fmt.Sprintf("\n\nCommand run was `%s`", strings.Join(os.Args, " ")))
+	if o.AuthorEmail != "" && o.AuthorName != "" {
+		commitMessage.WriteString(fmt.Sprintf("\n\nSigned-off-by: %s <%s>", o.AuthorName, o.AuthorEmail))
+	}
 	return commitMessage.String(), &gits.PullRequestDetails{
 		BranchName: fmt.Sprintf("bump-%s-version-%s", kind, string(uuid.NewUUID())),
 		Title:      title.String(),


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

If we can get the git author name and email, add `Signed-off-by: NAME: <EMAIL>` to commit messages generated by `jx step create pr`.

#### Special notes for the reviewer(s)

/assign @pmuir 

#### Which issue this PR fixes

fixes #5735 
