### PR TITLE
fix: Use requirements from TeamSettings instead of env var for vault URL check

### DIFF
--- a/jenkins-x-boot-vault.yml
+++ b/jenkins-x-boot-vault.yml
@@ -115,8 +115,6 @@ pipelineConfig:
                   secretKeyRef:
                     name: test-jenkins-user 
                     key: password
-              - name: JX_REQUIREMENT_VAULT_DISABLE_URL_DISCOVERY
-                value: "true"
             steps:
               - name: boot-vault-e2e-tests
                 image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}

--- a/pkg/cmd/step/verify/step_verify_environments_test.go
+++ b/pkg/cmd/step/verify/step_verify_environments_test.go
@@ -1,0 +1,108 @@
+package verify
+
+import (
+	"io/ioutil"
+	"path"
+	"testing"
+
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/cmd/clients/fake"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
+	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/yaml"
+)
+
+func TestStepVerifyEnvironmentsOptions_StoreRequirementsInTeamSettings(t *testing.T) {
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	options := &commonOpts
+	testhelpers.ConfigureTestOptions(options, options.Git(), options.Helm())
+
+	testOptions := &StepVerifyEnvironmentsOptions{
+		StepVerifyOptions: StepVerifyOptions{
+			StepOptions: step.StepOptions{
+				CommonOptions: options,
+			},
+		},
+	}
+
+	requirementsYamlFile := path.Join("test_data", "preinstall", "no_tls", "jx-requirements.yml")
+	exists, err := util.FileExists(requirementsYamlFile)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	bytes, err := ioutil.ReadFile(requirementsYamlFile)
+	assert.NoError(t, err)
+	requirements := &config.RequirementsConfig{}
+	err = yaml.Unmarshal(bytes, requirements)
+	assert.NoError(t, err)
+
+	err = testOptions.storeRequirementsInTeamSettings(requirements)
+	assert.NoError(t, err, "there shouldn't be any error adding the requirements to TeamSettings")
+
+	teamSettings, err := testOptions.TeamSettings()
+	assert.NoError(t, err)
+
+	requirementsCm := teamSettings.BootRequirements
+	assert.NotEqual(t, "", requirementsCm, "the BootRequirements field should be present and not empty")
+
+	mapRequirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	assert.NoError(t, err)
+
+	assert.Equal(t, requirements, mapRequirements)
+}
+
+func TestStepVerifyEnvironmentsOptions_StoreRequirementsConfigMapWithModification(t *testing.T) {
+	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
+	options := &commonOpts
+	testhelpers.ConfigureTestOptions(options, options.Git(), options.Helm())
+
+	requirementsYamlFile := path.Join("test_data", "preinstall", "no_tls", "jx-requirements.yml")
+	exists, err := util.FileExists(requirementsYamlFile)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	bytes, err := ioutil.ReadFile(requirementsYamlFile)
+	assert.NoError(t, err)
+	requirements := &config.RequirementsConfig{}
+	err = yaml.Unmarshal(bytes, requirements)
+	assert.NoError(t, err)
+
+	err = options.ModifyDevEnvironment(func(env *v1.Environment) error {
+		env.Spec.TeamSettings.BootRequirements = string(bytes)
+		return nil
+	})
+	assert.NoError(t, err)
+
+	// We make a modification to the requirements and we should see it when we retrieve the ConfigMap later
+	requirements.Storage.Logs = config.StorageEntryConfig{
+		Enabled: true,
+		URL:     "gs://randombucket",
+	}
+
+	testOptions := &StepVerifyEnvironmentsOptions{
+		StepVerifyOptions: StepVerifyOptions{
+			StepOptions: step.StepOptions{
+				CommonOptions: options,
+			},
+		},
+	}
+
+	err = testOptions.storeRequirementsInTeamSettings(requirements)
+	assert.NoError(t, err, "there shouldn't be any error updating the team settings")
+
+	teamSettings, err := testOptions.TeamSettings()
+	assert.NoError(t, err)
+
+	requirementsCm := teamSettings.BootRequirements
+	assert.NotEqual(t, "", requirementsCm, "the BootRequirements field should be present and not empty")
+
+	mapRequirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	assert.NoError(t, err)
+
+	assert.Equal(t, requirements.Storage.Logs, mapRequirements.Storage.Logs, "the change done before calling"+
+		"VerifyRequirementsInTeamSettings should be present in the retrieved configuration")
+}

--- a/pkg/cmd/step/verify/step_verify_preinstall_test.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall_test.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"testing"
 	"time"
 
 	"github.com/acarl005/stripansi"
-	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/cmd/clients/fake"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
@@ -17,10 +15,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/tests"
-	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 )
 
 var timeout = 1 * time.Second
