### PR TITLE
fix: only create/update dev environment repo when within `jx boot`

### DIFF
--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -731,11 +731,12 @@ func FindTagForVersion(dir string, version string, gitter Gitter) (string, error
 }
 
 // DuplicateGitRepoFromCommitish will duplicate branches (but not tags) from fromGitURL to toOrg/toName. It will reset the
-// head of the toBranch on the duplicated repo to fromCommitish. It returns the GitRepository for the duplicated repo
+// head of the toBranch on the duplicated repo to fromCommitish. It returns the GitRepository for the duplicated repo.
+// If the repository already exist and error is returned.
 func DuplicateGitRepoFromCommitish(toOrg string, toName string, fromGitURL string, fromCommitish string, toBranch string, private bool, provider GitProvider, gitter Gitter) (*GitRepository, error) {
-	duplicateInfo, err := provider.GetRepository(toOrg, toName)
+	_, err := provider.GetRepository(toOrg, toName)
 	if err == nil {
-		return duplicateInfo, nil
+		return nil, errors.Errorf("repository %s/%s already exists", toOrg, toName)
 	}
 
 	// If the duplicate doesn't exist create it
@@ -748,7 +749,7 @@ func DuplicateGitRepoFromCommitish(toOrg string, toName string, fromGitURL strin
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting repo for %s", fromGitURL)
 	}
-	duplicateInfo, err = provider.CreateRepository(toOrg, toName, private)
+	duplicateInfo, err := provider.CreateRepository(toOrg, toName, private)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create GitHub repo %s/%s", toOrg, toName)
 	}


### PR DESCRIPTION
fixes #5819

* only call `handleDevEnvironmentRepository` is in `jx boot`. This effectively pulls up ` o.isJXBoot()` one level 
* Let helpers#DuplicateGitRepoFromCommitish return an error if the target repo exists which is more in line with one would expect from the function name