### PR TITLE
fix: Don't patch unnecessarily

### DIFF
--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/app_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/app_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *apps) PatchUpdate(app *v1.App) (*v1.App, error) {
 	patch, err := util.CreatePatch(orig, app)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patchedApp, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/buildpack_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/buildpack_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *buildPacks) PatchUpdate(buildPack *v1.BuildPack) (*v1.BuildPack, error)
 	patch, err := util.CreatePatch(orig, buildPack)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/buildpack_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/buildpack_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdateBuildPackWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := buildPacks.PatchUpdate(testBuildPack)
+	updated, err := buildPacks.PatchUpdate(clonedBuildPack)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testBuildPack, updated)
 	assert.Equal(t, url, updated.Spec.GitURL)
@@ -118,8 +118,10 @@ func TestPatchUpdateBuildPackWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := buildPacks.PatchUpdate(testBuildPack)
+	url := "git@github.com:jenkins-x/jx.git"
+	clonedBuildPack := testBuildPack.DeepCopy()
+	clonedBuildPack.Spec.GitURL = url
+	updated, err := buildPacks.PatchUpdate(clonedBuildPack)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/commitstatus_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/commitstatus_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *commitStatuses) PatchUpdate(commitStatus *v1.CommitStatus) (*v1.CommitS
 	patch, err := util.CreatePatch(orig, commitStatus)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/commitstatus_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/commitstatus_expansion_test.go
@@ -77,7 +77,7 @@ func TestPatchUpdateCommitStatusWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := commitStatuses.PatchUpdate(testCommitStatus)
+	updated, err := commitStatuses.PatchUpdate(clonedCommitStatus)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testCommitStatus, updated)
 	assert.Equal(t, context, updated.Spec.Items[0].Context)
@@ -122,8 +122,14 @@ func TestPatchUpdateCommitStatusWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := commitStatuses.PatchUpdate(testCommitStatus)
+	context := "foo"
+	clonedCommitStatus := testCommitStatus.DeepCopy()
+	clonedCommitStatus.Spec.Items = []v1.CommitStatusDetails{
+		{
+			Context: context,
+		},
+	}
+	updated, err := commitStatuses.PatchUpdate(clonedCommitStatus)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/environment_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/environment_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *environments) PatchUpdate(environment *v1.Environment) (*v1.Environment
 	patch, err := util.CreatePatch(orig, environment)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/environment_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/environment_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdateEnvironmentWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := environments.PatchUpdate(testEnvironment)
+	updated, err := environments.PatchUpdate(clonedEnvironment)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testEnvironment, updated)
 	assert.Equal(t, namespace, updated.Spec.Namespace)
@@ -118,8 +118,10 @@ func TestPatchUpdateEnvironmentWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := environments.PatchUpdate(testEnvironment)
+	namespace := "jx"
+	clonedEnvironment := testEnvironment.DeepCopy()
+	clonedEnvironment.Spec.Namespace = namespace
+	updated, err := environments.PatchUpdate(clonedEnvironment)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/environmentrolebinding_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/environmentrolebinding_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *environmentRoleBindings) PatchUpdate(environmentRoleBinding *v1.Environ
 	patch, err := util.CreatePatch(orig, environmentRoleBinding)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/environmentrolebinding_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/environmentrolebinding_expansion_test.go
@@ -78,7 +78,7 @@ func TestPatchUpdateEnvironmentRoleBindingWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := environmentRoleBindings.PatchUpdate(testEnvironmentRoleBinding)
+	updated, err := environmentRoleBindings.PatchUpdate(clonedEnvironmentRoleBinding)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testEnvironmentRoleBinding, updated)
 	assert.Equal(t, subject, updated.Spec.Subjects[0].Name)
@@ -123,8 +123,14 @@ func TestPatchUpdateEnvironmentRoleBindingWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := environmentRoleBindings.PatchUpdate(testEnvironmentRoleBinding)
+	subject := "snafu"
+	clonedEnvironmentRoleBinding := testEnvironmentRoleBinding.DeepCopy()
+	clonedEnvironmentRoleBinding.Spec.Subjects = []rbacv1.Subject{
+		{
+			Name: subject,
+		},
+	}
+	updated, err := environmentRoleBindings.PatchUpdate(clonedEnvironmentRoleBinding)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/extension_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/extension_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *extensions) PatchUpdate(extension *v1.Extension) (*v1.Extension, error)
 	patch, err := util.CreatePatch(orig, extension)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/extension_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/extension_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdateExtensionWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := extensions.PatchUpdate(testExtension)
+	updated, err := extensions.PatchUpdate(clonedExtension)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testExtension, updated)
 	assert.Equal(t, name, updated.Spec.Name)
