### PR TITLE
feat: add the capability to configure exposer

### DIFF
--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -220,6 +220,8 @@ type IngressConfig struct {
 	// domain if you are using a dynamic domain resolver like `.nip.io` rather than a real DNS configuration.
 	// With this flag enabled the `Domain` value will be used and never re-created based on the current LoadBalancer IP address.
 	IgnoreLoadBalancer bool `json:"ignoreLoadBalancer,omitempty"`
+	// Exposer the exposer used to expose ingress endpoints. Defaults to "Ingress"
+	Exposer string `json:"exposer,omitempty"`
 	// NamespaceSubDomain the sub domain expression to expose ingress. Defaults to ".jx."
 	NamespaceSubDomain string `json:"namespaceSubDomain"`
 	// TLS enable automated TLS using certmanager


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

OpenShift can use `Route` to expose endpoints, the configmap for the exposer always set to the `Ingress` by `jx boot` before. With such parameter, we can configure exposer type.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->

Support:

https://github.com/jenkins-x-charts/jxboot-resources/pull/9
