### PR TITLE
fix: kuberhealthy protocol and authed redirect

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -99,7 +99,15 @@ func kuberHealthyRequest(kuberHealthURL string) ([]byte, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get password")
 		}
-		req.SetBasicAuth(username, pwd)
+
+		client = &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 2 {
+					return errors.New("stopped after 2 kuberhealthy redirects")
+				}
+				req.SetBasicAuth(username, pwd)
+				return nil
+			}}
 	}
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION

#### Description

http client requires a protocol when sending request to kuberhealthy in cluster. Out of cluster a follow redirect with auth is required to cover both http and https possibilities. 