### PR TITLE
[wip] feat: Handling git credentials via GIT_ASKPASS

### DIFF
--- a/jx/bdd/boot-vault/cluster.yaml
+++ b/jx/bdd/boot-vault/cluster.yaml
@@ -15,4 +15,3 @@ clusters:
       - command: jx
         args:
           - boot
-          - -b

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -387,12 +387,7 @@ func (o *StepVerifyEnvironmentsOptions) pushDevEnvironmentUpdates(environmentRep
 		}
 	}
 
-	userDetails := provider.UserAuth()
-	authenticatedPushURL, err := gitter.CreateAuthenticatedURL(environmentRepo.CloneURL, &userDetails)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create push URL for %s", environmentRepo.CloneURL)
-	}
-	err = gitter.Push(localRepoDir, authenticatedPushURL, true, "master")
+	err = gitter.Push(localRepoDir, "origin", true, "master")
 	if err != nil {
 		return errors.Wrapf(err, "unable to push %s to %s", localRepoDir, environmentRepo.URL)
 	}

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -698,6 +698,13 @@ func (g *GitCLI) SetRemoteURL(dir string, name string, gitURL string) error {
 			return err
 		}
 	}
+
+	// TODO issue-5772 Maybe there is a better way to set this? maybe so that the config is also set directly on clone
+	// TODO issue-5772 Need to look at the actual URL to do the rewrite
+	err = g.gitCmd(dir, "config", "url.https://token@github.com/.insteadOf", "https://github.com/")
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
fixes #5772

This is a possible solution for #5772 allowing you to re-run `jx boot` from the same directory multiple times.

At the same time, it could also serve as an alternative solution for #5463, replacing the need for a credential helper. The only drawback is that users might get prompted for a password/token when executing git commands directly. All `jx` executions would be covered.

We could also set `git config core.askpass ~/.jx/bin/git-askpass` directly into the git config as part of cloning / setting a remote. This way `jx` command executions as well as users direct git commands would be covered. We also would not have to set _GIT_ASKPASS_ on each `jx` command execution. 

Thoughts?

Note, this is just a POC. There are several TODOs left in the code. I'd like to determine whether this is a viable path forward.

