### PR TITLE
feat: get the current region and cluster name differently so we avoid wrong regions due to misconfiguration

### DIFF
--- a/pkg/cloud/amazon/common.go
+++ b/pkg/cloud/amazon/common.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/pkg/errors"
 )
 
@@ -72,6 +73,21 @@ func ParseContext(context string) (string, string, error) {
 		return "", "", errors.Errorf("unable to parse %s as <cluster_name>.<region>.*", context)
 	}
 	return result[1], result[2], nil
+}
+
+// GetCurrentlyConnectedRegionAndClusterName gets the current context for the connected cluster and parses it
+// to extract both the Region and the ClusterName
+func GetCurrentlyConnectedRegionAndClusterName() (string, string, error) {
+	kubeConfig, _, err := kube.NewKubeConfig().LoadConfig()
+	if err != nil {
+		return "", "", errors.Wrapf(err, "loading kubeconfig")
+	}
+	context := kube.Cluster(kubeConfig)
+	currentClusterName, currentRegion, err := ParseContext(context)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "parsing the current Kubeernetes context %s", context)
+	}
+	return currentClusterName, currentRegion, nil
 }
 
 // UserHomeDir returns the home directory for the user the process is running under.

--- a/pkg/cloud/amazon/ecr.go
+++ b/pkg/cloud/amazon/ecr.go
@@ -19,9 +19,11 @@ import (
 // GetAccountIDAndRegion returns the current account ID and region
 func GetAccountIDAndRegion(profile string, region string) (string, string, error) {
 	sess, err := NewAwsSession(profile, region)
-	region = *sess.Config.Region
+	// We nee to get the region from the connected cluster instead of the one configured for the calling user
+	// as it might not be found and it would then use the default (us-west-2)
+	_, region, err = GetCurrentlyConnectedRegionAndClusterName()
 	if err != nil {
-		return "", region, err
+		return "", "", err
 	}
 	svc := sts.New(sess)
 

--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -565,12 +565,10 @@ func (o *StepVerifyPreInstallOptions) gatherRequirements(requirements *config.Re
 		var currentRegion, currentClusterName string
 		var autoAcceptDefaults bool
 		if requirements.Cluster.Region == "" || requirements.Cluster.ClusterName == "" {
-			kubeConfig, _, err := o.Kube().LoadConfig()
+			currentClusterName, currentRegion, err = amazon.GetCurrentlyConnectedRegionAndClusterName()
 			if err != nil {
-				return nil, errors.Wrapf(err, "loading kubeconfig")
+				return requirements, errors.Wrap(err, "there was a problem obtaining the current cluster name and region")
 			}
-			context := kube.Cluster(kubeConfig)
-			currentClusterName, currentRegion, err = amazon.ParseContext(context)
 			if currentClusterName != "" && currentRegion != "" {
 				log.Logger().Infof("")
 				log.Logger().Infof("Currently connected cluster is %s in region %s", util.ColorInfo(currentClusterName), util.ColorInfo(currentRegion))


### PR DESCRIPTION
… wrong regions due to misconfiguration

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
A quick fix to use the right region when adding the default ERC registry when booting. 

With that, and the build pod assuming a role through the `tekton-bot` `Service Account`, we are able to build and push Docker images using Kaniko in EKS.

#### Which issue this PR fixes

fixes #5433 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
