### PR TITLE
fix: add a deprecation warning to `jx install`/`jx upgrade platform`

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -43,7 +43,7 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	randomdata "github.com/Pallinder/go-randomdata"
+	"github.com/Pallinder/go-randomdata"
 	"github.com/jenkins-x/jx/pkg/io/secrets"
 	kubevault "github.com/jenkins-x/jx/pkg/kube/vault"
 	"github.com/jenkins-x/jx/pkg/vault"
@@ -68,8 +68,8 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	survey "gopkg.in/AlecAivazis/survey.v1"
-	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/src-d/go-git.v4"
 	core_v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -552,6 +552,7 @@ func (options *InstallOptions) CheckFeatures() error {
 
 // Run implements this command
 func (options *InstallOptions) Run() error {
+	opts.LogInstallDeprecated()
 
 	err := options.GetConfiguration(&options)
 	if err != nil {

--- a/pkg/cmd/opts/constants.go
+++ b/pkg/cmd/opts/constants.go
@@ -19,4 +19,6 @@ work
 	DefaultIngressNamesapce = "kube-system"
 	// DefaultIngressServiceName default name for ingress controller service and deployment
 	DefaultIngressServiceName = "jxing-nginx-ingress-controller"
+
+	// DeprecatedWarning warning for old commands that pre-date boot
 )

--- a/pkg/cmd/opts/deprecations.go
+++ b/pkg/cmd/opts/deprecations.go
@@ -1,0 +1,14 @@
+package opts
+
+import (
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+)
+
+// LogInstallDeprecated logs a warning message about deprecation
+func LogInstallDeprecated() {
+	log.Logger().Warn("this command is now deprecated.")
+	log.Logger().Warnf("We now highly recommend you use %s instead:", util.ColorInfo("jx boot"))
+	log.Logger().Warnf("for more information see: %s\n\n", util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/"))
+
+}

--- a/pkg/cmd/opts/upgrade/upgrade_ingress.go
+++ b/pkg/cmd/opts/upgrade/upgrade_ingress.go
@@ -18,7 +18,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
-	survey "gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,6 +50,8 @@ type UpgradeIngressOptions struct {
 
 // Run implements the command
 func (o *UpgradeIngressOptions) Run() error {
+	opts.LogInstallDeprecated()
+
 	client, devNamespace, err := o.KubeClientAndDevNamespace()
 	if err != nil {
 		return fmt.Errorf("cannot connect to Kubernetes cluster: %v", err)

--- a/pkg/cmd/upgrade/upgrade_platform.go
+++ b/pkg/cmd/upgrade/upgrade_platform.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/config"
 	configio "github.com/jenkins-x/jx/pkg/io"
 	"github.com/jenkins-x/jx/pkg/platform"
-	survey "gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1"
 	"sigs.k8s.io/yaml"
 
 	"io/ioutil"
@@ -94,6 +94,8 @@ func NewCmdUpgradePlatform(commonOpts *opts.CommonOptions) *cobra.Command {
 
 // Run implements the command
 func (o *UpgradePlatformOptions) Run() error {
+	opts.LogInstallDeprecated()
+
 	surveyOpts := survey.WithStdio(o.In, o.Out, o.Err)
 
 	configStore := configio.NewFileStore()


### PR DESCRIPTION
to give folks a hint they should switch to `jx boot`

Signed-off-by: James Strachan <james.strachan@gmail.com>