@@ -118,8 +118,10 @@ func TestPatchUpdateExtensionWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := extensions.PatchUpdate(testExtension)
+	name := "fubu"
+	clonedExtension := testExtension.DeepCopy()
+	clonedExtension.Spec.Name = name
+	updated, err := extensions.PatchUpdate(clonedExtension)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/fact_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/fact_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *facts) PatchUpdate(fact *v1.Fact) (*v1.Fact, error) {
 	patch, err := util.CreatePatch(orig, fact)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/fact_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/fact_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdateFactWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := facts.PatchUpdate(testFact)
+	updated, err := facts.PatchUpdate(clonedFact)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testFact, updated)
 	assert.Equal(t, name, updated.Spec.Name)
@@ -118,8 +118,10 @@ func TestPatchUpdateFactWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := facts.PatchUpdate(testFact)
+	name := "susfu"
+	clonedFact := testFact.DeepCopy()
+	clonedFact.Spec.Name = name
+	updated, err := facts.PatchUpdate(clonedFact)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/gitservice_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/gitservice_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *gitServices) PatchUpdate(gitService *v1.GitService) (*v1.GitService, er
 	patch, err := util.CreatePatch(orig, gitService)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/gitservice_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/gitservice_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdateGitServiceWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := gitServices.PatchUpdate(testGitService)
+	updated, err := gitServices.PatchUpdate(clonedGitService)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testGitService, updated)
 	assert.Equal(t, name, updated.Spec.Name)
@@ -118,8 +118,10 @@ func TestPatchUpdateGitServiceWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := gitServices.PatchUpdate(testGitService)
+	name := "susfu"
+	clonedGitService := testGitService.DeepCopy()
+	clonedGitService.Spec.Name = name
+	updated, err := gitServices.PatchUpdate(clonedGitService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelineactivity_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelineactivity_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *pipelineActivities) PatchUpdate(pipelineActivity *v1.PipelineActivity) 
 	patch, err := util.CreatePatch(orig, pipelineActivity)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelineactivity_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelineactivity_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdatePipelineActivityWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := pipelineActivities.PatchUpdate(testPipelineActivity)
+	updated, err := pipelineActivities.PatchUpdate(clonedPipelineActivity)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testPipelineActivity, updated)
 	assert.Equal(t, name, updated.Spec.Pipeline)
@@ -118,8 +118,10 @@ func TestPatchUpdatePipelineActivityWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := pipelineActivities.PatchUpdate(testPipelineActivity)
+	name := "test"
+	clonedPipelineActivity := testPipelineActivity.DeepCopy()
+	clonedPipelineActivity.Spec.Pipeline = name
+	updated, err := pipelineActivities.PatchUpdate(clonedPipelineActivity)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelinestructure_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelinestructure_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *pipelineStructures) PatchUpdate(pipelineStructure *v1.PipelineStructure
 	patch, err := util.CreatePatch(orig, pipelineStructure)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelinestructure_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/pipelinestructure_expansion_test.go
@@ -72,7 +72,7 @@ func TestPatchUpdatePipelineStructureWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := pipelineStructures.PatchUpdate(testPipelineStructure)
+	updated, err := pipelineStructures.PatchUpdate(clonedPipelineStructure)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testPipelineStructure, updated)
 	assert.Equal(t, &ref, updated.PipelineRef)
@@ -117,8 +117,10 @@ func TestPatchUpdatePipelineStructureWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := pipelineStructures.PatchUpdate(testPipelineStructure)
+	ref := "susfu"
+	clonedPipelineStructure := testPipelineStructure.DeepCopy()
+	clonedPipelineStructure.PipelineRef = &ref
+	updated, err := pipelineStructures.PatchUpdate(clonedPipelineStructure)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/plugin_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/plugin_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *plugins) PatchUpdate(plugin *v1.Plugin) (*v1.Plugin, error) {
 	patch, err := util.CreatePatch(orig, plugin)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/plugin_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/plugin_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdatePluginWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := plugins.PatchUpdate(testPlugin)
+	updated, err := plugins.PatchUpdate(clonedPlugin)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testPlugin, updated)
 	assert.Equal(t, name, updated.Spec.Name)
@@ -117,8 +117,10 @@ func TestPatchUpdatePluginWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := plugins.PatchUpdate(testPlugin)
+	name := "susfu"
+	clonedPlugin := testPlugin.DeepCopy()
+	clonedPlugin.Spec.Name = name
+	updated, err := plugins.PatchUpdate(clonedPlugin)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/release_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/release_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *releases) PatchUpdate(release *v1.Release) (*v1.Release, error) {
 	patch, err := util.CreatePatch(orig, release)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/release_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/release_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdateReleaseWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := releases.PatchUpdate(testRelease)
+	updated, err := releases.PatchUpdate(clonedRelease)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testRelease, updated)
 	assert.Equal(t, name, updated.Spec.Name)
