### PR TITLE
feat: github app integration

### DIFF
--- a/pkg/cmd/step.go
+++ b/pkg/cmd/step.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/step/expose"
 	"github.com/jenkins-x/jx/pkg/cmd/step/get"
 	"github.com/jenkins-x/jx/pkg/cmd/step/git"
+	"github.com/jenkins-x/jx/pkg/cmd/step/github"
 	"github.com/jenkins-x/jx/pkg/cmd/step/helm"
 	"github.com/jenkins-x/jx/pkg/cmd/step/nexus"
 	"github.com/jenkins-x/jx/pkg/cmd/step/post"
@@ -86,6 +87,7 @@ func NewCmdStep(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.AddCommand(update.NewCmdStepUpdate(commonOpts))
 	cmd.AddCommand(report.NewCmdStepReport(commonOpts))
 	cmd.AddCommand(step.NewCmdStepOverrideRequirements(commonOpts))
+	cmd.AddCommand(github.NewCmdStepGithub(commonOpts))
 
 	return cmd
 }

--- a/pkg/cmd/step/github/step_github.go
+++ b/pkg/cmd/step/github/step_github.go
@@ -7,11 +7,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// StepVerifyOptions contains the command line flags
+// StepGithubOptions contains the command line flags
 type StepGithubOptions struct {
 	step.StepOptions
 }
 
