### PR TITLE
fix(logs): Get correct location For completed builds in GHE

### DIFF
--- a/pkg/collector/git_collector.go
+++ b/pkg/collector/git_collector.go
@@ -158,9 +158,13 @@ func (c *GitCollector) CollectData(data []byte, outputPath string) (string, erro
 	return u, err
 }
 
-func (c *GitCollector) generateURL(storageOrg string, storageRepoName string, rPath string) string {
-	// TODO only supporting github for now!!!
-	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", storageOrg, storageRepoName, c.gitBranch, rPath)
+func (c *GitCollector) generateURL(storageOrg string, storageRepoName string, rPath string) (url string) {
+	if !c.gitInfo.IsGitHub() && gits.SaasGitKind(c.gitInfo.Host) == gits.KindGitHub {
+		url = fmt.Sprintf("https://raw.%s/%s/%s/%s/%s", c.gitInfo.Host, storageOrg, storageRepoName, c.gitBranch, rPath)
+	} else {
+		// TODO only supporting github for now!!!
+		url = fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", storageOrg, storageRepoName, c.gitBranch, rPath)
+	}
 	log.Logger().Infof("Publishing %s", util.ColorInfo(url))
 	return url
 }


### PR DESCRIPTION
Why:

This change addresses the need by:

GitHub Enterprise Provider have different raw location for files

Signed-off-by: Jiang Yitao <jiangyt.cn@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
```
$ jx get build log
? Which build do you want to view the logs of?:  sosops/devops-staging/master #23
error: there was a problem obtaining the log file from the github pages URL https://raw.githubusercontent.com/sosops/devops-staging/gh-pages/jenkins-x/logs/sosops/devops-staging/master/23.log: status 404 Not Found when performing GET on https://xxxx@raw.githubusercontent.com/sosops/devops-staging/gh-pages/jenkins-x/logs/sosops/devops-staging/master/23.log
```
#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