@@ -219,97 +215,6 @@ func Test_abort_private_repos_with_github_provider(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Equal(t, "cannot continue without completed git requirements", err.Error())
-}
-
-func TestStepVerifyPreInstallOptions_VerifyRequirementsInTeamSettings(t *testing.T) {
-	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
-	options := &commonOpts
-	testhelpers.ConfigureTestOptions(options, options.Git(), options.Helm())
-
-	testOptions := &StepVerifyPreInstallOptions{
-		StepVerifyOptions: StepVerifyOptions{
-			StepOptions: step.StepOptions{
-				CommonOptions: options,
-			},
-		},
-	}
-
-	requirementsYamlFile := path.Join("test_data", "preinstall", "no_tls", "jx-requirements.yml")
-	exists, err := util.FileExists(requirementsYamlFile)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-
-	bytes, err := ioutil.ReadFile(requirementsYamlFile)
-	assert.NoError(t, err)
-	requirements := &config.RequirementsConfig{}
-	err = yaml.Unmarshal(bytes, requirements)
-	assert.NoError(t, err)
-
-	err = testOptions.VerifyRequirementsInTeamSettings("jx", requirements)
-	assert.NoError(t, err, "there shouldn't be any error adding the requirements to TeamSettings")
-
-	teamSettings, err := testOptions.TeamSettings()
-	assert.NoError(t, err)
-
-	requirementsCm := teamSettings.BootRequirements
-	assert.NotEqual(t, "", requirementsCm, "the BootRequirements field should be present and not empty")
-
-	mapRequirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
-	assert.NoError(t, err)
-
-	assert.Equal(t, requirements, mapRequirements)
-}
-
-func TestStepVerifyPreInstallOptions_VerifyRequirementsConfigMapWithModification(t *testing.T) {
-	commonOpts := opts.NewCommonOptionsWithFactory(fake.NewFakeFactory())
-	options := &commonOpts
-	testhelpers.ConfigureTestOptions(options, options.Git(), options.Helm())
-
-	requirementsYamlFile := path.Join("test_data", "preinstall", "no_tls", "jx-requirements.yml")
-	exists, err := util.FileExists(requirementsYamlFile)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-
-	bytes, err := ioutil.ReadFile(requirementsYamlFile)
-	assert.NoError(t, err)
-	requirements := &config.RequirementsConfig{}
-	err = yaml.Unmarshal(bytes, requirements)
-	assert.NoError(t, err)
-
-	err = options.ModifyDevEnvironment(func(env *v1.Environment) error {
-		env.Spec.TeamSettings.BootRequirements = string(bytes)
-		return nil
-	})
-	assert.NoError(t, err)
-
-	// We make a modification to the requirements and we should see it when we retrieve the ConfigMap later
-	requirements.Storage.Logs = config.StorageEntryConfig{
-		Enabled: true,
-		URL:     "gs://randombucket",
-	}
-
-	testOptions := &StepVerifyPreInstallOptions{
-		StepVerifyOptions: StepVerifyOptions{
-			StepOptions: step.StepOptions{
-				CommonOptions: options,
-			},
-		},
-	}
-
-	err = testOptions.VerifyRequirementsInTeamSettings("jx", requirements)
-	assert.NoError(t, err, "there shouldn't be any error creating the ConfigMap")
-
-	teamSettings, err := testOptions.TeamSettings()
-	assert.NoError(t, err)
-
-	requirementsCm := teamSettings.BootRequirements
-	assert.NotEqual(t, "", requirementsCm, "the BootRequirements field should be present and not empty")
-
-	mapRequirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
-	assert.NoError(t, err)
-
-	assert.Equal(t, requirements.Storage.Logs, mapRequirements.Storage.Logs, "the change done before calling"+
-		"VerifyRequirementsInTeamSettings should be present in the retrieved configuration")
 }
 
 func TestStepVerifyPreInstallOptions_UpdateVersionStreamRefInDevEnvironment(t *testing.T) {

--- a/pkg/kube/env.go
+++ b/pkg/kube/env.go
@@ -510,6 +510,19 @@ func DoCreateEnvironmentGitRepo(batchMode bool, authConfigSvc auth.ConfigService
 	return repo, provider, nil
 }
 
+// GetDevEnvTeamSettings gets the team settings from the specified namespace.
+func GetDevEnvTeamSettings(jxClient versioned.Interface, ns string) (*v1.TeamSettings, error) {
+	devEnv, err := GetDevEnvironment(jxClient, ns)
+	if err != nil {
+		log.Logger().Errorf("Error loading team settings. %v", err)
+		return nil, err
+	}
+	if devEnv != nil {
+		return &devEnv.Spec.TeamSettings, nil
+	}
+	return nil, fmt.Errorf("unable to find development environment in %s to get team settings", ns)
+}
+
 // GetDevEnvGitOwner gets the default GitHub owner/organisation to use for Environment repos. This takes the setting
 // from the 'jx' Dev Env to get the one that was selected at installation time.
 func GetDevEnvGitOwner(jxClient versioned.Interface) (string, error) {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We're now storing `jx-requirements.yaml` in `TeamSettings`, so let's check there for whether we should be discovering the Vault URL automatically or not, rather than using the env var override. Local `jx-requirements.yaml` still gets priority.

#### Special notes for the reviewer(s)

/assign @rawlingsj 
/assign @dgozalo 

#### Which issue this PR fixes

fixes #5746 