@@ -118,8 +118,10 @@ func TestPatchUpdateReleaseWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := releases.PatchUpdate(testRelease)
+	name := "susfu"
+	clonedRelease := testRelease.DeepCopy()
+	clonedRelease.Spec.Name = name
+	updated, err := releases.PatchUpdate(clonedRelease)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/sourcerepository_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/sourcerepository_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *sourceRepositories) PatchUpdate(sourceRepository *v1.SourceRepository) 
 	patch, err := util.CreatePatch(orig, sourceRepository)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/sourcerepository_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/sourcerepository_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdateSourceRepositoryWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := sourceRepositories.PatchUpdate(testSourceRepository)
+	updated, err := sourceRepositories.PatchUpdate(clonedSourceRepository)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testSourceRepository, updated)
 	assert.Equal(t, description, updated.Spec.Description)
@@ -118,7 +118,10 @@ func TestPatchUpdateSourceRepositoryWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-	updated, err := sourceRepositories.PatchUpdate(testSourceRepository)
+	description := "my repo"
+	clonedSourceRepository := testSourceRepository.DeepCopy()
+	clonedSourceRepository.Spec.Description = description
+	updated, err := sourceRepositories.PatchUpdate(clonedSourceRepository)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/team_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/team_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *teams) PatchUpdate(team *v1.Team) (*v1.Team, error) {
 	patch, err := util.CreatePatch(orig, team)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/team_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/team_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdateTeamWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := teams.PatchUpdate(testTeam)
+	updated, err := teams.PatchUpdate(clonedTeam)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testTeam, updated)
 	assert.Equal(t, label, updated.Spec.Label)
@@ -118,8 +118,10 @@ func TestPatchUpdateTeamWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := teams.PatchUpdate(testTeam)
+	label := "Black Team"
+	clonedTeam := testTeam.DeepCopy()
+	clonedTeam.Spec.Label = label
+	updated, err := teams.PatchUpdate(clonedTeam)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/user_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/user_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *users) PatchUpdate(user *v1.User) (*v1.User, error) {
 	patch, err := util.CreatePatch(orig, user)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/user_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/user_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdateUserWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := users.PatchUpdate(testUser)
+	updated, err := users.PatchUpdate(clonedUser)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testUser, updated)
 	assert.Equal(t, name, updated.Spec.Name)
@@ -118,8 +118,10 @@ func TestPatchUpdateUserWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := users.PatchUpdate(testUser)
+	name := "susfu"
+	clonedUser := testUser.DeepCopy()
+	clonedUser.Spec.Name = name
+	updated, err := users.PatchUpdate(clonedUser)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/workflow_expansion.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/workflow_expansion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	util "github.com/jenkins-x/jx/pkg/util/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,9 @@ func (c *workflows) PatchUpdate(workflow *v1.Workflow) (*v1.Workflow, error) {
 	patch, err := util.CreatePatch(orig, workflow)
 	if err != nil {
 		return nil, err
+	}
+	if bytes.Equal(patch, []byte("[]")) {
+		return orig, nil
 	}
 	patched, err := c.Patch(resourceName, types.JSONPatchType, patch)
 	if err != nil {

--- a/pkg/client/clientset/versioned/typed/jenkins.io/v1/workflow_expansion_test.go
+++ b/pkg/client/clientset/versioned/typed/jenkins.io/v1/workflow_expansion_test.go
@@ -73,7 +73,7 @@ func TestPatchUpdateWorkflowWithChange(t *testing.T) {
 		ns:     "default",
 	}
 
-	updated, err := workflows.PatchUpdate(testWorkflow)
+	updated, err := workflows.PatchUpdate(clonedWorkflow)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testWorkflow, updated)
 	assert.Equal(t, pipelineName, updated.Spec.PipelineName)
@@ -118,8 +118,10 @@ func TestPatchUpdateWorkflowWithErrorInPatch(t *testing.T) {
 		client: fakeClient,
 		ns:     "default",
 	}
-
-	updated, err := workflows.PatchUpdate(testWorkflow)
+	pipelineName := "dummy-pipeline"
+	clonedWorkflow := testWorkflow.DeepCopy()
+	clonedWorkflow.Spec.PipelineName = pipelineName
+	updated, err := workflows.PatchUpdate(clonedWorkflow)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Nil(t, updated)


### PR DESCRIPTION
This PR prevetns patch calls if the patch actually is empty.

Specifically this fixes problems when DevEnvAndTeamSettings in team_settings modifies the environment unnecessarily, thus mitigating problems for user without update permission.

fixes #5937