### PR TITLE
chore: Switch calls passing "o.In, o.Out, o.Err" to using a struct instead

### DIFF
--- a/pkg/apps/install.go
+++ b/pkg/apps/install.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -21,8 +20,6 @@ import (
 	"github.com/pborman/uuid"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -50,9 +47,7 @@ type InstallOptions struct {
 	Verbose         bool
 	DevEnv          *jenkinsv1.Environment
 	BatchMode       bool
-	In              terminal.FileReader
-	Out             terminal.FileWriter
-	Err             io.Writer
+	IOFileHandles   util.IOFileHandles
 	GitOps          bool
 	TeamName        string
 	BasePath        string
@@ -74,13 +69,12 @@ func (o *InstallOptions) AddApp(app string, version string, repository string, u
 		Items: valuesFiles,
 	}
 
-	username, password, err := helm.DecorateWithCredentials(repository, username, password, o.VaultClient, o.In,
-		o.Out, o.Err)
+	username, password, err := helm.DecorateWithCredentials(repository, username, password, o.VaultClient, o.IOFileHandles)
 	if err != nil {
 		return errors.Wrapf(err, "locating credentials for %s", repository)
 	}
 
-	_, err = helm.AddHelmRepoIfMissing(repository, "", username, password, o.Helmer, o.VaultClient, o.In, o.Out, o.Err)
+	_, err = helm.AddHelmRepoIfMissing(repository, "", username, password, o.Helmer, o.VaultClient, o.IOFileHandles)
 	if err != nil {
 		return errors.Wrapf(err, "adding helm repo")
 	}
@@ -223,12 +217,11 @@ func (o *InstallOptions) UpgradeApp(app string, version string, repository strin
 		releaseName = fmt.Sprintf("%s-%s", o.Namespace, app)
 	}
 
-	username, password, err := helm.DecorateWithCredentials(repository, username, password, o.VaultClient, o.In,
-		o.Out, o.Err)
+	username, password, err := helm.DecorateWithCredentials(repository, username, password, o.VaultClient, o.IOFileHandles)
 	if err != nil {
 		return errors.Wrapf(err, "locating credentials for %s", repository)
 	}
-	_, err = helm.AddHelmRepoIfMissing(repository, "", username, password, o.Helmer, o.VaultClient, o.In, o.Out, o.Err)
+	_, err = helm.AddHelmRepoIfMissing(repository, "", username, password, o.Helmer, o.VaultClient, o.IOFileHandles)
 
 	if err != nil {
 		return errors.Wrapf(err, "adding helm repo")
@@ -348,8 +341,7 @@ func (o *InstallOptions) createInterrogateChartFn(version string, chartName stri
 		for _, requirement := range requirements.Dependencies {
 			// repositories that start with an @ are aliases to helm repo names
 			if !strings.HasPrefix(requirement.Repository, "@") {
-				_, err := helm.AddHelmRepoIfMissing(requirement.Repository, "", "", "", o.Helmer, o.VaultClient, o.In,
-					o.Out, o.Err)
+				_, err := helm.AddHelmRepoIfMissing(requirement.Repository, "", "", "", o.Helmer, o.VaultClient, o.IOFileHandles)
 				if err != nil {
 					return &chartDetails, errors.Wrapf(err, "")
 				}
@@ -544,7 +536,7 @@ func (o *InstallOptions) createInterrogateChartFn(version string, chartName stri
 				if kube.PodStatus(completePod) == string(corev1.PodFailed) {
 					log.Logger().Errorf("Pod Log")
 					log.Logger().Errorf("-----------")
-					err := kube.TailLogs(o.Namespace, pod.Name, appResource.Spec.SchemaPreprocessor.Name, o.Err, o.Out)
+					err := kube.TailLogs(o.Namespace, pod.Name, appResource.Spec.SchemaPreprocessor.Name, o.IOFileHandles.Err, o.IOFileHandles.Out)
 					log.Logger().Errorf("-----------")
 					if err != nil {
 						return &chartDetails, errors.Wrapf(err, "getting pod logs for %s container %s", pod.Name,
@@ -571,7 +563,7 @@ func (o *InstallOptions) createInterrogateChartFn(version string, chartName stri
 				gitOpsURL = o.DevEnv.Spec.Source.URL
 			}
 			if schema != nil {
-				valuesFileName, cleanup, err := ProcessValues(schema, chartName, gitOpsURL, o.TeamName, o.BasePath, o.BatchMode, askExisting, o.VaultClient, existing, o.SecretsScheme, o.In, o.Out, o.Err, o.Verbose)
+				valuesFileName, cleanup, err := ProcessValues(schema, chartName, gitOpsURL, o.TeamName, o.BasePath, o.BatchMode, askExisting, o.VaultClient, existing, o.SecretsScheme, o.IOFileHandles, o.Verbose)
 				chartDetails.Cleanup = cleanup
 				if err != nil {
 					return &chartDetails, errors.WithStack(err)

--- a/pkg/apps/values.go
+++ b/pkg/apps/values.go
@@ -3,15 +3,11 @@ package apps
 import (
 	"encoding/base64"
 	"fmt"
-
-	"github.com/jenkins-x/jx/pkg/gits"
-	"github.com/jenkins-x/jx/pkg/secreturl"
-
-	"io"
 	"io/ioutil"
 	"strings"
 
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/secreturl"
 
 	"github.com/ghodss/yaml"
 	"github.com/jenkins-x/jx/pkg/environments"
@@ -95,14 +91,14 @@ func AddValuesToChart(name string, values []byte, verbose bool) (string, func(),
 
 //GenerateQuestions asks questions based on the schema
 func GenerateQuestions(schema []byte, batchMode bool, askExisting bool, basePath string, secretURLClient secreturl.Client,
-	existing map[string]interface{}, vaultScheme string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) ([]byte, error) {
+	existing map[string]interface{}, vaultScheme string, handles util.IOFileHandles) ([]byte, error) {
 	schemaOptions := surveyutils.JSONSchemaOptions{
 		VaultClient:         secretURLClient,
 		VaultScheme:         vaultScheme,
 		VaultBasePath:       basePath,
-		Out:                 out,
-		In:                  in,
-		OutErr:              outErr,
+		Out:                 handles.Out,
+		In:                  handles.In,
+		OutErr:              handles.Err,
 		IgnoreMissingValues: false,
 		NoAsk:               batchMode,
 		AutoAcceptDefaults:  batchMode,
@@ -149,9 +145,7 @@ func ProcessValues(
 	secretURLClient secreturl.Client,
 	existing map[string]interface{},
 	vaultScheme string,
-	in terminal.FileReader,
-	out terminal.FileWriter,
-	outErr io.Writer,
+	handles util.IOFileHandles,
 	verbose bool) (string, func(), error) {
 	var values []byte
 	var err error
@@ -166,7 +160,7 @@ func ProcessValues(
 			basepath = strings.Join([]string{"teams", teamName}, "/")
 		}
 	}
-	values, err = GenerateQuestions(schema, batchMode, askExisting, basepath, secretURLClient, existing, vaultScheme, in, out, outErr)
+	values, err = GenerateQuestions(schema, batchMode, askExisting, basepath, secretURLClient, existing, vaultScheme, handles)
 	if err != nil {
 		return "", func() {}, errors.Wrapf(err, "asking questions for schema")
 	}

--- a/pkg/auth/auth_config.go
+++ b/pkg/auth/auth_config.go
@@ -2,14 +2,12 @@ package auth
 
 import (
 	"fmt"
-	"io"
 	"net/url"
 	"sort"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/util"
 	survey "gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 func (c *AuthConfig) FindUserAuths(serverURL string) []*UserAuth {
@@ -218,7 +216,7 @@ func urlHostName(rawUrl string) string {
 	return strings.TrimSuffix(rawUrl, "/")
 }
 
-func (c *AuthConfig) PickServer(message string, batchMode bool, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (*AuthServer, error) {
+func (c *AuthConfig) PickServer(message string, batchMode bool, handles util.IOFileHandles) (*AuthServer, error) {
 	if c.Servers == nil || len(c.Servers) == 0 {
 		return nil, fmt.Errorf("No servers available!")
 	}
@@ -238,7 +236,7 @@ func (c *AuthConfig) PickServer(message string, batchMode bool, in terminal.File
 				Message: message,
 				Options: urls,
 			}
-			surveyOpts := survey.WithStdio(in, out, outErr)
+			surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 			err := survey.AskOne(prompt, &url, survey.Required, surveyOpts)
 			if err != nil {
 				return nil, err
@@ -254,10 +252,10 @@ func (c *AuthConfig) PickServer(message string, batchMode bool, in terminal.File
 }
 
 // PickServerAuth Pick the servers auth
-func (c *AuthConfig) PickServerUserAuth(server *AuthServer, message string, batchMode bool, org string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (*UserAuth, error) {
+func (c *AuthConfig) PickServerUserAuth(server *AuthServer, message string, batchMode bool, org string, handles util.IOFileHandles) (*UserAuth, error) {
 	url := server.URL
 	userAuths := c.FindUserAuths(url)
-	surveyOpts := survey.WithStdio(in, out, errOut)
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	if len(userAuths) == 1 {
 
 		auth := userAuths[0]
@@ -329,7 +327,7 @@ func (c *AuthConfig) PickServerUserAuth(server *AuthServer, message string, batc
 type PrintUserFn func(username string) error
 
 // EditUserAuth Lets the user input/edit the user auth
-func (c *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defaultUserName string, editUser, batchMode bool, fn PrintUserFn, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) error {
+func (c *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defaultUserName string, editUser, batchMode bool, fn PrintUserFn, handles util.IOFileHandles) error {
 	// default the user name if its empty
 	defaultUsername := c.DefaultUsername
 	if defaultUsername == "" {
@@ -351,7 +349,7 @@ func (c *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defaultUse
 	var err error
 
 	if editUser || auth.Username == "" {
-		auth.Username, err = util.PickValue(serverLabel+" username:", auth.Username, true, "", in, out, outErr)
+		auth.Username, err = util.PickValue(serverLabel+" username:", auth.Username, true, "", handles)
 		if err != nil {
 			return err
 		}
@@ -363,7 +361,7 @@ func (c *AuthConfig) EditUserAuth(serverLabel string, auth *UserAuth, defaultUse
 				return err
 			}
 		}
-		auth.ApiToken, err = util.PickPassword("API Token:", "", in, out, outErr)
+		auth.ApiToken, err = util.PickPassword("API Token:", "", handles)
 	}
 	return err
 }
@@ -395,7 +393,7 @@ func (c *AuthConfig) GetServerURLs() []string {
 }
 
 // PickOrCreateServer picks the server to use defaulting to the current server
-func (c *AuthConfig) PickOrCreateServer(fallbackServerURL string, serverURL string, message string, batchMode bool, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (*AuthServer, error) {
+func (c *AuthConfig) PickOrCreateServer(fallbackServerURL string, serverURL string, message string, batchMode bool, handles util.IOFileHandles) (*AuthServer, error) {
 	servers := c.Servers
 	if len(servers) == 0 {
 		if serverURL != "" {
@@ -431,7 +429,7 @@ func (c *AuthConfig) PickOrCreateServer(fallbackServerURL string, serverURL stri
 	if batchMode {
 		return c.GetOrCreateServer(defaultValue), nil
 	}
-	name, err := util.PickRequiredNameWithDefault(names, message, defaultValue, "", in, out, outErr)
+	name, err := util.PickRequiredNameWithDefault(names, message, defaultValue, "", handles)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/gke/vault/vault_backend.go
+++ b/pkg/cloud/gke/vault/vault_backend.go
@@ -2,13 +2,10 @@ package vault
 
 import (
 	"fmt"
-	"io"
-
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 )
@@ -77,7 +74,7 @@ func CreateVaultGCPServiceAccount(gcloud gke.GClouder, kubeClient kubernetes.Int
 }
 
 // CreateBucket Creates a bucket in GKE to store the backend (encrypted) data for vault
-func CreateBucket(gcloud gke.GClouder, vaultName, bucketName string, projectID, zone string, recreate bool, batchMode bool, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (string, error) {
+func CreateBucket(gcloud gke.GClouder, vaultName, bucketName string, projectID, zone string, recreate bool, batchMode bool, handles util.IOFileHandles) (string, error) {
 	if bucketName == "" {
 		bucketName = gke.BucketName(vaultName)
 	}
@@ -93,7 +90,7 @@ func CreateBucket(gcloud gke.GClouder, vaultName, bucketName string, projectID, 
 			log.Logger().Warnf("We are deleting the Vault bucket %s so that Vault will install cleanly", bucketName)
 		} else {
 			if !util.Confirm(fmt.Sprintf("We are about to delete bucket %q, so we can install a clean Vault. Are you sure: ", bucketName),
-				true, "We recommend you delete the Vault bucket on install to ensure Vault starts up reliably", in, out, outErr) {
+				true, "We recommend you delete the Vault bucket on install to ensure Vault starts up reliably", handles) {
 				return bucketName, nil
 			}
 		}

--- a/pkg/cmd/add/add_app.go
+++ b/pkg/cmd/add/add_app.go
@@ -133,11 +133,9 @@ func (o *AddAppOptions) Run() error {
 		o.Namespace = ns
 	}
 	installOpts := apps.InstallOptions{
-		In:            o.In,
+		IOFileHandles: o.GetIOFileHandles(),
 		DevEnv:        o.DevEnv,
 		Verbose:       o.Verbose,
-		Err:           o.Err,
-		Out:           o.Out,
 		GitOps:        o.GitOps,
 		BatchMode:     o.BatchMode,
 		AutoMerge:     o.AutoMerge,

--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -179,7 +179,7 @@ func (o *BootOptions) Run() error {
 
 			help := "A git clone of a Jenkins X Boot source repository is required for 'jx boot'"
 			message := "Do you want to clone the Jenkins X Boot Git repository?"
-			if !util.Confirm(message, true, help, o.In, o.Out, o.Err) {
+			if !util.Confirm(message, true, help, o.GetIOFileHandles()) {
 				return fmt.Errorf("Please run this command again inside a git clone from a Jenkins X Boot repository")
 			}
 		}

--- a/pkg/cmd/clients/fake/fake_factory.go
+++ b/pkg/cmd/clients/fake/fake_factory.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/jenkins-x/jx/pkg/cmd/clients"
+	"github.com/jenkins-x/jx/pkg/util"
 
 	"github.com/jenkins-x/jx/pkg/builds"
 	v1fake "github.com/jenkins-x/jx/pkg/client/clientset/versioned/fake"
@@ -18,22 +19,20 @@ import (
 	"github.com/jenkins-x/jx/pkg/vault"
 	certmngclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 
+	vaultoperatorclient "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 	"github.com/heptio/sonobuoy/pkg/client"
 	"github.com/heptio/sonobuoy/pkg/dynamic"
+	"github.com/jenkins-x/jx/pkg/auth"
+	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/kube"
 	kubevault "github.com/jenkins-x/jx/pkg/kube/vault"
 	"github.com/jenkins-x/jx/pkg/table"
-	"github.com/pkg/errors"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
-	vaultoperatorclient "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
-	"github.com/jenkins-x/jx/pkg/auth"
-	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	build "github.com/knative/build/pkg/client/clientset/versioned"
 	buildfake "github.com/knative/build/pkg/client/clientset/versioned/fake"
 	kserve "github.com/knative/serving/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
 	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	tektonfake "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
@@ -132,13 +131,13 @@ func (f *FakeFactory) WithBearerToken(token string) clients.Factory {
 }
 
 // CreateJenkinsClient creates a new Jenkins client
-func (f *FakeFactory) CreateJenkinsClient(kubeClient kubernetes.Interface, ns string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (gojenkins.JenkinsClient, error) {
-	return f.GetDelegateFactory().CreateJenkinsClient(kubeClient, ns, in, out, errOut)
+func (f *FakeFactory) CreateJenkinsClient(kubeClient kubernetes.Interface, ns string, handles util.IOFileHandles) (gojenkins.JenkinsClient, error) {
+	return f.GetDelegateFactory().CreateJenkinsClient(kubeClient, ns, handles)
 }
 
 // CreateCustomJenkinsClient creates a new Jenkins client for the given custom Jenkins App
-func (f *FakeFactory) CreateCustomJenkinsClient(kubeClient kubernetes.Interface, ns string, jenkinsServiceName string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (gojenkins.JenkinsClient, error) {
-	return f.GetDelegateFactory().CreateCustomJenkinsClient(kubeClient, ns, jenkinsServiceName, in, out, errOut)
+func (f *FakeFactory) CreateCustomJenkinsClient(kubeClient kubernetes.Interface, ns string, jenkinsServiceName string, handles util.IOFileHandles) (gojenkins.JenkinsClient, error) {
+	return f.GetDelegateFactory().CreateCustomJenkinsClient(kubeClient, ns, jenkinsServiceName, handles)
 }
 
 // GetJenkinsURL gets the Jenkins URL for the given namespace
@@ -384,8 +383,8 @@ func (f *FakeFactory) CreateMetricsClient() (*metricsclient.Clientset, error) {
 }
 
 // CreateGitProvider creates a new Git provider
-func (f *FakeFactory) CreateGitProvider(gitURL string, message string, authConfigSvc auth.ConfigService, gitKind string, batchMode bool, gitter gits.Gitter, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (gits.GitProvider, error) {
-	return f.GetDelegateFactory().CreateGitProvider(gitURL, message, authConfigSvc, gitKind, batchMode, gitter, in, out, errOut)
+func (f *FakeFactory) CreateGitProvider(gitURL string, message string, authConfigSvc auth.ConfigService, gitKind string, batchMode bool, gitter gits.Gitter, handles util.IOFileHandles) (gits.GitProvider, error) {
+	return f.GetDelegateFactory().CreateGitProvider(gitURL, message, authConfigSvc, gitKind, batchMode, gitter, handles)
 }
 
 // CreateKubeConfig creates the kubernetes configuration

--- a/pkg/cmd/clients/interface.go
+++ b/pkg/cmd/clients/interface.go
@@ -5,18 +5,17 @@ import (
 
 	gojenkins "github.com/jenkins-x/golang-jenkins"
 	"github.com/jenkins-x/jx/pkg/io/secrets"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/jenkins-x/jx/pkg/vault"
 
 	"github.com/heptio/sonobuoy/pkg/dynamic"
 	"github.com/jenkins-x/jx/pkg/helm"
 
 	"github.com/heptio/sonobuoy/pkg/client"
-	"github.com/jenkins-x/jx/pkg/gits"
-	"github.com/jenkins-x/jx/pkg/table"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/table"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -74,13 +73,13 @@ type Factory interface {
 	//
 
 	// CreateJenkinsClient creates a new Jenkins client
-	CreateJenkinsClient(kubeClient kubernetes.Interface, ns string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (gojenkins.JenkinsClient, error)
+	CreateJenkinsClient(kubeClient kubernetes.Interface, ns string, handles util.IOFileHandles) (gojenkins.JenkinsClient, error)
 
 	// CreateCustomJenkinsClient creates a new Jenkins client for the custom Jenkins App with the jenkinsServiceName
-	CreateCustomJenkinsClient(kubeClient kubernetes.Interface, ns string, jenkinsServiceName string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (gojenkins.JenkinsClient, error)
+	CreateCustomJenkinsClient(kubeClient kubernetes.Interface, ns string, jenkinsServiceName string, handles util.IOFileHandles) (gojenkins.JenkinsClient, error)
 
 	// CreateGitProvider creates a new Git provider
-	CreateGitProvider(string, string, auth.ConfigService, string, bool, gits.Gitter, terminal.FileReader, terminal.FileWriter, io.Writer) (gits.GitProvider, error)
+	CreateGitProvider(string, string, auth.ConfigService, string, bool, gits.Gitter, util.IOFileHandles) (gits.GitProvider, error)
 
 	// CreateComplianceClient creates a new compliance client
 	CreateComplianceClient() (*client.SonobuoyClient, error)

--- a/pkg/cmd/clients/mocks/factory.go
+++ b/pkg/cmd/clients/mocks/factory.go
@@ -19,13 +19,13 @@ import (
 	helm "github.com/jenkins-x/jx/pkg/helm"
 	secrets "github.com/jenkins-x/jx/pkg/io/secrets"
 	table "github.com/jenkins-x/jx/pkg/table"
+	util "github.com/jenkins-x/jx/pkg/util"
 	vault "github.com/jenkins-x/jx/pkg/vault"
 	versioned1 "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	versioned2 "github.com/knative/build/pkg/client/clientset/versioned"
 	versioned3 "github.com/knative/serving/pkg/client/clientset/versioned"
 	pegomock "github.com/petergtz/pegomock"
 	versioned4 "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	terminal "gopkg.in/AlecAivazis/survey.v1/terminal"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kubernetes "k8s.io/client-go/kubernetes"
@@ -196,11 +196,11 @@ func (mock *MockFactory) CreateComplianceClient() (*client.SonobuoyClient, error
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateCustomJenkinsClient(_param0 kubernetes.Interface, _param1 string, _param2 string, _param3 terminal.FileReader, _param4 terminal.FileWriter, _param5 io.Writer) (golang_jenkins.JenkinsClient, error) {
+func (mock *MockFactory) CreateCustomJenkinsClient(_param0 kubernetes.Interface, _param1 string, _param2 string, _param3 util.IOFileHandles) (golang_jenkins.JenkinsClient, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateCustomJenkinsClient", params, []reflect.Type{reflect.TypeOf((*golang_jenkins.JenkinsClient)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 golang_jenkins.JenkinsClient
 	var ret1 error
@@ -238,11 +238,11 @@ func (mock *MockFactory) CreateDynamicClient() (*dynamic.APIHelper, string, erro
 	return ret0, ret1, ret2
 }
 
-func (mock *MockFactory) CreateGitProvider(_param0 string, _param1 string, _param2 auth.ConfigService, _param3 string, _param4 bool, _param5 gits.Gitter, _param6 terminal.FileReader, _param7 terminal.FileWriter, _param8 io.Writer) (gits.GitProvider, error) {
+func (mock *MockFactory) CreateGitProvider(_param0 string, _param1 string, _param2 auth.ConfigService, _param3 string, _param4 bool, _param5 gits.Gitter, _param6 util.IOFileHandles) (gits.GitProvider, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateGitProvider", params, []reflect.Type{reflect.TypeOf((*gits.GitProvider)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 gits.GitProvider
 	var ret1 error
@@ -333,11 +333,11 @@ func (mock *MockFactory) CreateJenkinsAuthConfigService(_param0 kubernetes.Inter
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateJenkinsClient(_param0 kubernetes.Interface, _param1 string, _param2 terminal.FileReader, _param3 terminal.FileWriter, _param4 io.Writer) (golang_jenkins.JenkinsClient, error) {
+func (mock *MockFactory) CreateJenkinsClient(_param0 kubernetes.Interface, _param1 string, _param2 util.IOFileHandles) (golang_jenkins.JenkinsClient, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4}
+	params := []pegomock.Param{_param0, _param1, _param2}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateJenkinsClient", params, []reflect.Type{reflect.TypeOf((*golang_jenkins.JenkinsClient)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 golang_jenkins.JenkinsClient
 	var ret1 error
@@ -938,8 +938,8 @@ func (c *MockFactory_CreateComplianceClient_OngoingVerification) GetCapturedArgu
 func (c *MockFactory_CreateComplianceClient_OngoingVerification) GetAllCapturedArguments() {
 }
 
-func (verifier *VerifierMockFactory) CreateCustomJenkinsClient(_param0 kubernetes.Interface, _param1 string, _param2 string, _param3 terminal.FileReader, _param4 terminal.FileWriter, _param5 io.Writer) *MockFactory_CreateCustomJenkinsClient_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5}
+func (verifier *VerifierMockFactory) CreateCustomJenkinsClient(_param0 kubernetes.Interface, _param1 string, _param2 string, _param3 util.IOFileHandles) *MockFactory_CreateCustomJenkinsClient_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CreateCustomJenkinsClient", params, verifier.timeout)
 	return &MockFactory_CreateCustomJenkinsClient_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -949,12 +949,12 @@ type MockFactory_CreateCustomJenkinsClient_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockFactory_CreateCustomJenkinsClient_OngoingVerification) GetCapturedArguments() (kubernetes.Interface, string, string, terminal.FileReader, terminal.FileWriter, io.Writer) {
-	_param0, _param1, _param2, _param3, _param4, _param5 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1]
+func (c *MockFactory_CreateCustomJenkinsClient_OngoingVerification) GetCapturedArguments() (kubernetes.Interface, string, string, util.IOFileHandles) {
+	_param0, _param1, _param2, _param3 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1]
 }
 
-func (c *MockFactory_CreateCustomJenkinsClient_OngoingVerification) GetAllCapturedArguments() (_param0 []kubernetes.Interface, _param1 []string, _param2 []string, _param3 []terminal.FileReader, _param4 []terminal.FileWriter, _param5 []io.Writer) {
+func (c *MockFactory_CreateCustomJenkinsClient_OngoingVerification) GetAllCapturedArguments() (_param0 []kubernetes.Interface, _param1 []string, _param2 []string, _param3 []util.IOFileHandles) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]kubernetes.Interface, len(params[0]))
@@ -969,17 +969,9 @@ func (c *MockFactory_CreateCustomJenkinsClient_OngoingVerification) GetAllCaptur
 		for u, param := range params[2] {
 			_param2[u] = param.(string)
 		}
-		_param3 = make([]terminal.FileReader, len(params[3]))
+		_param3 = make([]util.IOFileHandles, len(params[3]))
 		for u, param := range params[3] {
-			_param3[u] = param.(terminal.FileReader)
-		}
-		_param4 = make([]terminal.FileWriter, len(params[4]))
-		for u, param := range params[4] {
-			_param4[u] = param.(terminal.FileWriter)
-		}
-		_param5 = make([]io.Writer, len(params[5]))
-		for u, param := range params[5] {
-			_param5[u] = param.(io.Writer)
+			_param3[u] = param.(util.IOFileHandles)
 		}
 	}
 	return
@@ -1002,8 +994,8 @@ func (c *MockFactory_CreateDynamicClient_OngoingVerification) GetCapturedArgumen
 func (c *MockFactory_CreateDynamicClient_OngoingVerification) GetAllCapturedArguments() {
 }
 
-func (verifier *VerifierMockFactory) CreateGitProvider(_param0 string, _param1 string, _param2 auth.ConfigService, _param3 string, _param4 bool, _param5 gits.Gitter, _param6 terminal.FileReader, _param7 terminal.FileWriter, _param8 io.Writer) *MockFactory_CreateGitProvider_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8}
+func (verifier *VerifierMockFactory) CreateGitProvider(_param0 string, _param1 string, _param2 auth.ConfigService, _param3 string, _param4 bool, _param5 gits.Gitter, _param6 util.IOFileHandles) *MockFactory_CreateGitProvider_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CreateGitProvider", params, verifier.timeout)
 	return &MockFactory_CreateGitProvider_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -1013,12 +1005,12 @@ type MockFactory_CreateGitProvider_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockFactory_CreateGitProvider_OngoingVerification) GetCapturedArguments() (string, string, auth.ConfigService, string, bool, gits.Gitter, terminal.FileReader, terminal.FileWriter, io.Writer) {
-	_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1], _param6[len(_param6)-1], _param7[len(_param7)-1], _param8[len(_param8)-1]
+func (c *MockFactory_CreateGitProvider_OngoingVerification) GetCapturedArguments() (string, string, auth.ConfigService, string, bool, gits.Gitter, util.IOFileHandles) {
+	_param0, _param1, _param2, _param3, _param4, _param5, _param6 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1], _param6[len(_param6)-1]
 }
 
-func (c *MockFactory_CreateGitProvider_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []auth.ConfigService, _param3 []string, _param4 []bool, _param5 []gits.Gitter, _param6 []terminal.FileReader, _param7 []terminal.FileWriter, _param8 []io.Writer) {
+func (c *MockFactory_CreateGitProvider_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []auth.ConfigService, _param3 []string, _param4 []bool, _param5 []gits.Gitter, _param6 []util.IOFileHandles) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(params[0]))
@@ -1045,17 +1037,9 @@ func (c *MockFactory_CreateGitProvider_OngoingVerification) GetAllCapturedArgume
 		for u, param := range params[5] {
 			_param5[u] = param.(gits.Gitter)
 		}
-		_param6 = make([]terminal.FileReader, len(params[6]))
+		_param6 = make([]util.IOFileHandles, len(params[6]))
 		for u, param := range params[6] {
-			_param6[u] = param.(terminal.FileReader)
-		}
-		_param7 = make([]terminal.FileWriter, len(params[7]))
-		for u, param := range params[7] {
-			_param7[u] = param.(terminal.FileWriter)
-		}
-		_param8 = make([]io.Writer, len(params[8]))
-		for u, param := range params[8] {
-			_param8[u] = param.(io.Writer)
+			_param6[u] = param.(util.IOFileHandles)
 		}
 	}
 	return
@@ -1183,8 +1167,8 @@ func (c *MockFactory_CreateJenkinsAuthConfigService_OngoingVerification) GetAllC
 	return
 }
 
-func (verifier *VerifierMockFactory) CreateJenkinsClient(_param0 kubernetes.Interface, _param1 string, _param2 terminal.FileReader, _param3 terminal.FileWriter, _param4 io.Writer) *MockFactory_CreateJenkinsClient_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4}
+func (verifier *VerifierMockFactory) CreateJenkinsClient(_param0 kubernetes.Interface, _param1 string, _param2 util.IOFileHandles) *MockFactory_CreateJenkinsClient_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CreateJenkinsClient", params, verifier.timeout)
 	return &MockFactory_CreateJenkinsClient_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -1194,12 +1178,12 @@ type MockFactory_CreateJenkinsClient_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockFactory_CreateJenkinsClient_OngoingVerification) GetCapturedArguments() (kubernetes.Interface, string, terminal.FileReader, terminal.FileWriter, io.Writer) {
-	_param0, _param1, _param2, _param3, _param4 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1]
+func (c *MockFactory_CreateJenkinsClient_OngoingVerification) GetCapturedArguments() (kubernetes.Interface, string, util.IOFileHandles) {
+	_param0, _param1, _param2 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1]
 }
 
-func (c *MockFactory_CreateJenkinsClient_OngoingVerification) GetAllCapturedArguments() (_param0 []kubernetes.Interface, _param1 []string, _param2 []terminal.FileReader, _param3 []terminal.FileWriter, _param4 []io.Writer) {
+func (c *MockFactory_CreateJenkinsClient_OngoingVerification) GetAllCapturedArguments() (_param0 []kubernetes.Interface, _param1 []string, _param2 []util.IOFileHandles) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]kubernetes.Interface, len(params[0]))
@@ -1210,17 +1194,9 @@ func (c *MockFactory_CreateJenkinsClient_OngoingVerification) GetAllCapturedArgu
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
 		}
-		_param2 = make([]terminal.FileReader, len(params[2]))
+		_param2 = make([]util.IOFileHandles, len(params[2]))
 		for u, param := range params[2] {
-			_param2[u] = param.(terminal.FileReader)
-		}
-		_param3 = make([]terminal.FileWriter, len(params[3]))
-		for u, param := range params[3] {
-			_param3[u] = param.(terminal.FileWriter)
-		}
-		_param4 = make([]io.Writer, len(params[4]))
-		for u, param := range params[4] {
-			_param4[u] = param.(io.Writer)
+			_param2[u] = param.(util.IOFileHandles)
 		}
 	}
 	return

--- a/pkg/cmd/controller/controller_backup.go
+++ b/pkg/cmd/controller/controller_backup.go
@@ -272,7 +272,7 @@ func (o *ControllerBackupOptions) getOrCreateBackupRepository() (string, error) 
 	defaultRepoName := fmt.Sprintf("organisation-%s-backup", o.Organisation)
 
 	details, err := gits.PickNewOrExistingGitRepository(o.BatchMode, authConfigSvc,
-		defaultRepoName, &o.GitRepositoryOptions, nil, nil, o.Git(), true, o.In, o.Out, o.Err)
+		defaultRepoName, &o.GitRepositoryOptions, nil, nil, o.Git(), true, o.GetIOFileHandles())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/controller/controller_team.go
+++ b/pkg/cmd/controller/controller_team.go
@@ -349,7 +349,7 @@ func (o *ControllerOptions) LoadProwOAuthConfig(ns string) (string, error) {
 	config := authConfigSvc.Config()
 	// lets assume github.com for now so ignore config.CurrentServer
 	server := config.GetOrCreateServer("https://github.com")
-	userAuth, err := config.PickServerUserAuth(server, "Git account to be used to send webhook events", true, "", o.In, o.Out, o.Err)
+	userAuth, err := config.PickServerUserAuth(server, "Git account to be used to send webhook events", true, "", o.GetIOFileHandles())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/controller/pipeline/pipelinerunner_cmd.go
+++ b/pkg/cmd/controller/pipeline/pipelinerunner_cmd.go
@@ -105,7 +105,7 @@ func (o *PipelineRunnerOptions) Run() error {
 		return err
 	}
 
-	metapipelineClient, err := metapipeline.NewMetaPipelineClient(o.Git(), o.In, o.Out, o.Err)
+	metapipelineClient, err := metapipeline.NewMetaPipelineClient(o.Git(), o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/create/create_addon_environment_controller.go
+++ b/pkg/cmd/create/create_addon_environment_controller.go
@@ -123,7 +123,7 @@ func (o *CreateAddonEnvironmentControllerOptions) Run() error {
 
 	// validate the git URL
 	if o.GitSourceURL == "" && !o.BatchMode {
-		o.GitSourceURL, err = util.PickValue("git repository to promote from: ", "", true, "please specify the GitOps repository used to store the kubernetes applications to deploy to this cluster", o.In, o.Out, o.Err)
+		o.GitSourceURL, err = util.PickValue("git repository to promote from: ", "", true, "please specify the GitOps repository used to store the kubernetes applications to deploy to this cluster", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ func (o *CreateAddonEnvironmentControllerOptions) Run() error {
 		o.GitKind = gits.SaasGitKind(serverURL)
 	}
 	if o.GitKind == "" && !o.BatchMode {
-		o.GitKind, err = util.PickName(gits.KindGits, "kind of git repository: ", "please specify the GitOps repository used to store the kubernetes applications to deploy to this cluster", o.In, o.Out, o.Err)
+		o.GitKind, err = util.PickName(gits.KindGits, "kind of git repository: ", "please specify the GitOps repository used to store the kubernetes applications to deploy to this cluster", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_archetype.go
+++ b/pkg/cmd/create/create_archetype.go
@@ -105,7 +105,7 @@ func (o *CreateArchetypeOptions) Run() error {
 		return fmt.Errorf("Failed to load Spring Boot model %s", err)
 	}
 	form := &o.Form
-	err = model.CreateSurvey(&o.Filter, o.PickVersion, form, o.In, o.Out, o.Err)
+	err = model.CreateSurvey(&o.Filter, o.PickVersion, form, o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}
@@ -142,21 +142,21 @@ func (o *CreateArchetypeOptions) CreateArchetype() error {
 		newline := false
 		if form.GroupId == "" {
 			newline = true
-			form.GroupId, err = util.PickValue("Group ID of the new application: ", "org.acme.demo", true, "", o.In, o.Out, o.Err)
+			form.GroupId, err = util.PickValue("Group ID of the new application: ", "org.acme.demo", true, "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
 		}
 		if form.ArtifactId == "" {
 			newline = true
-			form.ArtifactId, err = util.PickValue("Artifact ID of the new application: ", "mydemo", true, "", o.In, o.Out, o.Err)
+			form.ArtifactId, err = util.PickValue("Artifact ID of the new application: ", "mydemo", true, "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
 		}
 		if form.Version == "" {
 			newline = true
-			form.Version, err = util.PickValue("Snapshot Version of the new application: ", "1.0-SNAPSHOT", true, "", o.In, o.Out, o.Err)
+			form.Version, err = util.PickValue("Snapshot Version of the new application: ", "1.0-SNAPSHOT", true, "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/create/create_chat_token.go
+++ b/pkg/cmd/create/create_chat_token.go
@@ -111,7 +111,7 @@ func (o *CreateChatTokenOptions) Run() error {
 			return nil
 		}
 
-		err = config.EditUserAuth(server.Label(), userAuth, o.Username, false, o.BatchMode, f, o.In, o.Out, o.Err)
+		err = config.EditUserAuth(server.Label(), userAuth, o.Username, false, o.BatchMode, f, o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_cluster_aws.go
+++ b/pkg/cmd/create/create_cluster_aws.go
@@ -171,7 +171,7 @@ func (o *CreateClusterAWSOptions) Run() error {
 			}
 			c := len(availabilityZones)
 			if c > 0 {
-				zones, err = util.PickNameWithDefault(availabilityZones, "Pick Availability Zone: ", availabilityZones[c-1], "", o.In, o.Out, o.Err)
+				zones, err = util.PickNameWithDefault(availabilityZones, "Pick Availability Zone: ", availabilityZones[c-1], "", o.GetIOFileHandles())
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/create/create_codeship.go
+++ b/pkg/cmd/create/create_codeship.go
@@ -210,7 +210,7 @@ func (o *CreateCodeshipOptions) Run() error {
 	defaultRepoName := fmt.Sprintf("organisation-%s", o.Flags.OrganisationName)
 
 	details, err := gits.PickNewOrExistingGitRepository(o.BatchMode, authConfigSvc,
-		defaultRepoName, &o.GitRepositoryOptions, nil, nil, o.Git(), true, o.In, o.Out, o.Err)
+		defaultRepoName, &o.GitRepositoryOptions, nil, nil, o.Git(), true, o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -286,7 +286,7 @@ func (o *CreateDevPodOptions) Run() error {
 			}
 		}
 		if label == "" {
-			label, err = util.PickName(labels, "Pick which kind of DevPod you wish to create: ", "", o.In, o.Out, o.Err)
+			label, err = util.PickName(labels, "Pick which kind of DevPod you wish to create: ", "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/create/create_env.go
+++ b/pkg/cmd/create/create_env.go
@@ -189,7 +189,7 @@ func (o *CreateEnvOptions) Run() error {
 	env := v1.Environment{}
 	o.Options.Spec.PromotionStrategy = v1.PromotionStrategyType(o.PromotionStrategy)
 	gitProvider, err := kube.CreateEnvironmentSurvey(o.BatchMode, authConfigSvc, devEnv, &env, &o.Options, o.Update, o.ForkEnvironmentGitRepo, ns,
-		jxClient, kubeClient, envDir, &o.GitRepositoryOptions, o.HelmValuesConfig, o.Prefix, o.Git(), o.ResolveChartMuseumURL, o.In, o.Out, o.Err)
+		jxClient, kubeClient, envDir, &o.GitRepositoryOptions, o.HelmValuesConfig, o.Prefix, o.Git(), o.ResolveChartMuseumURL, o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/create/create_git_api_token.go
+++ b/pkg/cmd/create/create_git_api_token.go
@@ -129,7 +129,7 @@ func (o *CreateGitTokenOptions) Run() error {
 			return nil
 		}
 
-		err = config.EditUserAuth(server.Label(), userAuth, o.Username, false, o.BatchMode, f, o.In, o.Out, o.Err)
+		err = config.EditUserAuth(server.Label(), userAuth, o.Username, false, o.BatchMode, f, o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_issue.go
+++ b/pkg/cmd/create/create_issue.go
@@ -110,7 +110,7 @@ func (o *CreateIssueOptions) PopulateIssue(issue *gits.GitIssue) error {
 		if o.BatchMode {
 			return util.MissingOption(optionTitle)
 		}
-		title, err = util.PickValue("Issue title:", "", true, "", o.In, o.Out, o.Err)
+		title, err = util.PickValue("Issue title:", "", true, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_jenkins_token.go
+++ b/pkg/cmd/create/create_jenkins_token.go
@@ -195,7 +195,7 @@ func (o *CreateJenkinsUserOptions) Run() error {
 			return nil
 		}
 
-		err = config.EditUserAuth("Jenkins", userAuth, o.Username, false, o.BatchMode, f, o.In, o.Out, o.Err)
+		err = config.EditUserAuth("Jenkins", userAuth, o.Username, false, o.BatchMode, f, o.GetIOFileHandles())
 		if err != nil {
 			return errors.Wrapf(err, "updating the Jenkins auth configuration for user %q", o.Username)
 		}

--- a/pkg/cmd/create/create_jhipster.go
+++ b/pkg/cmd/create/create_jhipster.go
@@ -115,7 +115,7 @@ func (o *CreateJHipsterOptions) Run() error {
 		if o.BatchMode {
 			return util.MissingOption(opts.OptionOutputDir)
 		}
-		dir, err = util.PickValue("Pick the name of the new project:", "myhipster", true, "", o.In, o.Out, o.Err)
+		dir, err = util.PickValue("Pick the name of the new project:", "myhipster", true, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_lile.go
+++ b/pkg/cmd/create/create_lile.go
@@ -124,7 +124,7 @@ func (o *CreateLileOptions) Run() error {
 		if o.BatchMode {
 			return util.MissingOption(opts.OptionOutputDir)
 		}
-		dir, err = util.PickValue("Pick a name for the new project:", "myapp", true, "", o.In, o.Out, o.Err)
+		dir, err = util.PickValue("Pick a name for the new project:", "myapp", true, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_micro.go
+++ b/pkg/cmd/create/create_micro.go
@@ -140,7 +140,7 @@ For instructions please see: %s
 		if o.BatchMode {
 			return util.MissingOption(opts.OptionOutputDir)
 		}
-		dir, err = util.PickValue("Pick a fully qualified name for the new project:", "github.com/myuser/myapp", true, "", o.In, o.Out, o.Err)
+		dir, err = util.PickValue("Pick a fully qualified name for the new project:", "github.com/myuser/myapp", true, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_mlquickstart.go
+++ b/pkg/cmd/create/create_mlquickstart.go
@@ -3,7 +3,6 @@ package create
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -15,13 +14,11 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/jenkins-x/jx/pkg/quickstarts"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/quickstarts"
 	"github.com/spf13/cobra"
 
 	"github.com/jenkins-x/jx/pkg/auth"
@@ -222,9 +219,9 @@ func (o *CreateMLQuickstartOptions) Run() error {
 	}
 	var q *quickstarts.QuickstartForm
 	if o.BatchMode {
-		q, err = pickMLProject(model, &o.Filter, o.BatchMode, o.In, o.Out, o.Err)
+		q, err = pickMLProject(model, &o.Filter, o.BatchMode)
 	} else {
-		q, err = model.CreateSurvey(&o.Filter, o.BatchMode, o.In, o.Out, o.Err)
+		q, err = model.CreateSurvey(&o.Filter, o.BatchMode, o.GetIOFileHandles())
 	}
 
 	if err != nil {
@@ -363,7 +360,7 @@ func (o *CreateMLQuickstartOptions) LoadQuickstartsFromMap(config *auth.AuthConf
 }
 
 // PickMLProject picks a mlquickstart project set from filtered results
-func pickMLProject(model *quickstarts.QuickstartModel, filter *quickstarts.QuickstartFilter, batchMode bool, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (*quickstarts.QuickstartForm, error) {
+func pickMLProject(model *quickstarts.QuickstartModel, filter *quickstarts.QuickstartFilter, batchMode bool) (*quickstarts.QuickstartForm, error) {
 	mlquickstarts := model.Filter(filter)
 	names := []string{}
 	m := map[string]*quickstarts.Quickstart{}

--- a/pkg/cmd/create/create_project.go
+++ b/pkg/cmd/create/create_project.go
@@ -76,7 +76,7 @@ func NewCmdCreateProject(commonOpts *opts.CommonOptions) *cobra.Command {
 func (o *CreateProjectWizardOptions) Run() error {
 	name, err := util.PickName(createProjectNames, "Which kind of project you want to create: ",
 		"Jenkins X supports a number of diffferent wizards for creating or importing new projects.",
-		o.In, o.Out, o.Err)
+		o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func (o *CreateProjectWizardOptions) importDir() error {
 		return err
 	}
 	dir, err := util.PickValue("Which directory contains the source code: ", wd, true,
-		"Please specify the directory which contains the source code you want to use for your new project", o.In, o.Out, o.Err)
+		"Please specify the directory which contains the source code you want to use for your new project", o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func (o *CreateProjectWizardOptions) importDir() error {
 
 func (o *CreateProjectWizardOptions) importGit() error {
 	repoUrl, err := util.PickValue("Which git repository URL to import: ", "", true,
-		"Please specify the git URL which contains the source code you want to use for your new project", o.In, o.Out, o.Err)
+		"Please specify the git URL which contains the source code you want to use for your new project", o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/create/create_pullrequest.go
+++ b/pkg/cmd/create/create_pullrequest.go
@@ -142,7 +142,7 @@ func (o *CreatePullRequestOptions) createPullRequestDetails(gitInfo *gits.GitRep
 		if o.Body == "" {
 			o.Body = body
 		}
-		title, err = util.PickValue("PullRequest title:", defaultValue, true, "", o.In, o.Out, o.Err)
+		title, err = util.PickValue("PullRequest title:", defaultValue, true, "", o.GetIOFileHandles())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/create/create_quickstart.go
+++ b/pkg/cmd/create/create_quickstart.go
@@ -106,7 +106,7 @@ func (o *CreateQuickstartOptions) Run() error {
 		return fmt.Errorf("failed to load quickstarts: %s", err)
 	}
 
-	q, err := model.CreateSurvey(&o.Filter, o.BatchMode, o.In, o.Out, o.Err)
+	q, err := model.CreateSurvey(&o.Filter, o.BatchMode, o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/create/create_step.go
+++ b/pkg/cmd/create/create_step.go
@@ -168,19 +168,19 @@ func (o *CreateStepOptions) configureNewStepDetails(stepDetails *NewStepDetails)
 	var err error
 
 	if s.Pipeline == "" {
-		s.Pipeline, err = util.PickNameWithDefault(jenkinsfile.PipelineKinds, "Pick the pipeline kind: ", defaultPipeline, "which kind of pipeline do you want to add a step", o.In, o.Out, o.Err)
+		s.Pipeline, err = util.PickNameWithDefault(jenkinsfile.PipelineKinds, "Pick the pipeline kind: ", defaultPipeline, "which kind of pipeline do you want to add a step", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
 	}
 	if s.Lifecycle == "" {
-		s.Lifecycle, err = util.PickNameWithDefault(jenkinsfile.PipelineLifecycleNames, "Pick the lifecycle: ", defaultLifecycle, "which lifecycle (stage) do you want to add the step", o.In, o.Out, o.Err)
+		s.Lifecycle, err = util.PickNameWithDefault(jenkinsfile.PipelineLifecycleNames, "Pick the lifecycle: ", defaultLifecycle, "which lifecycle (stage) do you want to add the step", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
 	}
 	if s.Mode == "" {
-		s.Mode, err = util.PickNameWithDefault(jenkinsfile.CreateStepModes, "Pick the create mode: ", defaultMode, "which create mode do you want to use to add the step - pre (before), post (after) or replace?", o.In, o.Out, o.Err)
+		s.Mode, err = util.PickNameWithDefault(jenkinsfile.CreateStepModes, "Pick the create mode: ", defaultMode, "which create mode do you want to use to add the step - pre (before), post (after) or replace?", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_terraform.go
+++ b/pkg/cmd/create/create_terraform.go
@@ -333,7 +333,7 @@ func (options *CreateTerraformOptions) createOrganisationGitRepo() error {
 		}
 	} else {
 		details, err := gits.PickNewOrExistingGitRepository(options.BatchMode, authConfigSvc,
-			defaultRepoName, &options.InstallOptions.GitRepositoryOptions, nil, nil, options.Git(), true, options.In, options.Out, options.Err)
+			defaultRepoName, &options.InstallOptions.GitRepositoryOptions, nil, nil, options.Git(), true, options.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_terraform_gke.go
+++ b/pkg/cmd/create/create_terraform_gke.go
@@ -459,7 +459,7 @@ func (options *TerraformGKEOptions) createOrganisationGitRepo() error {
 		}
 	} else {
 		details, err := gits.PickNewOrExistingGitRepository(options.BatchMode, authConfigSvc,
-			defaultRepoName, &options.InstallOptions.GitRepositoryOptions, nil, nil, options.Git(), true, options.In, options.Out, options.Err)
+			defaultRepoName, &options.InstallOptions.GitRepositoryOptions, nil, nil, options.Git(), true, options.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_token_addon.go
+++ b/pkg/cmd/create/create_token_addon.go
@@ -123,7 +123,7 @@ func (o *CreateTokenAddonOptions) Run() error {
 				return nil
 			}
 
-			err = config.EditUserAuth(server.Label(), userAuth, o.Username, false, o.BatchMode, f, o.In, o.Out, o.Err)
+			err = config.EditUserAuth(server.Label(), userAuth, o.Username, false, o.BatchMode, f, o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/create/create_tracker_token.go
+++ b/pkg/cmd/create/create_tracker_token.go
@@ -111,7 +111,7 @@ func (o *CreateTrackerTokenOptions) Run() error {
 			return nil
 		}
 
-		err = config.EditUserAuth(server.Label(), userAuth, o.Username, false, o.BatchMode, f, o.In, o.Out, o.Err)
+		err = config.EditUserAuth(server.Label(), userAuth, o.Username, false, o.BatchMode, f, o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_variable.go
+++ b/pkg/cmd/create/create_variable.go
@@ -115,9 +115,9 @@ func (o *CreateVariableOptions) Run() error {
 		message := "environment variable name: "
 		help := "the name of the environment variable which is usually upper case without spaces or dashes"
 		if len(keys) == 0 {
-			name, err = util.PickValue(message, "", true, help, o.In, o.Out, o.Err)
+			name, err = util.PickValue(message, "", true, help, o.GetIOFileHandles())
 		} else {
-			name, err = util.PickName(keys, message, help, o.In, o.Out, o.Err)
+			name, err = util.PickName(keys, message, help, o.GetIOFileHandles())
 		}
 		if err != nil {
 			return err
@@ -128,7 +128,7 @@ func (o *CreateVariableOptions) Run() error {
 	}
 	if value == "" {
 		message := "environment variable value: "
-		value, err = util.PickValue(message, defaultValues[name], true, "", o.In, o.Out, o.Err)
+		value, err = util.PickValue(message, defaultValues[name], true, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_vault.go
+++ b/pkg/cmd/create/create_vault.go
@@ -148,7 +148,7 @@ func (o *CreateVaultOptions) Run() error {
 		// Prompt the user for the vault name
 		vaultName, _ = util.PickValue(
 			"Vault name:", "", true,
-			"The name of the vault that will be created", o.GetIn(), o.GetOut(), o.GetErr())
+			"The name of the vault that will be created", o.GetIOFileHandles())
 	}
 	teamSettings, err := o.TeamSettings()
 	if err != nil {
@@ -331,7 +331,7 @@ func (o *CreateVaultOptions) createVaultGKE(vaultOperatorClient versioned.Interf
 	}
 	log.Logger().Debugf("KMS Key '%s' created in keying '%s'", util.ColorInfo(kmsConfig.Key), util.ColorInfo(kmsConfig.Keyring))
 
-	vaultBucket, err := gkevault.CreateBucket(o.GCloud(), vaultName, bucketName, o.GKEProjectID, o.GKEZone, o.RecreateVaultBucket, o.BatchMode, o.In, o.Out, o.Err)
+	vaultBucket, err := gkevault.CreateBucket(o.GCloud(), vaultName, bucketName, o.GKEProjectID, o.GKEZone, o.RecreateVaultBucket, o.BatchMode, o.GetIOFileHandles())
 	if err != nil {
 		return errors.Wrap(err, "creating Vault GCS data bucket")
 	}

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -1208,7 +1208,7 @@ func (options *InstallOptions) selectJenkinsInstallation() error {
 				ServerlessJenkins,
 				StaticMasterJenkins,
 			}
-			jenkinsInstallOption, err := util.PickNameWithDefault(jenkinsInstallOptions, "Select Jenkins installation type:", ServerlessJenkins, "", options.In, options.Out, options.Err)
+			jenkinsInstallOption, err := util.PickNameWithDefault(jenkinsInstallOptions, "Select Jenkins installation type:", ServerlessJenkins, "", options.GetIOFileHandles())
 			if err != nil {
 				return errors.Wrap(err, "picking Jenkins installation type")
 			}
@@ -1375,14 +1375,14 @@ func (options *InstallOptions) configureGitAuth() error {
 		}
 		authServer = authConfig.GetOrCreateServerName(gitServer, "", kind)
 	} else {
-		authServer, err = authConfig.PickServer("Which Git provider:", options.BatchMode, options.In, options.Out, options.Err)
+		authServer, err = authConfig.PickServer("Which Git provider:", options.BatchMode, options.GetIOFileHandles())
 		if err != nil {
 			return errors.Wrap(err, "getting the git provider from user")
 		}
 	}
 
 	message := fmt.Sprintf("local Git user for %s server:", authServer.Label())
-	userAuth, err = authConfig.PickServerUserAuth(authServer, message, options.BatchMode, "", options.In, options.Out, options.Err)
+	userAuth, err = authConfig.PickServerUserAuth(authServer, message, options.BatchMode, "", options.GetIOFileHandles())
 	if err != nil {
 		return errors.Wrapf(err, "selecting the local user for git server %s", authServer.Label())
 	}
@@ -1395,7 +1395,7 @@ func (options *InstallOptions) configureGitAuth() error {
 		}
 		defaultUserName := ""
 		err = authConfig.EditUserAuth(authServer.Label(), userAuth, defaultUserName, false, options.BatchMode, f,
-			options.In, options.Out, options.Err)
+			options.GetIOFileHandles())
 		if err != nil {
 			return errors.Wrapf(err, "creating a user authentication for git server %s", authServer.Label())
 		}
@@ -1424,13 +1424,13 @@ func (options *InstallOptions) configureGitAuth() error {
 			pipelineAuthServer = authServer
 		} else {
 			pipelineAuthServerURL, err := util.PickValue("Git Service URL:", gits.GitHubURL, true, "",
-				options.In, options.Out, options.Err)
+				options.GetIOFileHandles())
 			if err != nil {
 				return errors.Wrap(err, "reading the pipelines Git service URL")
 			}
 			pipelineAuthServer, err = authConfig.PickOrCreateServer(gits.GitHubURL, pipelineAuthServerURL,
 				"Which Git Service do you wish to use:",
-				options.BatchMode, options.In, options.Out, options.Err)
+				options.BatchMode, options.GetIOFileHandles())
 			if err != nil {
 				return errors.Wrap(err, "selecting the pipelines Git Service")
 			}
@@ -1456,7 +1456,7 @@ func (options *InstallOptions) configureGitAuth() error {
 		}
 		defaultUserName := ""
 		err = authConfig.EditUserAuth(pipelineAuthServer.Label(), pipelineUserAuth, defaultUserName, false, options.BatchMode,
-			f, options.In, options.Out, options.Err)
+			f, options.GetIOFileHandles())
 		if err != nil {
 			return errors.Wrapf(err, "creating a pipeline user authentication for git server %s", authServer.Label())
 		}
@@ -1761,7 +1761,7 @@ func (options *InstallOptions) generateGitOpsDevEnvironmentConfig(gitOpsDir stri
 				return "", errors.Wrap(err, "building the git repository options for environment")
 			}
 			repo, gitProvider, err := kube.CreateEnvGitRepository(options.BatchMode, authConfigSvc, devEnv, devEnv, config, forkEnvGitURL, envDir,
-				gitRepoOptions, options.CreateEnvOptions.HelmValuesConfig, prefix, git, options.ResolveChartMuseumURL, options.In, options.Out, options.Err)
+				gitRepoOptions, options.CreateEnvOptions.HelmValuesConfig, prefix, git, options.ResolveChartMuseumURL, options.GetIOFileHandles())
 			if err != nil || repo == nil || gitProvider == nil {
 				return "", errors.Wrap(err, "creating git repository for the dev environment source")
 			}
@@ -1828,7 +1828,7 @@ func (options *InstallOptions) applyGitOpsDevEnvironmentConfig(gitOpsEnvDir stri
 	if options.Flags.GitOpsMode && !options.Flags.NoGitOpsEnvApply {
 		applyEnv := true
 		if !options.BatchMode {
-			if !util.Confirm("Would you like to setup the Development Environment from the source code now?", true, "Do you want to apply the development environment helm charts now?", options.In, options.Out, options.Err) {
+			if !util.Confirm("Would you like to setup the Development Environment from the source code now?", true, "Do you want to apply the development environment helm charts now?", options.GetIOFileHandles()) {
 				applyEnv = false
 			}
 		}

--- a/pkg/cmd/deletecmd/delete_app.go
+++ b/pkg/cmd/deletecmd/delete_app.go
@@ -82,14 +82,12 @@ func (o *DeleteAppOptions) Run() error {
 	o.GitOps, o.DevEnv = o.GetDevEnv()
 
 	installOptions := apps.InstallOptions{
-		In:        o.In,
-		DevEnv:    o.DevEnv,
-		Verbose:   o.Verbose,
-		Err:       o.Err,
-		Out:       o.Out,
-		GitOps:    o.GitOps,
-		BatchMode: o.BatchMode,
-		Helmer:    o.Helm(),
+		IOFileHandles: o.GetIOFileHandles(),
+		DevEnv:        o.DevEnv,
+		Verbose:       o.Verbose,
+		GitOps:        o.GitOps,
+		BatchMode:     o.BatchMode,
+		Helmer:        o.Helm(),
 	}
 
 	if o.GitOps {

--- a/pkg/cmd/deletecmd/delete_application.go
+++ b/pkg/cmd/deletecmd/delete_application.go
@@ -175,7 +175,7 @@ func (o *DeleteApplicationOptions) deleteProwApplication(repoService jenkinsv1.S
 	}
 
 	if len(o.Args) == 0 {
-		o.Args, err = util.SelectNamesWithFilter(names, "Pick Applications to remove from Prow:", o.SelectAll, o.SelectFilter, "", o.In, o.Out, o.Err)
+		o.Args, err = util.SelectNamesWithFilter(names, "Pick Applications to remove from Prow:", o.SelectAll, o.SelectFilter, "", o.GetIOFileHandles())
 		if err != nil {
 			return deletedApplications, err
 		}
@@ -296,7 +296,7 @@ func (o *DeleteApplicationOptions) deleteJenkinsApplication() (deletedApplicatio
 	}
 
 	if len(args) == 0 {
-		args, err = util.SelectNamesWithFilter(names, "Pick Applications to remove from Jenkins:", o.SelectAll, o.SelectFilter, "", o.In, o.Out, o.Err)
+		args, err = util.SelectNamesWithFilter(names, "Pick Applications to remove from Jenkins:", o.SelectAll, o.SelectFilter, "", o.GetIOFileHandles())
 		if err != nil {
 			return deletedApplications, err
 		}
@@ -313,7 +313,7 @@ func (o *DeleteApplicationOptions) deleteJenkinsApplication() (deletedApplicatio
 	deleteMessage := strings.Join(args, ", ")
 
 	if !o.BatchMode {
-		if !util.Confirm("You are about to delete these Applications from Jenkins: "+deleteMessage, false, "The list of Applications names to be deleted from Jenkins", o.In, o.Out, o.Err) {
+		if !util.Confirm("You are about to delete these Applications from Jenkins: "+deleteMessage, false, "The list of Applications names to be deleted from Jenkins", o.GetIOFileHandles()) {
 			return deletedApplications, err
 		}
 	}

--- a/pkg/cmd/deletecmd/delete_application_test.go
+++ b/pkg/cmd/deletecmd/delete_application_test.go
@@ -47,7 +47,7 @@ func TestDeleteApplicationInJenkins(t *testing.T) {
 	kubeClient, _, _ := mockFactory.CreateKubeClient()
 
 	jenkinsClient := clients_test.NewMockJenkinsClient()
-	pegomock.When(mockFactory.CreateJenkinsClient(kubeClient, "jx", commonOpts.In, commonOpts.Out, commonOpts.Err)).ThenReturn(pegomock.ReturnValue(jenkinsClient), pegomock.ReturnValue(nil))
+	pegomock.When(mockFactory.CreateJenkinsClient(kubeClient, "jx", commonOpts.GetIOFileHandles())).ThenReturn(pegomock.ReturnValue(jenkinsClient), pegomock.ReturnValue(nil))
 	job := gojenkins.Job{
 		Name:     testRepoName,
 		FullName: fmt.Sprintf("%s/%s", testOrgName, testRepoName),

--- a/pkg/cmd/deletecmd/delete_branch.go
+++ b/pkg/cmd/deletecmd/delete_branch.go
@@ -97,7 +97,7 @@ func (o *DeleteBranchOptions) Run() error {
 		if o.GitHost != "" {
 			server = config.GetOrCreateServer(o.GitHost)
 		} else {
-			server, err = config.PickServer("Pick the Git server to search for repositories", o.BatchMode, o.In, o.Out, o.Err)
+			server, err = config.PickServer("Pick the Git server to search for repositories", o.BatchMode, o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
@@ -106,7 +106,7 @@ func (o *DeleteBranchOptions) Run() error {
 	if server == nil {
 		return fmt.Errorf("No Git server provided")
 	}
-	userAuth, err := config.PickServerUserAuth(server, "Git user name", o.BatchMode, "", o.In, o.Out, o.Err)
+	userAuth, err := config.PickServerUserAuth(server, "Git user name", o.BatchMode, "", o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (o *DeleteBranchOptions) Run() error {
 	username := userAuth.Username
 	org := o.Organisation
 	if org == "" {
-		org, err = gits.PickOrganisation(provider, username, o.In, o.Out, o.Err)
+		org, err = gits.PickOrganisation(provider, username, o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -129,7 +129,7 @@ func (o *DeleteBranchOptions) Run() error {
 
 	names := o.Repositories
 	if len(names) == 0 {
-		repos, err := gits.PickRepositories(provider, org, "Which repositories do you want to remove branches from:", o.SelectAllRepos, o.SelectFilterRepos, o.In, o.Out, o.Err)
+		repos, err := gits.PickRepositories(provider, org, "Which repositories do you want to remove branches from:", o.SelectAllRepos, o.SelectFilterRepos, o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -159,7 +159,7 @@ func (o *DeleteBranchOptions) Run() error {
 			return errors.Wrapf(err, "Failed to get remote branches for %s/%s", org, name)
 		}
 
-		branches, err := util.SelectNamesWithFilter(branchNames, "Which remote branches do you to to delete: ", o.SelectAll, o.SelectFilter, "", o.In, o.Out, o.Err)
+		branches, err := util.SelectNamesWithFilter(branchNames, "Which remote branches do you to to delete: ", o.SelectAll, o.SelectFilter, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/deletecmd/delete_context.go
+++ b/pkg/cmd/deletecmd/delete_context.go
@@ -104,7 +104,7 @@ func (o *DeleteContextOptions) Run() error {
 		return util.InvalidArg(args[1], allNames)
 	}
 
-	selected, err := util.SelectNamesWithFilter(names, "Select the Kubernetes Contexts to delete: ", o.SelectAll, o.SelectFilter, "", o.In, o.Out, o.Err)
+	selected, err := util.SelectNamesWithFilter(names, "Select the Kubernetes Contexts to delete: ", o.SelectAll, o.SelectFilter, "", o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/deletecmd/delete_devpod.go
+++ b/pkg/cmd/deletecmd/delete_devpod.go
@@ -94,7 +94,7 @@ func (o *DeleteDevPodOptions) Run() error {
 	}
 
 	if len(devPods) == 0 {
-		devPods, err = util.PickNames(names, "Pick DevPod:", "", o.In, o.Out, o.Err)
+		devPods, err = util.PickNames(names, "Pick DevPod:", "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -102,7 +102,7 @@ func (o *DeleteDevPodOptions) Run() error {
 
 	deletePods := strings.Join(devPods, ", ")
 
-	if !o.BatchMode && !util.Confirm("You are about to delete the DevPods: "+deletePods, false, "The list of DevPods names to be deleted", o.In, o.Out, o.Err) {
+	if !o.BatchMode && !util.Confirm("You are about to delete the DevPods: "+deletePods, false, "The list of DevPods names to be deleted", o.GetIOFileHandles()) {
 		return nil
 	}
 	for _, name := range devPods {

--- a/pkg/cmd/deletecmd/delete_env.go
+++ b/pkg/cmd/deletecmd/delete_env.go
@@ -99,7 +99,7 @@ func (o *DeleteEnvOptions) Run() error {
 			}
 		}
 	} else {
-		name, err = kube.PickEnvironment(envNames, currentEnv, o.In, o.Out, o.Err)
+		name, err = kube.PickEnvironment(envNames, currentEnv, o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/deletecmd/delete_extension.go
+++ b/pkg/cmd/deletecmd/delete_extension.go
@@ -133,7 +133,7 @@ func (o *DeleteExtensionOptions) Run() error {
 		args = names
 	}
 	if len(args) == 0 && !o.BatchMode {
-		args, err = util.PickNames(names, "Pick Extension(s):", "", o.In, o.Out, o.Err)
+		args, err = util.PickNames(names, "Pick Extension(s):", "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -166,7 +166,7 @@ func (o *DeleteExtensionOptions) Run() error {
 	// TODO display the extensions to delete in a tree view
 	if !o.BatchMode && !util.Confirm(fmt.Sprintf("You are about to delete the Extensions: %s",
 		strings.Join(extensionsToDeleteStrings, ", ")), false,
-		"The list of Extensions to be deleted", o.In, o.Out, o.Err) {
+		"The list of Extensions to be deleted", o.GetIOFileHandles()) {
 		return nil
 	}
 	deletedExtensions := make([]string, 0)

--- a/pkg/cmd/deletecmd/delete_namespace.go
+++ b/pkg/cmd/deletecmd/delete_namespace.go
@@ -89,7 +89,7 @@ func (o *DeleteNamespaceOptions) Run() error {
 		if o.BatchMode {
 			return fmt.Errorf("Missing namespace name argument")
 		}
-		names, err = util.SelectNamesWithFilter(namespaceNames, "Which namespaces do you want to delete: ", o.SelectAll, o.SelectFilter, "", o.In, o.Out, o.Err)
+		names, err = util.SelectNamesWithFilter(namespaceNames, "Which namespaces do you want to delete: ", o.SelectAll, o.SelectFilter, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/deletecmd/delete_preview.go
+++ b/pkg/cmd/deletecmd/delete_preview.go
@@ -75,7 +75,7 @@ func (o *DeletePreviewOptions) Run() error {
 			}
 			selected := []string{}
 			for {
-				selected, err = util.PickNames(names, "Pick preview environments to delete: ", "", o.In, o.Out, o.Err)
+				selected, err = util.PickNames(names, "Pick preview environments to delete: ", "", o.GetIOFileHandles())
 				if err != nil {
 					return err
 				}
@@ -85,12 +85,12 @@ func (o *DeletePreviewOptions) Run() error {
 				log.Logger().Warn("\nYou did not select any preview environments to delete\n")
 				log.Logger().Infof("Press the %s to select a preview environment to delete\n", util.ColorInfo("[space bar]"))
 
-				if !util.Confirm("Do you want to pick a preview environment to delete?", true, "Use the space bar to select previews", o.In, o.Out, o.Err) {
+				if !util.Confirm("Do you want to pick a preview environment to delete?", true, "Use the space bar to select previews", o.GetIOFileHandles()) {
 					return nil
 				}
 			}
 			deletePreviews := strings.Join(selected, ", ")
-			if !util.Confirm("You are about to delete the Preview environments: "+deletePreviews, false, "The list of Preview Environments to be deleted", o.In, o.Out, o.Err) {
+			if !util.Confirm("You are about to delete the Preview environments: "+deletePreviews, false, "The list of Preview Environments to be deleted", o.GetIOFileHandles()) {
 				return nil
 			}
 

--- a/pkg/cmd/deletecmd/delete_quickstart_location.go
+++ b/pkg/cmd/deletecmd/delete_quickstart_location.go
@@ -107,7 +107,7 @@ func (o *DeleteQuickstartLocationOptions) Run() error {
 				names = append(names, key)
 			}
 
-			name, err := util.PickName(names, "Pick the quickstart git owner to remove from the team settings: ", "", o.In, o.Out, o.Err)
+			name, err := util.PickName(names, "Pick the quickstart git owner to remove from the team settings: ", "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/deletecmd/delete_repo.go
+++ b/pkg/cmd/deletecmd/delete_repo.go
@@ -96,7 +96,7 @@ func (o *DeleteRepoOptions) Run() error {
 		if o.GitHost != "" {
 			server = config.GetOrCreateServer(o.GitHost)
 		} else {
-			server, err = config.PickServer("Pick the Git server to search for repositories", o.BatchMode, o.In, o.Out, o.Err)
+			server, err = config.PickServer("Pick the Git server to search for repositories", o.BatchMode, o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
@@ -105,7 +105,7 @@ func (o *DeleteRepoOptions) Run() error {
 	if server == nil {
 		return fmt.Errorf("No Git server provided")
 	}
-	userAuth, err := config.PickServerUserAuth(server, "Git user name", o.BatchMode, "", o.In, o.Out, o.Err)
+	userAuth, err := config.PickServerUserAuth(server, "Git user name", o.BatchMode, "", o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (o *DeleteRepoOptions) Run() error {
 	username := userAuth.Username
 	org := o.Organisation
 	if org == "" {
-		org, err = gits.PickOrganisation(provider, username, o.In, o.Out, o.Err)
+		org, err = gits.PickOrganisation(provider, username, o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ func (o *DeleteRepoOptions) Run() error {
 
 	names := o.Repositories
 	if len(names) == 0 {
-		repos, err := gits.PickRepositories(provider, org, "Which repositories do you want to delete:", o.SelectAll, o.SelectFilter, o.In, o.Out, o.Err)
+		repos, err := gits.PickRepositories(provider, org, "Which repositories do you want to delete:", o.SelectAll, o.SelectFilter, o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/deletecmd/delete_team.go
+++ b/pkg/cmd/deletecmd/delete_team.go
@@ -92,7 +92,7 @@ func (o *DeleteTeamOptions) Run() error {
 		if o.BatchMode {
 			return fmt.Errorf("Missing team name argument")
 		}
-		names, err = util.SelectNamesWithFilter(teamNames, "Which teams do you want to delete: ", o.SelectAll, o.SelectFilter, "", o.In, o.Out, o.Err)
+		names, err = util.SelectNamesWithFilter(teamNames, "Which teams do you want to delete: ", o.SelectAll, o.SelectFilter, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/deletecmd/delete_user.go
+++ b/pkg/cmd/deletecmd/delete_user.go
@@ -90,7 +90,7 @@ func (o *DeleteUserOptions) Run() error {
 		if o.BatchMode {
 			return fmt.Errorf("Missing user login name argument")
 		}
-		names, err = util.SelectNamesWithFilter(userNames, "Which users do you want to delete: ", o.SelectAll, o.SelectFilter, "", o.In, o.Out, o.Err)
+		names, err = util.SelectNamesWithFilter(userNames, "Which users do you want to delete: ", o.SelectAll, o.SelectFilter, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/edit/edit.go
+++ b/pkg/cmd/edit/edit.go
@@ -110,9 +110,9 @@ func addTeamSettingsCommandsFromTags(baseCmd *cobra.Command, options *EditOption
 				} else if !options.BatchMode {
 					var err error
 					if structField.Type.String() == "string" {
-						value, err = util.PickValue(commandUsage+":", field.String(), true, "", options.In, options.Out, options.Err)
+						value, err = util.PickValue(commandUsage+":", field.String(), true, "", options.GetIOFileHandles())
 					} else if structField.Type.String() == "bool" {
-						value = util.Confirm(commandUsage+":", field.Bool(), "", options.In, options.Out, options.Err)
+						value = util.Confirm(commandUsage+":", field.Bool(), "", options.GetIOFileHandles())
 					}
 					helper.CheckErr(err)
 				} else {

--- a/pkg/cmd/edit/edit_addon.go
+++ b/pkg/cmd/edit/edit_addon.go
@@ -80,7 +80,7 @@ func (o *EditAddonOptions) Run() error {
 	charts := kube.AddonCharts
 	names := util.SortedMapKeys(charts)
 	if o.Name == "" {
-		o.Name, err = util.PickName(names, "Pick the addon to configure", "", o.In, o.Out, o.Err)
+		o.Name, err = util.PickName(names, "Pick the addon to configure", "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func (o *EditAddonOptions) Run() error {
 		}
 		config.Enabled = value
 	} else {
-		config.Enabled = util.Confirm("Enable addon "+o.Name, config.Enabled, "If an addon is enabled it is installed when using 'jx create cluster' or 'jx install'", o.In, o.Out, o.Err)
+		config.Enabled = util.Confirm("Enable addon "+o.Name, config.Enabled, "If an addon is enabled it is installed when using 'jx create cluster' or 'jx install'", o.GetIOFileHandles())
 	}
 
 	return addonConfig.Save()

--- a/pkg/cmd/edit/edit_app_jenkins_plugins.go
+++ b/pkg/cmd/edit/edit_app_jenkins_plugins.go
@@ -68,7 +68,7 @@ func (o *EditAppJenkinsPluginsOptions) Run() error {
 	// TODO load from the GitOps values.yaml folder
 	currentValues := []string{"jx-resources:1.0.0"}
 
-	selection, err := data.PickPlugins(currentValues, o.In, o.Out, o.Err)
+	selection, err := data.PickPlugins(currentValues, o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/edit/edit_buildpack.go
+++ b/pkg/cmd/edit/edit_buildpack.go
@@ -144,7 +144,7 @@ func (o *EditBuildPackOptions) Run() error {
 			}
 			var label string
 			if o.AdvancedMode {
-				label, err = util.PickNameWithDefault(labels, "Pick default workload build pack: ", defaultValue, "Build packs are used to automate your CI/CD pipelines when you create or import projects", o.In, o.Out, o.Err)
+				label, err = util.PickNameWithDefault(labels, "Pick default workload build pack: ", defaultValue, "Build packs are used to automate your CI/CD pipelines when you create or import projects", o.GetIOFileHandles())
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/edit/edit_config.go
+++ b/pkg/cmd/edit/edit_config.go
@@ -94,7 +94,7 @@ func (o *EditConfigOptions) Run() error {
 
 	kind := o.Kind
 	if kind == "" && !o.BatchMode {
-		kind, err = util.PickRequiredNameWithDefault(configKinds, "Which configuration do you want to edit", issueKind, "", o.In, o.Out, o.Err)
+		kind, err = util.PickRequiredNameWithDefault(configKinds, "Which configuration do you want to edit", issueKind, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -139,7 +139,7 @@ func (o *EditConfigOptions) EditIssueTracker(pc *config.ProjectConfig) (bool, er
 	if len(config.Servers) == 0 {
 		return answer, fmt.Errorf("No issue tracker servers available. Please add one via: jx create tracker server")
 	}
-	server, err := config.PickServer("Issue tracker service", o.BatchMode, o.In, o.Out, o.Err)
+	server, err := config.PickServer("Issue tracker service", o.BatchMode, o.GetIOFileHandles())
 	if err != nil {
 		return answer, err
 	}
@@ -152,7 +152,7 @@ func (o *EditConfigOptions) EditIssueTracker(pc *config.ProjectConfig) (bool, er
 	}
 	answer = true
 
-	it.Project, err = util.PickValue("Issue tracker project name: ", it.Project, true, "", o.In, o.Out, o.Err)
+	it.Project, err = util.PickValue("Issue tracker project name: ", it.Project, true, "", o.GetIOFileHandles())
 	if err != nil {
 		return answer, err
 	}
@@ -171,7 +171,7 @@ func (o *EditConfigOptions) EditChat(pc *config.ProjectConfig) (bool, error) {
 	if len(config.Servers) == 0 {
 		return answer, fmt.Errorf("No chat servers available. Please add one via: jx create chat server")
 	}
-	server, err := config.PickServer("Chat service", o.BatchMode, o.In, o.Out, o.Err)
+	server, err := config.PickServer("Chat service", o.BatchMode, o.GetIOFileHandles())
 	if err != nil {
 		return answer, err
 	}
@@ -184,11 +184,11 @@ func (o *EditConfigOptions) EditChat(pc *config.ProjectConfig) (bool, error) {
 	}
 	answer = true
 
-	it.DeveloperChannel, err = util.PickValue("Developer channel: ", it.DeveloperChannel, false, "", o.In, o.Out, o.Err)
+	it.DeveloperChannel, err = util.PickValue("Developer channel: ", it.DeveloperChannel, false, "", o.GetIOFileHandles())
 	if err != nil {
 		return answer, err
 	}
-	it.UserChannel, err = util.PickValue("User channel: ", it.UserChannel, false, "", o.In, o.Out, o.Err)
+	it.UserChannel, err = util.PickValue("User channel: ", it.UserChannel, false, "", o.GetIOFileHandles())
 	if err != nil {
 		return answer, err
 	}

--- a/pkg/cmd/edit/edit_deploy.go
+++ b/pkg/cmd/edit/edit_deploy.go
@@ -172,7 +172,7 @@ func (o *EditDeployKindOptions) pickDeployKind(defaultName string) (string, erro
 	if defaultName == "" || util.StringArrayIndex(deployKinds, defaultName) < 0 {
 		defaultName = "default"
 	}
-	name, err := util.PickNameWithDefault(deployKinds, "Pick the deployment kind: ", defaultName, "lets you switch between knative serve based deployments and default kubernetes deployments", o.In, o.Out, o.Err)
+	name, err := util.PickNameWithDefault(deployKinds, "Pick the deployment kind: ", defaultName, "lets you switch between knative serve based deployments and default kubernetes deployments", o.GetIOFileHandles())
 	if err != nil {
 		return name, err
 	}

--- a/pkg/cmd/edit/edit_env.go
+++ b/pkg/cmd/edit/edit_env.go
@@ -137,7 +137,7 @@ func (o *EditEnvOptions) Run() error {
 	} else {
 		name = o.Options.Name
 		if name == "" {
-			name, err = kube.PickEnvironment(envNames, currentEnv, o.In, o.Out, o.Err)
+			name, err = kube.PickEnvironment(envNames, currentEnv, o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
@@ -155,7 +155,7 @@ func (o *EditEnvOptions) Run() error {
 	}
 	o.Options.Spec.PromotionStrategy = v1.PromotionStrategyType(o.PromotionStrategy)
 	gitProvider, err := kube.CreateEnvironmentSurvey(o.BatchMode, authConfigSvc, devEnv, env, &o.Options, true, o.ForkEnvironmentGitRepo,
-		ns, jxClient, kubeClient, envDir, &o.GitRepositoryOptions, o.HelmValuesConfig, o.Prefix, o.Git(), o.ResolveChartMuseumURL, o.In, o.Out, o.Err)
+		ns, jxClient, kubeClient, envDir, &o.GitRepositoryOptions, o.HelmValuesConfig, o.Prefix, o.Git(), o.ResolveChartMuseumURL, o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/edit/edit_extensionsrepository.go
+++ b/pkg/cmd/edit/edit_extensionsrepository.go
@@ -144,7 +144,7 @@ func (o *EditExtensionsRepositoryOptions) Run() error {
 
 		}
 		asks = append(asks, other)
-		r, err := util.PickName(asks, "Pick the repository to use", "", o.In, o.Out, o.Err)
+		r, err := util.PickName(asks, "Pick the repository to use", "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func (o *EditExtensionsRepositoryOptions) Run() error {
 				"URL", "Helm", "GitHub",
 			}
 			current = jenkinsv1.ExtensionRepositoryReference{}
-			t, err := util.PickName(types, "What type of repository?", "", o.In, o.Out, o.Err)
+			t, err := util.PickName(types, "What type of repository?", "", o.GetIOFileHandles())
 			if t == "URL" {
 				prompt := &survey.Input{
 					Message: "Extensions Repository URL",

--- a/pkg/cmd/edit/edit_storage.go
+++ b/pkg/cmd/edit/edit_storage.go
@@ -97,7 +97,7 @@ func (o *EditStorageOptions) Run() error {
 
 	classifier := o.StorageLocation.Classifier
 	if classifier == "" && !o.BatchMode {
-		o.StorageLocation.Classifier, err = util.PickName(kube.Classifications, "Pick the content classification name", "The name is used as a key to store content in different locations", o.In, o.Out, o.Err)
+		o.StorageLocation.Classifier, err = util.PickName(kube.Classifications, "Pick the content classification name", "The name is used as a key to store content in different locations", o.GetIOFileHandles())
 		if err != nil {
 			return errors.Wrapf(err, "failed to pick the classification name")
 		}
@@ -116,7 +116,7 @@ func (o *EditStorageOptions) Run() error {
 			}
 		}
 		if o.StorageLocation.BucketURL == "" {
-			o.StorageLocation.BucketURL, err = util.PickValue("Bucket URL:", o.StorageLocation.BucketURL, false, "The go-cloud bucket URL for storage such as 'gs://mybucket/ or s3://bucket2/", o.In, o.Out, o.Err)
+			o.StorageLocation.BucketURL, err = util.PickValue("Bucket URL:", o.StorageLocation.BucketURL, false, "The go-cloud bucket URL for storage such as 'gs://mybucket/ or s3://bucket2/", o.GetIOFileHandles())
 			if err != nil {
 				return errors.Wrapf(err, "failed to pick the bucket URL")
 			}
@@ -129,7 +129,7 @@ func (o *EditStorageOptions) Run() error {
 				}
 				o.StorageLocation.GitURL = currentLocation.GitURL
 			} else {
-				o.StorageLocation.GitURL, err = util.PickValue("Git repository URL to store content:", currentLocation.GitURL, false, "The Git URL will be used to clone and push the storage to", o.In, o.Out, o.Err)
+				o.StorageLocation.GitURL, err = util.PickValue("Git repository URL to store content:", currentLocation.GitURL, false, "The Git URL will be used to clone and push the storage to", o.GetIOFileHandles())
 				if err != nil {
 					return errors.Wrapf(err, "failed to pick the git URL")
 				}

--- a/pkg/cmd/edit/edit_userrole.go
+++ b/pkg/cmd/edit/edit_userrole.go
@@ -110,7 +110,7 @@ func (o *EditUserRoleOptions) Run() error {
 		if o.BatchMode {
 			return util.MissingOption(optionLogin)
 		}
-		name, err = util.PickName(names, "Pick the user to edit", "", o.In, o.Out, o.Err)
+		name, err = util.PickName(names, "Pick the user to edit", "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func (o *EditUserRoleOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		userRoles, err = util.PickNamesWithDefaults(roleNames, currentRoles, "Roles for user: "+name, "", o.In, o.Out, o.Err)
+		userRoles, err = util.PickNamesWithDefaults(roleNames, currentRoles, "Roles for user: "+name, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/environment.go
+++ b/pkg/cmd/environment.go
@@ -91,7 +91,7 @@ func (o *EnvironmentOptions) Run() error {
 		env = args[0]
 	}
 	if env == "" && !o.BatchMode {
-		pick, err := kube.PickEnvironment(envNames, currentEnv, o.In, o.Out, o.Err)
+		pick, err := kube.PickEnvironment(envNames, currentEnv, o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/gc/gc_previews.go
+++ b/pkg/cmd/gc/gc_previews.go
@@ -103,7 +103,7 @@ func (o *GCPreviewsOptions) Run() error {
 				return err
 			}
 
-			gitProvider, err := gitInfo.CreateProvider(o.InCluster(), authConfigSvc, gitKind, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+			gitProvider, err := gitInfo.CreateProvider(o.InCluster(), authConfigSvc, gitKind, o.Git(), o.BatchMode, o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/get/get_apps.go
+++ b/pkg/cmd/get/get_apps.go
@@ -118,11 +118,9 @@ func (o *GetAppsOptions) Run() error {
 		return errors.Wrap(err, "getting the the GitOps environments dir")
 	}
 	installOptions := apps.InstallOptions{
-		In:              o.In,
+		IOFileHandles:   o.GetIOFileHandles(),
 		DevEnv:          o.DevEnv,
 		Verbose:         o.Verbose,
-		Err:             o.Err,
-		Out:             o.Out,
 		GitOps:          o.GitOps,
 		BatchMode:       o.BatchMode,
 		Helmer:          o.Helm(),

--- a/pkg/cmd/get/get_build_logs.go
+++ b/pkg/cmd/get/get_build_logs.go
@@ -170,7 +170,7 @@ func (o *GetBuildLogsOptions) Run() error {
 				break
 			}
 		}
-		name, err := util.PickNameWithDefault(names, "Which pipeline do you want to view the logs of?: ", defaultName, "", o.In, o.Out, o.Err)
+		name, err := util.PickNameWithDefault(names, "Which pipeline do you want to view the logs of?: ", defaultName, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -322,7 +322,7 @@ func (o *GetBuildLogsOptions) getTektonLogs(kubeClient kubernetes.Interface, tek
 		}
 	}
 
-	name, err := util.PickNameWithDefault(filteredNames, "Which build do you want to view the logs of?: ", defaultName, "", o.In, o.Out, o.Err)
+	name, err := util.PickNameWithDefault(filteredNames, "Which build do you want to view the logs of?: ", defaultName, "", o.GetIOFileHandles())
 	if err != nil {
 		return len(filteredNames) == 0, err
 	}

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -246,7 +246,7 @@ func (options *ImportOptions) Run() error {
 			serverURL := gitInfo.HostURLWithoutUser()
 			server = config.GetOrCreateServer(serverURL)
 		} else {
-			server, err = config.PickOrCreateServer(gits.GitHubURL, options.GitRepositoryOptions.ServerURL, "Which Git service do you wish to use", options.BatchMode, options.In, options.Out, options.Err)
+			server, err = config.PickOrCreateServer(gits.GitHubURL, options.GitRepositoryOptions.ServerURL, "Which Git service do you wish to use", options.BatchMode, options.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
@@ -260,7 +260,7 @@ func (options *ImportOptions) Run() error {
 		} else {
 			// Get the org in case there is more than one user auth on the server and batchMode is true
 			org := options.getOrganisationOrCurrentUser()
-			userAuth, err = config.PickServerUserAuth(server, "Git user name:", options.BatchMode, org, options.In, options.Out, options.Err)
+			userAuth, err = config.PickServerUserAuth(server, "Git user name:", options.BatchMode, org, options.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
@@ -279,7 +279,7 @@ func (options *ImportOptions) Run() error {
 			if options.GitRepositoryOptions.ApiToken != "" {
 				userAuth.ApiToken = options.GitRepositoryOptions.ApiToken
 			}
-			err = config.EditUserAuth(server.Label(), userAuth, userAuth.Username, false, options.BatchMode, f, options.In, options.Out, options.Err)
+			err = config.EditUserAuth(server.Label(), userAuth, userAuth.Username, false, options.BatchMode, f, options.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
@@ -430,7 +430,7 @@ func (options *ImportOptions) Run() error {
 
 // ImportProjectsFromGitHub import projects from github
 func (options *ImportOptions) ImportProjectsFromGitHub() error {
-	repos, err := gits.PickRepositories(options.GitProvider, options.Organisation, "Which repositories do you want to import", options.SelectAll, options.SelectFilter, options.In, options.Out, options.Err)
+	repos, err := gits.PickRepositories(options.GitProvider, options.Organisation, "Which repositories do you want to import", options.SelectAll, options.SelectFilter, options.GetIOFileHandles())
 	if err != nil {
 		return err
 	}
@@ -520,7 +520,7 @@ func (options *ImportOptions) DraftCreate() error {
 	options.Organisation = options.GetOrganisation()
 	if options.Organisation == "" {
 		gitUsername := options.GitUserAuth.Username
-		options.Organisation, err = gits.GetOwner(options.BatchMode, options.GitProvider, gitUsername, options.In, options.Out, options.Err)
+		options.Organisation, err = gits.GetOwner(options.BatchMode, options.GitProvider, gitUsername, options.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -530,7 +530,7 @@ func (options *ImportOptions) DraftCreate() error {
 		dir := options.Dir
 		_, defaultRepoName := filepath.Split(dir)
 
-		options.AppName, err = gits.GetRepoName(options.BatchMode, false, options.GitProvider, defaultRepoName, options.Organisation, options.In, options.Out, options.Err)
+		options.AppName, err = gits.GetRepoName(options.BatchMode, false, options.GitProvider, defaultRepoName, options.Organisation, options.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -628,7 +628,7 @@ func (options *ImportOptions) CreateNewRemoteRepository() error {
 	details := &options.GitDetails
 	if details.RepoName == "" {
 		details, err = gits.PickNewGitRepository(options.BatchMode, authConfigSvc, defaultRepoName, &options.GitRepositoryOptions,
-			options.GitServer, options.GitUserAuth, options.Git(), options.In, options.Out, options.Err)
+			options.GitServer, options.GitUserAuth, options.Git(), options.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -1478,7 +1478,7 @@ func (options *ImportOptions) GetGitRepositoryDetails() (*gits.CreateRepoData, e
 	options.GitRepositoryOptions.Owner = options.Organisation
 	options.GitRepositoryOptions.RepoName = options.Repository
 	details, err := gits.PickNewOrExistingGitRepository(options.BatchMode, authConfigSvc,
-		"", &options.GitRepositoryOptions, nil, nil, options.Git(), false, options.In, options.Out, options.Err)
+		"", &options.GitRepositoryOptions, nil, nil, options.Git(), false, options.GetIOFileHandles())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/initcmd/init.go
+++ b/pkg/cmd/initcmd/init.go
@@ -650,7 +650,7 @@ func (o *InitOptions) ValidateGit() error {
 	var err error
 	if userName == "" {
 		if !o.BatchMode {
-			userName, err = util.PickValue("Please enter the name you wish to use with git: ", "", true, "", o.In, o.Out, o.Err)
+			userName, err = util.PickValue("Please enter the name you wish to use with git: ", "", true, "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
@@ -665,7 +665,7 @@ func (o *InitOptions) ValidateGit() error {
 	}
 	if userEmail == "" {
 		if !o.BatchMode {
-			userEmail, err = util.PickValue("Please enter the email address you wish to use with git: ", "", true, "", o.In, o.Out, o.Err)
+			userEmail, err = util.PickValue("Please enter the email address you wish to use with git: ", "", true, "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -116,7 +116,7 @@ func (o *LogsOptions) Run() error {
 	name := ""
 	if len(args) == 0 {
 		if o.Label == "" && !o.KNativeBuild {
-			n, err := util.PickName(names, "Pick Deployment:", "", o.In, o.Out, o.Err)
+			n, err := util.PickName(names, "Pick Deployment:", "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/metrics.go
+++ b/pkg/cmd/metrics.go
@@ -90,7 +90,7 @@ func (o *MetricsOptions) Run() error {
 			if len(names) == 0 {
 				return fmt.Errorf("There are no Deployments running")
 			}
-			n, err := util.PickName(names, "Pick Deployment:", "", o.In, o.Out, o.Err)
+			n, err := util.PickName(names, "Pick Deployment:", "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/opts/addon.go
+++ b/pkg/cmd/opts/addon.go
@@ -19,7 +19,7 @@ func (o *CommonOptions) GetAddonAuth(serviceURL string) (*auth.AuthServer, *auth
 	config := authConfigSvc.Config()
 
 	server := config.GetOrCreateServer(serviceURL)
-	userAuth, err := config.PickServerUserAuth(server, "user to access the addon service at "+serviceURL, o.BatchMode, "", o.In, o.Out, o.Err)
+	userAuth, err := config.PickServerUserAuth(server, "user to access the addon service at "+serviceURL, o.BatchMode, "", o.GetIOFileHandles())
 	return server, userAuth, err
 }
 
@@ -42,7 +42,7 @@ func (o *CommonOptions) GetAddonAuthByKind(kind, serverURL string) (*auth.AuthSe
 		return nil, nil, fmt.Errorf("no server found for kind %s", kind)
 	}
 	message := "user to access the " + kind + " addon service at " + server.URL
-	userAuth, err := config.PickServerUserAuth(server, message, true, "", o.In, o.Out, o.Err)
+	userAuth, err := config.PickServerUserAuth(server, message, true, "", o.GetIOFileHandles())
 	return server, userAuth, err
 }
 

--- a/pkg/cmd/opts/auth.go
+++ b/pkg/cmd/opts/auth.go
@@ -238,7 +238,7 @@ func (o *CommonOptions) PickPipelineUserAuth(config *auth.AuthConfig, server *au
 	url := server.URL
 	userAuths := config.FindUserAuths(url)
 	if len(userAuths) > 1 {
-		userAuth, err = config.PickServerUserAuth(server, "user name for the Pipeline", o.BatchMode, "", o.In, o.Out, o.Err)
+		userAuth, err = config.PickServerUserAuth(server, "user name for the Pipeline", o.BatchMode, "", o.GetIOFileHandles())
 		if err != nil {
 			return userAuth, err
 		}

--- a/pkg/cmd/opts/cert_manager.go
+++ b/pkg/cmd/opts/cert_manager.go
@@ -26,7 +26,7 @@ func (o *CommonOptions) EnsureCertManager() error {
 				"CertManager deployment not found, shall we install it now?",
 				true,
 				"CertManager automatically configures Ingress rules with TLS using signed certificates from LetsEncrypt",
-				o.In, o.Out, o.Err)
+				o.GetIOFileHandles())
 		}
 		if ok {
 			log.Logger().Info("Installing cert-manager...")

--- a/pkg/cmd/opts/clusters.go
+++ b/pkg/cmd/opts/clusters.go
@@ -91,7 +91,7 @@ func (o *CommonOptions) GetOrPickClusterName(client cluster.Client, clusterName 
 		}
 		sort.Strings(names)
 
-		clusterName, err = util.PickName(names, "pick the cluster name", "you need to provide a cluster name to unlock", o.In, o.Out, o.Err)
+		clusterName, err = util.PickName(names, "pick the cluster name", "you need to provide a cluster name to unlock", o.GetIOFileHandles())
 		if err != nil {
 			return "", errors.Wrap(err, "failed to pick cluster name")
 		}

--- a/pkg/cmd/opts/common.go
+++ b/pkg/cmd/opts/common.go
@@ -682,7 +682,7 @@ func (o *CommonOptions) FindServer(config *auth.AuthConfig, serverFlags *ServerF
 				defaultServerName = s.Name
 			}
 		}
-		name, err := util.PickNameWithDefault(config.GetServerNames(), "Pick server to use: ", defaultServerName, "", o.In, o.Out, o.Err)
+		name, err := util.PickNameWithDefault(config.GetServerNames(), "Pick server to use: ", defaultServerName, "", o.GetIOFileHandles())
 		if err != nil {
 			return nil, err
 		}
@@ -717,7 +717,7 @@ func (o *CommonOptions) FindService(name string) (string, error) {
 			return "", err
 		}
 		if len(names) > 1 {
-			name, err = util.PickName(names, "Pick service to open: ", "", o.In, o.Out, o.Err)
+			name, err = util.PickName(names, "Pick service to open: ", "", o.GetIOFileHandles())
 			if err != nil {
 				return "", err
 			}
@@ -782,7 +782,7 @@ func (o *CommonOptions) FindServiceInNamespace(name string, ns string) (string, 
 			return "", err
 		}
 		if len(names) > 1 {
-			name, err = util.PickName(names, "Pick service to open: ", "", o.In, o.Out, o.Err)
+			name, err = util.PickName(names, "Pick service to open: ", "", o.GetIOFileHandles())
 			if err != nil {
 				return "", err
 			}
@@ -1187,6 +1187,15 @@ func (o *CommonOptions) InCDPipeline() bool {
 // SetBatchMode configures the batch mode
 func (o *CommonOptions) SetBatchMode(batchMode bool) {
 	o.factory.SetBatch(batchMode)
+}
+
+// GetIOFileHandles returns In, Out, and Err as an IOFileHandles struct
+func (o *CommonOptions) GetIOFileHandles() util.IOFileHandles {
+	return util.IOFileHandles{
+		Err: o.Err,
+		In:  o.In,
+		Out: o.Out,
+	}
 }
 
 // IstioClient creates a new Kubernetes client for Istio resources

--- a/pkg/cmd/opts/domain.go
+++ b/pkg/cmd/opts/domain.go
@@ -81,7 +81,7 @@ func (o *CommonOptions) GetDomain(client kubernetes.Interface, domain string, pr
 			}
 			for {
 				if util.Confirm("Would you like to register a wildcard DNS ALIAS to point at this ELB address? ", true,
-					"When using AWS we need to use a wildcard DNS alias to point at the ELB host name so you can access services inside Jenkins X and in your Environments.", o.In, o.Out, o.Err) {
+					"When using AWS we need to use a wildcard DNS alias to point at the ELB host name so you can access services inside Jenkins X and in your Environments.", o.GetIOFileHandles()) {
 					customDomain := ""
 					prompt := &survey.Input{
 						Message: "Your custom DNS name: ",
@@ -126,7 +126,7 @@ func (o *CommonOptions) GetDomain(client kubernetes.Interface, domain string, pr
 
 			addressIP := ""
 			if o.BatchMode || util.Confirm("Would you like wait and resolve this address to an IP address and use it for the domain?", true,
-				"Should we convert "+address+" to an IP address so we can access resources externally", o.In, o.Out, o.Err) {
+				"Should we convert "+address+" to an IP address so we can access resources externally", o.GetIOFileHandles()) {
 
 				log.Logger().Infof("Waiting for %s to be resolvable to an IP address...", util.ColorInfo(address))
 				f := func() error {

--- a/pkg/cmd/opts/git.go
+++ b/pkg/cmd/opts/git.go
@@ -46,7 +46,7 @@ func (o *CommonOptions) NewGitProvider(gitURL string, message string, authConfig
 	if o.factory == nil {
 		return nil, errors.New("command factory is not initialized")
 	}
-	return o.factory.CreateGitProvider(gitURL, message, authConfigSvc, gitKind, batchMode, gitter, o.In, o.Out, o.Err)
+	return o.factory.CreateGitProvider(gitURL, message, authConfigSvc, gitKind, batchMode, gitter, o.GetIOFileHandles())
 }
 
 // CreateGitProvider creates a git from the given directory
@@ -73,7 +73,7 @@ func (o *CommonOptions) CreateGitProvider(dir string) (*gits.GitRepository, gits
 		return gitInfo, nil, nil, err
 	}
 	gitKind, err := o.GitServerKind(gitInfo)
-	gitProvider, err := gitInfo.CreateProvider(cluster.IsInCluster(), authConfigSvc, gitKind, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+	gitProvider, err := gitInfo.CreateProvider(cluster.IsInCluster(), authConfigSvc, gitKind, o.Git(), o.BatchMode, o.GetIOFileHandles())
 	if err != nil {
 		return gitInfo, gitProvider, nil, err
 	}
@@ -294,7 +294,7 @@ func (o *CommonOptions) GitServerHostURLKind(hostURL string) (string, error) {
 		if o.BatchMode {
 			return "", fmt.Errorf("No Git server kind could be found for URL %s\nPlease try specify it via: jx create git server someKind %s", hostURL, hostURL)
 		}
-		kind, err = util.PickName(gits.KindGits, fmt.Sprintf("Pick what kind of Git server is: %s", hostURL), "", o.In, o.Out, o.Err)
+		kind, err = util.PickName(gits.KindGits, fmt.Sprintf("Pick what kind of Git server is: %s", hostURL), "", o.GetIOFileHandles())
 		if err != nil {
 			return "", err
 		}
@@ -322,7 +322,7 @@ func (o *CommonOptions) GitProviderForURL(gitURL string, message string) (gits.G
 	if err != nil {
 		return nil, err
 	}
-	return gitInfo.PickOrCreateProvider(authConfigSvc, message, o.BatchMode, gitKind, o.Git(), o.In, o.Out, o.Err)
+	return gitInfo.PickOrCreateProvider(authConfigSvc, message, o.BatchMode, gitKind, o.Git(), o.GetIOFileHandles())
 }
 
 // GitProviderForURL returns a GitProvider for the given Git server URL
@@ -334,7 +334,7 @@ func (o *CommonOptions) GitProviderForGitServerURL(gitServiceUrl string, gitKind
 	if err != nil {
 		return nil, err
 	}
-	return gits.CreateProviderForURL(cluster.IsInCluster(), authConfigSvc, gitKind, gitServiceUrl, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+	return gits.CreateProviderForURL(cluster.IsInCluster(), authConfigSvc, gitKind, gitServiceUrl, o.Git(), o.BatchMode, o.GetIOFileHandles())
 }
 
 // CreateGitProviderForURLWithoutKind creates a git provider from URL wihtout kind
@@ -408,7 +408,7 @@ func (o *CommonOptions) DisableFeatures(orgs []string, includes []string, exclud
 		if err != nil {
 			return errors.Wrapf(err, "creating git provider for %s", org)
 		}
-		err = features.DisableFeaturesForOrg(info.Organisation, includes, excludes, dryRun, o.BatchMode, provider, o.In, o.Out, o.Err)
+		err = features.DisableFeaturesForOrg(info.Organisation, includes, excludes, dryRun, o.BatchMode, provider, o.GetIOFileHandles())
 		if err != nil {
 			return errors.Wrapf(err, "disabling features for %s", org)
 		}

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -290,7 +290,7 @@ func (o *CommonOptions) AddHelmBinaryRepoIfMissing(url, repoName, username, pass
 	if err != nil {
 		vaultClient = nil
 	}
-	name, err := helm.AddHelmRepoIfMissing(url, repoName, username, password, o.Helm(), vaultClient, o.In, o.Out, o.Err)
+	name, err := helm.AddHelmRepoIfMissing(url, repoName, username, password, o.Helm(), vaultClient, o.GetIOFileHandles())
 	if err != nil {
 		return "", errors.WithStack(err)
 	}

--- a/pkg/cmd/opts/import.go
+++ b/pkg/cmd/opts/import.go
@@ -121,7 +121,7 @@ func (o *CommonOptions) ImportProject(gitURL string, dir string, jenkinsfile str
 					u = gitInfo.Host
 				}
 			}
-			user, err := config.PickServerUserAuth(server, "user name for the Jenkins Pipeline", batchMode, "", o.In, o.Out, o.Err)
+			user, err := config.PickServerUserAuth(server, "user name for the Jenkins Pipeline", batchMode, "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/opts/install.go
+++ b/pkg/cmd/opts/install.go
@@ -301,7 +301,7 @@ func (o *CommonOptions) Installhyperv() error {
 
 		message := fmt.Sprintf("Would you like to restart your computer?")
 
-		if util.Confirm(message, true, "Please indicate if you would like to restart your computer.", o.In, o.Out, o.Err) {
+		if util.Confirm(message, true, "Please indicate if you would like to restart your computer.", o.GetIOFileHandles()) {
 
 			err = o.RunCommand("powershell", "Enable-WindowsOptionalFeature", "-Online", "-FeatureName", "Microsoft-Hyper-V", "-All", "-NoRestart")
 			if err != nil {
@@ -1036,7 +1036,7 @@ func (o *CommonOptions) InstallProw(useTekton bool, useExternalDNS bool, isGitOp
 		// lets assume github.com for now so ignore config.CurrentServer
 		server := config.GetOrCreateServer("https://github.com")
 		message := fmt.Sprintf("%s bot user for CI/CD pipelines (not your personal Git user):", server.Label())
-		userAuth, err := config.PickServerUserAuth(server, message, o.BatchMode, "", o.In, o.Out, o.Err)
+		userAuth, err := config.PickServerUserAuth(server, message, o.BatchMode, "", o.GetIOFileHandles())
 		if err != nil {
 			return errors.Wrap(err, "picking bot user auth")
 		}

--- a/pkg/cmd/opts/issues.go
+++ b/pkg/cmd/opts/issues.go
@@ -52,7 +52,7 @@ func (o *CommonOptions) CreateIssueProvider(dir string) (issues.IssueProvider, e
 				}
 				config := authConfigSvc.Config()
 				server := config.GetOrCreateServer(it.URL)
-				userAuth, err := config.PickServerUserAuth(server, "user to access the issue tracker", o.BatchMode, "", o.In, o.Out, o.Err)
+				userAuth, err := config.PickServerUserAuth(server, "user to access the issue tracker", o.BatchMode, "", o.GetIOFileHandles())
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/cmd/opts/jenkins.go
+++ b/pkg/cmd/opts/jenkins.go
@@ -75,7 +75,7 @@ func (o *CommonOptions) JenkinsClient() (gojenkins.JenkinsClient, error) {
 		}
 
 		o.factory.SetBatch(o.BatchMode)
-		jenkins, err := o.factory.CreateJenkinsClient(kubeClient, ns, o.In, o.Out, o.Err)
+		jenkins, err := o.factory.CreateJenkinsClient(kubeClient, ns, o.GetIOFileHandles())
 
 		if err != nil {
 			return nil, err
@@ -92,7 +92,7 @@ func (o *CommonOptions) CustomJenkinsClient(jenkinsServiceName string) (gojenkin
 		return nil, err
 	}
 	o.factory.SetBatch(o.BatchMode)
-	return o.factory.CreateCustomJenkinsClient(kubeClient, ns, jenkinsServiceName, o.In, o.Out, o.Err)
+	return o.factory.CreateCustomJenkinsClient(kubeClient, ns, jenkinsServiceName, o.GetIOFileHandles())
 }
 
 // CustomJenkinsURL returns the default or the custom Jenkins URL
@@ -139,7 +139,7 @@ func (o *CommonOptions) PickCustomJenkinsName(jenkinsSelector *JenkinsSelectorOp
 			if o.BatchMode {
 				return "", util.MissingOptionWithOptions("jenkins-name", names)
 			}
-			customJenkinsName, err = util.PickName(names, "Pick which custom Jenkins App you wish to use: ", "Jenkins Apps are a way to add custom Jenkins servers into Jenkins X", o.GetIn(), o.GetOut(), o.GetErr())
+			customJenkinsName, err = util.PickName(names, "Pick which custom Jenkins App you wish to use: ", "Jenkins Apps are a way to add custom Jenkins servers into Jenkins X", o.GetIOFileHandles())
 			if err != nil {
 				return "", err
 			}
@@ -295,7 +295,7 @@ func (o *CommonOptions) UpdateJenkinsURL(namespaces []string) error {
 
 		log.Logger().Infof("Updating Jenkins with new external URL details %s", externalURL)
 
-		jenkins, err := o.factory.CreateJenkinsClient(client, n, o.In, o.Out, o.Err)
+		jenkins, err := o.factory.CreateJenkinsClient(client, n, o.GetIOFileHandles())
 
 		if err != nil {
 			return err

--- a/pkg/cmd/opts/upgrade/upgrade_ingress.go
+++ b/pkg/cmd/opts/upgrade/upgrade_ingress.go
@@ -78,7 +78,7 @@ func (o *UpgradeIngressOptions) Run() error {
 
 	// confirm values
 	if !o.BatchMode {
-		if !util.Confirm(fmt.Sprintf("Using config values %v, ok?", o.IngressConfig), true, "", o.In, o.Out, o.Err) {
+		if !util.Confirm(fmt.Sprintf("Using config values %v, ok?", o.IngressConfig), true, "", o.GetIOFileHandles()) {
 			log.Logger().Infof("Terminating")
 			return nil
 		}
@@ -255,7 +255,7 @@ func (o *UpgradeIngressOptions) updateResources(previousWebHookEndpoint string) 
 	log.Logger().Infof("Updated webhook endpoint %s", updatedWebHookEndpoint)
 	updateWebHooks := true
 	if !o.BatchMode {
-		if !util.Confirm("Do you want to update all existing webhooks?", true, "", o.In, o.Out, o.Err) {
+		if !util.Confirm("Do you want to update all existing webhooks?", true, "", o.GetIOFileHandles()) {
 			updateWebHooks = false
 		}
 	}
@@ -430,24 +430,24 @@ func (o *UpgradeIngressOptions) confirmExposecontrollerConfig() error {
 			}
 		}
 	} else {
-		o.IngressConfig.Exposer, err = util.PickNameWithDefault([]string{"Ingress", "Route"}, "Expose type", o.IngressConfig.Exposer, "", o.In, o.Out, o.Err)
+		o.IngressConfig.Exposer, err = util.PickNameWithDefault([]string{"Ingress", "Route"}, "Expose type", o.IngressConfig.Exposer, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
 
-		o.IngressConfig.Domain, err = util.PickValue("Domain:", o.IngressConfig.Domain, true, "", o.In, o.Out, o.Err)
+		o.IngressConfig.Domain, err = util.PickValue("Domain:", o.IngressConfig.Domain, true, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
 
 		if !strings.HasSuffix(o.IngressConfig.Domain, "nip.io") {
 			if !o.BatchMode {
-				o.IngressConfig.TLS = util.Confirm("If your network is publicly available would you like to enable cluster wide TLS?", true, "Enables cert-manager and configures TLS with signed certificates from LetsEncrypt", o.In, o.Out, o.Err)
+				o.IngressConfig.TLS = util.Confirm("If your network is publicly available would you like to enable cluster wide TLS?", true, "Enables cert-manager and configures TLS with signed certificates from LetsEncrypt", o.GetIOFileHandles())
 			}
 
 			if o.IngressConfig.TLS {
 				log.Logger().Infof("If testing LetsEncrypt you should use staging as you may be rate limited using production.")
-				clusterIssuer, err := util.PickNameWithDefault([]string{"staging", "production"}, "Use LetsEncrypt staging or production?", "production", "", o.In, o.Out, o.Err)
+				clusterIssuer, err := util.PickNameWithDefault([]string{"staging", "production"}, "Use LetsEncrypt staging or production?", "production", "", o.GetIOFileHandles())
 				// if the cluster issuer is production the string needed by letsencrypt is prod
 				if clusterIssuer == "production" {
 					clusterIssuer = "prod"
@@ -466,13 +466,13 @@ func (o *UpgradeIngressOptions) confirmExposecontrollerConfig() error {
 					o.IngressConfig.Email = strings.TrimSpace(email1)
 				}
 
-				o.IngressConfig.Email, err = util.PickValue("Email address to register with LetsEncrypt:", o.IngressConfig.Email, true, "", o.In, o.Out, o.Err)
+				o.IngressConfig.Email, err = util.PickValue("Email address to register with LetsEncrypt:", o.IngressConfig.Email, true, "", o.GetIOFileHandles())
 				if err != nil {
 					return err
 				}
 			}
 		}
-		o.IngressConfig.UrlTemplate, err = util.PickValue("URLTemplate (press <Enter> to keep the current value):", o.IngressConfig.UrlTemplate, false, "", o.In, o.Out, o.Err)
+		o.IngressConfig.UrlTemplate, err = util.PickValue("URLTemplate (press <Enter> to keep the current value):", o.IngressConfig.UrlTemplate, false, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -607,7 +607,7 @@ func (o *UpgradeIngressOptions) updateWebHooks(oldHookEndpoint string, newHookEn
 	username := userAuth.Username
 
 	// organisation
-	organisation, err := gits.PickOrganisation(git, username, o.In, o.Out, o.Err)
+	organisation, err := gits.PickOrganisation(git, username, o.GetIOFileHandles())
 	updateWebHook.Username = ReturnUserNameIfPicked(organisation, username)
 	if err != nil {
 		return errors.Wrap(err, "unable to determine git provider")

--- a/pkg/cmd/opts/version.go
+++ b/pkg/cmd/opts/version.go
@@ -147,5 +147,5 @@ func (o *CommonOptions) CloneJXVersionsRepo(versionRepository string, versionRef
 	if err != nil {
 		log.Logger().Debugf("Unable to load team settings because %v", err)
 	}
-	return versionstreamrepo.CloneJXVersionsRepo(versionRepository, versionRef, settings, o.Git(), o.BatchMode, o.AdvancedMode, o.In, o.Out, o.Err)
+	return versionstreamrepo.CloneJXVersionsRepo(versionRepository, versionRef, settings, o.Git(), o.BatchMode, o.AdvancedMode, o.GetIOFileHandles())
 }

--- a/pkg/cmd/promote/promote.go
+++ b/pkg/cmd/promote/promote.go
@@ -215,7 +215,7 @@ func (o *PromoteOptions) Run() error {
 				names = append(names, n)
 			}
 		}
-		o.Environment, err = kube.PickEnvironment(names, "", o.In, o.Out, o.Err)
+		o.Environment, err = kube.PickEnvironment(names, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -945,7 +945,7 @@ func (o *PromoteOptions) CommentOnIssues(targetNS string, environment *v1.Enviro
 		return err
 	}
 
-	provider, err := gitInfo.PickOrCreateProvider(authConfigSvc, "user name to comment on issues", o.BatchMode, gitKind, o.Git(), o.In, o.Out, o.Err)
+	provider, err := gitInfo.PickOrCreateProvider(authConfigSvc, "user name to comment on issues", o.BatchMode, gitKind, o.Git(), o.GetIOFileHandles())
 	if err != nil {
 		return err
 	}
@@ -1050,7 +1050,7 @@ func (o *PromoteOptions) SearchForChart(filter string) (string, error) {
 		names = append(names, text)
 		m[text] = &charts[i]
 	}
-	name, err := util.PickName(names, "Pick chart to promote: ", "", o.In, o.Out, o.Err)
+	name, err := util.PickName(names, "Pick chart to promote: ", "", o.GetIOFileHandles())
 	if err != nil {
 		return answer, err
 	}

--- a/pkg/cmd/rsh/rsh.go
+++ b/pkg/cmd/rsh/rsh.go
@@ -141,7 +141,7 @@ func (o *RshOptions) Run() error {
 	name := o.Pod
 	if len(args) == 0 {
 		if util.StringArrayIndex(names, name) < 0 {
-			n, err := util.PickName(names, "Pick Pod:", "", o.In, o.Out, o.Err)
+			n, err := util.PickName(names, "Pick Pod:", "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
@@ -157,7 +157,7 @@ func (o *RshOptions) Run() error {
 					filteredNames = append(filteredNames, n)
 				}
 			}
-			n, err := util.PickName(filteredNames, "Pick Pod:", "", o.In, o.Out, o.Err)
+			n, err := util.PickName(filteredNames, "Pick Pod:", "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/start/start_pipeline.go
+++ b/pkg/cmd/start/start_pipeline.go
@@ -167,7 +167,7 @@ func (o *StartPipelineOptions) Run() error {
 				break
 			}
 		}
-		name, err := util.PickNameWithDefault(names, "Which pipeline do you want to start: ", defaultName, "", o.In, o.Out, o.Err)
+		name, err := util.PickNameWithDefault(names, "Which pipeline do you want to start: ", defaultName, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -225,7 +225,7 @@ func (o *StartPipelineOptions) createMetaPipeline(jobName string) error {
 	}
 
 	log.Logger().Debug("creating meta pipeline client")
-	client, err := metapipeline.NewMetaPipelineClient(o.Git(), o.In, o.Out, o.Err)
+	client, err := metapipeline.NewMetaPipelineClient(o.Git(), o.GetIOFileHandles())
 	if err != nil {
 		return errors.Wrap(err, "unable to create meta pipeline client")
 	}

--- a/pkg/cmd/step/create/pr/step_create_pr_versions.go
+++ b/pkg/cmd/step/create/pr/step_create_pr_versions.go
@@ -213,7 +213,7 @@ func (o *StepCreatePullRequestVersionsOptions) Run() error {
 		for _, kind := range o.Kinds {
 			switch kind {
 			case string(versionstream.KindChart):
-				modifyFns = append(modifyFns, pro.WrapChangeFilesWithCommitFn("versions", operations.CreateChartChangeFilesFn(o.Name, o.Version, kind, &pro, o.Helm(), vaultClient, o.In, o.Out, o.Err)))
+				modifyFns = append(modifyFns, pro.WrapChangeFilesWithCommitFn("versions", operations.CreateChartChangeFilesFn(o.Name, o.Version, kind, &pro, o.Helm(), vaultClient, o.GetIOFileHandles())))
 			}
 
 		}
@@ -314,7 +314,7 @@ func (o *StepCreatePullRequestVersionsOptions) CreatePullRequestUpdateVersionFil
 					if err != nil {
 						vaultClient = nil
 					}
-					cff = pro.WrapChangeFilesWithCommitFn(kindStr, operations.CreateChartChangeFilesFn(name, "", kindStr, &pro, o.Helm(), vaultClient, o.In, o.Out, o.Err))
+					cff = pro.WrapChangeFilesWithCommitFn(kindStr, operations.CreateChartChangeFilesFn(name, "", kindStr, &pro, o.Helm(), vaultClient, o.GetIOFileHandles()))
 				case string(versionstream.KindGit):
 					cff = pro.WrapChangeFilesWithCommitFn(kindStr, pro.CreatePullRequestGitReleasesFn(name))
 				}

--- a/pkg/cmd/step/create/step_create_values.go
+++ b/pkg/cmd/step/create/step_create_values.go
@@ -206,7 +206,7 @@ func (o *StepCreateValuesOptions) CreateValuesFile(secretURLClient secreturl.Cli
 		return errors.Wrapf(err, "failed to load values file %s", o.ValuesFile)
 	}
 
-	valuesFileName, cleanup, err := apps.ProcessValues(schema, o.Name, gitOpsURL, teamName, o.BasePath, o.BatchMode, false, secretURLClient, existing, o.SecretsScheme, o.In, o.Out, o.Err, o.Verbose)
+	valuesFileName, cleanup, err := apps.ProcessValues(schema, o.Name, gitOpsURL, teamName, o.BasePath, o.BatchMode, false, secretURLClient, existing, o.SecretsScheme, o.GetIOFileHandles(), o.Verbose)
 	defer cleanup()
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/cmd/step/git/step_git_validate.go
+++ b/pkg/cmd/step/git/step_git_validate.go
@@ -64,7 +64,7 @@ func (o *StepGitValidateOptions) Run() error {
 		userName = os.Getenv("GIT_AUTHOR_NAME")
 		if userName == "" {
 			if !o.BatchMode {
-				userName, err = util.PickValue("Please enter the name you wish to use with git: ", "", true, "", o.In, o.Out, o.Err)
+				userName, err = util.PickValue("Please enter the name you wish to use with git: ", "", true, "", o.GetIOFileHandles())
 				if err != nil {
 					return err
 				}
@@ -89,7 +89,7 @@ func (o *StepGitValidateOptions) Run() error {
 		userEmail = os.Getenv("GIT_AUTHOR_EMAIL")
 		if userEmail == "" {
 			if !o.BatchMode {
-				userEmail, err = util.PickValue("Please enter the email address you wish to use with git: ", "", true, "", o.In, o.Out, o.Err)
+				userEmail, err = util.PickValue("Please enter the email address you wish to use with git: ", "", true, "", o.GetIOFileHandles())
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/step/report/step_report_image_version.go
+++ b/pkg/cmd/step/report/step_report_image_version.go
@@ -264,7 +264,7 @@ func (o *StepReportImageVersionOptions) generateReport(imagesDir string) error {
 		}
 		if !o.BatchMode {
 			if !util.Confirm(fmt.Sprintf("are you ready to delete the Job %s", job.Name), true,
-				"we should delete the job when it is finished", o.In, o.Out, o.Err) {
+				"we should delete the job when it is finished", o.GetIOFileHandles()) {
 				return nil
 			}
 		}

--- a/pkg/cmd/step/step_blog.go
+++ b/pkg/cmd/step/step_blog.go
@@ -634,7 +634,7 @@ func (o *StepBlogOptions) CreateChatProvider(chatConfig *config.ChatConfig) (cha
 	config := authConfigSvc.Config()
 
 	server := config.GetOrCreateServer(u)
-	userAuth, err := config.PickServerUserAuth(server, "user to access the chat service at "+u, o.BatchMode, "", o.In, o.Out, o.Err)
+	userAuth, err := config.PickServerUserAuth(server, "user to access the chat service at "+u, o.BatchMode, "", o.GetIOFileHandles())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/step/step_changelog.go
+++ b/pkg/cmd/step/step_changelog.go
@@ -326,7 +326,7 @@ func (o *StepChangelogOptions) Run() error {
 
 	gitKind, err := o.GitServerKind(gitInfo)
 	foundGitProvider := true
-	gitProvider, err := o.State.GitInfo.CreateProvider(o.InCluster(), authConfigSvc, gitKind, o.Git(), o.BatchMode, o.In, o.Out, o.Err)
+	gitProvider, err := o.State.GitInfo.CreateProvider(o.InCluster(), authConfigSvc, gitKind, o.Git(), o.BatchMode, o.GetIOFileHandles())
 	if err != nil {
 		foundGitProvider = false
 		log.Logger().Warnf("Could not create GitProvide so cannot update the release notes: %s", err)

--- a/pkg/cmd/step/update/release/step_update_release_github.go
+++ b/pkg/cmd/step/update/release/step_update_release_github.go
@@ -115,7 +115,7 @@ func (o *StepUpdateReleaseGitHubOptions) Run() error {
 	o.State.GitInfo = gitInfo
 
 	gitKind, err := o.GitServerKind(gitInfo)
-	gitProvider, err := o.State.GitInfo.CreateProvider(o.InCluster(), authConfigSvc, gitKind, o.Git(), false, o.In, o.Out, o.Err)
+	gitProvider, err := o.State.GitInfo.CreateProvider(o.InCluster(), authConfigSvc, gitKind, o.Git(), false, o.GetIOFileHandles())
 	if err != nil {
 		return errors.Wrap(err, "Could not create GitProvider, unable to update the release state %s")
 	}

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -317,7 +317,7 @@ func (o *StepVerifyEnvironmentsOptions) createEnvironmentRepository(name string,
 			IgnoreExistingRepository: true,
 		}
 
-		_, _, err = kube.DoCreateEnvironmentGitRepo(batchMode, authConfigSvc, environment, forkGitURL, envDir, gitRepoOptions, helmValues, prefix, gitter, o.ResolveChartMuseumURL, o.In, o.Out, o.Err)
+		_, _, err = kube.DoCreateEnvironmentGitRepo(batchMode, authConfigSvc, environment, forkGitURL, envDir, gitRepoOptions, helmValues, prefix, gitter, o.ResolveChartMuseumURL, o.GetIOFileHandles())
 		if err != nil {
 			return errors.Wrapf(err, "failed to create git repository for gitURL %s", gitURL)
 		}

--- a/pkg/cmd/step/verify/step_verify_packages.go
+++ b/pkg/cmd/step/verify/step_verify_packages.go
@@ -145,7 +145,7 @@ func (o *StepVerifyPackagesOptions) verifyJXVersion(resolver *versionstream.Vers
 	} else {
 		log.Logger().Info("\n")
 		message := fmt.Sprintf("Would you like to upgrade to the %s version?", info("jx"))
-		if util.Confirm(message, true, "Please indicate if you would like to upgrade the binary version.", o.In, o.Out, o.Err) {
+		if util.Confirm(message, true, "Please indicate if you would like to upgrade the binary version.", o.GetIOFileHandles()) {
 			options := &upgrade.UpgradeCLIOptions{
 				CreateOptions: create.CreateOptions{
 					CommonOptions: o.CommonOptions,

--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -482,7 +482,7 @@ func (o *StepVerifyPreInstallOptions) gatherRequirements(requirements *config.Re
 	}
 	var err error
 	if requirements.Cluster.Provider == "" {
-		requirements.Cluster.Provider, err = util.PickName(cloud.KubernetesProviders, "Select Kubernetes provider", "the type of Kubernetes installation", o.In, o.Out, o.Err)
+		requirements.Cluster.Provider, err = util.PickName(cloud.KubernetesProviders, "Select Kubernetes provider", "the type of Kubernetes installation", o.GetIOFileHandles())
 		if err != nil {
 			return nil, errors.Wrap(err, "selecting Kubernetes provider")
 		}
@@ -511,7 +511,7 @@ func (o *StepVerifyPreInstallOptions) gatherRequirements(requirements *config.Re
 			if currentClusterName != "" && currentProject != "" && currentZone != "" {
 				log.Logger().Infof("")
 				log.Logger().Infof("Currently connected cluster is %s in %s in project %s", util.ColorInfo(currentClusterName), util.ColorInfo(currentZone), util.ColorInfo(currentProject))
-				autoAcceptDefaults = util.Confirm(fmt.Sprintf("Do you want to jx boot the %s cluster?", util.ColorInfo(currentClusterName)), true, "Enter Y to use the currently connected cluster or enter N to specify a different cluster", o.In, o.Out, o.Err)
+				autoAcceptDefaults = util.Confirm(fmt.Sprintf("Do you want to jx boot the %s cluster?", util.ColorInfo(currentClusterName)), true, "Enter Y to use the currently connected cluster or enter N to specify a different cluster", o.GetIOFileHandles())
 			} else {
 				log.Logger().Infof("Enter the cluster you want to jx boot")
 			}
@@ -542,7 +542,7 @@ func (o *StepVerifyPreInstallOptions) gatherRequirements(requirements *config.Re
 				requirements.Cluster.ClusterName = currentClusterName
 			} else {
 				requirements.Cluster.ClusterName, err = util.PickValue("Cluster name", currentClusterName, true,
-					"The name for your cluster", o.In, o.Out, o.Err)
+					"The name for your cluster", o.GetIOFileHandles())
 				if err != nil {
 					return nil, errors.Wrap(err, "getting cluster name")
 				}
@@ -572,7 +572,7 @@ func (o *StepVerifyPreInstallOptions) gatherRequirements(requirements *config.Re
 			if currentClusterName != "" && currentRegion != "" {
 				log.Logger().Infof("")
 				log.Logger().Infof("Currently connected cluster is %s in region %s", util.ColorInfo(currentClusterName), util.ColorInfo(currentRegion))
-				autoAcceptDefaults = util.Confirm(fmt.Sprintf("Do you want to jx boot the %s cluster?", util.ColorInfo(currentClusterName)), true, "Enter Y to use the currently connected cluster or enter N to specify a different cluster", o.In, o.Out, o.Err)
+				autoAcceptDefaults = util.Confirm(fmt.Sprintf("Do you want to jx boot the %s cluster?", util.ColorInfo(currentClusterName)), true, "Enter Y to use the currently connected cluster or enter N to specify a different cluster", o.GetIOFileHandles())
 			} else {
 				log.Logger().Infof("Enter the cluster you want to jx boot")
 			}
@@ -588,7 +588,7 @@ func (o *StepVerifyPreInstallOptions) gatherRequirements(requirements *config.Re
 				requirements.Cluster.ClusterName = currentClusterName
 			} else {
 				requirements.Cluster.ClusterName, err = util.PickValue("Cluster name", currentClusterName, true,
-					"The name for your cluster", o.In, o.Out, o.Err)
+					"The name for your cluster", o.GetIOFileHandles())
 				if err != nil {
 					return nil, errors.Wrap(err, "getting cluster name")
 				}
@@ -652,7 +652,7 @@ func (o *StepVerifyPreInstallOptions) gatherGitRequirements(requirements *config
 			"Jenkins X leverages GitOps to track and control what gets deployed into environments.  "+
 				"This requires a Git repository per environment. "+
 				"This question is asking for the Git Owner where these repositories will live.",
-			o.In, o.Out, o.Err)
+			o.GetIOFileHandles())
 		if err != nil {
 			return errors.Wrap(err, "error configuring git owner for env repositories")
 		}
@@ -679,7 +679,7 @@ func (o *StepVerifyPreInstallOptions) verifyPrivateRepos(requirements *config.Re
 	if requirements.Cluster.GitKind == "github" {
 		message := fmt.Sprintf("If '%s' is an GitHub organisation it needs to have a paid subscription to create private repos. Do you wish to continue?", requirements.Cluster.EnvironmentGitOwner)
 		help := fmt.Sprint("GitHub organisation on a free plan cannot create private repositories. You either need to upgrade, use a GitHub user instead or use public repositories.")
-		confirmed := util.Confirm(message, false, help, o.In, o.Out, o.Err)
+		confirmed := util.Confirm(message, false, help, o.GetIOFileHandles())
 		if !confirmed {
 			return errors.New("cannot continue without completed git requirements")
 		}
@@ -743,7 +743,7 @@ func (o *StepVerifyPreInstallOptions) verifyTLS(requirements *config.Requirement
 
 			message := fmt.Sprintf("Do you wish to continue?")
 			help := fmt.Sprintf("Jenkins X needs TLS enabled to send secrets securely. We strongly recommend enabling TLS.")
-			value := util.Confirm(message, false, help, o.In, o.Out, o.Err)
+			value := util.Confirm(message, false, help, o.GetIOFileHandles())
 			if !value {
 				return errors.Errorf("cannot continue because TLS is not enabled.")
 			}
@@ -776,7 +776,7 @@ func (o *StepVerifyPreInstallOptions) verifyStorageEntry(requirements *config.Re
 		}
 		message := fmt.Sprintf("%s bucket URL. Press enter to create and use a new bucket", text)
 		help := fmt.Sprintf("please enter the URL of the bucket to use for storage using the format %s://<bucket-name>", scheme)
-		value, err := util.PickValue(message, "", false, help, o.In, o.Out, o.Err)
+		value, err := util.PickValue(message, "", false, help, o.GetIOFileHandles())
 		if err != nil {
 			return errors.Wrapf(err, "failed to pick storage bucket for %s", name)
 		}
@@ -942,7 +942,7 @@ func (o *StepVerifyPreInstallOptions) showProvideFeedbackMessage() bool {
 	log.Logger().Info("jx boot has only been validated on GKE, we'd love feedback and contributions for other Kubernetes providers")
 	if !o.BatchMode {
 		return util.Confirm("Continue execution anyway?",
-			true, "", o.In, o.Out, o.Err)
+			true, "", o.GetIOFileHandles())
 	}
 	log.Logger().Info("Running in Batch Mode, execution will continue")
 	return true

--- a/pkg/cmd/stop/stop_pipeline.go
+++ b/pkg/cmd/stop/stop_pipeline.go
@@ -115,7 +115,7 @@ func (o *StopPipelineOptions) stopJenkinsJob() error {
 				break
 			}
 		}
-		name, err := util.PickNameWithDefault(names, "Which pipelines do you want to stop: ", defaultName, "", o.In, o.Out, o.Err)
+		name, err := util.PickNameWithDefault(names, "Which pipelines do you want to stop: ", defaultName, "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
@@ -204,12 +204,12 @@ func (o *StopPipelineOptions) cancelPipelineRun() error {
 
 	args := o.Args
 	if len(args) == 0 {
-		name, err := util.PickName(names, "Which pipeline do you want to stop: ", "select a pipeline to cancel", o.In, o.Out, o.Err)
+		name, err := util.PickName(names, "Which pipeline do you want to stop: ", "select a pipeline to cancel", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}
 
-		if !util.Confirm(fmt.Sprintf("cancel pipeline %s", name), true, "you can always restart a cancelled pipeline with 'jx start pipeline'", o.In, o.Out, o.Err) {
+		if !util.Confirm(fmt.Sprintf("cancel pipeline %s", name), true, "you can always restart a cancelled pipeline with 'jx start pipeline'", o.GetIOFileHandles()) {
 			return nil
 		}
 		args = []string{name}

--- a/pkg/cmd/team.go
+++ b/pkg/cmd/team.go
@@ -84,7 +84,7 @@ func (o *TeamOptions) Run() error {
 		team = args[0]
 	}
 	if team == "" && !o.BatchMode {
-		pick, err := util.PickName(teamNames, "Pick Team: ", "", o.In, o.Out, o.Err)
+		pick, err := util.PickName(teamNames, "Pick Team: ", "", o.GetIOFileHandles())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/uninstall/uninstall.go
+++ b/pkg/cmd/uninstall/uninstall.go
@@ -89,7 +89,7 @@ func (o *UninstallOptions) Run() error {
 			}
 
 			uninstall := util.Confirm("Uninstall JX - this command will remove all JX components and delete all namespaces created by Jenkins X. Do you wish to continue?", false,
-				help, o.In, o.Out, o.Err)
+				help, o.GetIOFileHandles())
 			if !uninstall {
 				return nil
 			}
@@ -100,7 +100,7 @@ func (o *UninstallOptions) Run() error {
 			msg := fmt.Sprintf("This action will permanently delete Jenkins X from the Kubernetes context %s. "+
 				"Please type in the name of the context to confirm:", util.ColorInfo(currentContext))
 			helpMsg := "To prevent accidental uninstallation from the wrong cluster, you must enter the current Kubernetes context."
-			targetContext, err = util.PickValue(msg, "", true, helpMsg, o.In, o.Out, o.Err)
+			targetContext, err = util.PickValue(msg, "", true, helpMsg, o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/upgrade/upgrade_addon_prow.go
+++ b/pkg/cmd/upgrade/upgrade_addon_prow.go
@@ -113,7 +113,7 @@ func (o *UpgradeAddonProwOptions) Run() error {
 					"you like to install the latest Knative Build?\nWARNING: this will remove the previous version and " +
 					"install the latest, any existing builds or custom changes to BuildTemplate resources will be lost"
 
-				if !util.Confirm(message, false, "", o.In, o.Out, o.Err) {
+				if !util.Confirm(message, false, "", o.GetIOFileHandles()) {
 					return nil
 				}
 

--- a/pkg/cmd/upgrade/upgrade_apps.go
+++ b/pkg/cmd/upgrade/upgrade_apps.go
@@ -124,11 +124,9 @@ func (o *UpgradeAppsOptions) Run() error {
 	}
 
 	installOpts := apps.InstallOptions{
-		In:            o.In,
+		IOFileHandles: o.GetIOFileHandles(),
 		DevEnv:        o.DevEnv,
 		Verbose:       o.Verbose,
-		Err:           o.Err,
-		Out:           o.Out,
 		GitOps:        o.GitOps,
 		BatchMode:     o.BatchMode,
 		AutoMerge:     o.AutoMerge,

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -119,7 +119,7 @@ func (o *VersionOptions) upgradeCliIfNeeded(resolver *versionstream.VersionResol
 		} else {
 			log.Logger().Info("\n")
 			message := fmt.Sprintf("Would you like to upgrade to the %s version?", app)
-			if util.Confirm(message, true, "Please indicate if you would like to upgrade the binary version.", o.In, o.Out, o.Err) {
+			if util.Confirm(message, true, "Please indicate if you would like to upgrade the binary version.", o.GetIOFileHandles()) {
 				options := &upgrade.UpgradeCLIOptions{
 					CreateOptions: create.CreateOptions{
 						CommonOptions: o.CommonOptions,

--- a/pkg/gits/features/disable_features.go
+++ b/pkg/gits/features/disable_features.go
@@ -2,11 +2,8 @@ package features
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strings"
-
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/log"
 
@@ -26,7 +23,7 @@ import (
 //
 // If includes is not empty only those that match an include will be operated on. If dryRun is true, the operations to
 // be done will printed and but nothing done. If batchMode is false, then each change will be prompted.
-func DisableFeaturesForOrg(org string, includes []string, excludes []string, dryRun bool, batchMode bool, provider gits.GitProvider, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) error {
+func DisableFeaturesForOrg(org string, includes []string, excludes []string, dryRun bool, batchMode bool, provider gits.GitProvider, handles util.IOFileHandles) error {
 
 	type closeTypes struct {
 		*gits.GitRepository
@@ -176,7 +173,7 @@ Wiki Pages: %s
 			} else {
 
 				if !batchMode {
-					proceed := util.Confirm(fmt.Sprintf("Are you sure you want to disable %s on %s", strings.Join(toClose, ","), util.ColorInfo(fmt.Sprintf("%s/%s", c.Organisation, c.Name))), true, "", in, out, errOut)
+					proceed := util.Confirm(fmt.Sprintf("Are you sure you want to disable %s on %s", strings.Join(toClose, ","), util.ColorInfo(fmt.Sprintf("%s/%s", c.Organisation, c.Name))), true, "", handles)
 					if !proceed {
 						continue
 					}

--- a/pkg/gits/features/disable_features_test.go
+++ b/pkg/gits/features/disable_features_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/issues"
 	"github.com/jenkins-x/jx/pkg/tests"
+	"github.com/jenkins-x/jx/pkg/util"
 
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/stretchr/testify/assert"
@@ -215,7 +216,12 @@ func TestDisableIssuesForOrg(t *testing.T) {
 
 				terminal := tests.NewTerminal(t, nil)
 
-				err := DisableFeaturesForOrg("acme", tt.args.includes, tt.args.excludes, tt.args.dryRun, true, provider, terminal.In, terminal.Out, terminal.Err)
+				handles := util.IOFileHandles{
+					Err: terminal.Err,
+					In:  terminal.In,
+					Out: terminal.Out,
+				}
+				err := DisableFeaturesForOrg("acme", tt.args.includes, tt.args.excludes, tt.args.dryRun, true, provider, handles)
 
 				if tt.wantErr {
 					assert.Error(t, err)

--- a/pkg/gits/git_repo.go
+++ b/pkg/gits/git_repo.go
@@ -2,14 +2,12 @@ package gits
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type CreateRepoData struct {
@@ -44,7 +42,7 @@ func (d *CreateRepoData) CreateRepository() (*GitRepository, error) {
 }
 
 func PickNewOrExistingGitRepository(batchMode bool, authConfigSvc auth.ConfigService, defaultRepoName string,
-	repoOptions *GitRepositoryOptions, server *auth.AuthServer, userAuth *auth.UserAuth, git Gitter, allowExistingRepo bool, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (*CreateRepoData, error) {
+	repoOptions *GitRepositoryOptions, server *auth.AuthServer, userAuth *auth.UserAuth, git Gitter, allowExistingRepo bool, handles util.IOFileHandles) (*CreateRepoData, error) {
 	config := authConfigSvc.Config()
 
 	var err error
@@ -68,7 +66,7 @@ func PickNewOrExistingGitRepository(batchMode bool, authConfigSvc auth.ConfigSer
 					}
 				}
 			} else {
-				server, err = config.PickServer("Which Git service?", batchMode, in, out, errOut)
+				server, err = config.PickServer("Which Git service?", batchMode, handles)
 				if err != nil {
 					return nil, err
 				}
@@ -98,7 +96,7 @@ func PickNewOrExistingGitRepository(batchMode bool, authConfigSvc auth.ConfigSer
 				}
 				userAuth = ua
 			} else {
-				userAuth, err = config.PickServerUserAuth(server, "Git user name?", batchMode, "", in, out, errOut)
+				userAuth, err = config.PickServerUserAuth(server, "Git user name?", batchMode, "", handles)
 				if err != nil {
 					return nil, err
 				}
@@ -112,13 +110,13 @@ func PickNewOrExistingGitRepository(batchMode bool, authConfigSvc auth.ConfigSer
 
 	if userAuth.IsInvalid() {
 		f := func(username string) error {
-			git.PrintCreateRepositoryGenerateAccessToken(server, username, out)
+			git.PrintCreateRepositoryGenerateAccessToken(server, username, handles.Out)
 			return nil
 		}
 
 		// TODO could we guess this based on the users ~/.git for github?
 		defaultUserName := ""
-		err = config.EditUserAuth(server.Label(), userAuth, defaultUserName, true, batchMode, f, in, out, errOut)
+		err = config.EditUserAuth(server.Label(), userAuth, defaultUserName, true, batchMode, f, handles)
 		if err != nil {
 			return nil, err
 		}
@@ -144,7 +142,7 @@ func PickNewOrExistingGitRepository(batchMode bool, authConfigSvc auth.ConfigSer
 
 	owner := repoOptions.Owner
 	if owner == "" {
-		owner, err = GetOwner(batchMode, provider, gitUsername, in, out, errOut)
+		owner, err = GetOwner(batchMode, provider, gitUsername, handles)
 		if err != nil {
 			return nil, err
 		}
@@ -154,7 +152,7 @@ func PickNewOrExistingGitRepository(batchMode bool, authConfigSvc auth.ConfigSer
 
 	repoName := repoOptions.RepoName
 	if repoName == "" {
-		repoName, err = GetRepoName(batchMode, allowExistingRepo, provider, defaultRepoName, owner, in, out, errOut)
+		repoName, err = GetRepoName(batchMode, allowExistingRepo, provider, defaultRepoName, owner, handles)
 		if err != nil {
 			return nil, err
 		}
@@ -182,8 +180,8 @@ func PickNewOrExistingGitRepository(batchMode bool, authConfigSvc auth.ConfigSer
 	}, err
 }
 
-func GetRepoName(batchMode, allowExistingRepo bool, provider GitProvider, defaultRepoName, owner string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (string, error) {
-	surveyOpts := survey.WithStdio(in, out, errOut)
+func GetRepoName(batchMode, allowExistingRepo bool, provider GitProvider, defaultRepoName, owner string, handles util.IOFileHandles) (string, error) {
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	repoName := ""
 	if batchMode {
 		repoName = defaultRepoName
@@ -219,12 +217,12 @@ func GetRepoName(batchMode, allowExistingRepo bool, provider GitProvider, defaul
 	return repoName, nil
 }
 
-func GetOwner(batchMode bool, provider OrganisationLister, gitUsername string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (string, error) {
+func GetOwner(batchMode bool, provider OrganisationLister, gitUsername string, handles util.IOFileHandles) (string, error) {
 	owner := ""
 	if batchMode {
 		owner = gitUsername
 	} else {
-		org, err := PickOwner(provider, gitUsername, in, out, errOut)
+		org, err := PickOwner(provider, gitUsername, handles)
 		if err != nil {
 			return "", err
 		}
@@ -237,6 +235,6 @@ func GetOwner(batchMode bool, provider OrganisationLister, gitUsername string, i
 }
 
 func PickNewGitRepository(batchMode bool, authConfigSvc auth.ConfigService, defaultRepoName string,
-	repoOptions *GitRepositoryOptions, server *auth.AuthServer, userAuth *auth.UserAuth, git Gitter, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (*CreateRepoData, error) {
-	return PickNewOrExistingGitRepository(batchMode, authConfigSvc, defaultRepoName, repoOptions, server, userAuth, git, false, in, out, outErr)
+	repoOptions *GitRepositoryOptions, server *auth.AuthServer, userAuth *auth.UserAuth, git Gitter, handles util.IOFileHandles) (*CreateRepoData, error) {
+	return PickNewOrExistingGitRepository(batchMode, authConfigSvc, defaultRepoName, repoOptions, server, userAuth, git, false, handles)
 }

--- a/pkg/gits/operations/pull_request_op.go
+++ b/pkg/gits/operations/pull_request_op.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/secreturl"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 
@@ -529,7 +528,7 @@ func (o *PullRequestOperation) CreatePullRequestGitReleasesFn(name string) Chang
 // empty it will fetch the latest version using helmer, using the vaultClient to get the repo creds or prompting using
 // in, out and outErr
 func CreateChartChangeFilesFn(name string, version string, kind string, pro *PullRequestOperation, helmer helm.Helmer,
-	vaultClient secreturl.Client, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) ChangeFilesFn {
+	vaultClient secreturl.Client, handles util.IOFileHandles) ChangeFilesFn {
 	return func(dir string, gitInfo *gits.GitRepository) ([]string, error) {
 		if version == "" && kind == string(versionstream.KindChart) {
 			parts := strings.Split(name, "/")
@@ -547,7 +546,7 @@ func CreateChartChangeFilesFn(name string, version string, kind string, pro *Pul
 					} else if len(urls) == 0 {
 						log.Logger().Warnf("helm repo %s has more than no urls, not adding", prefix)
 					}
-					prefix, err = helm.AddHelmRepoIfMissing(urls[0], prefix, "", "", helmer, vaultClient, in, out, outErr)
+					prefix, err = helm.AddHelmRepoIfMissing(urls[0], prefix, "", "", helmer, vaultClient, handles)
 					if err != nil {
 						return nil, errors.Wrapf(err, "adding repository %s with url %s", prefix, urls[0])
 					}

--- a/pkg/gits/operations/pull_request_op_test.go
+++ b/pkg/gits/operations/pull_request_op_test.go
@@ -583,7 +583,7 @@ func TestCreateChartChangeFilesFn(t *testing.T) {
 		}, helmer)
 		vaultClient := vault_test.NewMockClient()
 		pro := operations.PullRequestOperation{}
-		fn := operations.CreateChartChangeFilesFn("acme/roadrunner", "1.0.1", "charts", &pro, helmer, vaultClient, nil, nil, nil)
+		fn := operations.CreateChartChangeFilesFn("acme/roadrunner", "1.0.1", "charts", &pro, helmer, vaultClient, util.IOFileHandles{})
 		dir, err := ioutil.TempDir("", "")
 		defer func() {
 			err := os.RemoveAll(dir)
@@ -611,7 +611,7 @@ func TestCreateChartChangeFilesFn(t *testing.T) {
 		}, helmer)
 		vaultClient := vault_test.NewMockClient()
 		pro := operations.PullRequestOperation{}
-		fn := operations.CreateChartChangeFilesFn("acme/wile", "1.0.1", "charts", &pro, helmer, vaultClient, nil, nil, nil)
+		fn := operations.CreateChartChangeFilesFn("acme/wile", "1.0.1", "charts", &pro, helmer, vaultClient, util.IOFileHandles{})
 		dir, err := ioutil.TempDir("", "")
 		defer func() {
 			err := os.RemoveAll(dir)
@@ -654,7 +654,7 @@ func TestCreateChartChangeFilesFn(t *testing.T) {
 		pegomock.When(helmer.IsRepoMissing("https://acme.com/charts")).ThenReturn(pegomock.ReturnValue(false), pegomock.ReturnValue("acme"), pegomock.ReturnValue(nil))
 		vaultClient := vault_test.NewMockClient()
 		pro := operations.PullRequestOperation{}
-		fn := operations.CreateChartChangeFilesFn("acme/wile", "", "charts", &pro, helmer, vaultClient, nil, nil, nil)
+		fn := operations.CreateChartChangeFilesFn("acme/wile", "", "charts", &pro, helmer, vaultClient, util.IOFileHandles{})
 		dir, err := ioutil.TempDir("", "")
 		defer func() {
 			err := os.RemoveAll(dir)

--- a/pkg/gits/provider_test.go
+++ b/pkg/gits/provider_test.go
@@ -801,11 +801,13 @@ func TestCreateGitProviderFromURL(t *testing.T) {
 				}
 
 				var result gits.GitProvider
+				handles := util.IOFileHandles{}
 				if console != nil {
-					result, err = gits.CreateProviderForURL(tc.inCluster, *authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, console.In, console.Out, console.Err)
-				} else {
-					result, err = gits.CreateProviderForURL(tc.inCluster, *authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, nil, nil, nil)
+					handles.In = console.In
+					handles.Out = console.Out
+					handles.Err = console.Err
 				}
+				result, err = gits.CreateProviderForURL(tc.inCluster, *authSvc, tc.providerKind, tc.hostURL, tc.git, tc.batchMode, handles)
 				if tc.wantError {
 					assert.Error(r, err, "should fail to create provider")
 					assert.Nil(r, result, "created provider should be nil")

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -91,11 +91,16 @@ func kuberHealthyRequest(kuberHealthURL string) ([]byte, error) {
 	}
 
 	if !cluster.IsInCluster() {
-		username, err := util.PickValue("Enter your admin username: ", "", true, "", os.Stdin, os.Stdout, os.Stderr)
+		handles := util.IOFileHandles{
+			Err: os.Stderr,
+			In:  os.Stdin,
+			Out: os.Stdout,
+		}
+		username, err := util.PickValue("Enter your admin username: ", "", true, "", handles)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get username")
 		}
-		pwd, err := util.PickPassword("Enter your admin password:", "", os.Stdin, os.Stdout, os.Stderr) // pragma: allowlist secret
+		pwd, err := util.PickPassword("Enter your admin password:", "", handles) // pragma: allowlist secret
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get password")
 		}

--- a/pkg/helm/helm_helpers.go
+++ b/pkg/helm/helm_helpers.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -18,7 +17,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/versionstream"
 
 	survey "gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/pborman/uuid"
 
@@ -681,8 +679,7 @@ func LoadParameters(dir string, secretURLClient secreturl.Client) (chartutil.Val
 // The repo name may have a suffix added in order to prevent name collisions, and is returned for this reason.
 // The username and password will be stored in vault for the URL (if vault is enabled).
 func AddHelmRepoIfMissing(helmURL, repoName, username, password string, helmer Helmer,
-	secretURLClient secreturl.Client, in terminal.FileReader,
-	out terminal.FileWriter, outErr io.Writer) (string, error) {
+	secretURLClient secreturl.Client, handles util.IOFileHandles) (string, error) {
 	missing, existingName, err := helmer.IsRepoMissing(helmURL)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to check if the repository with URL '%s' is missing", helmURL)
@@ -712,7 +709,7 @@ func AddHelmRepoIfMissing(helmURL, repoName, username, password string, helmer H
 			}
 		}
 		log.Logger().Infof("Adding missing Helm repo: %s %s", util.ColorInfo(repoName), util.ColorInfo(helmURL))
-		username, password, err = DecorateWithCredentials(helmURL, username, password, secretURLClient, in, out, outErr)
+		username, password, err = DecorateWithCredentials(helmURL, username, password, secretURLClient, handles)
 		if err != nil {
 			return "", errors.WithStack(err)
 		}
@@ -728,8 +725,7 @@ func AddHelmRepoIfMissing(helmURL, repoName, username, password string, helmer H
 }
 
 // DecorateWithCredentials will, if vault is installed, store or replace the username or password
-func DecorateWithCredentials(repo string, username string, password string, secretURLClient secreturl.Client, in terminal.FileReader,
-	out terminal.FileWriter, outErr io.Writer) (string,
+func DecorateWithCredentials(repo string, username string, password string, secretURLClient secreturl.Client, handles util.IOFileHandles) (string,
 	string, error) {
 	if repo != "" && secretURLClient != nil {
 		creds := HelmRepoCredentials{}
@@ -749,7 +745,7 @@ func DecorateWithCredentials(repo string, username string, password string, secr
 			cred = existingCred
 		}
 
-		err := PromptForRepoCredsIfNeeded(repo, &cred, in, out, outErr)
+		err := PromptForRepoCredsIfNeeded(repo, &cred, handles)
 		if err != nil {
 			return "", "", errors.Wrapf(err, "prompting for creds for %s", repo)
 		}
@@ -770,7 +766,7 @@ func DecorateWithCredentials(repo string, username string, password string, secr
 		Username: username,
 		Password: password,
 	}
-	err := PromptForRepoCredsIfNeeded(repo, &cred, in, out, outErr)
+	err := PromptForRepoCredsIfNeeded(repo, &cred, handles)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "prompting for creds for %s", repo)
 	}
@@ -837,16 +833,15 @@ func SetValuesToMap(setValues []string) map[string]interface{} {
 
 // PromptForRepoCredsIfNeeded will prompt for repo credentials if required. It first checks the existing cred (
 // if any) and then prompts for new credentials up to 3 times, trying each set.
-func PromptForRepoCredsIfNeeded(repo string, cred *HelmRepoCredential, in terminal.FileReader,
-	out terminal.FileWriter, outErr io.Writer) error {
-	if repo == FakeChartmusuem || in == nil || out == nil || outErr == nil {
+func PromptForRepoCredsIfNeeded(repo string, cred *HelmRepoCredential, handles util.IOFileHandles) error {
+	if repo == FakeChartmusuem || handles.In == nil || handles.Out == nil || handles.Err == nil {
 		// Avoid doing this in tests!
 		return nil
 	}
 	u := fmt.Sprintf("%s/index.yaml", strings.TrimSuffix(repo, "/"))
 
 	httpClient := &http.Client{}
-	surveyOpts := survey.WithStdio(in, out, outErr)
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	if cred.Username == "" && cred.Password == "" {
 		// Try without any auth
 		req, err := http.NewRequest("GET", u, nil)

--- a/pkg/helm/helm_helpers_test.go
+++ b/pkg/helm/helm_helpers_test.go
@@ -106,7 +106,7 @@ func TestStoreCredentials(t *testing.T) {
 	repository := "http://charts.acme.com"
 	username := uuid.New()
 	password := uuid.New()
-	username, password, err := helm.DecorateWithCredentials(repository, username, password, vaultClient, nil, nil, nil)
+	username, password, err := helm.DecorateWithCredentials(repository, username, password, vaultClient, util.IOFileHandles{})
 	assert2.NoError(t, err)
 	vaultClient.VerifyWasCalledOnce().WriteObject(helm.RepoVaultPath, helm.HelmRepoCredentials{
 		repository: helm.HelmRepoCredential{
@@ -135,8 +135,7 @@ func TestRetrieveCredentials(t *testing.T) {
 			nil,
 		}
 	})
-	retrievedUsername, retrievedPassword, err := helm.DecorateWithCredentials(repository, "", "", vaultClient, nil,
-		nil, nil)
+	retrievedUsername, retrievedPassword, err := helm.DecorateWithCredentials(repository, "", "", vaultClient, util.IOFileHandles{})
 	assert2.NoError(t, err)
 	vaultClient.VerifyWasCalledOnce().ReadObject(pegomock.EqString(helm.RepoVaultPath), pegomock.AnyInterface())
 	assert2.Equal(t, username, retrievedUsername)
@@ -165,7 +164,7 @@ func TestOverrideCredentials(t *testing.T) {
 		}
 	})
 	retrievedUsername, retrievedPassword, err := helm.DecorateWithCredentials(repository, newUsername, newPassword,
-		vaultClient, nil, nil, nil)
+		vaultClient, util.IOFileHandles{})
 	assert2.NoError(t, err)
 	assert2.Equal(t, newUsername, retrievedUsername)
 	assert2.Equal(t, newPassword, retrievedPassword)

--- a/pkg/jenkins/update_center.go
+++ b/pkg/jenkins/update_center.go
@@ -3,7 +3,6 @@ package jenkins
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"sort"
 	"strings"
@@ -12,7 +11,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -170,7 +168,7 @@ func LoadUpdateCenterData(data []byte) (*UpdateCenter, error) {
 }
 
 // PickPlugins provides the user with a list of plugins that can be added to a Jenkins App
-func (u *UpdateCenter) PickPlugins(currentValues []string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) ([]string, error) {
+func (u *UpdateCenter) PickPlugins(currentValues []string, handles util.IOFileHandles) ([]string, error) {
 	names := []string{}
 	pluginMap := map[string]string{}
 	maxLen := 1
@@ -202,7 +200,7 @@ func (u *UpdateCenter) PickPlugins(currentValues []string, in terminal.FileReade
 	sort.Strings(names)
 	help := "select the Jenkins plugins you wish to include inside your Jenkins App"
 	message := "pick Jenkins plugins to include in your Jenkins App: "
-	selection, err := util.PickNamesWithDefaults(names, defaults, message, help, in, out, outErr)
+	selection, err := util.PickNamesWithDefaults(names, defaults, message, help, handles)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jenkins/utils.go
+++ b/pkg/jenkins/utils.go
@@ -13,10 +13,9 @@ import (
 	jenkauth "github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
-func GetJenkinsClient(url string, batch bool, configService jenkauth.ConfigService, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (gojenkins.JenkinsClient, error) {
+func GetJenkinsClient(url string, batch bool, configService jenkauth.ConfigService, handles util.IOFileHandles) (gojenkins.JenkinsClient, error) {
 	if url == "" {
 		return nil, errors.New("no external Jenkins URL found in the development namespace!\nAre you sure you installed Jenkins X? Try: https://jenkins-x.io/getting-started/")
 	}
@@ -53,7 +52,7 @@ func GetJenkinsClient(url string, batch bool, configService jenkauth.ConfigServi
 			a := config.FindUserAuth(url, username)
 			if a != nil {
 				if a.IsInvalid() {
-					auth, err = EditUserAuth(url, configService, config, a, tokenUrl, batch, in, out, outErr)
+					auth, err = EditUserAuth(url, configService, config, a, tokenUrl, batch, handles)
 					if err != nil {
 						return nil, err
 					}
@@ -62,7 +61,7 @@ func GetJenkinsClient(url string, batch bool, configService jenkauth.ConfigServi
 				}
 			} else {
 				// lets create a new Auth
-				auth, err = EditUserAuth(url, configService, config, &auth, tokenUrl, batch, in, out, outErr)
+				auth, err = EditUserAuth(url, configService, config, &auth, tokenUrl, batch, handles)
 				if err != nil {
 					return nil, err
 				}
@@ -117,7 +116,7 @@ func JenkinsLoginURL(url string) string {
 	return util.UrlJoin(url, "/login")
 }
 
-func EditUserAuth(url string, configService jenkauth.ConfigService, config *jenkauth.AuthConfig, auth *jenkauth.UserAuth, tokenUrl string, batchMode bool, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (jenkauth.UserAuth, error) {
+func EditUserAuth(url string, configService jenkauth.ConfigService, config *jenkauth.AuthConfig, auth *jenkauth.UserAuth, tokenUrl string, batchMode bool, handles util.IOFileHandles) (jenkauth.UserAuth, error) {
 
 	log.Logger().Infof("\nTo be able to connect to the Jenkins server we need a username and API Token\n")
 
@@ -129,7 +128,7 @@ func EditUserAuth(url string, configService jenkauth.ConfigService, config *jenk
 
 	defaultUsername := "admin"
 
-	err := config.EditUserAuth("Jenkins", auth, defaultUsername, true, batchMode, f, in, out, outErr)
+	err := config.EditUserAuth("Jenkins", auth, defaultUsername, true, batchMode, f, handles)
 	if err != nil {
 		return *auth, err
 	}

--- a/pkg/kube/env.go
+++ b/pkg/kube/env.go
@@ -23,7 +23,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	survey "gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -38,8 +37,8 @@ type ResolveChartMuseumURLFn func() (string, error)
 // from the CLI
 func CreateEnvironmentSurvey(batchMode bool, authConfigSvc auth.ConfigService, devEnv *v1.Environment, data *v1.Environment,
 	config *v1.Environment, update bool, forkEnvGitURL string, ns string, jxClient versioned.Interface, kubeClient kubernetes.Interface, envDir string,
-	gitRepoOptions *gits.GitRepositoryOptions, helmValues config.HelmValuesConfig, prefix string, git gits.Gitter, chartMusemFn ResolveChartMuseumURLFn, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (gits.GitProvider, error) {
-	surveyOpts := survey.WithStdio(in, out, errOut)
+	gitRepoOptions *gits.GitRepositoryOptions, helmValues config.HelmValuesConfig, prefix string, git gits.Gitter, chartMusemFn ResolveChartMuseumURLFn, handles util.IOFileHandles) (gits.GitProvider, error) {
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	name := data.Name
 	createMode := name == ""
 	if createMode {
@@ -169,7 +168,7 @@ func CreateEnvironmentSurvey(batchMode bool, authConfigSvc auth.ConfigService, d
 	data.Spec.RemoteCluster = config.Spec.RemoteCluster
 	if !batchMode {
 		data.Spec.RemoteCluster = util.Confirm("Environment in separate cluster to Dev Environment:",
-			data.Spec.RemoteCluster, " Is this Environment going to be in a different cluster to the Development environment. For help on Multi Cluster support see: https://jenkins-x.io/getting-started/multi-cluster/", in, out, errOut)
+			data.Spec.RemoteCluster, " Is this Environment going to be in a different cluster to the Development environment. For help on Multi Cluster support see: https://jenkins-x.io/getting-started/multi-cluster/", handles)
 	}
 	if config.Spec.Cluster != "" {
 		data.Spec.Cluster = config.Spec.Cluster
@@ -264,15 +263,15 @@ func CreateEnvironmentSurvey(batchMode bool, authConfigSvc auth.ConfigService, d
 		}
 		log.Logger().Infof("Using %s environment git owner in batch mode.", util.ColorInfo(gitRepoOptions.Owner))
 	}
-	_, gitProvider, err := CreateEnvGitRepository(batchMode, authConfigSvc, devEnv, data, config, forkEnvGitURL, envDir, gitRepoOptions, helmValues, prefix, git, chartMusemFn, in, out, errOut)
+	_, gitProvider, err := CreateEnvGitRepository(batchMode, authConfigSvc, devEnv, data, config, forkEnvGitURL, envDir, gitRepoOptions, helmValues, prefix, git, chartMusemFn, handles)
 	return gitProvider, err
 }
 
 // CreateEnvGitRepository creates the git repository for the given Environment
-func CreateEnvGitRepository(batchMode bool, authConfigSvc auth.ConfigService, devEnv *v1.Environment, data *v1.Environment, config *v1.Environment, forkEnvGitURL string, envDir string, gitRepoOptions *gits.GitRepositoryOptions, helmValues config.HelmValuesConfig, prefix string, git gits.Gitter, chartMusemFn ResolveChartMuseumURLFn, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (*gits.GitRepository, gits.GitProvider, error) {
+func CreateEnvGitRepository(batchMode bool, authConfigSvc auth.ConfigService, devEnv *v1.Environment, data *v1.Environment, config *v1.Environment, forkEnvGitURL string, envDir string, gitRepoOptions *gits.GitRepositoryOptions, helmValues config.HelmValuesConfig, prefix string, git gits.Gitter, chartMusemFn ResolveChartMuseumURLFn, handles util.IOFileHandles) (*gits.GitRepository, gits.GitProvider, error) {
 	var gitProvider gits.GitProvider
 	var repo *gits.GitRepository
-	surveyOpts := survey.WithStdio(in, out, errOut)
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	createRepo := false
 	if config.Spec.Source.URL != "" {
 		data.Spec.Source.URL = config.Spec.Source.URL
@@ -310,7 +309,7 @@ func CreateEnvGitRepository(batchMode bool, authConfigSvc auth.ConfigService, de
 				if createRepo {
 					showURLEdit = false
 					var err error
-					repo, gitProvider, err = DoCreateEnvironmentGitRepo(batchMode, authConfigSvc, data, forkEnvGitURL, envDir, gitRepoOptions, helmValues, prefix, git, chartMusemFn, in, out, errOut)
+					repo, gitProvider, err = DoCreateEnvironmentGitRepo(batchMode, authConfigSvc, data, forkEnvGitURL, envDir, gitRepoOptions, helmValues, prefix, git, chartMusemFn, handles)
 					if err != nil {
 						return repo, gitProvider, errors.Wrap(err, "creating environment git repository")
 					}
@@ -361,9 +360,9 @@ func CreateEnvGitRepository(batchMode bool, authConfigSvc auth.ConfigService, de
 // DoCreateEnvironmentGitRepo actually creates the git repository for the environment
 func DoCreateEnvironmentGitRepo(batchMode bool, authConfigSvc auth.ConfigService, env *v1.Environment, forkEnvGitURL string,
 	environmentsDir string, gitRepoOptions *gits.GitRepositoryOptions, helmValues config.HelmValuesConfig, prefix string,
-	git gits.Gitter, chartMuseumFn ResolveChartMuseumURLFn, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (*gits.GitRepository, gits.GitProvider, error) {
+	git gits.Gitter, chartMuseumFn ResolveChartMuseumURLFn, handles util.IOFileHandles) (*gits.GitRepository, gits.GitProvider, error) {
 	defaultRepoName := fmt.Sprintf("environment-%s-%s", prefix, env.Name)
-	details, err := gits.PickNewGitRepository(batchMode, authConfigSvc, defaultRepoName, gitRepoOptions, nil, nil, git, in, out, outErr)
+	details, err := gits.PickNewGitRepository(batchMode, authConfigSvc, defaultRepoName, gitRepoOptions, nil, nil, git, handles)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "picking new git repository for environment")
 	}
@@ -393,11 +392,11 @@ func DoCreateEnvironmentGitRepo(batchMode bool, authConfigSvc auth.ConfigService
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "cloning environment from %q into %q", pushGitURL, dir)
 		}
-		err = ModifyNamespace(out, dir, env, git, chartMuseumFn)
+		err = ModifyNamespace(handles.Out, dir, env, git, chartMuseumFn)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "modifying environment namespace")
 		}
-		err = addValues(out, dir, helmValues, git)
+		err = addValues(handles.Out, dir, helmValues, git)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "adding helm values to the environment")
 		}
@@ -448,11 +447,11 @@ func DoCreateEnvironmentGitRepo(batchMode bool, authConfigSvc auth.ConfigService
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "pulling upstream of forked environment repository")
 				}
-				err = ModifyNamespace(out, dir, env, git, chartMuseumFn)
+				err = ModifyNamespace(handles.Out, dir, env, git, chartMuseumFn)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "modifying namespace of forked environment")
 				}
-				err = addValues(out, dir, helmValues, git)
+				err = addValues(handles.Out, dir, helmValues, git)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "adding helm values to the forked environment repo")
 				}
@@ -492,11 +491,11 @@ func DoCreateEnvironmentGitRepo(batchMode bool, authConfigSvc auth.ConfigService
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "updating remote %q", pushGitURL)
 			}
-			err = ModifyNamespace(out, dir, env, git, chartMuseumFn)
+			err = ModifyNamespace(handles.Out, dir, env, git, chartMuseumFn)
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "modifying dev environment namespace")
 			}
-			err = addValues(out, dir, helmValues, git)
+			err = addValues(handles.Out, dir, helmValues, git)
 			if err != nil {
 				return nil, nil, errors.Wrap(err, "adding helm values into environment git repository")
 			}
@@ -929,8 +928,8 @@ func GetTeams(kubeClient kubernetes.Interface) ([]*corev1.Namespace, []string, e
 	return answer, names, nil
 }
 
-func PickEnvironment(envNames []string, defaultEnv string, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (string, error) {
-	surveyOpts := survey.WithStdio(in, out, errOut)
+func PickEnvironment(envNames []string, defaultEnv string, handles util.IOFileHandles) (string, error) {
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	name := ""
 	if len(envNames) == 0 {
 		return "", nil

--- a/pkg/kube/env_test.go
+++ b/pkg/kube/env_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/tests"
+	"github.com/jenkins-x/jx/pkg/util"
 	v1 "k8s.io/api/core/v1"
 
 	git_mocks "github.com/jenkins-x/jx/pkg/gits/mocks"
@@ -213,6 +214,11 @@ func TestCreateEnvironmentSurvey(t *testing.T) {
 	}
 	prefix := ""
 	gitter := git_mocks.NewMockGitter()
+	handles := util.IOFileHandles{
+		Err: console.Err,
+		In:  console.In,
+		Out: console.Out,
+	}
 
 	_, err := kube.CreateEnvironmentSurvey(
 		batchMode,
@@ -231,9 +237,7 @@ func TestCreateEnvironmentSurvey(t *testing.T) {
 		prefix,
 		gitter,
 		nil,
-		console.In,
-		console.Out,
-		console.Err,
+		handles,
 	)
 	assert.NoError(t, err, "Should not error")
 

--- a/pkg/kube/vault/vault_factory.go
+++ b/pkg/kube/vault/vault_factory.go
@@ -52,6 +52,7 @@ type OptionsInterface interface {
 	GetIn() terminal.FileReader
 	GetOut() terminal.FileWriter
 	GetErr() io.Writer
+	GetIOFileHandles() util.IOFileHandles
 }
 
 // VaultClientFactory keeps the configuration required to build a new vault client factory

--- a/pkg/kube/vault/vault_selector.go
+++ b/pkg/kube/vault/vault_selector.go
@@ -3,11 +3,9 @@ package vault
 import (
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/util"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -20,9 +18,7 @@ type Selector interface {
 type vaultSelector struct {
 	vaultOperatorClient versioned.Interface
 	kubeClient          kubernetes.Interface
-	In                  terminal.FileReader
-	Out                 terminal.FileWriter
-	Err                 io.Writer
+	Handles             util.IOFileHandles
 }
 
 // NewVaultSelector creates a new vault selector
@@ -39,8 +35,8 @@ func NewVaultSelector(o OptionsInterface) (Selector, error) {
 	v := &vaultSelector{
 		vaultOperatorClient: operator,
 		kubeClient:          kubeclient,
+		Handles:             o.GetIOFileHandles(),
 	}
-	v.In, v.Out, v.Err = o.GetIn(), o.GetOut(), o.GetErr()
 	return v, nil
 }
 
@@ -78,7 +74,7 @@ func (v *vaultSelector) selectVault(vaults []*Vault) (*Vault, error) {
 		vaultNames[i] = vault.Name
 	}
 
-	vaultName, err := util.PickName(vaultNames, "Select Vault:", "", v.In, v.Out, v.Err)
+	vaultName, err := util.PickName(vaultNames, "Select Vault:", "", v.Handles)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/maven/archetype.go
+++ b/pkg/maven/archetype.go
@@ -3,7 +3,6 @@ package maven
 import (
 	"bytes"
 	"encoding/xml"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/util"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -214,8 +212,8 @@ func LoadArchetypes(name string, archetypeCatalogURL string, cacheDir string) (*
 	return &model, nil
 }
 
-func (model *ArchetypeModel) CreateSurvey(data *ArchetypeFilter, pickVersion bool, form *ArchetypeForm, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) error {
-	surveyOpts := survey.WithStdio(in, out, errOut)
+func (model *ArchetypeModel) CreateSurvey(data *ArchetypeFilter, pickVersion bool, form *ArchetypeForm, handles util.IOFileHandles) error {
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	groupIds := data.GroupIds
 	if len(data.GroupIds) == 0 {
 		filteredGroups := model.GroupIDs(data.GroupIdFilter)

--- a/pkg/quickstarts/model.go
+++ b/pkg/quickstarts/model.go
@@ -2,7 +2,6 @@ package quickstarts
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/versionstream"
 	"github.com/pkg/errors"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 const (
@@ -114,8 +112,8 @@ func (model *QuickstartModel) Add(q *Quickstart) bool {
 }
 
 // CreateSurvey creates a survey to query pick a quickstart
-func (model *QuickstartModel) CreateSurvey(filter *QuickstartFilter, batchMode bool, in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (*QuickstartForm, error) {
-	surveyOpts := survey.WithStdio(in, out, errOut)
+func (model *QuickstartModel) CreateSurvey(filter *QuickstartFilter, batchMode bool, handles util.IOFileHandles) (*QuickstartForm, error) {
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	language := filter.Language
 	if language != "" {
 		languages := model.Languages()

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/log"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/pkg/errors"
 )
@@ -26,6 +27,14 @@ const (
 	MaximumNewDirectoryAttempts = 1000
 )
 
+// IOFileHandles is a struct for holding CommonOptions' In, Out, and Err I/O handles, to simplify function calls.
+type IOFileHandles struct {
+	Err io.Writer
+	In  terminal.FileReader
+	Out terminal.FileWriter
+}
+
+// FileExists checks if path exists and is a file
 func FileExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err == nil {

--- a/pkg/util/pickers.go
+++ b/pkg/util/pickers.go
@@ -2,17 +2,15 @@ package util
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/log"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // PickValue gets an answer to a prompt from a user's free-form input
-func PickValue(message string, defaultValue string, required bool, help string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (string, error) {
+func PickValue(message string, defaultValue string, required bool, help string, handles IOFileHandles) (string, error) {
 	answer := ""
 	prompt := &survey.Input{
 		Message: message,
@@ -23,7 +21,7 @@ func PickValue(message string, defaultValue string, required bool, help string, 
 	if !required {
 		validator = nil
 	}
-	surveyOpts := survey.WithStdio(in, out, outErr)
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	err := survey.AskOne(prompt, &answer, validator, surveyOpts)
 	if err != nil {
 		return "", err
@@ -32,14 +30,14 @@ func PickValue(message string, defaultValue string, required bool, help string, 
 }
 
 // PickPassword gets a password (via hidden input) from a user's free-form input
-func PickPassword(message string, help string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (string, error) {
+func PickPassword(message string, help string, handles IOFileHandles) (string, error) {
 	answer := ""
 	prompt := &survey.Password{
 		Message: message,
 		Help:    help,
 	}
 	validator := survey.Required
-	surveyOpts := survey.WithStdio(in, out, outErr)
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	err := survey.AskOne(prompt, &answer, validator, surveyOpts)
 	if err != nil {
 		return "", err
@@ -48,7 +46,7 @@ func PickPassword(message string, help string, in terminal.FileReader, out termi
 }
 
 // PickNameWithDefault gets the user to pick an option from a list of options, with a default option specified
-func PickNameWithDefault(names []string, message string, defaultValue string, help string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (string, error) {
+func PickNameWithDefault(names []string, message string, defaultValue string, help string, handles IOFileHandles) (string, error) {
 	name := ""
 	if len(names) == 0 {
 		return "", nil
@@ -60,7 +58,7 @@ func PickNameWithDefault(names []string, message string, defaultValue string, he
 			Options: names,
 			Default: defaultValue,
 		}
-		surveyOpts := survey.WithStdio(in, out, outErr)
+		surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 		err := survey.AskOne(prompt, &name, nil, surveyOpts)
 		if err != nil {
 			return "", err
@@ -70,7 +68,7 @@ func PickNameWithDefault(names []string, message string, defaultValue string, he
 }
 
 // PickRequiredNameWithDefault gets the user to pick an option from a list of options, with a default option specified
-func PickRequiredNameWithDefault(names []string, message string, defaultValue string, help string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (string, error) {
+func PickRequiredNameWithDefault(names []string, message string, defaultValue string, help string, handles IOFileHandles) (string, error) {
 	name := ""
 	if len(names) == 0 {
 		return "", nil
@@ -83,7 +81,7 @@ func PickRequiredNameWithDefault(names []string, message string, defaultValue st
 			Default: defaultValue,
 			Help:    help,
 		}
-		surveyOpts := survey.WithStdio(in, out, outErr)
+		surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 		err := survey.AskOne(prompt, &name, survey.Required, surveyOpts)
 		if err != nil {
 			return "", err
@@ -93,17 +91,17 @@ func PickRequiredNameWithDefault(names []string, message string, defaultValue st
 }
 
 // PickName gets the user to pick an option from a list of options
-func PickName(names []string, message string, help string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) (string, error) {
-	return PickNameWithDefault(names, message, "", help, in, out, outErr)
+func PickName(names []string, message string, help string, handles IOFileHandles) (string, error) {
+	return PickNameWithDefault(names, message, "", help, handles)
 }
 
 // PickNames gets the user to pick multiple selections from a list of options
-func PickNames(names []string, message string, help string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) ([]string, error) {
-	return PickNamesWithDefaults(names, nil, message, help, in, out, outErr)
+func PickNames(names []string, message string, help string, handles IOFileHandles) ([]string, error) {
+	return PickNamesWithDefaults(names, nil, message, help, handles)
 }
 
 // PickNamesWithDefaults gets the user to pick multiple selections from a list of options with a set of default selections
-func PickNamesWithDefaults(names []string, defaults []string, message string, help string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) ([]string, error) {
+func PickNamesWithDefaults(names []string, defaults []string, message string, help string, handles IOFileHandles) ([]string, error) {
 	picked := []string{}
 	if len(names) == 0 {
 		return picked, nil
@@ -116,7 +114,7 @@ func PickNamesWithDefaults(names []string, defaults []string, message string, he
 			Default: defaults,
 			Help:    help,
 		}
-		surveyOpts := survey.WithStdio(in, out, outErr)
+		surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 		err := survey.AskOne(prompt, &picked, nil, surveyOpts)
 		if err != nil {
 			return picked, err
@@ -126,7 +124,7 @@ func PickNamesWithDefaults(names []string, defaults []string, message string, he
 }
 
 // SelectNamesWithFilter selects from a list of names with a given filter. Optionally selecting them all
-func SelectNamesWithFilter(names []string, message string, selectAll bool, filter string, help string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) ([]string, error) {
+func SelectNamesWithFilter(names []string, message string, selectAll bool, filter string, help string, handles IOFileHandles) ([]string, error) {
 	filtered := []string{}
 	for _, name := range names {
 		if filter == "" || strings.Index(name, filter) >= 0 {
@@ -136,11 +134,11 @@ func SelectNamesWithFilter(names []string, message string, selectAll bool, filte
 	if len(filtered) == 0 {
 		return nil, fmt.Errorf("No names match filter: %s", filter)
 	}
-	return SelectNames(filtered, message, selectAll, help, in, out, outErr)
+	return SelectNames(filtered, message, selectAll, help, handles)
 }
 
 // SelectNames select which names from the list should be chosen
-func SelectNames(names []string, message string, selectAll bool, help string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) ([]string, error) {
+func SelectNames(names []string, message string, selectAll bool, help string, handles IOFileHandles) ([]string, error) {
 	answer := []string{}
 	if len(names) == 0 {
 		return answer, fmt.Errorf("No names to choose from")
@@ -155,20 +153,20 @@ func SelectNames(names []string, message string, selectAll bool, help string, in
 	if selectAll {
 		prompt.Default = names
 	}
-	surveyOpts := survey.WithStdio(in, out, outErr)
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	err := survey.AskOne(prompt, &answer, nil, surveyOpts)
 	return answer, err
 }
 
 // Confirm prompts the user to confirm something
-func Confirm(message string, defaultValue bool, help string, in terminal.FileReader, out terminal.FileWriter, outErr io.Writer) bool {
+func Confirm(message string, defaultValue bool, help string, handles IOFileHandles) bool {
 	answer := defaultValue
 	prompt := &survey.Confirm{
 		Message: message,
 		Default: defaultValue,
 		Help:    help,
 	}
-	surveyOpts := survey.WithStdio(in, out, outErr)
+	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
 	survey.AskOne(prompt, &answer, nil, surveyOpts)
 	log.Blank()
 	return answer

--- a/pkg/versionstream/versionstreamrepo/gitrepo_integration_test.go
+++ b/pkg/versionstream/versionstreamrepo/gitrepo_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/jenkins-x/jx/pkg/versionstream/versionstreamrepo"
 	"github.com/stretchr/testify/assert"
 
@@ -48,9 +49,7 @@ func TestCloneJXVersionsRepoWithDefaultURL(t *testing.T) {
 		gitter,
 		true,
 		false,
-		nil,
-		nil,
-		nil,
+		util.IOFileHandles{},
 	)
 
 	// Get the latest tag so that we know the correct expected verion ref.
@@ -156,9 +155,7 @@ func TestCloneJXVersionsRepoReplacingCurrent(t *testing.T) {
 		gitter,
 		true,
 		false,
-		nil,
-		nil,
-		nil,
+		util.IOFileHandles{},
 	)
 
 	// Get the latest tag so that we know the correct expected version ref.
@@ -190,9 +187,7 @@ func TestCloneJXVersionsRepoReplacingCurrent(t *testing.T) {
 		gitter,
 		true,
 		false,
-		nil,
-		nil,
-		nil,
+		util.IOFileHandles{},
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, dir)
@@ -239,9 +234,7 @@ func TestCloneJXVersionsRepoWithTeamSettings(t *testing.T) {
 		gitter,
 		true,
 		false,
-		nil,
-		nil,
-		nil,
+		util.IOFileHandles{},
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, dir)
@@ -284,9 +277,7 @@ func TestCloneJXVersionsRepoWithATag(t *testing.T) {
 		gitter,
 		true,
 		false,
-		nil,
-		nil,
-		nil,
+		util.IOFileHandles{},
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, dir)
@@ -329,9 +320,7 @@ func TestCloneJXVersionsRepoWithABranch(t *testing.T) {
 		gitter,
 		true,
 		false,
-		nil,
-		nil,
-		nil,
+		util.IOFileHandles{},
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, dir)
@@ -377,9 +366,7 @@ func TestCloneJXVersionsRepoWithACommit(t *testing.T) {
 		gitter,
 		true,
 		false,
-		nil,
-		nil,
-		nil,
+		util.IOFileHandles{},
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, dir)
@@ -425,9 +412,7 @@ func TestCloneJXVersionsRepoWithAnUntaggedCommit(t *testing.T) {
 		gitter,
 		true,
 		false,
-		nil,
-		nil,
-		nil,
+		util.IOFileHandles{},
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, dir)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Calls to `survey.WithStdio(o.In, o.Out, o.Err)` stay the same, since that's from a dependency. I left the setting of `o.In`, `o.Out`, and `o.Err` as is - I just added `CommonOptions.GetIOFileHandles()` and switched any other uses of `o.In, o.Out, o.Err` to use `o.GetIOFileHandles()` instead.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

fixes #5901 