+// NewCmdStepGithub access to github commands
 func NewCmdStepGithub(commonOpts *opts.CommonOptions) *cobra.Command {
 	options := &StepGithubOptions{
 		StepOptions: step.StepOptions{

--- a/pkg/cmd/step/github/step_github.go
+++ b/pkg/cmd/step/github/step_github.go
@@ -1,0 +1,40 @@
+package github
+
+import (
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
+	"github.com/spf13/cobra"
+)
+
+// StepVerifyOptions contains the command line flags
+type StepGithubOptions struct {
+	step.StepOptions
+}
+
+func NewCmdStepGithub(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := &StepGithubOptions{
+		StepOptions: step.StepOptions{
+			CommonOptions: commonOpts,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "github",
+		Short: "github [command]",
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+	cmd.AddCommand(NewCmdStepGithubApp(commonOpts))
+
+	return cmd
+}
+
+// Run implements this command
+func (o *StepGithubOptions) Run() error {
+	return o.Cmd.Help()
+}

--- a/pkg/cmd/step/github/step_github_app.go
+++ b/pkg/cmd/step/github/step_github_app.go
@@ -1,0 +1,40 @@
+package github
+
+import (
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
+	"github.com/spf13/cobra"
+)
+
+// StepVerifyOptions contains the command line flags
+type StepGithubAppOptions struct {
+	step.StepOptions
+}
+
+func NewCmdStepGithubApp(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := &StepGithubOptions{
+		StepOptions: step.StepOptions{
+			CommonOptions: commonOpts,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "app",
+		Short: "github app [command]",
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+	cmd.AddCommand(NewCmdStepGithubAppToken(commonOpts))
+
+	return cmd
+}
+
+// Run implements this command
+func (o *StepGithubAppOptions) Run() error {
+	return o.Cmd.Help()
+}

--- a/pkg/cmd/step/github/step_github_app.go
+++ b/pkg/cmd/step/github/step_github_app.go
@@ -7,11 +7,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// StepVerifyOptions contains the command line flags
+// StepGithubOptions contains the command line flags
 type StepGithubAppOptions struct {
 	step.StepOptions
 }
 
+// NewCmdStepGithubApp access to github app commands
 func NewCmdStepGithubApp(commonOpts *opts.CommonOptions) *cobra.Command {
 	options := &StepGithubOptions{
 		StepOptions: step.StepOptions{

--- a/pkg/cmd/step/github/step_github_app_token.go
+++ b/pkg/cmd/step/github/step_github_app_token.go
@@ -1,0 +1,265 @@
+package github
+
+import (
+	"fmt"
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
+	"github.com/jenkins-x/jx/pkg/cmd/templates"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/github"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/tenant"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"strings"
+)
+
+// StepVerifyPodCountOptions contains the command line flags
+type StepGithubAppTokenOptions struct {
+	step.StepOptions
+	GithubOrg         string
+	Dir               string
+	TenantServiceUrl  string
+	TenantServiceAuth string
+	GithubAppUrl      string
+}
+
+var (
+	stepGithubAppTokenLong = templates.LongDesc(`
+		This step requests the installation token from the tenant service and then calls the github app to get an installation token.
+	`)
+
+	stepGitHubAppTokenExample = templates.Examples(`
+		jx step github app token
+	`)
+)
+
+// NewCmdStepGithubApp calls the Jenkins-X github app to get an access token
+func NewCmdStepGithubAppToken(commonOpts *opts.CommonOptions) *cobra.Command {
+
+	options := StepGithubAppTokenOptions{
+		StepOptions: step.StepOptions{
+			CommonOptions: commonOpts,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "token",
+		Short:   "requests an installation token from the github app",
+		Long:    stepGithubAppTokenLong,
+		Example: stepGitHubAppTokenExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.GithubOrg, "org", "o", "", "the github organisation the app has been installed into")
+	cmd.Flags().StringVarP(&options.Dir, "dir", "d", ".", "the directory to look for the values.yaml file")
+	cmd.Flags().StringVarP(&options.TenantServiceUrl, "tenantServiceUrl", "t", "", "the tenant service url")
+	cmd.Flags().StringVarP(&options.TenantServiceAuth, "tenantServiceAuth", "a", "", "the tenant service auth")
+	cmd.Flags().StringVarP(&options.GithubAppUrl, "githubAppUrl", "g", "", "the github app url")
+
+	return cmd
+}
+
+// Run implements this command
+func (options *StepGithubAppTokenOptions) Run() error {
+
+	requirements, requirementsFileName, err := config.LoadRequirementsConfig(options.Dir)
+	if err != nil {
+		log.Logger().Error("Unable to find requirements file %q", requirementsFileName)
+		return errors.Wrapf(err, "failed to load Jenkins X requirements")
+	}
+
+	if options.GithubOrg == "" && requirements.Cluster.EnvironmentGitOwner != "" {
+		options.GithubOrg = requirements.Cluster.EnvironmentGitOwner
+		log.Logger().Debugf("github organisation is %s", options.GithubOrg)
+	}
+
+	if options.GithubOrg == "" {
+		return errors.New("unable to find github organisation")
+	}
+
+	if options.TenantServiceUrl == "" && requirements.Ingress.DomainIssuerURL != "" {
+		options.TenantServiceUrl = requirements.Ingress.DomainIssuerURL
+		log.Logger().Debugf("tenant service url %q", options.TenantServiceUrl)
+
+	}
+	if options.TenantServiceUrl == "" {
+		return errors.New("unable to find tenant service url")
+	}
+
+	if options.TenantServiceAuth == "" {
+		options.TenantServiceAuth, err = options.getTenantServiceBasicAuth()
+		if err != nil {
+			log.Logger().Error("unable to get tenant service auth")
+			return errors.Wrapf(err, "unable to get tenant service auth")
+		}
+	}
+
+	if options.TenantServiceAuth == "" {
+		return errors.New("Unable to get tenant service auth")
+	}
+
+	installationId, err := options.getInstallationId()
+	if err != nil {
+		log.Logger().Error("Unable to get installation id")
+		return errors.Wrapf(err, "Unable to get installation id")
+	}
+	log.Logger().Debugf("installationId is %s\n", installationId)
+
+	installationToken, err := options.getInstallationToken(installationId)
+	if err != nil {
+		log.Logger().Error("Unable to get installation token")
+		return errors.Wrapf(err, "Unable to get installation token")
+	}
+
+	err = options.createSecret(installationToken, requirements)
+	if err != nil {
+		log.Logger().Error("Error writing secret")
+		return err
+	}
+
+	log.Logger().Debugf("installationToken is %s\n", installationToken)
+	return err
+}
+
+func (options *StepGithubAppTokenOptions) createSecret(token string, requirements *config.RequirementsConfig) error {
+
+	var gitKind, gitName, gitServer, namespace string
+	if requirements.Cluster.GitKind != "" {
+		gitKind = requirements.Cluster.GitKind
+	} else {
+		gitKind = "github"
+	}
+
+	if requirements.Cluster.GitName != "" {
+		gitName = requirements.Cluster.GitName
+	} else {
+		gitName = "github"
+	}
+
+	if requirements.Cluster.GitServer != "" {
+		gitServer = requirements.Cluster.GitServer
+	} else {
+		gitServer = "https://github.com"
+	}
+	name := "jx-pipeline-git"
+	name = strings.Join([]string{name, gitKind, gitName}, "-")
+
+	log.Logger().Debugf("Creating or updating secret %s", name)
+
+	labels := map[string]string{
+		"jenkins.io/service-kind":     gitKind,
+		"jenkins.io/created-by":       "jx",
+		"jenkins.io/credentials-type": "usernamePassword",
+		"jenkins.io/kind":             "git",
+	}
+
+	annotations := map[string]string{
+		"jenkins.io/url":                     gitServer,
+		"jenkins.io/name":                    gitName,
+		"jenkins.io/credentials-description": "API Token for acccessing " + gitServer + " Git service inside pipelines",
+		"build.knative.dev/git-0":            gitServer,
+	}
+
+	data := map[string][]byte{
+		"password": []byte(token),
+		"username": []byte("jenkins-x[bot]"),
+	}
+
+	k8Secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:                       name,
+			DeletionGracePeriodSeconds: nil,
+			Labels:                     labels,
+			Annotations:                annotations,
+		},
+		Data: data,
+	}
+
+	kubeClient, err := options.KubeClient()
+	if err != nil {
+		log.Logger().Errorf("error getting kube client %v", err)
+		return err
+	}
+
+	if requirements.Cluster.Namespace != "" {
+		namespace = requirements.Cluster.Namespace
+	} else {
+		namespace = "jx"
+	}
+
+	coreV1 := kubeClient.CoreV1()
+	secretInterface := coreV1.Secrets(namespace)
+	currentSecret, err := secretInterface.Get(name, metav1.GetOptions{})
+	if err != nil {
+		log.Logger().Errorf("error getting secret %v", err)
+	}
+	if currentSecret != nil {
+		_, err = secretInterface.Update(k8Secret)
+		if err != nil {
+			log.Logger().Errorf("error updating secret %v", err)
+		}
+		log.Logger().Debugf("Secret %s updated", name)
+	} else {
+		_, err = secretInterface.Create(k8Secret)
+		if err != nil {
+			log.Logger().Errorf("error creating secret %v", err)
+		}
+		log.Logger().Debugf("Secret %s created", name)
+	}
+
+	return err
+}
+
+func (options *StepGithubAppTokenOptions) getTenantServiceBasicAuth() (string, error) {
+	username := os.Getenv(config.RequirementDomainIssuerUsername)
+	password := os.Getenv(config.RequirementDomainIssuerPassword)
+
+	if username == "" {
+		return "", errors.Errorf("no %s environment variable found", config.RequirementDomainIssuerUsername)
+	}
+	if password == "" {
+		return "", errors.Errorf("no %s environment variable found", config.RequirementDomainIssuerPassword)
+	}
+
+	tenantServiceAuth := fmt.Sprintf("%s:%s", username, password)
+	return tenantServiceAuth, nil
+}
+
+func (options *StepGithubAppTokenOptions) getInstallationId() (string, error) {
+	org := options.GithubOrg
+	log.Logger().Debugf("github org %s", org)
+	tenantServiceClient := tenant.NewTenantClient()
+
+	installationId, err := tenantServiceClient.GetInstallationId(options.TenantServiceUrl, options.TenantServiceAuth, org)
+	if err != nil {
+		log.Logger().Errorf("error calling tenant service %v", err)
+		return "", err
+	}
+
+	log.Logger().Debugf("installation id %q\n", installationId)
+	return installationId, nil
+}
+
+func (options *StepGithubAppTokenOptions) getInstallationToken(installationId string) (string, error) {
+	org := options.GithubOrg
+	log.Logger().Debugf("github org %s\n", org)
+
+	installationToken, err := github.GetInstallationToken(options.GithubAppUrl, installationId)
+	if err != nil {
+		log.Logger().Errorf("error calling github app %v", err)
+		return "", err
+	}
+
+	log.Logger().Debugf("installation token %q", installationToken)
+	return installationToken.InstallationToken, nil
+}

--- a/pkg/cmd/step/github/step_github_app_token.go
+++ b/pkg/cmd/step/github/step_github_app_token.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 )
 
-// StepVerifyPodCountOptions contains the command line flags
+// StepGithubAppTokenOptions contains the command line flags
 type StepGithubAppTokenOptions struct {
 	step.StepOptions
 	GithubOrg         string
@@ -38,7 +38,7 @@ var (
 	`)
 )
 
-// NewCmdStepGithubApp calls the Jenkins-X github app to get an access token
+// NewCmdStepGithubAppToken calls the Jenkins-X github app to get an access token
 func NewCmdStepGithubAppToken(commonOpts *opts.CommonOptions) *cobra.Command {
 
 	options := StepGithubAppTokenOptions{
@@ -175,7 +175,7 @@ func (options *StepGithubAppTokenOptions) createSecret(token string, requirement
 		"username": []byte("jenkins-x[bot]"),
 	}
 
-	k8Secret := &v1.Secret{
+	k8Secret := &v1.Secret{ //pragma: allowlist secret
 		ObjectMeta: metav1.ObjectMeta{
 			Name:                       name,
 			DeletionGracePeriodSeconds: nil,
@@ -202,8 +202,7 @@ func (options *StepGithubAppTokenOptions) createSecret(token string, requirement
 	currentSecret, err := secretInterface.Get(name, metav1.GetOptions{})
 	if err != nil {
 		log.Logger().Errorf("error getting secret %v", err)
-	}
-	if currentSecret != nil {
+	} else if currentSecret != nil {
 		_, err = secretInterface.Update(k8Secret)
 		if err != nil {
 			log.Logger().Errorf("error updating secret %v", err)
@@ -240,21 +239,21 @@ func (options *StepGithubAppTokenOptions) getInstallationId() (string, error) {
 	log.Logger().Debugf("github org %s", org)
 	tenantServiceClient := tenant.NewTenantClient()
 
-	installationId, err := tenantServiceClient.GetInstallationId(options.TenantServiceUrl, options.TenantServiceAuth, org)
+	installationID, err := tenantServiceClient.GetInstallationID(options.TenantServiceUrl, options.TenantServiceAuth, org)
 	if err != nil {
 		log.Logger().Errorf("error calling tenant service %v", err)
 		return "", err
 	}
 
-	log.Logger().Debugf("installation id %q\n", installationId)
-	return installationId, nil
+	log.Logger().Debugf("installation id %q\n", installationID)
+	return installationID, nil
 }
 
-func (options *StepGithubAppTokenOptions) getInstallationToken(installationId string) (string, error) {
+func (options *StepGithubAppTokenOptions) getInstallationToken(installationID string) (string, error) {
 	org := options.GithubOrg
 	log.Logger().Debugf("github org %s\n", org)
 
-	installationToken, err := github.GetInstallationToken(options.GithubAppUrl, installationId)
+	installationToken, err := github.GetInstallationToken(options.GithubAppUrl, installationID)
 	if err != nil {
 		log.Logger().Errorf("error calling github app %v", err)
 		return "", err

--- a/pkg/cmd/step/github/step_github_app_token.go
+++ b/pkg/cmd/step/github/step_github_app_token.go
@@ -2,6 +2,9 @@ package github
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
@@ -12,10 +15,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/tenant"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
-	"strings"
 )
 
 // StepGithubAppTokenOptions contains the command line flags
@@ -175,7 +176,7 @@ func (options *StepGithubAppTokenOptions) createSecret(token string, requirement
 		"username": []byte("jenkins-x[bot]"),
 	}
 
-	k8Secret := &v1.Secret{ //pragma: allowlist secret
+	k8Secret := &corev1.Secret{ //pragma: allowlist secret
 		ObjectMeta: metav1.ObjectMeta{
 			Name:                       name,
 			DeletionGracePeriodSeconds: nil,

--- a/pkg/cmd/step/github/step_github_app_token.go
+++ b/pkg/cmd/step/github/step_github_app_token.go
@@ -75,7 +75,7 @@ func (options *StepGithubAppTokenOptions) Run() error {
 
 	requirements, requirementsFileName, err := config.LoadRequirementsConfig(options.Dir)
 	if err != nil {
-		log.Logger().Error("Unable to find requirements file %q", requirementsFileName)
+		log.Logger().Errorf("Unable to find requirements file %q", requirementsFileName)
 		return errors.Wrapf(err, "failed to load Jenkins X requirements")
 	}
 

--- a/pkg/github/github_app.go
+++ b/pkg/github/github_app.go
@@ -9,21 +9,23 @@ import (
 	"net/url"
 )
 
+// InstallationToken represents an installation from the github app
 type InstallationToken struct {
 	InstallationToken string `json:installationToken`
-	InstallationId    string `json:installation_id`
+	InstallationID    string `json:installation_id`
 	ExpireAt          string `json:expires_at`
 }
 
+// GetInstallationToken retrieves a github app installation token
 func GetInstallationToken(githubAppUrl string, installationId string) (InstallationToken, error) {
-	requestUrl := fmt.Sprintf("%s/installation_token", githubAppUrl)
+	requestURL := fmt.Sprintf("%s/installation_token", githubAppUrl)
 
 	params := url.Values{}
 	params.Set("installation-id", installationId)
 
-	respBody, err := util.CallWithExponentialBackOff(requestUrl, "", "GET", []byte{}, params)
+	respBody, err := util.CallWithExponentialBackOff(requestURL, "", "GET", []byte{}, params)
 	if err != nil {
-		return InstallationToken{}, errors.Wrapf(err, "error getting installation id via %s", requestUrl)
+		return InstallationToken{}, errors.Wrapf(err, "error getting installation id via %s", requestURL)
 	}
 
 	var installationToken InstallationToken

--- a/pkg/github/github_app.go
+++ b/pkg/github/github_app.go
@@ -1,0 +1,37 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+	"net/url"
+)
+
+type InstallationToken struct {
+	InstallationToken string `json:installationToken`
+	InstallationId    string `json:installation_id`
+	ExpireAt          string `json:expires_at`
+}
+
+func GetInstallationToken(githubAppUrl string, installationId string) (InstallationToken, error) {
+	requestUrl := fmt.Sprintf("%s/installation_token", githubAppUrl)
+
+	params := url.Values{}
+	params.Set("installation-id", installationId)
+
+	respBody, err := util.CallWithExponentialBackOff(requestUrl, "", "GET", []byte{}, params)
+	if err != nil {
+		return InstallationToken{}, errors.Wrapf(err, "error getting installation id via %s", requestUrl)
+	}
+
+	var installationToken InstallationToken
+	err = json.Unmarshal(respBody, &installationToken)
+	if err != nil {
+		return InstallationToken{}, errors.Wrap(err, "unmarshalling json message")
+	}
+	log.Logger().Debugf("github app installation token is %s", installationToken)
+
+	return installationToken, nil
+}

--- a/pkg/github/github_app.go
+++ b/pkg/github/github_app.go
@@ -3,10 +3,11 @@ package github
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
-	"net/url"
 )
 
 // InstallationToken represents an installation from the github app

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -3,14 +3,14 @@ package tenant
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/cloud/gke"
-	"github.com/jenkins-x/jx/pkg/util"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
 
+	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -65,7 +65,7 @@ type Result struct {
 	Message string `json:"message"`
 }
 
-func (tCli *tenantClient) GetInstallationId(tenantServiceURL string, tenantServiceAuth string, gitHubOrg string) (string, error) {
+func (tCli *tenantClient) GetInstallationID(tenantServiceURL string, tenantServiceAuth string, gitHubOrg string) (string, error) {
 	requestUrl := fmt.Sprintf("%s%s/installation-id", tenantServiceURL, basePath)
 
 	params := url.Values{}

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -1,19 +1,15 @@
 package tenant
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"github.com/jenkins-x/jx/pkg/cloud/gke"
+	"github.com/jenkins-x/jx/pkg/util"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
-	"strings"
-	"time"
 
-	"github.com/jenkins-x/jx/pkg/cloud/gke"
-
-	"github.com/cenkalti/backoff"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/pkg/errors"
 )
@@ -59,9 +55,34 @@ type Domain struct {
 	} `json:"data"`
 }
 
+type Installation struct {
+	InstallationId string `json:installation-id`
+	Organisation   string `json:org`
+}
+
 // Result type for nameservers response
 type Result struct {
 	Message string `json:"message"`
+}
+
+func (tCli *tenantClient) GetInstallationId(tenantServiceURL string, tenantServiceAuth string, gitHubOrg string) (string, error) {
+	requestUrl := fmt.Sprintf("%s%s/installation-id", tenantServiceURL, basePath)
+
+	params := url.Values{}
+	params.Set("org", gitHubOrg)
+
+	respBody, err := util.CallWithExponentialBackOff(requestUrl, tenantServiceAuth, "GET", []byte{}, params)
+	if err != nil {
+		return "", errors.Wrapf(err, "error getting installation id via %s", requestUrl)
+	}
+
+	var installation Installation
+	err = json.Unmarshal(respBody, &installation)
+	if err != nil {
+		return "", errors.Wrap(err, "unmarshalling json message")
+	}
+
+	return installation.InstallationId, nil
 }
 
 func (tCli *tenantClient) GetTenantSubDomain(tenantServiceURL string, tenantServiceAuth string, projectID string, cluster string, gcloud gke.GClouder) (string, error) {
@@ -83,7 +104,7 @@ func (tCli *tenantClient) GetTenantSubDomain(tenantServiceURL string, tenantServ
 		return "", errors.Wrap(err, "error marshalling struct into json")
 	}
 	if projectID != "" {
-		respBody, err := tCli.callWithExponentialBackOff(url, tenantServiceAuth, "POST", reqBody)
+		respBody, err := util.CallWithExponentialBackOff(url, tenantServiceAuth, "POST", reqBody, nil)
 		if err != nil {
 			return "", errors.Wrapf(err, "error getting tenant sub-domain via %s", url)
 		}
@@ -137,7 +158,7 @@ func (tCli *tenantClient) PostTenantZoneNameServers(tenantServiceURL string, ten
 	}
 
 	if projectID != "" && zone != "" && len(nameServers) > 0 {
-		respBody, err = tCli.callWithExponentialBackOff(url, tenantServiceAuth, "POST", reqBody)
+		respBody, err = util.CallWithExponentialBackOff(url, tenantServiceAuth, "POST", reqBody, nil)
 		if err != nil {
 			return errors.Wrapf(err, "error posting tenant sub-domain nameservers via %s", url)
 		}
@@ -155,61 +176,13 @@ func (tCli *tenantClient) PostTenantZoneNameServers(tenantServiceURL string, ten
 // NewTenantClient creates a new tenant client
 func NewTenantClient(options ...Option) *tenantClient {
 	tCli := tenantClient{
-		httpClient: &http.Client{},
+		httpClient: util.GetClient(),
 	}
 
 	for option := range options {
 		options[option](&tCli)
 	}
 	return &tCli
-}
-
-func (tCli *tenantClient) callWithExponentialBackOff(url string, auth string, httpMethod string, reqBody []byte) ([]byte, error) {
-	log.Logger().Debugf("%sing %s to %s", httpMethod, reqBody, url)
-	resp, respBody := &http.Response{}, []byte{}
-	if url != "" && httpMethod != "" {
-		f := func() error {
-			req, err := http.NewRequest(httpMethod, url, bytes.NewBuffer(reqBody))
-			req.Header.Set("Content-Type", "application/json")
-			if !strings.Contains(url, "localhost") || !strings.Contains(url, "127.0.0.1") {
-				if strings.Count(auth, ":") == 1 {
-					jxBasicAuthUser, jxBasicAuthPass := getBasicAuthUserAndPassword(auth)
-					req.SetBasicAuth(jxBasicAuthUser, jxBasicAuthPass)
-				}
-			}
-
-			resp, err = tCli.httpClient.Do(req)
-			if err != nil {
-				return backoff.Permanent(err)
-			}
-			if resp.StatusCode < 200 && resp.StatusCode >= 300 {
-				return errors.Errorf("%s not available, error was %d %s", url, resp.StatusCode, resp.Status)
-			}
-			respBody, err = ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return backoff.Permanent(errors.Wrap(err, "parsing response body"))
-			}
-			resp.Body.Close()
-			return nil
-		}
-		exponentialBackOff := backoff.NewExponentialBackOff()
-		timeout := 1 * time.Minute
-		exponentialBackOff.MaxElapsedTime = timeout
-		exponentialBackOff.Reset()
-		err := backoff.Retry(f, exponentialBackOff)
-		if err != nil {
-			return []byte{}, errors.Wrapf(err, "error getting tenant sub-domain via %s", url)
-		}
-	}
-	return respBody, nil
-}
-
-func getBasicAuthUserAndPassword(auth string) (string, string) {
-	if auth != "" {
-		creds := strings.Fields(strings.Replace(auth, ":", " ", -1))
-		return creds[0], creds[1]
-	}
-	return "", ""
 }
 
 // ValidateDomainName checks for compliance in a supplied domain name

--- a/pkg/tenant/tenant_test.go
+++ b/pkg/tenant/tenant_test.go
@@ -8,9 +8,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	gke_test "github.com/jenkins-x/jx/pkg/cloud/gke/mocks"
+	gkeTest "github.com/jenkins-x/jx/pkg/cloud/gke/mocks"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/petergtz/pegomock"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +42,7 @@ func TestClientGetTenantSubDomain(t *testing.T) {
 	cli := NewTenantClient()
 	cli.httpClient = httpClient
 
-	gclouder := &gke_test.MockGClouder{}
+	gclouder := &gkeTest.MockGClouder{}
 	pegomock.When(gclouder.CreateDNSZone("cheese", "cheese.wine.com")).ThenReturn("123", []string{"abc"}, nil)
 
 	s, err := cli.GetTenantSubDomain("http://localhost", "", projectID, cluster, gclouder)
@@ -82,7 +82,7 @@ func testingHTTPClient(handler http.Handler) (*http.Client, func()) {
 
 func TestGetBasicAuthUserAndPassword(t *testing.T) {
 	auth := "some_user:some_password"
-	user, pass := getBasicAuthUserAndPassword(auth)
+	user, pass := util.GetBasicAuthUserAndPassword(auth)
 	assert.Equal(t, auth, user+":"+pass)
 }
 

--- a/pkg/util/http_utils.go
+++ b/pkg/util/http_utils.go
@@ -2,7 +2,7 @@ package util
 
 import (
 	"bytes"
-	"github.com/pkg/errors"
+
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-
 	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/pkg/errors"
 )
 
 // defaults mirror the default http.Transport values
@@ -83,7 +83,7 @@ func CallWithExponentialBackOff(url string, auth string, httpMethod string, reqB
 			req.Header.Set("Content-Type", "application/json")
 			if !strings.Contains(url, "localhost") || !strings.Contains(url, "127.0.0.1") {
 				if strings.Count(auth, ":") == 1 {
-					jxBasicAuthUser, jxBasicAuthPass := getBasicAuthUserAndPassword(auth)
+					jxBasicAuthUser, jxBasicAuthPass := GetBasicAuthUserAndPassword(auth)
 					req.SetBasicAuth(jxBasicAuthUser, jxBasicAuthPass)
 				}
 			}
@@ -118,7 +118,7 @@ func CallWithExponentialBackOff(url string, auth string, httpMethod string, reqB
 	return respBody, nil
 }
 
-func getBasicAuthUserAndPassword(auth string) (string, string) {
+func GetBasicAuthUserAndPassword(auth string) (string, string) {
 	if auth != "" {
 		creds := strings.Fields(strings.Replace(auth, ":", " ", -1))
 		return creds[0], creds[1]

--- a/pkg/util/http_utils.go
+++ b/pkg/util/http_utils.go
@@ -73,6 +73,7 @@ func getBoolFromEnv(key string, fallback bool) bool {
 	return fallback
 }
 
+// CallWithExponentialBackOff make a http call with exponential backoff retry
 func CallWithExponentialBackOff(url string, auth string, httpMethod string, reqBody []byte, reqParams url.Values) ([]byte, error) {
 	log.Logger().Debugf("%sing %s to %s", httpMethod, reqBody, url)
 	resp, respBody := &http.Response{}, []byte{}


### PR DESCRIPTION
As part of the github app integration, we need the ability to query the github app for an installation token during `jx boot` and then refresh at regular intervals. Creating a step command to allow us to do this. The command will query the tenant service to get an installation id and then a github app to get an installation token. This token is then written to a k8 secret

Command:
`jx step github app token`



Signed-off-by: warrenbailey <warren@warrenbailey.net>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
