### PR TITLE
feat(pipeline): Allow activity for next build number and branch as revision

### DIFF
--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -54,6 +54,7 @@ type testCase struct {
 	useKaniko             bool
 	pipelineUserName      string
 	pipelineUserEmail     string
+	branchAsRevision      bool
 }
 
 func TestGenerateTektonCRDs(t *testing.T) {
@@ -336,12 +337,13 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			kind:         "release",
 		},
 		{
-			name:         "distribute-parallel-across-nodes",
-			language:     "none",
-			repoName:     "js-test-repo",
-			organization: "abayer",
-			branch:       "really-long",
-			kind:         "release",
+			name:             "distribute-parallel-across-nodes",
+			language:         "none",
+			repoName:         "js-test-repo",
+			organization:     "abayer",
+			branch:           "really-long",
+			kind:             "release",
+			branchAsRevision: true,
 		},
 		{
 			name:                  "no_pipeline_for_kind",
@@ -422,9 +424,10 @@ func TestGenerateTektonCRDs(t *testing.T) {
 					Name:         tt.repoName,
 					Organisation: tt.organization,
 				},
-				Branch:       tt.branch,
-				PipelineKind: tt.kind,
-				NoKaniko:     !tt.useKaniko,
+				Branch:              tt.branch,
+				UseBranchAsRevision: tt.branchAsRevision,
+				PipelineKind:        tt.kind,
+				NoKaniko:            !tt.useKaniko,
 				StepOptions: step.StepOptions{
 					CommonOptions: &opts.CommonOptions{
 						ServiceAccount: "tekton-bot",

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelineresources.yml
@@ -7,7 +7,7 @@ items:
   spec:
     params:
     - name: revision
-      value: v0.0.1
+      value: really-long
     - name: url
       value: https://github.com/abayer/js-test-repo
     type: git

--- a/pkg/tekton/metapipeline/client.go
+++ b/pkg/tekton/metapipeline/client.go
@@ -30,6 +30,14 @@ type PipelineCreateParam struct {
 	// DefaultImage defines the default image used for pipeline tasks if no other image is specified.
 	// This parameter is optional and mainly used for development.
 	DefaultImage string
+
+	// UseActivityForNextBuildNumber overrides the default behavior of getting the next build number via SourceRepository,
+	// and instead determines the next build number based on existing PipelineActivitys.
+	UseActivityForNextBuildNumber bool
+
+	// UseBranchAsRevision forces step_create_task to use the branch it's passed as the revision to checkout for release
+	// pipelines, rather than use the version tag
+	UseBranchAsRevision bool
 }
 
 // Client defines the interface for meta pipeline creation and application.

--- a/pkg/tekton/metapipeline/clientfactory.go
+++ b/pkg/tekton/metapipeline/clientfactory.go
@@ -113,7 +113,7 @@ func (c *clientFactory) Create(param PipelineCreateParam) (kube.PromoteStepActiv
 	// resourceName is shared across all builds of a branch, while the pipelineName is unique for each build.
 	resourceName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String(), nil, "")
 	pipelineName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String(), c.tektonClient, c.ns)
-	buildNumber, err := tekton.GenerateNextBuildNumber(c.tektonClient, c.jxClient, c.ns, gitInfo, branchIdentifier, retryDuration, param.Context)
+	buildNumber, err := tekton.GenerateNextBuildNumber(c.tektonClient, c.jxClient, c.ns, gitInfo, branchIdentifier, retryDuration, param.Context, param.UseActivityForNextBuildNumber)
 	if err != nil {
 		return kube.PromoteStepActivityKey{}, tekton.CRDWrapper{}, errors.Wrap(err, "unable to determine next build number")
 	}
@@ -126,23 +126,24 @@ func (c *clientFactory) Create(param PipelineCreateParam) (kube.PromoteStepActiv
 	}
 
 	crdCreationParams := CRDCreationParameters{
-		Namespace:        c.ns,
-		Context:          param.Context,
-		PipelineName:     pipelineName,
-		ResourceName:     resourceName,
-		PipelineKind:     param.PipelineKind,
-		BuildNumber:      buildNumber,
-		BranchIdentifier: branchIdentifier,
-		PullRef:          param.PullRef,
-		SourceDir:        defaultCheckoutDir,
-		PodTemplates:     podTemplates,
-		ServiceAccount:   param.ServiceAccount,
-		Labels:           param.Labels,
-		EnvVars:          param.EnvVariables,
-		DefaultImage:     param.DefaultImage,
-		Apps:             extendingApps,
-		VersionsDir:      c.versionDir,
-		GitInfo:          *gitInfo,
+		Namespace:           c.ns,
+		Context:             param.Context,
+		PipelineName:        pipelineName,
+		ResourceName:        resourceName,
+		PipelineKind:        param.PipelineKind,
+		BuildNumber:         buildNumber,
+		BranchIdentifier:    branchIdentifier,
+		PullRef:             param.PullRef,
+		SourceDir:           defaultCheckoutDir,
+		PodTemplates:        podTemplates,
+		ServiceAccount:      param.ServiceAccount,
+		Labels:              param.Labels,
+		EnvVars:             param.EnvVariables,
+		DefaultImage:        param.DefaultImage,
+		Apps:                extendingApps,
+		VersionsDir:         c.versionDir,
+		GitInfo:             *gitInfo,
+		UseBranchAsRevision: param.UseBranchAsRevision,
 	}
 
 	return c.createActualCRDs(buildNumber, branchIdentifier, param.Context, param.PullRef, crdCreationParams)

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -38,23 +38,24 @@ const (
 
 // CRDCreationParameters are the parameters needed to create the Tekton CRDs
 type CRDCreationParameters struct {
-	Namespace        string
-	Context          string
-	PipelineName     string
-	ResourceName     string
-	PipelineKind     PipelineKind
-	BuildNumber      string
-	GitInfo          gits.GitRepository
-	BranchIdentifier string
-	PullRef          PullRef
-	SourceDir        string
-	PodTemplates     map[string]*corev1.Pod
-	ServiceAccount   string
-	Labels           map[string]string
-	EnvVars          map[string]string
-	DefaultImage     string
-	Apps             []jenkinsv1.App
-	VersionsDir      string
+	Namespace           string
+	Context             string
+	PipelineName        string
+	ResourceName        string
+	PipelineKind        PipelineKind
+	BuildNumber         string
+	GitInfo             gits.GitRepository
+	BranchIdentifier    string
+	PullRef             PullRef
+	SourceDir           string
+	PodTemplates        map[string]*corev1.Pod
+	ServiceAccount      string
+	Labels              map[string]string
+	EnvVars             map[string]string
+	DefaultImage        string
+	Apps                []jenkinsv1.App
+	VersionsDir         string
+	UseBranchAsRevision bool
 }
 
 // createMetaPipelineCRDs creates the Tekton CRDs needed to execute the meta pipeline.
@@ -241,7 +242,9 @@ func stepCreateTektonCRDs(params CRDCreationParameters) syntax.Step {
 	if params.Context != "" {
 		args = append(args, "--context", params.Context)
 	}
-
+	if params.UseBranchAsRevision {
+		args = append(args, "--branch-as-revision")
+	}
 	for k, v := range params.Labels {
 		args = append(args, "--label", fmt.Sprintf("%s=%s", k, v))
 	}

--- a/pkg/tekton/test_data/next_build_number/no_activities/activities.yml
+++ b/pkg/tekton/test_data/next_build_number/no_activities/activities.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+items: []
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""
+

--- a/pkg/tekton/test_data/next_build_number/unparseable_build_number/activities.yml
+++ b/pkg/tekton/test_data/next_build_number/unparseable_build_number/activities.yml
@@ -1,0 +1,131 @@
+apiVersion: v1
+items:
+  - apiVersion: jenkins.io/v1
+    kind: PipelineActivity
+    metadata:
+      creationTimestamp: "2019-10-23T07:44:15Z"
+      generation: 25
+      labels:
+        branch: master
+        build: "308thisisnotvalid"
+        context: release
+        owner: jenkins-x
+        provider: github
+        repository: jx
+      name: jenkins-x-jx-master-308
+      namespace: jx
+      resourceVersion: "37492250"
+      selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/jenkins-x-jx-master-308
+      uid: e9b98219-f568-11e9-9480-42010a840121
+    spec:
+      author: abayer
+      batchPipelineActivity: {}
+      build: "308thisisnotvalid"
+      buildLogsUrl: gs://jx-prod-logs/jenkins-x/logs/jenkins-x/jx/master/308.log
+      completedTimestamp: "2019-10-23T08:33:36Z"
+      context: release
+      gitBranch: master
+      gitOwner: jenkins-x
+      gitRepository: jx
+      gitUrl: https://github.com/jenkins-x/jx.git
+      lastCommitMessage: |-
+        chore: Switch calls passing "o.In, o.Out, o.Err" to using a struct instead
+
+        fixes #5901
+
+        Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>
+      lastCommitSHA: 6b5d29ba137b03a16693f8f1059c4f2da4278015
+      pipeline: jenkins-x/jx/master
+      startedTimestamp: "2019-10-23T07:44:17Z"
+      status: Succeeded
+      steps: []
+      version: 2.0.902
+    status: {}
+  - apiVersion: jenkins.io/v1
+    kind: PipelineActivity
+    metadata:
+      creationTimestamp: "2019-10-23T00:30:18Z"
+      generation: 23
+      labels:
+        branch: master
+        build: "307"
+        context: release
+        owner: jenkins-x
+        provider: github
+        repository: jx
+      name: jenkins-x-jx-master-307
+      namespace: jx
+      resourceVersion: "37327384"
+      selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/jenkins-x-jx-master-307
+      uid: 49fc8f9f-f52c-11e9-9480-42010a840121
+    spec:
+      author: rawlingsj
+      batchPipelineActivity: {}
+      build: "307"
+      buildLogsUrl: gs://jx-prod-logs/jenkins-x/logs/jenkins-x/jx/master/307.log
+      completedTimestamp: "2019-10-23T01:20:56Z"
+      context: release
+      gitBranch: master
+      gitOwner: jenkins-x
+      gitRepository: jx
+      gitUrl: https://github.com/jenkins-x/jx.git
+      lastCommitMessage: |-
+        feat: lets add a specific wait-for-chart step so that pipelines can wait until a helm index has been updated to contain the newly released chart
+
+        Signed-off-by: James Rawlings <rawlingsj80@gmail.com>
+      lastCommitSHA: 7ae01e5e215861023bbd64d2d523c3e72903a512
+      pipeline: jenkins-x/jx/master
+      startedTimestamp: "2019-10-23T00:30:19Z"
+      status: Succeeded
+      steps: []
+      version: 2.0.901
+    status: {}
+  - apiVersion: jenkins.io/v1
+    kind: PipelineActivity
+    metadata:
+      creationTimestamp: "2019-10-22T20:05:33Z"
+      generation: 28
+      labels:
+        branch: master
+        build: "306"
+        context: release
+        owner: jenkins-x
+        provider: github
+        repository: jx
+      name: jenkins-x-jx-master-306
+      namespace: jx
+      resourceVersion: "37217195"
+      selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/jenkins-x-jx-master-306
+      uid: 4e2a72e6-f507-11e9-9480-42010a840121
+    spec:
+      author: abayer
+      batchPipelineActivity: {}
+      build: "306"
+      buildLogsUrl: gs://jx-prod-logs/jenkins-x/logs/jenkins-x/jx/master/306.log
+      completedTimestamp: "2019-10-22T20:53:58Z"
+      context: release
+      gitBranch: master
+      gitOwner: jenkins-x
+      gitRepository: jx
+      gitUrl: https://github.com/jenkins-x/jx.git
+      lastCommitMessage: |-
+        fix(pipeline): Use standard version stream cloning logic in metapipeline
+
+        Now that the standard version stream cloning logic has merged, let's
+        use that in metapipeline rather than its own logic.
+
+        fixes #5075
+
+        Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>
+      lastCommitSHA: 67f0a3f82559731cb4369fa5b5aec1246c74e684
+      pipeline: jenkins-x/jx/master
+      startedTimestamp: "2019-10-22T20:05:35Z"
+      status: Succeeded
+      steps: []
+      version: 2.0.900
+    status: {}
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""
+

--- a/pkg/tekton/test_data/next_build_number/valid/activities.yml
+++ b/pkg/tekton/test_data/next_build_number/valid/activities.yml
@@ -1,0 +1,131 @@
+apiVersion: v1
+items:
+  - apiVersion: jenkins.io/v1
+    kind: PipelineActivity
+    metadata:
+      creationTimestamp: "2019-10-23T07:44:15Z"
+      generation: 25
+      labels:
+        branch: master
+        build: "308"
+        context: release
+        owner: jenkins-x
+        provider: github
+        repository: jx
+      name: jenkins-x-jx-master-308
+      namespace: jx
+      resourceVersion: "37492250"
+      selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/jenkins-x-jx-master-308
+      uid: e9b98219-f568-11e9-9480-42010a840121
+    spec:
+      author: abayer
+      batchPipelineActivity: {}
+      build: "308"
+      buildLogsUrl: gs://jx-prod-logs/jenkins-x/logs/jenkins-x/jx/master/308.log
+      completedTimestamp: "2019-10-23T08:33:36Z"
+      context: release
+      gitBranch: master
+      gitOwner: jenkins-x
+      gitRepository: jx
+      gitUrl: https://github.com/jenkins-x/jx.git
+      lastCommitMessage: |-
+        chore: Switch calls passing "o.In, o.Out, o.Err" to using a struct instead
+
+        fixes #5901
+
+        Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>
+      lastCommitSHA: 6b5d29ba137b03a16693f8f1059c4f2da4278015
+      pipeline: jenkins-x/jx/master
+      startedTimestamp: "2019-10-23T07:44:17Z"
+      status: Succeeded
+      steps: []
+      version: 2.0.902
+    status: {}
+  - apiVersion: jenkins.io/v1
+    kind: PipelineActivity
+    metadata:
+      creationTimestamp: "2019-10-23T00:30:18Z"
+      generation: 23
+      labels:
+        branch: master
+        build: "307"
+        context: release
+        owner: jenkins-x
+        provider: github
+        repository: jx
+      name: jenkins-x-jx-master-307
+      namespace: jx
+      resourceVersion: "37327384"
+      selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/jenkins-x-jx-master-307
+      uid: 49fc8f9f-f52c-11e9-9480-42010a840121
+    spec:
+      author: rawlingsj
+      batchPipelineActivity: {}
+      build: "307"
+      buildLogsUrl: gs://jx-prod-logs/jenkins-x/logs/jenkins-x/jx/master/307.log
+      completedTimestamp: "2019-10-23T01:20:56Z"
+      context: release
+      gitBranch: master
+      gitOwner: jenkins-x
+      gitRepository: jx
+      gitUrl: https://github.com/jenkins-x/jx.git
+      lastCommitMessage: |-
+        feat: lets add a specific wait-for-chart step so that pipelines can wait until a helm index has been updated to contain the newly released chart
+
+        Signed-off-by: James Rawlings <rawlingsj80@gmail.com>
+      lastCommitSHA: 7ae01e5e215861023bbd64d2d523c3e72903a512
+      pipeline: jenkins-x/jx/master
+      startedTimestamp: "2019-10-23T00:30:19Z"
+      status: Succeeded
+      steps: []
+      version: 2.0.901
+    status: {}
+  - apiVersion: jenkins.io/v1
+    kind: PipelineActivity
+    metadata:
+      creationTimestamp: "2019-10-22T20:05:33Z"
+      generation: 28
+      labels:
+        branch: master
+        build: "306"
+        context: release
+        owner: jenkins-x
+        provider: github
+        repository: jx
+      name: jenkins-x-jx-master-306
+      namespace: jx
+      resourceVersion: "37217195"
+      selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/jenkins-x-jx-master-306
+      uid: 4e2a72e6-f507-11e9-9480-42010a840121
+    spec:
+      author: abayer
+      batchPipelineActivity: {}
+      build: "306"
+      buildLogsUrl: gs://jx-prod-logs/jenkins-x/logs/jenkins-x/jx/master/306.log
+      completedTimestamp: "2019-10-22T20:53:58Z"
+      context: release
+      gitBranch: master
+      gitOwner: jenkins-x
+      gitRepository: jx
+      gitUrl: https://github.com/jenkins-x/jx.git
+      lastCommitMessage: |-
+        fix(pipeline): Use standard version stream cloning logic in metapipeline
+
+        Now that the standard version stream cloning logic has merged, let's
+        use that in metapipeline rather than its own logic.
+
+        fixes #5075
+
+        Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>
+      lastCommitSHA: 67f0a3f82559731cb4369fa5b5aec1246c74e684
+      pipeline: jenkins-x/jx/master
+      startedTimestamp: "2019-10-22T20:05:35Z"
+      status: Succeeded
+      steps: []
+      version: 2.0.900
+    status: {}
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""
+


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

With the new `UseActivityForNextBuildNumber` and `UseBranchAsRevision` boolean parameters for `PipelineCreateParam`, you can force the metapipeline to:

* Determine the next build number by looking at the build numbers on `PipelineActivity`s for this org/repo/branch combination, rather than using (and if need be creating) the `SourceRepository`.
* Pass the new `--branch-as-revision` flag to `jx step create task`, which will override the default behavior of using the new version tag to checkout for release pipelines, instead just using the given branch.

#### Special notes for the reviewer(s)

/assign @hferentschik 
/assign @pmuir 
/assign @rawlingsj 

#### Which issue this PR fixes

fixes #5909
