### PR TITLE
fix: Bring back, and fix, locking version stream to tags

### DIFF
--- a/pkg/boot/constants.go
+++ b/pkg/boot/constants.go
@@ -6,4 +6,12 @@ const (
 	// OverrideTLSWarningEnvVarName is an environment variable set in BDD tests to override the error (in batch mode)
 	// that is created if TLS is not enabled
 	OverrideTLSWarningEnvVarName = "TESTING_ONLY_OVERRIDE_TLS_WARNING"
+	// ConfigBaseRefEnvVarName is the env var name used in the pipeline to reference the base used for the config
+	ConfigBaseRefEnvVarName = "CONFIG_BASE_REF"
+	// ConfigRepoURLEnvVarName is the env var name used in the pipeline to reference the URL of the config
+	ConfigRepoURLEnvVarName = "CONFIG_REPO_URL"
+	// VersionsRepoURLEnvVarName is the env var name used in the pipeline to reference the URL of versions repo
+	VersionsRepoURLEnvVarName = "VERSIONS_REPO_URL"
+	// VersionsRepoBaseRefEnvVarName is the env var name used in the pipeline to reference the ref of versions repo
+	VersionsRepoBaseRefEnvVarName = "VERSIONS_BASE_REF"
 )

--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/jenkins-x/jx/pkg/versionstream"
+
+	"github.com/jenkins-x/jx/pkg/boot"
 	v1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -270,9 +272,11 @@ func (o *BootOptions) Run() error {
 	so.EndStep = o.EndStep
 
 	so.AdditionalEnvVars = map[string]string{
-		"JX_NO_TILLER":    "true",
-		"REPO_URL":        gitURL,
-		"BASE_CONFIG_REF": gitRef,
+		"JX_NO_TILLER":                     "true",
+		boot.ConfigRepoURLEnvVarName:       gitURL,
+		boot.ConfigBaseRefEnvVarName:       gitRef,
+		boot.VersionsRepoURLEnvVarName:     requirements.VersionStream.URL,
+		boot.VersionsRepoBaseRefEnvVarName: requirements.VersionStream.Ref,
 	}
 	if requirements.Cluster.HelmMajorVersion == "3" {
 		so.AdditionalEnvVars["JX_HELM3"] = "true"

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -676,7 +676,7 @@ func (options *InstallOptions) Run() error {
 		return errors.Wrap(err, "configuring the docker registry")
 	}
 
-	versionsRepoDir, err := options.CloneJXVersionsRepo(options.Flags.VersionsRepository, options.Flags.VersionsGitRef)
+	versionsRepoDir, _, err := options.CloneJXVersionsRepo(options.Flags.VersionsRepository, options.Flags.VersionsGitRef)
 	if err != nil {
 		return errors.Wrap(err, "cloning the jx versions repo")
 	}

--- a/pkg/cmd/opts/expose.go
+++ b/pkg/cmd/opts/expose.go
@@ -12,7 +12,7 @@ func (o *CommonOptions) Expose(devNamespace, targetNamespace, password string) e
 	if err != nil {
 		return errors.Wrap(err, "creating cert-manager client")
 	}
-	versionsDir, err := o.CloneJXVersionsRepo("", "")
+	versionsDir, _, err := o.CloneJXVersionsRepo("", "")
 	if err != nil {
 		return errors.Wrapf(err, "failed to clone the Jenkins X versions repository")
 	}
@@ -21,7 +21,7 @@ func (o *CommonOptions) Expose(devNamespace, targetNamespace, password string) e
 
 // RunExposecontroller runs exponse controller in the given target dir with the given ingress configuration
 func (o *CommonOptions) RunExposecontroller(devNamespace, targetNamespace string, ic kube.IngressConfig, services ...string) error {
-	versionsDir, err := o.CloneJXVersionsRepo("", "")
+	versionsDir, _, err := o.CloneJXVersionsRepo("", "")
 	if err != nil {
 		return errors.Wrapf(err, "failed to clone the Jenkins X versions repository")
 	}

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -1,7 +1,6 @@
 package opts
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -10,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"github.com/jenkins-x/jx/pkg/versionstream"
 
@@ -19,9 +17,6 @@ import (
 	"github.com/pborman/uuid"
 
 	"github.com/jenkins-x/jx/pkg/environments"
-	"gopkg.in/src-d/go-git.v4/plumbing"
-
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/kube"
@@ -29,9 +24,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
-	survey "gopkg.in/AlecAivazis/survey.v1"
-	git "gopkg.in/src-d/go-git.v4"
-	gitconfig "gopkg.in/src-d/go-git.v4/config"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -403,7 +395,7 @@ func (o *CommonOptions) InstallChartWithOptionsAndTimeout(options helm.InstallCh
 		return err
 	}
 	if options.VersionsDir == "" {
-		options.VersionsDir, err = o.CloneJXVersionsRepo(options.VersionsGitURL, options.VersionsGitRef)
+		options.VersionsDir, _, err = o.CloneJXVersionsRepo(options.VersionsGitURL, options.VersionsGitRef)
 		if err != nil {
 			return err
 		}
@@ -456,196 +448,6 @@ func (o *CommonOptions) detectSecretsLocation() secrets.SecretsLocationKind {
 // SetSecretURLClient sets the Secret URL Client
 func (o *CommonOptions) SetSecretURLClient(client secreturl.Client) {
 	o.secretURLClient = client
-}
-
-// CloneJXVersionsRepo clones the jenkins-x versions repo to a local working dir
-func (o *CommonOptions) CloneJXVersionsRepo(versionRepository string, versionRef string) (string, error) {
-	surveyOpts := survey.WithStdio(o.In, o.Out, o.Err)
-	configDir, err := util.ConfigDir()
-	if err != nil {
-		return "", fmt.Errorf("error determining config dir %v", err)
-	}
-	wrkDir := filepath.Join(configDir, "jenkins-x-versions")
-
-	if versionRepository == "" || versionRef == "" {
-		settings, err := o.TeamSettings()
-		if err != nil {
-			return "", errors.Wrapf(err, "failed to load TeamSettings")
-		}
-		if versionRepository == "" {
-			versionRepository = settings.VersionStreamURL
-		}
-		if versionRef == "" {
-			versionRef = settings.VersionStreamRef
-		}
-	}
-	if versionRepository == "" {
-		versionRepository = config.DefaultVersionsURL
-	}
-
-	log.Logger().Debugf("Current configuration dir: %s", configDir)
-	log.Logger().Debugf("versionRepository: %s git ref: %s", versionRepository, versionRef)
-
-	// If the repo already exists let's try to fetch the latest version
-	if exists, err := util.DirExists(wrkDir); err == nil && exists {
-		repo, err := git.PlainOpen(wrkDir)
-		if err != nil {
-			log.Logger().Errorf("Error opening %s", wrkDir)
-			return o.deleteAndReClone(wrkDir, versionRepository, versionRef, o.Out)
-		}
-		remote, err := repo.Remote("origin")
-		if err != nil {
-			log.Logger().Errorf("Error getting remote origin")
-			return o.deleteAndReClone(wrkDir, versionRepository, versionRef, o.Out)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-		defer cancel()
-
-		remoteRefs := "+refs/heads/master:refs/remotes/origin/master"
-		if versionRef != "" {
-			remoteRefs = "+refs/heads/" + versionRef + ":refs/remotes/origin/" + versionRef
-		}
-		err = remote.FetchContext(ctx, &git.FetchOptions{
-			RefSpecs: []gitconfig.RefSpec{
-				gitconfig.RefSpec(remoteRefs),
-			},
-		})
-
-		// The repository is up to date
-		if err == git.NoErrAlreadyUpToDate {
-			if versionRef != "" {
-				err = o.Git().Checkout(wrkDir, versionRef)
-				if err != nil {
-					return o.deleteAndReClone(wrkDir, versionRepository, versionRef, o.Out)
-				}
-			}
-			return wrkDir, nil
-		} else if err != nil {
-			return o.deleteAndReClone(wrkDir, versionRepository, versionRef, o.Out)
-		}
-
-		pullLatest := false
-		if o.BatchMode {
-			pullLatest = true
-		} else if o.AdvancedMode {
-			confirm := &survey.Confirm{
-				Message: "A local Jenkins X versions repository already exists, pull the latest?",
-				Default: true,
-			}
-			err = survey.AskOne(confirm, &pullLatest, nil, surveyOpts)
-			if err != nil {
-				log.Logger().Errorf("Error confirming if we should pull latest, skipping %s", wrkDir)
-			}
-		} else {
-			pullLatest = true
-			log.Logger().Infof(util.QuestionAnswer("A local Jenkins X versions repository already exists, pulling the latest", util.YesNo(pullLatest)))
-		}
-		if pullLatest {
-			w, err := repo.Worktree()
-			if err == nil {
-				err := w.Pull(&git.PullOptions{RemoteName: "origin"})
-				if err != nil {
-					return "", errors.Wrap(err, "pulling the latest")
-				}
-			}
-		}
-		if versionRef != "" {
-			err = o.Git().Checkout(wrkDir, versionRef)
-			if err != nil {
-				return o.deleteAndReClone(wrkDir, versionRepository, versionRef, o.Out)
-			}
-		}
-		return wrkDir, err
-	} else {
-		return o.deleteAndReClone(wrkDir, versionRepository, versionRef, o.Out)
-	}
-}
-
-func (o *CommonOptions) deleteAndReClone(wrkDir string, versionRepository string, referenceName string, fw terminal.FileWriter) (string, error) {
-	log.Logger().Info("Deleting and cloning the Jenkins X versions repo")
-	err := os.RemoveAll(wrkDir)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to delete dir %s: %s\n", wrkDir, err.Error())
-	}
-	err = os.MkdirAll(wrkDir, util.DefaultWritePermissions)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to ensure directory is created %s", wrkDir)
-	}
-	err = o.clone(wrkDir, versionRepository, referenceName, fw)
-	if err != nil {
-		return "", err
-	}
-	return wrkDir, err
-}
-
-func (o *CommonOptions) clone(wrkDir string, versionRepository string, referenceName string, fw terminal.FileWriter) error {
-	if referenceName == "" || referenceName == "master" {
-		referenceName = "refs/heads/master"
-	} else if !strings.Contains(referenceName, "/") {
-		if strings.HasPrefix(referenceName, "PR-") {
-			prNumber := strings.TrimPrefix(referenceName, "PR-")
-
-			log.Logger().Infof("Cloning the Jenkins X versions repo %s with PR: %s to %s", util.ColorInfo(versionRepository), util.ColorInfo(referenceName), util.ColorInfo(wrkDir))
-			return o.shallowCloneGitRepositoryToDir(wrkDir, versionRepository, prNumber, "")
-		}
-		log.Logger().Infof("Cloning the Jenkins X versions repo %s with revision %s to %s", util.ColorInfo(versionRepository), util.ColorInfo(referenceName), util.ColorInfo(wrkDir))
-
-		err := o.Git().Clone(versionRepository, wrkDir)
-		if err != nil {
-			return errors.Wrapf(err, "failed to clone repository: %s to dir %s", versionRepository, wrkDir)
-		}
-		err = o.RunCommandFromDir(wrkDir, "git", "fetch", "origin", referenceName)
-		if err != nil {
-			return errors.Wrapf(err, "failed to git fetch origin %s for repo: %s in dir %s", referenceName, versionRepository, wrkDir)
-		}
-		err = o.Git().Checkout(wrkDir, "FETCH_HEAD")
-		if err != nil {
-			return errors.Wrapf(err, "failed to checkout FETCH_HEAD of repo: %s in dir %s", versionRepository, wrkDir)
-		}
-		return nil
-
-		// TODO doesn't seem to work at all for a git ref....
-		//return o.shallowCloneGitRepositoryToDir(wrkDir, versionRepository, "", referenceName)
-	}
-	log.Logger().Infof("Cloning the Jenkins X versions repo %s with ref %s to %s", util.ColorInfo(versionRepository), util.ColorInfo(referenceName), util.ColorInfo(wrkDir))
-	_, err := git.PlainClone(wrkDir, false, &git.CloneOptions{
-		URL:           versionRepository,
-		ReferenceName: plumbing.ReferenceName(referenceName),
-		SingleBranch:  true,
-		Progress:      nil,
-	})
-	if err != nil {
-		return errors.Wrapf(err, "failed to clone reference: %s", referenceName)
-	}
-	return err
-}
-
-func (o *CommonOptions) shallowCloneGitRepositoryToDir(dir string, gitURL string, pullRequestNumber string, revision string) error {
-	if pullRequestNumber != "" {
-		log.Logger().Infof("shallow cloning pull request %s of repository %s to temp dir %s", gitURL,
-			pullRequestNumber, dir)
-		err := o.Git().ShallowClone(dir, gitURL, "", pullRequestNumber)
-		if err != nil {
-			return errors.Wrapf(err, "shallow cloning pull request %s of repository %s to temp dir %s\n", gitURL,
-				pullRequestNumber, dir)
-		}
-	} else if revision != "" {
-		log.Logger().Infof("shallow cloning revision %s of repository %s to temp dir %s", gitURL,
-			revision, dir)
-		err := o.Git().ShallowClone(dir, gitURL, revision, "")
-		if err != nil {
-			return errors.Wrapf(err, "shallow cloning revision %s of repository %s to temp dir %s\n", gitURL,
-				revision, dir)
-		}
-	} else {
-		log.Logger().Infof("shallow cloning master of repository %s to temp dir %s", gitURL, dir)
-		err := o.Git().ShallowClone(dir, gitURL, "", "")
-		if err != nil {
-			return errors.Wrapf(err, "shallow cloning master of repository %s to temp dir %s\n", gitURL, dir)
-		}
-	}
-
-	return nil
 }
 
 // DeleteChart deletes the given chart

--- a/pkg/cmd/opts/team_settings.go
+++ b/pkg/cmd/opts/team_settings.go
@@ -36,7 +36,10 @@ const (
 // TeamSettings returns the team settings
 func (o *CommonOptions) TeamSettings() (*v1.TeamSettings, error) {
 	_, teamSettings, err := o.DevEnvAndTeamSettings()
-	return teamSettings, err
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return teamSettings, nil
 }
 
 // DevEnvAndTeamSettings returns the Dev Environment and Team settings

--- a/pkg/cmd/opts/upgrade/upgrade_ingress.go
+++ b/pkg/cmd/opts/upgrade/upgrade_ingress.go
@@ -18,7 +18,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/AlecAivazis/survey.v1"
+	survey "gopkg.in/AlecAivazis/survey.v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +72,8 @@ func (o *UpgradeIngressOptions) Run() error {
 	// wizard to ask for config values
 	err = o.confirmExposecontrollerConfig()
 	if err != nil {
-		return errors.Wrap(err, "configure exposecontroller")
+		return errors.Wrap(err, ""+
+			"configure exposecontroller")
 	}
 
 	// confirm values

--- a/pkg/cmd/opts/version.go
+++ b/pkg/cmd/opts/version.go
@@ -3,6 +3,8 @@ package opts
 import (
 	"strings"
 
+	"github.com/jenkins-x/jx/pkg/versionstream/versionstreamrepo"
+
 	"github.com/jenkins-x/jx/pkg/versionstream"
 
 	"github.com/jenkins-x/jx/pkg/log"
@@ -13,7 +15,7 @@ import (
 
 // CreateVersionResolver creates a new VersionResolver service
 func (o *CommonOptions) CreateVersionResolver(repo string, gitRef string) (*versionstream.VersionResolver, error) {
-	versionsDir, err := o.CloneJXVersionsRepo(repo, gitRef)
+	versionsDir, _, err := o.CloneJXVersionsRepo(repo, gitRef)
 	if err != nil {
 		return nil, err
 	}
@@ -137,4 +139,13 @@ func (o *CommonOptions) GetVersionNumber(kind versionstream.VersionKind, name, r
 		return "", err
 	}
 	return versioner.StableVersionNumber(kind, name)
+}
+
+// CloneJXVersionsRepo clones the jenkins-x versions repo to a local working dir
+func (o *CommonOptions) CloneJXVersionsRepo(versionRepository string, versionRef string) (string, string, error) {
+	settings, err := o.TeamSettings()
+	if err != nil {
+		log.Logger().Debugf("Unable to load team settings because %v", err)
+	}
+	return versionstreamrepo.CloneJXVersionsRepo(versionRepository, versionRef, settings, o.Git(), o.BatchMode, o.AdvancedMode, o.In, o.Out, o.Err)
 }

--- a/pkg/cmd/step/get/step_get_version_changeset.go
+++ b/pkg/cmd/step/get/step_get_version_changeset.go
@@ -80,7 +80,7 @@ func NewCmdStepGetVersionChangeSet(commonOpts *opts.CommonOptions) *cobra.Comman
 // Run implements the command
 func (o *StepGetVersionChangeSetOptions) Run() error {
 	if o.VersionsDir == "" {
-		versionDir, err := o.CloneJXVersionsRepo(o.VersionsRepository, o.VersionsGitRef)
+		versionDir, _, err := o.CloneJXVersionsRepo(o.VersionsRepository, o.VersionsGitRef)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/jenkins-x/jx/pkg/boot"
 	"github.com/jenkins-x/jx/pkg/helm"
 	"sigs.k8s.io/yaml"
 
@@ -27,8 +28,6 @@ import (
 
 const (
 	jxInterpretPipelineEnvKey = "JX_INTERPRET_PIPELINE"
-	configRepoURLEnvKey       = "REPO_URL"
-	configRepoRefEnvKey       = "BASE_CONFIG_REF"
 )
 
 // StepVerifyEnvironmentsOptions contains the command line flags
@@ -99,6 +98,22 @@ func (o *StepVerifyEnvironmentsOptions) Run() error {
 	if err != nil {
 		return err
 	}
+	log.Logger().Infof("the git repositories for the environments look good\n")
+	fmt.Println()
+	return nil
+}
+
+func (o *StepVerifyEnvironmentsOptions) prDevEnvironment(gitRepoName string, environmentsOrg string, privateRepo bool, user *auth.UserAuth, requirements *config.RequirementsConfig, server *auth.AuthServer, createPr bool) error {
+	fromGitURL := os.Getenv(boot.ConfigRepoURLEnvVarName)
+	gitRef := os.Getenv(boot.ConfigBaseRefEnvVarName)
+
+	log.Logger().Debugf("Defined %s env variable value: %s", boot.ConfigRepoURLEnvVarName, fromGitURL)
+	log.Logger().Debugf("Defined %s env variable value: %s", boot.ConfigBaseRefEnvVarName, gitRef)
+
+	_, err := gits.ParseGitURL(fromGitURL)
+	if err != nil {
+		return err
+	}
 
 	log.Logger().Infof("The environment git repositories look good\n")
 	fmt.Println()
@@ -137,20 +152,20 @@ func (o *StepVerifyEnvironmentsOptions) isJXBoot() bool {
 func (o *StepVerifyEnvironmentsOptions) readEnvironment() (string, string, error) {
 	var missingRepoURLErr, missingReoRefErr error
 
-	fromGitURL, foundURL := os.LookupEnv(configRepoURLEnvKey)
+	fromGitURL, foundURL := os.LookupEnv(boot.ConfigRepoURLEnvVarName)
 	if !foundURL {
-		missingRepoURLErr = errors.Errorf("the environment variable %s must be specified", configRepoURLEnvKey)
+		missingRepoURLErr = errors.Errorf("the environment variable %s must be specified", boot.ConfigRepoURLEnvVarName)
 	}
-	gitRef, foundRef := os.LookupEnv(configRepoRefEnvKey)
+	gitRef, foundRef := os.LookupEnv(boot.ConfigBaseRefEnvVarName)
 	if !foundRef {
-		missingReoRefErr = errors.Errorf("the environment variable %s must be specified", configRepoRefEnvKey)
+		missingReoRefErr = errors.Errorf("the environment variable %s must be specified", boot.ConfigBaseRefEnvVarName)
 	}
 
 	err := util.CombineErrors(missingRepoURLErr, missingReoRefErr)
 
 	if err == nil {
-		log.Logger().Debugf("Defined %s env variable value: %s", configRepoURLEnvKey, fromGitURL)
-		log.Logger().Debugf("Defined %s env variable value: %s", configRepoRefEnvKey, gitRef)
+		log.Logger().Debugf("Defined %s env variable value: %s", boot.ConfigRepoURLEnvVarName, fromGitURL)
+		log.Logger().Debugf("Defined %s env variable value: %s", boot.ConfigBaseRefEnvVarName, gitRef)
 	}
 
 	return fromGitURL, gitRef, err

--- a/pkg/cmd/step/verify/step_verify_environments_test.go
+++ b/pkg/cmd/step/verify/step_verify_environments_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/boot"
 	"github.com/jenkins-x/jx/pkg/cmd/clients/fake"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
@@ -136,15 +137,15 @@ func Test_IsJXBoot(t *testing.T) {
 }
 
 func Test_ReadEnvironment(t *testing.T) {
-	origConfigRepoURL, foundConfigRepoURLEnvKey := os.LookupEnv(configRepoURLEnvKey)
-	origConfigRepoRef, foundConfigRepoRefEnvKey := os.LookupEnv(configRepoRefEnvKey)
+	origConfigRepoURL, foundConfigRepoURLEnvKey := os.LookupEnv(boot.ConfigRepoURLEnvVarName)
+	origConfigRepoRef, foundConfigRepoRefEnvKey := os.LookupEnv(boot.ConfigBaseRefEnvVarName)
 	defer func() {
 		if foundConfigRepoURLEnvKey {
-			_ = os.Setenv(configRepoURLEnvKey, origConfigRepoURL)
+			_ = os.Setenv(boot.ConfigRepoURLEnvVarName, origConfigRepoURL)
 		}
 
 		if foundConfigRepoRefEnvKey {
-			_ = os.Setenv(configRepoRefEnvKey, origConfigRepoRef)
+			_ = os.Setenv(boot.ConfigBaseRefEnvVarName, origConfigRepoRef)
 		}
 	}()
 
@@ -157,26 +158,26 @@ func Test_ReadEnvironment(t *testing.T) {
 		errorString string
 	}{
 		{"https://github.com/jenkins-x/jenkins-x-boot-config", "master", false, ""},
-		{"https://github.com/jenkins-x/jenkins-x-boot-config", "", true, "the environment variable BASE_CONFIG_REF must be specified"},
-		{"", "master", true, "the environment variable REPO_URL must be specified"},
-		{"", "", true, "[the environment variable REPO_URL must be specified, the environment variable BASE_CONFIG_REF must be specified]"},
+		{"https://github.com/jenkins-x/jenkins-x-boot-config", "", true, "the environment variable CONFIG_BASE_REF must be specified"},
+		{"", "master", true, "the environment variable CONFIG_REPO_URL must be specified"},
+		{"", "", true, "[the environment variable CONFIG_REPO_URL must be specified, the environment variable CONFIG_BASE_REF must be specified]"},
 	}
 
 	for _, testCase := range tests {
 		t.Run(fmt.Sprintf("%s-%s", testCase.url, testCase.ref), func(t *testing.T) {
 			if testCase.url == "" {
-				err := os.Unsetenv(configRepoURLEnvKey)
+				err := os.Unsetenv(boot.ConfigRepoURLEnvVarName)
 				assert.NoError(t, err)
 			} else {
-				err := os.Setenv(configRepoURLEnvKey, testCase.url)
+				err := os.Setenv(boot.ConfigRepoURLEnvVarName, testCase.url)
 				assert.NoError(t, err)
 			}
 
 			if testCase.ref == "" {
-				err := os.Unsetenv(configRepoRefEnvKey)
+				err := os.Unsetenv(boot.ConfigBaseRefEnvVarName)
 				assert.NoError(t, err)
 			} else {
-				err := os.Setenv(configRepoRefEnvKey, testCase.ref)
+				err := os.Setenv(boot.ConfigBaseRefEnvVarName, testCase.ref)
 				assert.NoError(t, err)
 
 			}

--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -607,6 +607,24 @@ func (o *StepVerifyPreInstallOptions) gatherRequirements(requirements *config.Re
 		return nil, errors.Wrap(err, "error gathering git requirements")
 	}
 
+	// Lock the version stream to a tag
+	if requirements.VersionStream.Ref == "" {
+		requirements.VersionStream.Ref = os.Getenv(boot.VersionsRepoBaseRefEnvVarName)
+	}
+	if requirements.VersionStream.URL == "" {
+		requirements.VersionStream.URL = os.Getenv(boot.VersionsRepoURLEnvVarName)
+	}
+
+	// attempt to resolve the version stream ref to a tag
+	_, ref, err := o.CloneJXVersionsRepo(requirements.VersionStream.URL, requirements.VersionStream.Ref)
+	if err != nil {
+		return nil, errors.Wrapf(err, "resolving version stream ref")
+	}
+	if ref != "" && ref != requirements.VersionStream.Ref {
+		log.Logger().Infof("Locking version stream %s to release %s. Jenkins X will use this release rather than %s to resolve all versions from now on.", util.ColorInfo(requirements.VersionStream.URL), util.ColorInfo(ref), requirements.VersionStream.Ref)
+		requirements.VersionStream.Ref = ref
+	}
+
 	err = requirements.SaveConfig(requirementsFileName)
 	if err != nil {
 		return nil, errors.Wrap(err, "error saving requirements file")

--- a/pkg/cmd/upgrade/upgrade_boot.go
+++ b/pkg/cmd/upgrade/upgrade_boot.go
@@ -185,7 +185,7 @@ func (o *UpgradeBootOptions) requirementsVersionStream() (*config.VersionStreamC
 }
 
 func (o *UpgradeBootOptions) upgradeAvailable(versionStreamURL string, versionStreamRef string, upgradeRef string) (string, error) {
-	versionsDir, err := o.CloneJXVersionsRepo(versionStreamURL, upgradeRef)
+	versionsDir, _, err := o.CloneJXVersionsRepo(versionStreamURL, upgradeRef)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to clone versions repo %s", versionStreamURL)
 	}

--- a/pkg/cmd/upgrade/upgrade_platform.go
+++ b/pkg/cmd/upgrade/upgrade_platform.go
@@ -152,7 +152,7 @@ func (o *UpgradePlatformOptions) Run() error {
 	io := &create.InstallOptions{}
 	io.CommonOptions = o.CommonOptions
 	io.Flags = o.InstallFlags
-	versionsDir, err := io.CloneJXVersionsRepo(o.Flags.VersionsRepository, o.Flags.VersionsGitRef)
+	versionsDir, _, err := io.CloneJXVersionsRepo(o.Flags.VersionsRepository, o.Flags.VersionsGitRef)
 	if err != nil {
 		return err
 	}

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -27,7 +27,8 @@ const (
 )
 
 var (
-	numberRegex = regexp.MustCompile("[0-9]")
+	numberRegex        = regexp.MustCompile("[0-9]")
+	splitDescribeRegex = regexp.MustCompile(`(?:~|\^|-g)`)
 )
 
 // GitCLI implements common git actions based on git CLI
@@ -1143,4 +1144,25 @@ func (g *GitCLI) CherryPick(dir string, commitish string) error {
 // CherryPickTheirs does a git cherry-pick of commit
 func (g *GitCLI) CherryPickTheirs(dir string, commitish string) error {
 	return g.gitCmd(dir, "cherry-pick", commitish, "--strategy=recursive", "-X", "theirs")
+}
+
+// Describe does a git describe of commitish, optionally adding the abbrev arg if not empty
+func (g *GitCLI) Describe(dir string, contains bool, commitish string, abbrev string) (string, string, error) {
+	args := []string{"describe", commitish}
+	if abbrev != "" {
+		args = append(args, fmt.Sprintf("--abbrev=%s", abbrev))
+	}
+	if contains {
+		args = append(args, "--contains")
+	}
+	out, err := g.gitCmdWithOutput(dir, args...)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "running git %s", strings.Join(args, " "))
+	}
+	trimmed := strings.TrimSpace(strings.Trim(out, "\n"))
+	parts := splitDescribeRegex.Split(trimmed, -1)
+	if len(parts) == 2 {
+		return parts[0], parts[1], nil
+	}
+	return parts[0], "", nil
 }

--- a/pkg/gits/git_cli_test.go
+++ b/pkg/gits/git_cli_test.go
@@ -756,3 +756,77 @@ func TestGitCLI_Remotes(t *testing.T) {
 		})
 	}
 }
+
+func TestDescribe(t *testing.T) {
+	tests := []struct {
+		initFn   func(dir string, gitter gits.Gitter) error
+		name     string
+		want     []string
+		wantErr  bool
+		contains bool
+		abbrev   string // Number of hex digits from object name, defaults to 7
+	}{
+		{
+			initFn: func(dir string, git gits.Gitter) error {
+				err := git.Init(dir)
+				assert.NoError(t, err)
+
+				err = git.AddCommit(dir, "Initial Commit")
+				assert.NoError(t, err)
+				err = git.CreateTag(dir, "v0.0.1", "First Tag")
+				assert.NoError(t, err)
+				return err
+			},
+			name:     "Valid commit and tag, !contains, abbrev=default",
+			wantErr:  false,
+			contains: false,
+			abbrev:   "",
+		},
+		{
+			initFn: func(dir string, git gits.Gitter) error {
+				var err error
+				assert.NoError(t, err)
+				err = git.Init(dir)
+				assert.NoError(t, err)
+
+				err = git.AddCommit(dir, "Initial Commit")
+				assert.NoError(t, err)
+				return err
+			},
+			name:     "Commit but no tag, !contains, abbrev=default",
+			wantErr:  true,
+			contains: false,
+			abbrev:   "",
+		},
+	}
+
+	for _, test := range tests {
+		dir, err := ioutil.TempDir("", "")
+		assert.NoError(t, err)
+		defer func() {
+			os.RemoveAll(dir)
+		}()
+
+		gitCli := gits.NewGitCLI()
+
+		err = test.initFn(dir, gitCli)
+		assert.NoError(t, err)
+		parts1, parts2, err := gitCli.Describe(
+			dir,
+			test.contains,
+			"HEAD",
+			test.abbrev,
+		)
+
+		if !test.wantErr {
+			assert.NoError(t, err)
+			assert.NotNil(t, parts1)
+			assert.Equal(t, "", parts2)
+		} else {
+			assert.Error(t, err)
+			assert.Equal(t, "", parts1)
+			assert.Equal(t, "", parts2)
+		}
+	}
+
+}

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -657,6 +657,6 @@ func (g *GitFake) CherryPickTheirs(dir string, commit string) error {
 }
 
 // Describe does a git describe of commitish, optionally adding the abbrev arg if not empty
-func (g *GitFake) Describe(dir string, contains bool, commitish string, abbrev string) (string, string, error) {
+func (g *GitFake) Describe(dir string, contains bool, commitish string, abbrev string, fallback bool) (string, string, error) {
 	return "", "", nil
 }

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -655,3 +655,8 @@ func (g *GitFake) CherryPick(dir string, commit string) error {
 func (g *GitFake) CherryPickTheirs(dir string, commit string) error {
 	return nil
 }
+
+// Describe does a git describe of commitish, optionally adding the abbrev arg if not empty
+func (g *GitFake) Describe(dir string, contains bool, commitish string, abbrev string) (string, string, error) {
+	return "", "", nil
+}

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -510,6 +510,6 @@ func (g *GitLocal) CherryPickTheirs(dir string, commit string) error {
 }
 
 // Describe does a git describe of commitish, optionally adding the abbrev arg if not empty
-func (g *GitLocal) Describe(dir string, contains bool, commitish string, abbrev string) (string, string, error) {
-	return g.GitCLI.Describe(dir, false, commitish, abbrev)
+func (g *GitLocal) Describe(dir string, contains bool, commitish string, abbrev string, fallback bool) (string, string, error) {
+	return g.GitCLI.Describe(dir, false, commitish, abbrev, fallback)
 }

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -508,3 +508,8 @@ func (g *GitLocal) CherryPick(dir string, commit string) error {
 func (g *GitLocal) CherryPickTheirs(dir string, commit string) error {
 	return g.GitCLI.CherryPickTheirs(dir, commit)
 }
+
+// Describe does a git describe of commitish, optionally adding the abbrev arg if not empty
+func (g *GitLocal) Describe(dir string, contains bool, commitish string, abbrev string) (string, string, error) {
+	return g.GitCLI.Describe(dir, false, commitish, abbrev)
+}

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -276,7 +276,7 @@ type Gitter interface {
 	GetCommits(dir string, start string, end string) ([]GitCommit, error)
 	RevParse(dir string, rev string) (string, error)
 	GetCommitsNotOnAnyRemote(dir string, branch string) ([]GitCommit, error)
-	Describe(dir string, contains bool, commitish string, abbrev string) (string, string, error)
+	Describe(dir string, contains bool, commitish string, abbrev string, fallback bool) (string, string, error)
 
 	GetRevisionBeforeDate(dir string, t time.Time) (string, error)
 	GetRevisionBeforeDateText(dir string, dateText string) (string, error)

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -276,6 +276,7 @@ type Gitter interface {
 	GetCommits(dir string, start string, end string) ([]GitCommit, error)
 	RevParse(dir string, rev string) (string, error)
 	GetCommitsNotOnAnyRemote(dir string, branch string) ([]GitCommit, error)
+	Describe(dir string, contains bool, commitish string, abbrev string) (string, string, error)
 
 	GetRevisionBeforeDate(dir string, t time.Time) (string, error)
 	GetRevisionBeforeDateText(dir string, dateText string) (string, error)

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -400,6 +400,29 @@ func (mock *MockGitter) DeleteRemoteBranch(_param0 string, _param1 string, _para
 	return ret0
 }
 
+func (mock *MockGitter) Describe(_param0 string, _param1 bool, _param2 string, _param3 string) (string, string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("Describe", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 string
+	var ret2 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(string)
+		}
+		if result[2] != nil {
+			ret2 = result[2].(error)
+		}
+	}
+	return ret0, ret1, ret2
+}
+
 func (mock *MockGitter) Diff(_param0 string) (string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -2350,6 +2373,45 @@ func (c *MockGitter_DeleteRemoteBranch_OngoingVerification) GetAllCapturedArgume
 		_param2 = make([]string, len(params[2]))
 		for u, param := range params[2] {
 			_param2[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) Describe(_param0 string, _param1 bool, _param2 string, _param3 string) *MockGitter_Describe_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Describe", params, verifier.timeout)
+	return &MockGitter_Describe_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_Describe_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_Describe_OngoingVerification) GetCapturedArguments() (string, bool, string, string) {
+	_param0, _param1, _param2, _param3 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1]
+}
+
+func (c *MockGitter_Describe_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []bool, _param2 []string, _param3 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(params[0]))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]bool, len(params[1]))
+		for u, param := range params[1] {
+			_param1[u] = param.(bool)
+		}
+		_param2 = make([]string, len(params[2]))
+		for u, param := range params[2] {
+			_param2[u] = param.(string)
+		}
+		_param3 = make([]string, len(params[3]))
+		for u, param := range params[3] {
+			_param3[u] = param.(string)
 		}
 	}
 	return

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -400,11 +400,11 @@ func (mock *MockGitter) DeleteRemoteBranch(_param0 string, _param1 string, _para
 	return ret0
 }
 
-func (mock *MockGitter) Describe(_param0 string, _param1 bool, _param2 string, _param3 string) (string, string, error) {
+func (mock *MockGitter) Describe(_param0 string, _param1 bool, _param2 string, _param3 string, _param4 bool) (string, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
 	}
-	params := []pegomock.Param{_param0, _param1, _param2, _param3}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("Describe", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 string
 	var ret1 string
@@ -2378,8 +2378,8 @@ func (c *MockGitter_DeleteRemoteBranch_OngoingVerification) GetAllCapturedArgume
 	return
 }
 
-func (verifier *VerifierMockGitter) Describe(_param0 string, _param1 bool, _param2 string, _param3 string) *MockGitter_Describe_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1, _param2, _param3}
+func (verifier *VerifierMockGitter) Describe(_param0 string, _param1 bool, _param2 string, _param3 string, _param4 bool) *MockGitter_Describe_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Describe", params, verifier.timeout)
 	return &MockGitter_Describe_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -2389,12 +2389,12 @@ type MockGitter_Describe_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockGitter_Describe_OngoingVerification) GetCapturedArguments() (string, bool, string, string) {
-	_param0, _param1, _param2, _param3 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1]
+func (c *MockGitter_Describe_OngoingVerification) GetCapturedArguments() (string, bool, string, string, bool) {
+	_param0, _param1, _param2, _param3, _param4 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1]
 }
 
-func (c *MockGitter_Describe_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []bool, _param2 []string, _param3 []string) {
+func (c *MockGitter_Describe_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []bool, _param2 []string, _param3 []string, _param4 []bool) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(params[0]))
@@ -2412,6 +2412,10 @@ func (c *MockGitter_Describe_OngoingVerification) GetAllCapturedArguments() (_pa
 		_param3 = make([]string, len(params[3]))
 		for u, param := range params[3] {
 			_param3[u] = param.(string)
+		}
+		_param4 = make([]bool, len(params[4]))
+		for u, param := range params[4] {
+			_param4[u] = param.(bool)
 		}
 	}
 	return

--- a/pkg/versionstream/versionstreamrepo/gitrepo.go
+++ b/pkg/versionstream/versionstreamrepo/gitrepo.go
@@ -1,0 +1,265 @@
+package versionstreamrepo
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jenkins-x/jx/pkg/gits"
+	gitconfig "gopkg.in/src-d/go-git.v4/config"
+
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+	survey "gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+// CloneJXVersionsRepo clones the jenkins-x versions repo to a local working dir
+func CloneJXVersionsRepo(versionRepository string, versionRef string, settings *v1.TeamSettings, gitter gits.Gitter, batchMode bool, advancedMode bool, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (string, string, error) {
+	dir, versionRef, err := cloneJXVersionsRepo(versionRepository, versionRef, settings, gitter, batchMode, advancedMode, in, out, errOut)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "")
+	}
+	if versionRef != "" {
+		resolved, err := resolveRefToTag(dir, versionRef, gitter)
+		if err != nil {
+			return "", "", errors.WithStack(err)
+		}
+		return dir, resolved, nil
+	}
+	return dir, "", nil
+}
+
+func cloneJXVersionsRepo(versionRepository string, versionRef string, settings *v1.TeamSettings, gitter gits.Gitter, batchMode bool, advancedMode bool, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (string, string, error) {
+	surveyOpts := survey.WithStdio(in, out, errOut)
+	configDir, err := util.ConfigDir()
+	if err != nil {
+		return "", "", fmt.Errorf("error determining config dir %v", err)
+	}
+	wrkDir := filepath.Join(configDir, "jenkins-x-versions")
+
+	if settings != nil {
+		if versionRepository == "" {
+			versionRepository = settings.VersionStreamURL
+		}
+		if versionRef == "" {
+			versionRef = settings.VersionStreamRef
+		}
+	}
+	if versionRepository == "" {
+		versionRepository = config.DefaultVersionsURL
+	}
+
+	log.Logger().Debugf("Current configuration dir: %s", configDir)
+	log.Logger().Debugf("versionRepository: %s git ref: %s", versionRepository, versionRef)
+
+	// If the repo already exists let's try to fetch the latest version
+	if exists, err := util.DirExists(wrkDir); err == nil && exists {
+		repo, err := git.PlainOpen(wrkDir)
+		if err != nil {
+			log.Logger().Errorf("Error opening %s", wrkDir)
+			_, err := deleteAndReClone(wrkDir, versionRepository, versionRef, gitter, out)
+			if err != nil {
+				return "", "", errors.WithStack(err)
+			}
+		}
+		remote, err := repo.Remote("origin")
+		if err != nil {
+			log.Logger().Errorf("Error getting remote origin")
+			dir, err := deleteAndReClone(wrkDir, versionRepository, versionRef, gitter, out)
+			if err != nil {
+				return "", "", errors.WithStack(err)
+			}
+			return dir, versionRef, nil
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+
+		remoteRefs := "+refs/heads/master:refs/remotes/origin/master"
+		if versionRef != "" {
+			remoteRefs = "+refs/heads/" + versionRef + ":refs/remotes/origin/" + versionRef
+		}
+		err = remote.FetchContext(ctx, &git.FetchOptions{
+			RefSpecs: []gitconfig.RefSpec{
+				gitconfig.RefSpec(remoteRefs),
+			},
+		})
+
+		// The repository is up to date
+		if err == git.NoErrAlreadyUpToDate {
+			if versionRef != "" {
+				err = gitter.Checkout(wrkDir, versionRef)
+				if err != nil {
+					dir, err := deleteAndReClone(wrkDir, versionRepository, versionRef, gitter, out)
+					if err != nil {
+						return "", "", errors.WithStack(err)
+					}
+					return dir, versionRef, nil
+				}
+			}
+			return wrkDir, versionRef, nil
+		} else if err != nil {
+			dir, err := deleteAndReClone(wrkDir, versionRepository, versionRef, gitter, out)
+			if err != nil {
+				return "", "", errors.WithStack(err)
+			}
+			return dir, versionRef, nil
+		}
+
+		pullLatest := false
+		if batchMode {
+			pullLatest = true
+		} else if advancedMode {
+			confirm := &survey.Confirm{
+				Message: "A local Jenkins X versions repository already exists, pull the latest?",
+				Default: true,
+			}
+			err = survey.AskOne(confirm, &pullLatest, nil, surveyOpts)
+			if err != nil {
+				log.Logger().Errorf("Error confirming if we should pull latest, skipping %s", wrkDir)
+			}
+		} else {
+			pullLatest = true
+			log.Logger().Infof(util.QuestionAnswer("A local Jenkins X versions repository already exists, pulling the latest", util.YesNo(pullLatest)))
+		}
+		if pullLatest {
+			w, err := repo.Worktree()
+			if err == nil {
+				err := w.Pull(&git.PullOptions{RemoteName: "origin"})
+				if err != nil {
+					return "", "", errors.Wrap(err, "pulling the latest")
+				}
+			}
+		}
+		if versionRef != "" {
+			err = gitter.Checkout(wrkDir, versionRef)
+			if err != nil {
+				dir, err := deleteAndReClone(wrkDir, versionRepository, versionRef, gitter, out)
+				if err != nil {
+					return "", "", errors.WithStack(err)
+				}
+				return dir, versionRef, nil
+			}
+		}
+		return wrkDir, versionRef, err
+	}
+	dir, err := deleteAndReClone(wrkDir, versionRepository, versionRef, gitter, out)
+	if err != nil {
+		return "", "", errors.WithStack(err)
+	}
+	return dir, versionRef, nil
+}
+
+func deleteAndReClone(wrkDir string, versionRepository string, referenceName string, gitter gits.Gitter, fw terminal.FileWriter) (string, error) {
+	log.Logger().Info("Deleting and cloning the Jenkins X versions repo")
+	err := os.RemoveAll(wrkDir)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to delete dir %s: %s\n", wrkDir, err.Error())
+	}
+	err = os.MkdirAll(wrkDir, util.DefaultWritePermissions)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to ensure directory is created %s", wrkDir)
+	}
+	_, err = clone(wrkDir, versionRepository, referenceName, gitter, fw)
+	if err != nil {
+		return "", err
+	}
+	return wrkDir, err
+}
+
+func clone(wrkDir string, versionRepository string, referenceName string, gitter gits.Gitter, fw terminal.FileWriter) (string, error) {
+	if referenceName == "" || referenceName == "master" {
+		referenceName = "refs/heads/master"
+	} else if !strings.Contains(referenceName, "/") {
+		if strings.HasPrefix(referenceName, "PR-") {
+			prNumber := strings.TrimPrefix(referenceName, "PR-")
+
+			log.Logger().Infof("Cloning the Jenkins X versions repo %s with PR: %s to %s", util.ColorInfo(versionRepository), util.ColorInfo(referenceName), util.ColorInfo(wrkDir))
+			return "", shallowCloneGitRepositoryToDir(wrkDir, versionRepository, prNumber, "", gitter)
+		}
+		log.Logger().Infof("Cloning the Jenkins X versions repo %s with revision %s to %s", util.ColorInfo(versionRepository), util.ColorInfo(referenceName), util.ColorInfo(wrkDir))
+
+		err := gitter.Clone(versionRepository, wrkDir)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to clone repository: %s to dir %s", versionRepository, wrkDir)
+		}
+		cmd := util.Command{
+			Dir:  wrkDir,
+			Name: "git",
+			Args: []string{"fetch", "origin", referenceName},
+		}
+		_, err = cmd.RunWithoutRetry()
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to git fetch origin %s for repo: %s in dir %s", referenceName, versionRepository, wrkDir)
+		}
+		err = gitter.Checkout(wrkDir, "FETCH_HEAD")
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to checkout FETCH_HEAD of repo: %s in dir %s", versionRepository, wrkDir)
+		}
+		return "", nil
+	}
+	log.Logger().Infof("Cloning the Jenkins X versions repo %s with ref %s to %s", util.ColorInfo(versionRepository), util.ColorInfo(referenceName), util.ColorInfo(wrkDir))
+	_, err := git.PlainClone(wrkDir, false, &git.CloneOptions{
+		URL:           versionRepository,
+		ReferenceName: plumbing.ReferenceName(referenceName),
+		SingleBranch:  true,
+		Progress:      nil,
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to clone reference: %s", referenceName)
+	}
+	return "", err
+}
+
+func shallowCloneGitRepositoryToDir(dir string, gitURL string, pullRequestNumber string, revision string, gitter gits.Gitter) error {
+	if pullRequestNumber != "" {
+		log.Logger().Infof("shallow cloning pull request %s of repository %s to temp dir %s", gitURL,
+			pullRequestNumber, dir)
+		err := gitter.ShallowClone(dir, gitURL, "", pullRequestNumber)
+		if err != nil {
+			return errors.Wrapf(err, "shallow cloning pull request %s of repository %s to temp dir %s\n", gitURL,
+				pullRequestNumber, dir)
+		}
+	} else if revision != "" {
+		log.Logger().Infof("shallow cloning revision %s of repository %s to temp dir %s", gitURL,
+			revision, dir)
+		err := gitter.ShallowClone(dir, gitURL, revision, "")
+		if err != nil {
+			return errors.Wrapf(err, "shallow cloning revision %s of repository %s to temp dir %s\n", gitURL,
+				revision, dir)
+		}
+	} else {
+		log.Logger().Infof("shallow cloning master of repository %s to temp dir %s", gitURL, dir)
+		err := gitter.ShallowClone(dir, gitURL, "", "")
+		if err != nil {
+			return errors.Wrapf(err, "shallow cloning master of repository %s to temp dir %s\n", gitURL, dir)
+		}
+	}
+
+	return nil
+}
+
+func resolveRefToTag(dir string, commitish string, gitter gits.Gitter) (string, error) {
+	err := gitter.FetchTags(dir)
+	if err != nil {
+		return "", errors.Wrapf(err, "fetching tags")
+	}
+	resolved, _, err := gitter.Describe(dir, true, commitish, "0")
+	if err != nil {
+		return "", errors.Wrapf(err, "running git describe %s --abbrev=0", commitish)
+	}
+	if resolved != "" {
+		return resolved, nil
+	}
+	return resolved, nil
+}

--- a/pkg/versionstream/versionstreamrepo/gitrepo.go
+++ b/pkg/versionstream/versionstreamrepo/gitrepo.go
@@ -254,7 +254,7 @@ func resolveRefToTag(dir string, commitish string, gitter gits.Gitter) (string, 
 	if err != nil {
 		return "", errors.Wrapf(err, "fetching tags")
 	}
-	resolved, _, err := gitter.Describe(dir, true, commitish, "0")
+	resolved, _, err := gitter.Describe(dir, true, commitish, "0", true)
 	if err != nil {
 		return "", errors.Wrapf(err, "running git describe %s --abbrev=0", commitish)
 	}

--- a/pkg/versionstream/versionstreamrepo/gitrepo_integration_test.go
+++ b/pkg/versionstream/versionstreamrepo/gitrepo_integration_test.go
@@ -1,0 +1,239 @@
+// +build integration
+
+package versionstreamrepo_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/versionstream/versionstreamrepo"
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+)
+
+const (
+	RepoURL           = "https://github.com/jenkins-x/jenkins-x-versions"
+	TagFromDefaultURL = "v1.0.114"
+	FirstTag          = "v0.0.1"
+	SecondTag         = "v0.0.2"
+	BranchRef         = "master"
+	HEAD              = "HEAD"
+)
+
+func TestCloneJXVersionsRepoWithDefaultURL(t *testing.T) {
+	gitter := gits.NewGitCLI()
+	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
+		"",
+		TagFromDefaultURL,
+		nil,
+		gitter,
+		true,
+		false,
+		nil,
+		nil,
+		nil,
+	)
+
+	// Get the latest tag so that we know the correct expected verion ref.
+	tag, _, err := gitter.Describe(dir, false, TagFromDefaultURL, "")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, dir)
+	assert.NotNil(t, versionRef)
+	assert.Equal(t, tag, versionRef)
+}
+
+func initializeTempGitRepo(gitter gits.Gitter) (string, string, error) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", "", err
+	}
+
+	err = gitter.Init(dir)
+	if err != nil {
+		return "", "", err
+	}
+
+	err = gitter.AddCommit(dir, "Initial Commit")
+	if err != nil {
+		return "", "", err
+	}
+
+	err = gitter.CreateTag(dir, FirstTag, "First Tag")
+	if err != nil {
+		return "", "", err
+	}
+
+	testFile, err := ioutil.TempFile(dir, "versionstreams-test-")
+	if err != nil {
+		return "", "", err
+	}
+
+	testFileContents := []byte("foo")
+	_, err = testFile.Write(testFileContents)
+	if err != nil {
+		return "", "", err
+	}
+
+	err = gitter.AddCommit(dir, "Adding foo")
+	if err != nil {
+		return "", "", err
+	}
+
+	testFileContents = []byte("bar")
+	_, err = testFile.Write(testFileContents)
+	if err != nil {
+		return "", "", err
+	}
+
+	err = gitter.AddCommit(dir, "Adding bar")
+	if err != nil {
+		return "", "", err
+	}
+
+	err = gitter.CreateTag(dir, SecondTag, "Second Tag")
+	if err != nil {
+		return "", "", err
+	}
+
+	return fmt.Sprint(dir), testFile.Name(), nil
+}
+
+func TestCloneJXVersionsRepoWithTeamSettings(t *testing.T) {
+	gitter := gits.NewGitCLI()
+	gitDir, testFileName, err := initializeTempGitRepo(gitter)
+	defer func() {
+		err := os.RemoveAll(gitDir)
+		assert.NoError(t, err)
+	}()
+	assert.NoError(t, err)
+	settings := &v1.TeamSettings{
+		VersionStreamURL: gitDir,
+		VersionStreamRef: FirstTag,
+	}
+	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
+		"",
+		"",
+		settings,
+		gitter,
+		true,
+		false,
+		nil,
+		nil,
+		nil,
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, dir)
+	assert.NotNil(t, versionRef)
+	assert.Equal(t, FirstTag, versionRef)
+
+	err = gitter.Checkout(dir, versionRef)
+	assert.NoError(t, err)
+
+	actualFileContents, err := ioutil.ReadFile(testFileName)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("foobar"), actualFileContents)
+}
+
+func TestCloneJXVersionsRepoWithATag(t *testing.T) {
+	gitter := gits.NewGitCLI()
+	gitDir, testFileName, err := initializeTempGitRepo(gitter)
+	defer func() {
+		err := os.RemoveAll(gitDir)
+		assert.NoError(t, err)
+	}()
+	assert.NoError(t, err)
+	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
+		gitDir,
+		FirstTag,
+		nil,
+		gitter,
+		true,
+		false,
+		nil,
+		nil,
+		nil,
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, dir)
+	assert.NotNil(t, versionRef)
+	assert.Equal(t, FirstTag, versionRef)
+
+	err = gitter.Checkout(dir, versionRef)
+	assert.NoError(t, err)
+
+	actualFileContents, err := ioutil.ReadFile(testFileName)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("foobar"), actualFileContents)
+}
+
+func TestCloneJXVersionsRepoWithABranch(t *testing.T) {
+	gitter := gits.NewGitCLI()
+	gitDir, testFileName, err := initializeTempGitRepo(gitter)
+	defer func() {
+		err := os.RemoveAll(gitDir)
+		assert.NoError(t, err)
+	}()
+	assert.NoError(t, err)
+	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
+		gitDir,
+		BranchRef,
+		nil,
+		gitter,
+		true,
+		false,
+		nil,
+		nil,
+		nil,
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, dir)
+	assert.NotNil(t, versionRef)
+	assert.Equal(t, SecondTag, versionRef)
+
+	err = gitter.Checkout(dir, versionRef)
+	assert.NoError(t, err)
+
+	actualFileContents, err := ioutil.ReadFile(testFileName)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("foobar"), actualFileContents)
+}
+
+func TestCloneJXVersionsRepoWithACommit(t *testing.T) {
+	gitter := gits.NewGitCLI()
+	gitDir, testFileName, err := initializeTempGitRepo(gitter)
+	defer func() {
+		err := os.RemoveAll(gitDir)
+		assert.NoError(t, err)
+	}()
+	assert.NoError(t, err)
+
+	headMinusOne, err := gitter.RevParse(gitDir, "HEAD~1")
+
+	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
+		fmt.Sprintf("file://%s", gitDir),
+		headMinusOne,
+		nil,
+		gitter,
+		true,
+		false,
+		nil,
+		nil,
+		nil,
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, dir)
+	assert.NotNil(t, versionRef)
+	assert.Equal(t, SecondTag, versionRef)
+
+	err = gitter.Checkout(dir, versionRef)
+	assert.NoError(t, err)
+
+	actualFileContents, err := ioutil.ReadFile(testFileName)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("foobar"), actualFileContents)
+}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

* De-reverts #5110, in the process reverting #5870.
* `gitter.Describe` should fall back on just returning the original ref if the commit-ish is untagged.
* The tests in `gitrepo_integration_test.go` weren't actually doing the right thing or testing the right thing.

#### Special notes for the reviewer(s)

/assign @pmuir 
/assign @wbrefvem 

#### Which issue this PR fixes

fixes #5087