### PR TITLE
feat: set helm values for environment charts so that we can generate …

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -912,10 +912,10 @@ func (options *InstallOptions) init() error {
 			ecConfig.PathMode = options.Flags.ExposeControllerPathMode
 			log.Logger().Infof("set exposeController Config PathMode %s", ecConfig.PathMode)
 		}
-		if (ecConfig.UrlTemplate == "" && options.Flags.ExposeControllerURLTemplate != "") ||
+		if (ecConfig.URLTemplate == "" && options.Flags.ExposeControllerURLTemplate != "") ||
 			(options.Flags.ExposeControllerURLTemplate != "" && options.InitOptions.Flags.ExternalDNS) {
-			ecConfig.UrlTemplate = options.Flags.ExposeControllerURLTemplate
-			log.Logger().Infof("set exposeController Config URLTemplate %s", ecConfig.UrlTemplate)
+			ecConfig.URLTemplate = options.Flags.ExposeControllerURLTemplate
+			log.Logger().Infof("set exposeController Config URLTemplate %s", ecConfig.URLTemplate)
 		}
 		if isOpenShiftProvider(options.Flags.Provider) {
 			ecConfig.Exposer = "Route"
@@ -2565,7 +2565,7 @@ func (options *InstallOptions) saveIngressConfig() (*kube.IngressConfig, error) 
 		Domain:      domain,
 		TLS:         tls,
 		Exposer:     exposeController.Config.Exposer,
-		UrlTemplate: exposeController.Config.UrlTemplate,
+		UrlTemplate: exposeController.Config.URLTemplate,
 	}
 	// save ingress config details to a configmap
 	_, err = options.saveAsConfigMap(kube.IngressConfigConfigmap, ic)

--- a/pkg/cmd/opts/upgrade/upgrade_ingress.go
+++ b/pkg/cmd/opts/upgrade/upgrade_ingress.go
@@ -471,7 +471,7 @@ func (o *UpgradeIngressOptions) confirmExposecontrollerConfig() error {
 				}
 			}
 		}
-		o.IngressConfig.UrlTemplate, err = util.PickValue("UrlTemplate (press <Enter> to keep the current value):", o.IngressConfig.UrlTemplate, false, "", o.In, o.Out, o.Err)
+		o.IngressConfig.UrlTemplate, err = util.PickValue("URLTemplate (press <Enter> to keep the current value):", o.IngressConfig.UrlTemplate, false, "", o.In, o.Out, o.Err)
 		if err != nil {
 			return err
 		}

--- a/pkg/config/helm_values.go
+++ b/pkg/config/helm_values.go
@@ -7,18 +7,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ExposeDefaultURLTemplate is the default url template format needed by exposecontroller to create ingress rules that work with wiuldcard certs
+const ExposeDefaultURLTemplate = "{{.Service}}-{{.Namespace}}.{{.Domain}}"
+
 type ExposeControllerConfig struct {
-	Domain       string `json:"domain,omitempty"`
-	Exposer      string `json:"exposer,omitempty"`
-	HTTP         string `json:"http,omitempty"`
-	TLSAcme      string `json:"tlsacme,omitempty"`
-	PathMode     string `json:"pathMode,omitempty"`
-	UrlTemplate  string `json:"urltemplate,omitempty"`
-	IngressClass string `json:"ingressClass,omitempty"`
+	Domain        string `json:"domain,omitempty"`
+	Exposer       string `json:"exposer,omitempty"`
+	HTTP          string `json:"http,omitempty"`
+	TLSAcme       string `json:"tlsacme,omitempty"`
+	PathMode      string `json:"pathMode,omitempty"`
+	URLTemplate   string `json:"urltemplate,omitempty"`
+	IngressClass  string `json:"ingressClass,omitempty"`
+	TLSSecretName string `json:"tlsSecretName,omitempty"`
 }
 type ExposeController struct {
 	Config      ExposeControllerConfig `json:"config,omitempty"`
 	Annotations map[string]string      `json:"Annotations,omitempty"`
+	Production  bool                   `json:"production,omitempty"`
 }
 
 type JenkinsValuesConfig struct {
@@ -100,7 +105,7 @@ func (c *HelmValuesConfig) AddExposeControllerValues(cmd *cobra.Command, ignoreD
 	cmd.Flags().StringVarP(&c.ExposeController.Config.HTTP, "http", "", "true", "Toggle creating http or https ingress rules")
 	cmd.Flags().StringVarP(&c.ExposeController.Config.Exposer, "exposer", "", "Ingress", "Used to describe which strategy exposecontroller should use to access applications")
 	cmd.Flags().StringVarP(&c.ExposeController.Config.TLSAcme, "tls-acme", "", "", "Used to enable automatic TLS for ingress")
-	cmd.Flags().StringVarP(&c.ExposeController.Config.UrlTemplate, "urltemplate", "", "", "For ingress; exposers can set the urltemplate to expose")
+	cmd.Flags().StringVarP(&c.ExposeController.Config.URLTemplate, "urltemplate", "", "", "For ingress; exposers can set the urltemplate to expose")
 	cmd.Flags().StringVarP(&c.ExposeController.Config.IngressClass, "ingress-class", "", "", "Used to set the ingress.class annotation in exposecontroller created ingress")
 	cmd.Flags().BoolVarP(&keepJob, "keep-exposecontroller-job", "", false, "Prevents Helm deleting the exposecontroller Job and Pod after running.  Useful for debugging exposecontroller logs but you will need to manually delete the job if you update an environment")
 

--- a/pkg/config/helm_values_test.go
+++ b/pkg/config/helm_values_test.go
@@ -58,7 +58,7 @@ func TestEnvironmentExposecontrollerHelmValuesWithUrlTemplate(t *testing.T) {
 	values.ExposeController.Config.Domain = "jenkinsx.io"
 	values.ExposeController.Config.HTTP = "false"
 	values.ExposeController.Config.TLSAcme = "false"
-	values.ExposeController.Config.UrlTemplate = "{{.Service}}-{{.Namespace}}.{{.Domain}}"
+	values.ExposeController.Config.URLTemplate = "{{.Service}}-{{.Namespace}}.{{.Domain}}"
 	assert.Equal(t, helmValuesFromFile, values, "expected exposecontroller helm values do not match")
 }
 


### PR DESCRIPTION
…ingress rules for applications that work with TLS and external dns
