### PR TITLE
WIP: fix: Use URL-appropriate boot upgrade branch in version stream

### DIFF
--- a/pkg/cmd/upgrade/upgrade_boot.go
+++ b/pkg/cmd/upgrade/upgrade_boot.go
@@ -42,10 +42,6 @@ var (
 `)
 )
 
-const (
-	upgradeVersionStreamRef = "master"
-)
-
 // NewCmdUpgradeBoot creates the command
 func NewCmdUpgradeBoot(commonOpts *opts.CommonOptions) *cobra.Command {
 	options := &UpgradeBootOptions{
@@ -85,6 +81,8 @@ func (o *UpgradeBootOptions) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get requirements version stream")
 	}
+
+	upgradeVersionStreamRef := o.determineUpgradeVersionStreamRef(reqsVersionStream.URL)
 
 	upgradeVersionSha, err := o.upgradeAvailable(reqsVersionStream.URL, reqsVersionStream.Ref, upgradeVersionStreamRef)
 	if err != nil {
@@ -133,6 +131,13 @@ func (o *UpgradeBootOptions) Run() error {
 		return errors.Wrapf(err, "failed to delete local branch %s", localBranch)
 	}
 	return nil
+}
+
+func (o UpgradeBootOptions) determineUpgradeVersionStreamRef(versionStreamURL string) string {
+	if versionStreamURL == config.DefaultCloudBeesVersionsURL {
+		return config.DefaultCloudBeesVersionsRef
+	}
+	return config.DefaultVersionsRef
 }
 
 func (o UpgradeBootOptions) determineBootConfigURL(versionStreamURL string) (string, error) {

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -142,7 +142,7 @@ const (
 	// DefaultCloudBeesVersionsURL default version stream url for cloudbees jenkins x distribution
 	DefaultCloudBeesVersionsURL = "https://github.com/cloudbees/cloudbees-jenkins-x-versions.git"
 	// DefaultCloudBeesVersionsRef default version stream ref for cloudbees jenkins x distribution
-	DefaultCloudBeesVersionsRef = "master"
+	DefaultCloudBeesVersionsRef = "stable"
 )
 
 // EnvironmentConfig configures the organisation and repository name of the git repositories for environments


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

We already have this configured in `install_requirements`; we should use it in `jx upgrade boot` as well.

Also changes the CloudBees default version stream ref for...reasons.

#### Special notes for the reviewer(s)

/assign @pmuir 
/assign @macox 
/assign @daveconde 

#### Which issue this PR fixes

n/a