### PR TITLE
fix: default gitRef to master if not in default/specified version stream

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -168,16 +168,11 @@ func (o *BootOptions) Run() error {
 		repo := gitInfo.Name
 		cloneDir := filepath.Join(o.Dir, repo)
 
-		if gitRef == "" {
+		if o.GitRef == "" {
 			gitRef, err = o.determineGitRef(requirements, gitURL)
 			if err != nil {
 				return errors.Wrapf(err, "failed to determine git ref")
 			}
-		}
-
-		if gitRef == "" {
-			log.Logger().Info("no gitref found, defaulting to master")
-			gitRef = "master"
 		}
 
 		if !o.BatchMode {
@@ -371,18 +366,16 @@ func (o *BootOptions) determineGitRef(requirements *config.RequirementsConfig, g
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create version resolver")
 	}
+	log.Logger().Infof("Attempting to resolve version for boot config %s from %s", util.ColorInfo(gitURL), util.ColorInfo(requirements.VersionStream.URL))
 	gitRef, err := resolver.ResolveGitVersion(gitURL)
 	if err != nil {
 		return "", errors.Wrapf(err, fmt.Sprintf("failed to resolve version for %s in version stream %s",
 			gitURL, requirements.VersionStream.URL))
 	}
 	if gitRef == "" {
-		log.Logger().Infof("Attempting to resolve version for upstream boot config %s", util.ColorInfo(config.DefaultBootRepository))
-		gitRef, err = resolver.ResolveGitVersion(config.DefaultBootRepository)
-		if err != nil {
-			return "", errors.Wrapf(err, fmt.Sprintf("failed to resolve version for %s in version stream %s",
-				config.DefaultBootRepository, requirements.VersionStream.URL))
-		}
+		log.Logger().Infof("no version for %s found in version stream %s, defaulting to %",
+			util.ColorInfo(gitURL), util.ColorInfo(requirements.VersionStream.URL), util.ColorInfo("master"))
+		gitRef = "master"
 	}
 	return gitRef, nil
 }

--- a/pkg/cmd/boot/boot_test.go
+++ b/pkg/cmd/boot/boot_test.go
@@ -1,0 +1,82 @@
+package boot
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/jenkins-x/jx/pkg/versionstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBootOptions options for the command
+type TestBootOptions struct {
+	BootOptions
+}
+
+const (
+	defaultBootRequirements = "test_data/requirements/jx-requirements.yml"
+)
+
+func (o *TestBootOptions) setup(bootRequirements string) {
+	o.BootOptions = BootOptions{
+		CommonOptions:    &opts.CommonOptions{},
+		RequirementsFile: bootRequirements,
+	}
+}
+
+func TestDetermineGitRef_DefaultGitUrl(t *testing.T) {
+	t.Parallel()
+
+	o := TestBootOptions{}
+	o.setup(defaultBootRequirements)
+
+	dir := o.createTmpRequirements(t)
+	requirements, _, err := config.LoadRequirementsConfig(dir)
+	require.NoError(t, err, "unable to load tmp jx-requirements")
+	resolver := &versionstream.VersionResolver{
+		VersionsDir: filepath.Join("test_data", "jenkins-x-versions"),
+	}
+
+	gitRef, err := o.determineGitRef(resolver, requirements, config.DefaultBootRepository)
+	require.NoError(t, err, "unable to determineGitRef")
+	assert.Equal(t, "1.0.32", gitRef, "determineGitRef")
+}
+
+func TestDetermineGitRef_GitURLNotInVersionStream(t *testing.T) {
+	t.Parallel()
+
+	o := TestBootOptions{}
+	o.setup(defaultBootRequirements)
+
+	dir := o.createTmpRequirements(t)
+	requirements, _, err := config.LoadRequirementsConfig(dir)
+	require.NoError(t, err, "unable to load tmp jx-requirements")
+	resolver := &versionstream.VersionResolver{
+		VersionsDir: filepath.Join("test_data", "jenkins-x-versions"),
+	}
+
+	gitRef, err := o.determineGitRef(resolver, requirements, "https://github.com/my-fork/my-boot-config.git")
+	require.NoError(t, err, "unable to determineGitRef")
+	assert.Equal(t, "master", gitRef, "determineGitRef")
+}
+
+func (o *TestBootOptions) createTmpRequirements(t *testing.T) string {
+	from, err := os.Open(o.RequirementsFile)
+	require.NoError(t, err, "unable to open test jx-requirements")
+
+	tmpDir, err := ioutil.TempDir("", "")
+	err = os.MkdirAll(tmpDir, util.DefaultWritePermissions)
+	to, err := os.Create(filepath.Join(tmpDir, "jx-requirements.yml"))
+	require.NoError(t, err, "unable to create tmp jx-requirements")
+
+	_, err = io.Copy(to, from)
+	require.NoError(t, err, "unable to copy test jx-requirements to tmp")
+	return tmpDir
+}

--- a/pkg/cmd/boot/test_data/jenkins-x-versions/git/github.com/jenkins-x/jenkins-x-boot-config.yml
+++ b/pkg/cmd/boot/test_data/jenkins-x-versions/git/github.com/jenkins-x/jenkins-x-boot-config.yml
@@ -1,0 +1,2 @@
+gitUrl: https://github.com/jenkins-x/jenkins-x-boot-config
+version: 1.0.32

--- a/pkg/cmd/boot/test_data/requirements/jx-requirements.yml
+++ b/pkg/cmd/boot/test_data/requirements/jx-requirements.yml
@@ -1,0 +1,12 @@
+cluster:
+  clusterName: my-cluster-name
+  gitKind: github
+  gitName: github
+  gitServer: https://github.com
+  namespace: jx
+  project: my-project-id
+  provider: gke
+versionStream:
+  ref: "2367726d02b8c"
+  url: https://github.com/jenkins-x/jenkins-x-versions.git
+webhook: prow


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

#### Description

When `jx boot`ing if no gitRef is specified if should look it up from the version stream being used.  If it is not found in the version stream then `master` should be used.
