### PR TITLE
fix: BDD test reports don't stash after using a test cluster

### DIFF
--- a/jenkins-x-bdd.yml
+++ b/jenkins-x-bdd.yml
@@ -152,6 +152,10 @@ pipelineConfig:
                   - --suite-name
                   - "Static_BDD_Tests"
 
+              - name: clear-kubeconfig
+                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                command: rm ~/.kube/config
+
               - name: stash-html-report
                 image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
                 command: jx

--- a/jenkins-x-boot-vault.yml
+++ b/jenkins-x-boot-vault.yml
@@ -138,17 +138,9 @@ pipelineConfig:
                   - --suite-name
                   - "BDD_Boot_Vault_Tests"
 
-              - name: stash_xml_report
+              - name: clear-kubeconfig
                 image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
-                command: jx
-                args:
-                  - step
-                  - stash
-                  - -c
-                  - e2e-tests
-                  - -p
-                  - "/workspace/source/build/reports/create_spring_application.junit.xml"
-                  - --bucket-url gs://jx-prod-logs
+                command: rm ~/.kube/config
 
               - name: stash_html_report
                 image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -139,6 +139,10 @@ pipelineConfig:
                   - --suite-name
                   - "BDD_Tekton_Tests"
 
+              - name: clear-kubeconfig
+                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                command: rm ~/.kube/config
+
               - name: stash-xml-report
                 image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
                 command: jx

