### PR TITLE
fix: Add support for eks arns as context names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -171,5 +171,3 @@ replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v10.15.5+incompatible
 
 replace github.com/banzaicloud/bank-vaults => github.com/banzaicloud/bank-vaults v0.0.0-20190508130850-5673d28c46bd
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -171,3 +171,5 @@ replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v10.15.5+incompatible
 
 replace github.com/banzaicloud/bank-vaults => github.com/banzaicloud/bank-vaults v0.0.0-20190508130850-5673d28c46bd
+
+go 1.13

--- a/pkg/cloud/amazon/common.go
+++ b/pkg/cloud/amazon/common.go
@@ -71,7 +71,7 @@ func ParseContext(context string) (string, string, error) {
 	result := reg.FindStringSubmatch(context)
 	// Also check if the context name matchesAWS ARN format as defined:
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonelasticcontainerserviceforkubernetes.html#amazonelasticcontainerserviceforkubernetes-resources-for-iam-policies
-	arnReg := regexp.MustCompile(`arn:aws:eks:((us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d):[0-9]*:cluster/([a-zA-Z][-a-zA-Z0-9]*)`)
+	arnReg := regexp.MustCompile(`arn:aws:eks:((?:us(?:-gov)?|ap|ca|cn|eu|sa)-(?:central|(?:north|south)?(?:east|west)?)-\d):[0-9]*:cluster\/([a-zA-Z][-a-zA-Z0-9]*)`)
 	arnResult := arnReg.FindStringSubmatch(context)
 	if len(result) >= 3 {
 		return result[1], result[2], nil

--- a/pkg/cloud/amazon/common.go
+++ b/pkg/cloud/amazon/common.go
@@ -69,8 +69,10 @@ func ResolveRegionWithoutOptions() (string, error) {
 func ParseContext(context string) (string, string, error) {
 	reg := regexp.MustCompile(`([a-zA-Z][-a-zA-Z0-9]*)\.((us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d)\.*`)
 	result := reg.FindStringSubmatch(context)
+	// Also check if the context name matchesAWS ARN format as defined:
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonelasticcontainerserviceforkubernetes.html#amazonelasticcontainerserviceforkubernetes-resources-for-iam-policies
 	arnReg := regexp.MustCompile(`arn:aws:eks:((us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d):[0-9]*:cluster/([a-zA-Z][-a-zA-Z0-9]*)`)
-	arnResult := reg.FindStringSubmatch(context)
+	arnResult := arnReg.FindStringSubmatch(context)
 	if len(result) >= 3 {
 		return result[1], result[2], nil
 	} else if len(arnResult) >= 3 {

--- a/pkg/cloud/amazon/common_test.go
+++ b/pkg/cloud/amazon/common_test.go
@@ -134,6 +134,11 @@ func TestParseContext(t *testing.T) {
 			cluster: "cluster-name-jx",
 			region:  "eu-north-4",
 		},
+		"full cluster name eks arn": {
+			context: "arn:aws:eks:us-east-1:111111111111:cluster/cluster-name-jx",
+			cluster: "cluster-name-jx",
+			region:  "us-east-1",
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
The regex to determine the EKS cluster name and region does not support the EKS ARN which is the format of the context name generated by `aws eks update-kubeconfig` 
This issue appears when running `jx boot` and `jx install`

Added functionality where an attempt is made to retrieve the eks cluster name from AWS via the AWS eks sdk looping through all the eks clusters until one is found that has an endpoint matching the one in the current kubeconfig context.

Also includes a small typo fix

#### Special notes for the reviewer(s)
I was unable to run `make build` as i received the following errors:
```
make build
CGO_ENABLED=0 GO111MODULE=on go build -ldflags " -X github.com/jenkins-x/jx/pkg/version.Version=2.0.882-dev+66cb8bdc8 -X github.com/jenkins-x/jx/pkg/version.Revision='66cb8bdc8' -X github.com/jenkins-x/jx/pkg/version.Branch='andrewhertog/eks-arn-support' -X github.com/jenkins-x/jx/pkg/version.BuildDate='20191016-14:52:57' -X github.com/jenkins-x/jx/pkg/version.GoVersion='1.13.1'" -o build/jx cmd/jx/jx.go
go: k8s.io/client-go@v2.0.0-alpha.0.0.20190115164855-701b91367003+incompatible: invalid pseudo-version: preceding tag (v2.0.0-alpha.0) not found
make: *** [build] Error 1
```
This is my first time ever working on a go project so any feedback is welcome

#### Which issue this PR fixes

fixes #5844, fixes #5841

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->


Update: Fixed this by changing from Go1.13 to Go1.11
Update: Added AWS sdk lookup for cluster name