### PR TITLE
fix: ensure helm is using requirements version stream

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2019-10-15T22:49:52Z",
+  "generated_at": "2019-10-22T15:55:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -522,7 +522,7 @@
       {
         "hashed_secret": "beb491c17c5298f5a9848c1d4b34ead07094fceb",
         "is_secret": true,
-        "line_number": 332,
+        "line_number": 327,
         "type": "Secret Keyword"
       }
     ],

--- a/pkg/cmd/create/create_addon_vault.go
+++ b/pkg/cmd/create/create_addon_vault.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jenkins-x/jx/pkg/config"
+
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
 	"github.com/jenkins-x/jx/pkg/helm"
@@ -69,11 +71,11 @@ func NewCmdCreateAddonVault(commonOpts *opts.CommonOptions) *cobra.Command {
 
 // Run implements the command
 func (o *CreateAddonVaultOptions) Run() error {
-	return InstallVaultOperator(o.CommonOptions, o.Namespace)
+	return InstallVaultOperator(o.CommonOptions, o.Namespace, nil)
 }
 
 // InstallVaultOperator installs a vault operator in the namespace provided
-func InstallVaultOperator(o *opts.CommonOptions, namespace string) error {
+func InstallVaultOperator(o *opts.CommonOptions, namespace string, vs *config.VersionStreamConfig) error {
 	err := o.EnsureHelm()
 	if err != nil {
 		return errors.Wrap(err, "checking if helm is installed")
@@ -98,6 +100,12 @@ func InstallVaultOperator(o *opts.CommonOptions, namespace string) error {
 		Ns:          namespace,
 		SetValues:   values,
 	}
+
+	if vs != nil {
+		helmOptions.VersionsGitURL = vs.URL
+		helmOptions.VersionsGitRef = vs.Ref
+	}
+
 	err = o.InstallChartWithOptions(helmOptions)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("installing %s chart", releaseName))

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -2298,7 +2298,7 @@ func (options *InstallOptions) createSystemVault(client kubernetes.Interface, na
 		// Configure the vault flag if only GitOps mode is on
 		options.Flags.Vault = true
 
-		err := InstallVaultOperator(options.CommonOptions, namespace)
+		err := InstallVaultOperator(options.CommonOptions, namespace, nil)
 		if err != nil {
 			return errors.Wrap(err, "unable to install vault operator")
 		}

--- a/pkg/cmd/step/boot/step_boot_vault.go
+++ b/pkg/cmd/step/boot/step_boot_vault.go
@@ -185,7 +185,7 @@ func (o *StepBootVaultOptions) Run() error {
 	}
 	opts.SetValues = strings.Join(values, ",")
 	log.Logger().Infof("installing vault operator with helm values:  %s", util.ColorInfo(opts.SetValues))
-	err = create.InstallVaultOperator(opts, ns)
+	err = create.InstallVaultOperator(opts, ns, &requirements.VersionStream)
 	if err != nil {
 		return errors.Wrap(err, "unable to install vault operator")
 	}

--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -364,6 +364,11 @@ func (o *StepHelmApplyOptions) Run() error {
 		ValueFiles:  valueFiles,
 		Dir:         dir,
 	}
+	if o.Boot {
+		helmOptions.VersionsGitURL = requirements.VersionStream.URL
+		helmOptions.VersionsGitRef = requirements.VersionStream.Ref
+	}
+
 	if o.Wait {
 		helmOptions.Wait = true
 		err = o.InstallChartWithOptionsAndTimeout(helmOptions, "600")

--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -255,11 +255,6 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 
 	// Lets update the TeamSettings with the VersionStream data from the jx-requirements.yaml file so we make sure
 	// we are upgrading with the latest versions
-	err = o.updateVersionStreamRefInDevEnvironment(requirements)
-	if err != nil {
-		return errors.Wrap(err, "error updating the versions stream reference in the dev environment's TeamSettings")
-	}
-
 	log.Logger().Infof("the cluster looks good, you are ready to '%s' now!", info("jx boot"))
 	fmt.Println()
 	return nil
@@ -887,29 +882,6 @@ func (o *StepVerifyPreInstallOptions) verifyIngress(requirements *config.Require
 		if err != nil {
 			return errors.Wrapf(err, "failed to save changes to file: %s", requirementsFileName)
 		}
-	}
-	return nil
-}
-
-// updateVersionStreamRefInDevEnvironment takes the current value of the VersionStream in jx-requirements.yaml and
-// updates it in the TeamSettings within the Dev Environment CRD
-func (o StepVerifyPreInstallOptions) updateVersionStreamRefInDevEnvironment(requirements *config.RequirementsConfig) error {
-	jxClient, ns, err := o.JXClient()
-	if err != nil {
-		return errors.Wrap(err, "there was a problem obtaining the Jx client")
-	}
-	devEnv, err := jxClient.JenkinsV1().Environments(ns).Get("dev", metav1.GetOptions{})
-	if err != nil {
-		// otherwise, we probably haven't booted yet, so it's ok if we can't find it
-		log.Logger().Info("The Dev environment could not be updated with the most recent version stream")
-		return nil
-	}
-	devEnv.Spec.TeamSettings.VersionStreamURL = requirements.VersionStream.URL
-	devEnv.Spec.TeamSettings.VersionStreamRef = requirements.VersionStream.Ref
-
-	_, err = jxClient.JenkinsV1().Environments(ns).PatchUpdate(devEnv)
-	if err != nil {
-		return errors.Wrap(err, "there was a problem updating the Dev environment's Team Settings versions refs")
 	}
 	return nil
 }


### PR DESCRIPTION
#### Description

- Installation of the vault operator was not using version stream specified in the requirements for `jx boot`. It was not set in the helm InstallChartOptions and was ignoring what was set in teamsettings and then defaulted to the default version stream.  This fix passes the values through in InstallChartOptions.

- Similarly in `jx step helm apply` this PR now passes the version steam config from requirements through in helm InstallChartOptions. 

- `jx step verify preinstall` was updating the team settings prior to the above steps. This wasn't taken effect however, as the team settings is being ignored. Removing this functionality as the above means it's no longer required, and this also prevents team settings being updated in multiple places. It should reflect what is in the dev-env template in a `jx boot` gitops cluster.