### PR TITLE
fix: Mark steps after a failed step as not executed in PipelineActivity

### DIFF
--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelineruns.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pipelineruns.yml
@@ -69,16 +69,16 @@ items:
           - name: create-effective-pipeline
             terminated:
               containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
-              exitCode: 0
+              exitCode: 1
               finishedAt: "2019-09-10T17:07:35Z"
-              reason: Completed
+              reason: Error
               startedAt: "2019-09-10T17:07:26Z"
           - name: create-tekton-crds
             terminated:
               containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
-              exitCode: 1
+              exitCode: 0
               finishedAt: "2019-09-10T17:08:20Z"
-              reason: Error
+              reason: Completed
               startedAt: "2019-09-10T17:07:27Z"
           - name: git-source-meta-cb-kubecd-bdd-spring-15681-d925z
             terminated:

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pods.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/cluster_state/pods.yml
@@ -625,9 +625,9 @@ items:
       state:
         terminated:
           containerID: docker://58e2714e5547bc1e5228a3a20670f0a5de34b9ccf21b995136cfa96870240909
-          exitCode: 0
+          exitCode: 1
           finishedAt: "2019-09-10T17:07:35Z"
-          reason: Completed
+          reason: Error
           startedAt: "2019-09-10T17:07:26Z"
     - containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
       image: gcr.io/jenkinsxio/builder-maven:0.0.0-SNAPSHOT-PR-5411-40
@@ -639,9 +639,9 @@ items:
       state:
         terminated:
           containerID: docker://a0f8fbbfd6ab4080db9276e0aaedb3df941b6a0e99f24d693f9429c1d4f88094
-          exitCode: 1
+          exitCode: 0
           finishedAt: "2019-09-10T17:08:20Z"
-          reason: Error
+          reason: Completed
           startedAt: "2019-09-10T17:07:27Z"
     - containerID: docker://2f94880db188f839b490cecf829c5552f9bc656330f4385ca3c1fcb029989b17
       image: gcr.io/jenkinsxio/builder-jx:0.1.747

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/expected/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/expected/activity.yml
@@ -63,11 +63,11 @@ spec:
       - completedTimestamp: "2019-09-10T17:07:35Z"
         name: Create Effective Pipeline
         startedTimestamp: "2019-09-10T17:07:30Z"
-        status: Succeeded
+        status: Failed
       - completedTimestamp: "2019-09-10T17:08:20Z"
         name: Create Tekton Crds
         startedTimestamp: "2019-09-10T17:07:35Z"
-        status: Failed
+        status: NotExecuted
   version: 0.0.1
   workflowStatus: Running
 status: {}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

If a step in a pod fails, the steps after it will all end up terminated with a 0 exit code, making the build controller think they were actually successful. They weren't - they were never actually run. So let's mark them as not executed.

#### Special notes for the reviewer(s)

/assign @dgozalo 
/assign @romainverduci 

#### Which issue this PR fixes

fixes #5768