--- a/pkg/builds/build_info.go
+++ b/pkg/builds/build_info.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -103,7 +104,7 @@ func CreateBuildPodInfo(pod *corev1.Pod) *BuildPodInfo {
 			if v.Name == "PULL_BASE_SHA" {
 				pullBaseSha = v.Value
 			}
-			if v.Name == "BRANCH_NAME" {
+			if v.Name == util.EnvVarBranchName {
 				branch = v.Value
 			}
 			if v.Name == "REPO_OWNER" {

--- a/pkg/builds/build_number.go
+++ b/pkg/builds/build_number.go
@@ -64,7 +64,7 @@ func getDownwardAPILabelsMap() map[string]string {
 
 // GetBranchName returns the branch name using environment variables and/or pod Downward API
 func GetBranchName() string {
-	branch := os.Getenv("BRANCH_NAME")
+	branch := os.Getenv(util.EnvVarBranchName)
 	if branch == "" {
 		m := getDownwardAPILabelsMap()
 		if m != nil {

--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -842,7 +842,7 @@ func (o *PreviewOptions) DefaultValues(ns string, warnMissingName bool) error {
 	}
 
 	if o.PullRequest == "" {
-		o.PullRequest = os.Getenv("BRANCH_NAME")
+		o.PullRequest = os.Getenv(util.EnvVarBranchName)
 	}
 
 	o.PullRequestName = strings.TrimPrefix(o.PullRequest, "PR-")

--- a/pkg/cmd/start/start_pipeline.go
+++ b/pkg/cmd/start/start_pipeline.go
@@ -32,7 +32,6 @@ import (
 const (
 	repoOwnerEnv      = "REPO_OWNER"
 	repoNameEnv       = "REPO_NAME"
-	jmbrBranchName    = "BRANCH_NAME"
 	jmbrSourceURL     = "SOURCE_URL"
 	releaseBranchName = "master"
 )
@@ -312,7 +311,7 @@ func (o *StartPipelineOptions) createProwJob(jobname string) error {
 		env := map[string]string{}
 
 		// enrich with jenkins multi branch plugin env vars
-		env[jmbrBranchName] = branch
+		env[util.EnvVarBranchName] = branch
 		env[jmbrSourceURL] = jobSpec.BuildSpec.Source.Git.Url
 		env[repoOwnerEnv] = org
 		env[repoNameEnv] = repo

--- a/pkg/cmd/step/bdd/step_bdd.go
+++ b/pkg/cmd/step/bdd/step_bdd.go
@@ -374,7 +374,7 @@ func (o *StepBDDOptions) gitProviderUrl() string {
 // teamNameSuffix returns a team name suffix using the current branch +
 func (o *StepBDDOptions) teamNameSuffix() string {
 	repo := os.Getenv("REPO_NAME")
-	branch := os.Getenv("BRANCH_NAME")
+	branch := os.Getenv(util.EnvVarBranchName)
 	buildNumber := builds.GetBuildNumber()
 	if buildNumber == "" {
 		buildNumber = "1"

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -966,9 +966,9 @@ func (o *StepCreateTaskOptions) modifyEnvVars(container *corev1.Container, globa
 		}
 	}
 	if branch != "" {
-		if kube.GetSliceEnvVar(envVars, "BRANCH_NAME") == nil {
+		if kube.GetSliceEnvVar(envVars, util.EnvVarBranchName) == nil {
 			envVars = append(envVars, corev1.EnvVar{
-				Name:  "BRANCH_NAME",
+				Name:  util.EnvVarBranchName,
 				Value: branch,
 			})
 		}

--- a/pkg/cmd/step/pr/step_pr_labels.go
+++ b/pkg/cmd/step/pr/step_pr_labels.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/util"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -84,7 +85,7 @@ func (o *StepPRLabelsOptions) Run() error {
 	}
 
 	if o.PullRequest == "" {
-		o.PullRequest = strings.TrimPrefix(os.Getenv("BRANCH_NAME"), "PR-")
+		o.PullRequest = strings.TrimPrefix(os.Getenv(util.EnvVarBranchName), "PR-")
 	}
 
 	if o.Prefix == "" {

--- a/pkg/cmd/step/step_stash_integration_test.go
+++ b/pkg/cmd/step/step_stash_integration_test.go
@@ -4,12 +4,14 @@ package step_test
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
 	step2 "github.com/jenkins-x/jx/pkg/cmd/opts/step"
 	"github.com/jenkins-x/jx/pkg/cmd/step"
 	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
+	"github.com/jenkins-x/jx/pkg/util"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -55,6 +57,78 @@ func TestStepStash(t *testing.T) {
 	assert.NoError(t, err)
 
 	generatedFile := filepath.Join(tempDir, o.ToPath, testData)
+	assert.FileExists(t, generatedFile)
+
+	tests.AssertTextFileContentsEqual(t, testData, generatedFile)
+}
+
+func TestStepStashBranchNameFromEnv(t *testing.T) {
+	originalJxHome, tempJxHome, err := testhelpers.CreateTestJxHomeDir()
+	assert.NoError(t, err)
+	defer func() {
+		err := testhelpers.CleanupTestJxHomeDir(originalJxHome, tempJxHome)
+		assert.NoError(t, err)
+	}()
+	originalKubeCfg, tempKubeCfg, err := testhelpers.CreateTestKubeConfigDir()
+	assert.NoError(t, err)
+	defer func() {
+		err := testhelpers.CleanupTestKubeConfigDir(originalKubeCfg, tempKubeCfg)
+		assert.NoError(t, err)
+	}()
+
+	origBranchName := os.Getenv(util.EnvVarBranchName)
+	_ = os.Setenv(util.EnvVarBranchName, "master")
+	origBuildID := os.Getenv("BUILD_ID")
+	_ = os.Unsetenv("BUILD_ID")
+	origJxBuildNum := os.Getenv("JX_BUILD_NUMBER")
+	_ = os.Unsetenv("JX_BUILD_NUMBER")
+	origBuildNum := os.Getenv("BUILD_NUMBER")
+	_ = os.Setenv("BUILD_NUMBER", "4")
+	defer func() {
+		if origBranchName != "" {
+			_ = os.Setenv(util.EnvVarBranchName, origBranchName)
+		} else {
+			_ = os.Unsetenv(util.EnvVarBranchName)
+		}
+		if origBuildID != "" {
+			_ = os.Setenv("BUILD_ID", origBuildID)
+		} else {
+			_ = os.Unsetenv("BUILD_ID")
+		}
+		if origBuildNum != "" {
+			_ = os.Setenv("BUILD_NUMBER", origBuildNum)
+		} else {
+			_ = os.Unsetenv("BUILD_NUMBER")
+		}
+		if origJxBuildNum != "" {
+			_ = os.Setenv("JX_BUILD_NUMBER", origJxBuildNum)
+		} else {
+			_ = os.Unsetenv("JX_BUILD_NUMBER")
+		}
+	}()
+
+	tempDir, err := ioutil.TempDir("", "test-step-collect")
+	assert.NoError(t, err)
+
+	testData := "test_data/step_collect/junit.xml"
+
+	o := &step.StepStashOptions{
+		StepOptions: step2.StepOptions{
+			CommonOptions: &opts.CommonOptions{},
+		},
+	}
+	o.StorageLocation.Classifier = "tests"
+	o.StorageLocation.BucketURL = "file://" + tempDir
+	o.StorageLocation.GitBranch = "gh-pages"
+	o.Pattern = []string{testData}
+	o.ProjectGitURL = "https://github.com/jenkins-x/dummy-repo.git"
+	testhelpers.ConfigureTestOptions(o.CommonOptions, &gits.GitFake{}, helm_test.NewMockHelmer())
+
+	err = o.Run()
+	assert.NoError(t, err)
+
+	outputPath := filepath.Join("jenkins-x", o.StorageLocation.Classifier, "jenkins-x", "dummy-repo", "master", "4")
+	generatedFile := filepath.Join(tempDir, outputPath, testData)
 	assert.FileExists(t, generatedFile)
 
 	tests.AssertTextFileContentsEqual(t, testData, generatedFile)

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -335,7 +335,7 @@ func buildEnvParams(params CRDCreationParameters) []corev1.EnvVar {
 	branch := params.BranchIdentifier
 	if branch != "" {
 		envVars = append(envVars, corev1.EnvVar{
-			Name:  "BRANCH_NAME",
+			Name:  util.EnvVarBranchName,
 			Value: branch,
 		})
 	}

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/tekton/syntax"
+	"github.com/jenkins-x/jx/pkg/util"
 	knativeapis "github.com/knative/pkg/apis"
 	"github.com/pkg/errors"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -209,7 +210,7 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 			if v.Name == "PULL_BASE_SHA" {
 				pullBaseSha = v.Value
 			}
-			if v.Name == "BRANCH_NAME" {
+			if v.Name == util.EnvVarBranchName {
 				branch = v.Value
 			}
 			if v.Name == "REPO_OWNER" {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -21,4 +21,7 @@ const (
 
 	// DefaultGitUserEmail default value to use for git "user.email"
 	DefaultGitUserEmail = "jenkins-x@googlegroups.com"
+
+	// EnvVarBranchName is the environment variable that will hold the name of the branch being built during pipelines
+	EnvVarBranchName = "BRANCH_NAME"
 )


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

So let's delete `~/.kube/config`, which just contains the test cluster in it, before we stash anything.

#### Special notes for the reviewer(s)

/assign @dgozalo 

#### Which issue this PR fixes

n/a