### PR TITLE
fix(pipeline): Use standard version stream cloning logic in metapipeline

### DIFF
--- a/pkg/cmd/controller/pipeline/pipelinerunner_cmd.go
+++ b/pkg/cmd/controller/pipeline/pipelinerunner_cmd.go
@@ -105,7 +105,7 @@ func (o *PipelineRunnerOptions) Run() error {
 		return err
 	}
 
-	metapipelineClient, err := metapipeline.NewMetaPipelineClient()
+	metapipelineClient, err := metapipeline.NewMetaPipelineClient(o.Git(), o.In, o.Out, o.Err)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/start/start_pipeline.go
+++ b/pkg/cmd/start/start_pipeline.go
@@ -225,7 +225,7 @@ func (o *StartPipelineOptions) createMetaPipeline(jobName string) error {
 	}
 
 	log.Logger().Debug("creating meta pipeline client")
-	client, err := metapipeline.NewMetaPipelineClient()
+	client, err := metapipeline.NewMetaPipelineClient(o.Git(), o.In, o.Out, o.Err)
 	if err != nil {
 		return errors.Wrap(err, "unable to create meta pipeline client")
 	}

--- a/pkg/tekton/metapipeline/clientfactory.go
+++ b/pkg/tekton/metapipeline/clientfactory.go
@@ -2,11 +2,11 @@ package metapipeline
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
-	"strings"
 	"time"
 
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/apps"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	jxclient "github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -16,10 +16,11 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/tekton"
-	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/jenkins-x/jx/pkg/versionstream/versionstreamrepo"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	kubeclient "k8s.io/client-go/kubernetes"
@@ -41,6 +42,11 @@ type clientFactory struct {
 	kubeClient   kubernetes.Interface
 	ns           string
 
+	git    gits.Gitter
+	stderr io.Writer
+	stdin  terminal.FileReader
+	stdout terminal.FileWriter
+
 	versionDir       string
 	versionStreamURL string
 	versionStreamRef string
@@ -49,23 +55,23 @@ type clientFactory struct {
 // NewMetaPipelineClient creates a new client for the creation and application of meta pipelines.
 // The responsibility of the meta pipeline is to prepare the execution pipeline and to allow Apps to contribute
 // the this execution pipeline.
-func NewMetaPipelineClient() (Client, error) {
+func NewMetaPipelineClient(gitter gits.Gitter, stdin terminal.FileReader, stdout terminal.FileWriter, stderr io.Writer) (Client, error) {
 	tektonClient, jxClient, kubeClient, ns, err := getClientsAndNamespace()
 	if err != nil {
 		return nil, err
 	}
 
-	return NewMetaPipelineClientWithClientsAndNamespace(jxClient, tektonClient, kubeClient, ns)
+	return NewMetaPipelineClientWithClientsAndNamespace(jxClient, tektonClient, kubeClient, ns, gitter, stdin, stdout, stderr)
 }
 
 // NewMetaPipelineClientWithClientsAndNamespace creates a new client for the creation and application of meta pipelines using the specified parameters.
-func NewMetaPipelineClientWithClientsAndNamespace(jxClient versioned.Interface, tektonClient tektonclient.Interface, kubeClient kubernetes.Interface, ns string) (Client, error) {
-	url, ref, err := versionStreamURLAndRef(jxClient, ns)
+func NewMetaPipelineClientWithClientsAndNamespace(jxClient versioned.Interface, tektonClient tektonclient.Interface, kubeClient kubernetes.Interface, ns string, gitter gits.Gitter, stdin terminal.FileReader, stdout terminal.FileWriter, stderr io.Writer) (Client, error) {
+	teamSettings, url, ref, err := versionStreamURLAndRef(jxClient, ns)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to determine versions stream URL and ref")
 	}
 
-	versionDir, err := cloneVersionStream(url, ref)
+	versionDir, _, err := versionstreamrepo.CloneJXVersionsRepo(url, ref, teamSettings, gitter, true, false, stdin, stdout, stderr)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to clone version dir")
 	}
@@ -75,6 +81,10 @@ func NewMetaPipelineClientWithClientsAndNamespace(jxClient versioned.Interface, 
 		tektonClient:     tektonClient,
 		kubeClient:       kubeClient,
 		ns:               ns,
+		git:              gitter,
+		stdin:            stdin,
+		stdout:           stdout,
+		stderr:           stderr,
 		versionDir:       versionDir,
 		versionStreamURL: url,
 		versionStreamRef: ref,
@@ -196,14 +206,14 @@ func (c *clientFactory) determineBranchIdentifier(pipelineType PipelineKind, pul
 	return branch, nil
 }
 
-func versionStreamURLAndRef(jxClient versioned.Interface, ns string) (string, string, error) {
+func versionStreamURLAndRef(jxClient versioned.Interface, ns string) (*v1.TeamSettings, string, string, error) {
 	devEnv, err := kube.GetDevEnvironment(jxClient, ns)
 	if err != nil {
-		return "", "", errors.Wrap(err, "unable to retrieve team environment")
+		return nil, "", "", errors.Wrap(err, "unable to retrieve team environment")
 	}
 
 	if devEnv == nil {
-		return config.DefaultVersionsURL, config.DefaultVersionsRef, nil
+		return nil, config.DefaultVersionsURL, config.DefaultVersionsRef, nil
 	}
 
 	teamSettings := devEnv.Spec.TeamSettings
@@ -216,18 +226,20 @@ func versionStreamURLAndRef(jxClient versioned.Interface, ns string) (string, st
 		ref = config.DefaultVersionsRef
 	}
 
-	return url, ref, nil
+	return &teamSettings, url, ref, nil
 }
 
 func (c *clientFactory) cloneVersionStreamIfNeeded() error {
-	url, ref, err := versionStreamURLAndRef(c.jxClient, c.ns)
+	teamSettings, url, ref, err := versionStreamURLAndRef(c.jxClient, c.ns)
 	if err != nil {
 		return err
 	}
 
 	if c.versionStreamURL != url || c.versionStreamRef != ref {
 		oldVersionStreamDir := c.versionDir
-		c.versionDir, err = cloneVersionStream(url, ref)
+		c.versionDir, _, err = versionstreamrepo.CloneJXVersionsRepo(url, ref, teamSettings, c.git, true, false, c.stdin, c.stdout, c.stderr)
+		c.versionStreamURL = url
+		c.versionStreamRef = ref
 		if err != nil {
 			return err
 		}
@@ -235,68 +247,6 @@ func (c *clientFactory) cloneVersionStreamIfNeeded() error {
 	}
 
 	return nil
-}
-
-func cloneVersionStream(url string, ref string) (string, error) {
-	dir, err := ioutil.TempDir("", "jx-version-repo-")
-	if err != nil {
-		return "", errors.Wrap(err, "unable to create temp dir for version stream")
-	}
-
-	logger.Debugf("cloning version stream url: %s ref: %s into %s", url, ref, dir)
-
-	// Not using GitCLi Clone/ShallowClone atm, since it does not work with tags.
-	// Once https://github.com/jenkins-x/jx/issues/5087 is resolved we should switch to that.
-	// As a quick hack is assumes that any ref with a '.' won't be a SHA.
-	if ref == "master" || strings.Contains(ref, ".") {
-		args := []string{"clone", "--depth", "1", "--branch", ref, url, "."}
-		cmd := util.Command{
-			Dir:  dir,
-			Name: "git",
-			Args: args,
-		}
-		output, err := cmd.RunWithoutRetry()
-		if err != nil {
-			return "", errors.Wrapf(err, "unable to clone version stream and checking out branch/tag: %s", output)
-		}
-	} else {
-		// assuming we deal with a SHA
-		args := []string{"clone", url, "."}
-		cmd := util.Command{
-			Dir:  dir,
-			Name: "git",
-			Args: args,
-		}
-		output, err := cmd.RunWithoutRetry()
-		if err != nil {
-			return "", errors.Wrapf(err, "unable to clone version stream: %s", output)
-		}
-
-		// Fetch PR refs before checking out the ref
-		args = []string{"fetch", "origin", ref}
-		cmd = util.Command{
-			Dir:  dir,
-			Name: "git",
-			Args: args,
-		}
-		output, err = cmd.RunWithoutRetry()
-		if err != nil {
-			return "", errors.Wrapf(err, "unable to fetch pull request refs for version stream: %s", output)
-		}
-
-		args = []string{"checkout", ref}
-		cmd = util.Command{
-			Dir:  dir,
-			Name: "git",
-			Args: args,
-		}
-		output, err = cmd.RunWithoutRetry()
-		if err != nil {
-			return "", errors.Wrapf(err, "unable checkout sha %s for version stream %s: %s", ref, url, output)
-		}
-	}
-
-	return dir, err
 }
 
 func getClientsAndNamespace() (tektonclient.Interface, jxclient.Interface, kubeclient.Interface, string, error) {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Now that the standard version stream cloning logic has merged, let's use that in metapipeline rather than its own logic.

#### Special notes for the reviewer(s)

/assign @pmuir 
/assign @hferentschik 

#### Which issue this PR fixes

fixes #5075
