### PR TITLE
fix: define the TLS secret name in each environment ingress config

### DIFF
--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -418,15 +418,19 @@ func (o *StepVerifyEnvironmentsOptions) createEnvironmentHelmValues(requirements
 	helmValues := config.HelmValuesConfig{
 		ExposeController: &config.ExposeController{
 			Config: config.ExposeControllerConfig{
-				Domain:        domain,
-				Exposer:       exposer,
-				HTTP:          useHTTP,
-				TLSAcme:       tlsAcme,
-				URLTemplate:   config.ExposeDefaultURLTemplate,
-				TLSSecretName: envCfg.Ingress.TLS.SecretName,
+				Domain:      domain,
+				Exposer:     exposer,
+				HTTP:        useHTTP,
+				TLSAcme:     tlsAcme,
+				URLTemplate: config.ExposeDefaultURLTemplate,
 			},
 			Production: envCfg.Ingress.TLS.Production,
 		},
+	}
+
+	// Only set the secret name if TLS is enabled else exposecontroller thinks the ingress needs TLS
+	if envCfg.Ingress.TLS.Enabled {
+		helmValues.ExposeController.Config.TLSSecretName = envCfg.Ingress.TLS.SecretName
 	}
 
 	return helmValues, nil

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -430,7 +430,15 @@ func (o *StepVerifyEnvironmentsOptions) createEnvironmentHelmValues(requirements
 
 	// Only set the secret name if TLS is enabled else exposecontroller thinks the ingress needs TLS
 	if envCfg.Ingress.TLS.Enabled {
-		helmValues.ExposeController.Config.TLSSecretName = envCfg.Ingress.TLS.SecretName
+		secretName := envCfg.Ingress.TLS.SecretName
+		if secretName == "" {
+			if envCfg.Ingress.TLS.Production {
+				secretName = fmt.Sprintf("tls-%s-p", domain)
+			} else {
+				secretName = fmt.Sprintf("tls-%s-s", domain)
+			}
+		}
+		helmValues.ExposeController.Config.TLSSecretName = secretName
 	}
 
 	return helmValues, nil

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/jenkins-x/jx/pkg/helm"
 	"sigs.k8s.io/yaml"
@@ -70,7 +69,7 @@ func (o *StepVerifyEnvironmentsOptions) Run() error {
 		return err
 	}
 
-	requirements, _, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir)
 	if err != nil {
 		return err
 	}
@@ -85,7 +84,10 @@ func (o *StepVerifyEnvironmentsOptions) Run() error {
 		gitURL := env.Spec.Source.URL
 		if gitURL != "" && (env.Spec.Kind == v1.EnvironmentKindTypePermanent || (env.Spec.Kind == v1.EnvironmentKindTypeDevelopment && requirements.GitOps)) {
 			log.Logger().Infof("Validating git repository for %s environment at URL %s\n", info(name), info(gitURL))
-
+			err = o.updateEnvironmentIngressConfig(requirements, requirementsFileName, env)
+			if err != nil {
+				return errors.Wrapf(err, "updating the ingress config for environment %q", env.GetName())
+			}
 			err = o.validateGitRepository(name, requirements, env, gitURL)
 			if err != nil {
 				return err
@@ -408,8 +410,7 @@ func (o *StepVerifyEnvironmentsOptions) createEnvironmentHelmValues(requirements
 	}
 	useHTTP := "true"
 	tlsAcme := "false"
-
-	if requirements.Ingress.TLS.Enabled {
+	if envCfg.Ingress.TLS.Enabled {
 		useHTTP = "false"
 		tlsAcme = "true"
 	}
@@ -417,28 +418,33 @@ func (o *StepVerifyEnvironmentsOptions) createEnvironmentHelmValues(requirements
 	helmValues := config.HelmValuesConfig{
 		ExposeController: &config.ExposeController{
 			Config: config.ExposeControllerConfig{
-				Domain:      domain,
-				Exposer:     exposer,
-				HTTP:        useHTTP,
-				TLSAcme:     tlsAcme,
-				URLTemplate: config.ExposeDefaultURLTemplate,
+				Domain:        domain,
+				Exposer:       exposer,
+				HTTP:          useHTTP,
+				TLSAcme:       tlsAcme,
+				URLTemplate:   config.ExposeDefaultURLTemplate,
+				TLSSecretName: envCfg.Ingress.TLS.SecretName,
 			},
+			Production: envCfg.Ingress.TLS.Production,
 		},
 	}
 
-	// set the exposecontroller helm values needed to create an ingress rule with TLS pointing to the right secret containing the cert
-	secretName := ""
-	if requirements.Ingress.TLS.Production {
-		helmValues.ExposeController.Production = true
-		secretName = fmt.Sprintf("tls-%s-p", domain)
-	} else {
-		secretName = fmt.Sprintf("tls-%s-s", domain)
-	}
-
-	// only set the secret name if TLS is enabled else exposecontroller thinks the ingress needs TLS
-	if requirements.Ingress.TLS.Enabled {
-		helmValues.ExposeController.Config.TLSSecretName = strings.Replace(secretName, ".", "-", -1)
-	}
-
 	return helmValues, nil
+}
+
+func (o *StepVerifyEnvironmentsOptions) updateEnvironmentIngressConfig(requirements *config.RequirementsConfig, requirementsFileName string, env *v1.Environment) error {
+	if env.Spec.Kind != v1.EnvironmentKindTypeDevelopment {
+		return nil
+	}
+
+	// Override the dev environemtn ingress config from main ingress config
+	name := env.GetName()
+	for i, e := range requirements.Environments {
+		if e.Key == name {
+			requirements.Environments[i].Ingress = requirements.Ingress
+			break
+		}
+	}
+
+	return requirements.SaveConfig(requirementsFileName)
 }

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -168,16 +168,16 @@ type EnvironmentConfig struct {
 // IngressConfig contains dns specific requirements
 type IngressConfig struct {
 	// DNS is enabled
-	ExternalDNS bool `json:"externalDNS"`
+	ExternalDNS bool `json:"externalDNS,omitempty"`
 	// CloudDNSSecretName secret name which contains the service account for external-dns and cert-manager issuer to
 	// access the Cloud DNS service to resolve a DNS challenge
 	CloudDNSSecretName string `json:"cloud_dns_secret_name,omitempty"`
 	// Domain to expose ingress endpoints
-	Domain string `json:"domain"`
+	Domain string `json:"domain,omitempty"`
 	// NamespaceSubDomain the sub domain expression to expose ingress. Defaults to ".jx."
-	NamespaceSubDomain string `json:"namespaceSubDomain"`
+	NamespaceSubDomain string `json:"namespaceSubDomain,omitempty"`
 	// TLS enable automated TLS using certmanager
-	TLS TLSConfig `json:"tls"`
+	TLS TLSConfig `json:"tls,omitempty"`
 	// DomainIssuerURL contains a URL used to retrieve a Domain
 	DomainIssuerURL string `json:"domainIssuerURL,omitempty"`
 }
@@ -185,14 +185,14 @@ type IngressConfig struct {
 // TLSConfig contains TLS specific requirements
 type TLSConfig struct {
 	// TLS enabled
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled,omitempty"`
 	// Email address to register with services like LetsEncrypt
-	Email string `json:"email"`
+	Email string `json:"email,omitempty"`
 	// Production false uses self-signed certificates from the LetsEncrypt staging server, true enables the production
 	// server which incurs higher rate limiting https://letsencrypt.org/docs/rate-limits/
-	Production bool `json:"production"`
+	Production bool `json:"production,omitempty"`
 	// SecretName the name of the secret which contains the TLS certificate
-	SecretName string `json:"secretName"`
+	SecretName string `json:"secretName,omitempty"`
 }
 
 // JxInstallProfile contains the jx profile info

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -191,6 +191,8 @@ type TLSConfig struct {
 	// Production false uses self-signed certificates from the LetsEncrypt staging server, true enables the production
 	// server which incurs higher rate limiting https://letsencrypt.org/docs/rate-limits/
 	Production bool `json:"production"`
+	// SecretName the name of the secret which contains the TLS certificate
+	SecretName string `json:"secretName"`
 }
 
 // JxInstallProfile contains the jx profile info

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -168,16 +168,16 @@ type EnvironmentConfig struct {
 // IngressConfig contains dns specific requirements
 type IngressConfig struct {
 	// DNS is enabled
-	ExternalDNS bool `json:"externalDNS,omitempty"`
+	ExternalDNS bool `json:"externalDNS"`
 	// CloudDNSSecretName secret name which contains the service account for external-dns and cert-manager issuer to
 	// access the Cloud DNS service to resolve a DNS challenge
 	CloudDNSSecretName string `json:"cloud_dns_secret_name,omitempty"`
 	// Domain to expose ingress endpoints
-	Domain string `json:"domain,omitempty"`
+	Domain string `json:"domain"`
 	// NamespaceSubDomain the sub domain expression to expose ingress. Defaults to ".jx."
-	NamespaceSubDomain string `json:"namespaceSubDomain,omitempty"`
+	NamespaceSubDomain string `json:"namespaceSubDomain"`
 	// TLS enable automated TLS using certmanager
-	TLS TLSConfig `json:"tls,omitempty"`
+	TLS TLSConfig `json:"tls"`
 	// DomainIssuerURL contains a URL used to retrieve a Domain
 	DomainIssuerURL string `json:"domainIssuerURL,omitempty"`
 }
@@ -185,12 +185,12 @@ type IngressConfig struct {
 // TLSConfig contains TLS specific requirements
 type TLSConfig struct {
 	// TLS enabled
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 	// Email address to register with services like LetsEncrypt
-	Email string `json:"email,omitempty"`
+	Email string `json:"email"`
 	// Production false uses self-signed certificates from the LetsEncrypt staging server, true enables the production
 	// server which incurs higher rate limiting https://letsencrypt.org/docs/rate-limits/
-	Production bool `json:"production,omitempty"`
+	Production bool `json:"production"`
 	// SecretName the name of the secret which contains the TLS certificate
 	SecretName string `json:"secretName,omitempty"`
 }


### PR DESCRIPTION
Also override the dev environment ingress config with the main ingress config. They should be identical.
In the near future, we should deprecated the main ingress config in favour of dev env ingress config.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->