### PR TITLE
fix: Reducing and structuring the log output of `jx boot`

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -245,7 +245,7 @@ func (o *BootOptions) Run() error {
 		return err
 	}
 	if !isBootClone {
-		return fmt.Errorf("No requirements file %s are you sure you are running this command inside a GitOps clone?", requirementsFile)
+		return fmt.Errorf("no requirements file %s are you sure you are running this command inside a GitOps clone?", requirementsFile)
 	}
 
 	err = o.verifyRequirements(requirements, requirementsFile)
@@ -253,7 +253,7 @@ func (o *BootOptions) Run() error {
 		return err
 	}
 
-	log.Logger().Infof("booting up Jenkins X")
+	log.Logger().Infof("Booting Jenkins X")
 
 	// now lets really boot
 	_, so := create.NewCmdStepCreateTaskAndOption(o.CommonOptions)
@@ -316,7 +316,6 @@ func (o *BootOptions) Run() error {
 	no := &namespace.NamespaceOptions{}
 	no.CommonOptions = o.CommonOptions
 	no.Args = []string{requirements.Cluster.Namespace}
-	log.Logger().Infof("switching to the namespace %s so that you can use %s commands on the installation", info(requirements.Cluster.Namespace), info("jx"))
 	return no.Run()
 }
 

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -3019,7 +3019,7 @@ func (options *InstallOptions) CloneJXCloudEnvironmentsRepo() (string, error) {
 	if options.Flags.CloudEnvRepository == "" {
 		options.Flags.CloudEnvRepository = opts.DefaultCloudEnvironmentsURL
 	}
-	log.Logger().Infof("Cloning the Jenkins X cloud environments repo to %s", wrkDir)
+	log.Logger().Debugf("Cloning the Jenkins X cloud environments repo to %s", wrkDir)
 	_, err = git.PlainClone(wrkDir, false, &git.CloneOptions{
 		URL:           options.Flags.CloudEnvRepository,
 		ReferenceName: "refs/heads/master",

--- a/pkg/cmd/opts/domain.go
+++ b/pkg/cmd/opts/domain.go
@@ -38,7 +38,7 @@ func (o *CommonOptions) GetDomain(client kubernetes.Interface, domain string, pr
 			address = ip
 		} else {
 			info := util.ColorInfo
-			log.Logger().Infof("\nWaiting to find the external host name of the ingress controller Service in namespace %s with name %s",
+			log.Logger().Infof("Waiting to find the external host name of the ingress controller Service in namespace %s with name %s",
 				info(ingressNamespace), info(ingressService))
 			if provider == cloud.KUBERNETES {
 				log.Logger().Infof("If you are installing Jenkins X on premise you may want to use the '--on-premise' flag or specify the '--external-ip' flags. See: %s",

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -226,7 +226,7 @@ func (o *CommonOptions) InitHelm(config InitHelmConfig) error {
 	if err != nil {
 		return err
 	}
-	log.Logger().Info("helm installed and configured")
+	log.Logger().Info("Helm installed and configured")
 
 	return nil
 }

--- a/pkg/cmd/step/helm/step_helm.go
+++ b/pkg/cmd/step/helm/step_helm.go
@@ -230,7 +230,6 @@ func (o *StepHelmOptions) discoverValuesFiles(dir string) ([]string, error) {
 func (o *StepHelmOptions) getOrCreateVersionResolver(requirementsConfig *config.RequirementsConfig) (*versionstream.VersionResolver, error) {
 	if o.versionResolver == nil {
 		vs := requirementsConfig.VersionStream
-		log.Logger().Infof("verifying the helm requirements versions in dir: %s using version stream URL: %s and git ref: %s\n", o.Dir, vs.URL, vs.Ref)
 
 		var err error
 		o.versionResolver, err = o.CreateVersionResolver(vs.URL, vs.Ref)
@@ -274,7 +273,7 @@ func (o *StepHelmOptions) verifyRequirementsYAML(resolver *versionstream.Version
 			}
 			dep.Version = newVersion
 			modified = true
-			log.Logger().Infof("adding version %s to dependency %s in file %s", newVersion, name, fileName)
+			log.Logger().Debugf("adding version %s to dependency %s in file %s", newVersion, name, fileName)
 		}
 	}
 
@@ -283,7 +282,7 @@ func (o *StepHelmOptions) verifyRequirementsYAML(resolver *versionstream.Version
 		if err != nil {
 			return errors.Wrapf(err, "failed to save %s", fileName)
 		}
-		log.Logger().Infof("adding dependency versions to file %s", fileName)
+		log.Logger().Debugf("adding dependency versions to file %s", fileName)
 	}
 	return nil
 }
@@ -295,12 +294,13 @@ func (o *StepHelmOptions) replaceMissingVersionsFromVersionStream(requirementsCo
 		return errors.Wrapf(err, "failed to check for file %s", fileName)
 	}
 	if !exists {
-		log.Logger().Infof("no requirements file: %s so not checking for missing versions\n", fileName)
+		log.Logger().Infof("No requirements file: %s so not checking for missing versions\n", fileName)
 		return nil
 	}
 
 	vs := requirementsConfig.VersionStream
-	log.Logger().Infof("verifying the helm requirements versions in dir: %s using version stream URL: %s and git ref: %s\n", o.Dir, vs.URL, vs.Ref)
+
+	log.Logger().Infof("Verifying the helm requirements versions in dir: %s using version stream URL: %s and git ref: %s\n", o.Dir, vs.URL, vs.Ref)
 
 	resolver, err := o.getOrCreateVersionResolver(requirementsConfig)
 	if err != nil {

--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -192,7 +192,7 @@ func (o *StepHelmApplyOptions) Run() error {
 		return fmt.Errorf("could not find the relative name of the directory %s", dir)
 	}
 	tmpDir := filepath.Join(rootTmpDir, name)
-	log.Logger().Infof("Copying the helm source directory %s to a temporary location for building and applying %s\n", info(dir), info(tmpDir))
+	log.Logger().Debugf("Copying the helm source directory %s to a temporary location for building and applying %s\n", info(dir), info(tmpDir))
 
 	err = os.MkdirAll(tmpDir, util.DefaultWritePermissions)
 	if err != nil {
@@ -203,7 +203,7 @@ func (o *StepHelmApplyOptions) Run() error {
 		return errors.Wrapf(err, "failed to copy helm dir %s to temporary dir %s", dir, tmpDir)
 	}
 	dir = tmpDir
-	log.Logger().Infof("Applying helm chart at %s as release name %s to namespace %s", info(dir), info(releaseName), info(ns))
+	log.Logger().Debugf("Applying helm chart at %s as release name %s to namespace %s", info(dir), info(releaseName), info(ns))
 
 	o.Helm().SetCWD(dir)
 
@@ -229,7 +229,7 @@ func (o *StepHelmApplyOptions) Run() error {
 		}
 		for _, sf := range secretsFiles {
 			if util.StringArrayIndex(valueFiles, sf) < 0 {
-				log.Logger().Infof("adding secret file %s", sf)
+				log.Logger().Debugf("adding secret file %s", sf)
 				valueFiles = append(valueFiles, sf)
 			}
 		}
@@ -276,13 +276,13 @@ func (o *StepHelmApplyOptions) Run() error {
 	if err != nil {
 		return errors.Wrapf(err, "writing values.yaml for tree to %s", chartValuesFile)
 	}
-	log.Logger().Infof("Wrote chart values.yaml %s generated from directory tree", chartValuesFile)
+	log.Logger().Debugf("Wrote chart values.yaml %s generated from directory tree", chartValuesFile)
 
 	data, err := ioutil.ReadFile(chartValuesFile)
 	if err != nil {
 		log.Logger().Warnf("failed to load file %s: %s", chartValuesFile, err.Error())
 	} else {
-		log.Logger().Infof("generated helm %s", chartValuesFile)
+		log.Logger().Debugf("generated helm %s", chartValuesFile)
 
 		valuesText := string(data)
 		if !o.NoMasking {
@@ -290,10 +290,10 @@ func (o *StepHelmApplyOptions) Run() error {
 			valuesText = masker.MaskLog(valuesText)
 		}
 
-		log.Logger().Infof("\n%s\n", util.ColorStatus(valuesText))
+		log.Logger().Debugf("\n%s\n", util.ColorStatus(valuesText))
 	}
 
-	log.Logger().Infof("Using values files: %s", strings.Join(valueFiles, ", "))
+	log.Logger().Debugf("Using values files: %s", strings.Join(valueFiles, ", "))
 
 	if o.Boot {
 		err = o.replaceMissingVersionsFromVersionStream(requirements, dir)
@@ -418,7 +418,7 @@ func DefaultEnvironments(c *config.RequirementsConfig, devGitInfo *gits.GitRepos
 }
 
 func (o *StepHelmApplyOptions) applyTemplateOverrides(chartName string) error {
-	log.Logger().Infof("Applying chart overrides")
+	log.Logger().Debugf("Applying chart overrides")
 	templateOverrides, err := filepath.Glob(chartName + "/../*/templates/*.yaml")
 	for _, overrideSrc := range templateOverrides {
 		if !strings.Contains(overrideSrc, "/env/") {
@@ -437,14 +437,14 @@ func (o *StepHelmApplyOptions) applyTemplateOverrides(chartName string) error {
 				if exists, err := util.DirExists(depChartDir); err == nil && !exists {
 					chartArchives, _ := filepath.Glob(filepath.Join(depChartsDir, depChartName+"*.tgz"))
 					if len(chartArchives) == 1 {
-						log.Logger().Infof("Exploding chart %s", chartArchives[0])
+						log.Logger().Debugf("Exploding chart %s", chartArchives[0])
 						archiver.Unarchive(chartArchives[0], depChartsDir)
 						// Remove the unexploded chart
 						os.Remove(chartArchives[0])
 					}
 				}
 				overrideDst := filepath.Join(depChartDir, "templates", templateName)
-				log.Logger().Infof("Copying chart override %s", overrideSrc)
+				log.Logger().Debugf("Copying chart override %s", overrideSrc)
 				err = ioutil.WriteFile(overrideDst, data, util.DefaultWritePermissions)
 				if err != nil {
 					log.Logger().Warnf("Error copying template %s to %s %v", overrideSrc, overrideDst, err)
@@ -457,7 +457,7 @@ func (o *StepHelmApplyOptions) applyTemplateOverrides(chartName string) error {
 }
 
 func (o *StepHelmApplyOptions) applyAppsTemplateOverrides(chartName string) error {
-	log.Logger().Infof("Applying Apps chart overrides")
+	log.Logger().Debugf("Applying Apps chart overrides")
 	templateOverrides, err := filepath.Glob(chartName + "/../*/*/templates/app.yaml")
 	for _, overrideSrc := range templateOverrides {
 		data, err := ioutil.ReadFile(overrideSrc)
@@ -470,13 +470,13 @@ func (o *StepHelmApplyOptions) applyAppsTemplateOverrides(chartName string) erro
 			chartArchives, _ := filepath.Glob(filepath.Join(depChartsDir, depChartName+"*.tgz"))
 			if len(chartArchives) == 1 {
 				uuid, _ := uuid.NewUUID()
-				log.Logger().Infof("Exploding App chart %s", chartArchives[0])
+				log.Logger().Debugf("Exploding App chart %s", chartArchives[0])
 				explodedChartTempDir := filepath.Join(os.TempDir(), uuid.String())
 				if err = archiver.Unarchive(chartArchives[0], explodedChartTempDir); err != nil {
 					return defineAppsChartOverridingError(chartName, err)
 				}
 				overrideDst := filepath.Join(explodedChartTempDir, depChartName, "templates", templateName)
-				log.Logger().Infof("Copying chart override %s", overrideSrc)
+				log.Logger().Debugf("Copying chart override %s", overrideSrc)
 				err = ioutil.WriteFile(overrideDst, data, util.DefaultWritePermissions)
 				if err != nil {
 					log.Logger().Warnf("Error copying template %s to %s %v", overrideSrc, overrideDst, err)
@@ -501,7 +501,7 @@ func defineAppsChartOverridingError(chartName string, err error) error {
 }
 
 func (o *StepHelmApplyOptions) fetchSecretFilesFromVault(dir string, store configio.ConfigStore) ([]string, error) {
-	log.Logger().Infof("Fetching secrets from vault into directory %q", dir)
+	log.Logger().Debugf("Fetching secrets from vault into directory %q", dir)
 	files := []string{}
 	client, err := o.SystemVaultClient(kube.DefaultNamespace)
 	if err != nil {
@@ -541,7 +541,7 @@ func (o *StepHelmApplyOptions) fetchSecretFilesFromVault(dir string, store confi
 		if err != nil {
 			return files, errors.Wrapf(err, "saving the secret file %q", secretFile)
 		}
-		log.Logger().Infof("Saved secrets file %s", util.ColorInfo(secretFile))
+		log.Logger().Debugf("Saved secrets file %s", util.ColorInfo(secretFile))
 		files = append(files, secretFile)
 	}
 	return files, nil

--- a/pkg/cmd/step/helm/step_helm_version.go
+++ b/pkg/cmd/step/helm/step_helm_version.go
@@ -72,7 +72,7 @@ func (o *StepHelmVersionOptions) Run() error {
 		version = builds.GetBuildNumber()
 	}
 	if version == "" {
-		return fmt.Errorf("No version specified and could not detect the build number via $BUILD_NUMBER")
+		return fmt.Errorf("no version specified and could not detect the build number via $BUILD_NUMBER")
 	}
 	var err error
 	dir := o.Dir
@@ -88,7 +88,7 @@ func (o *StepHelmVersionOptions) Run() error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("No chart exists at %s", chartFile)
+		return fmt.Errorf("no chart exists at %s", chartFile)
 	}
 	err = helm.SetChartVersion(chartFile, version)
 	if err != nil {

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -102,7 +102,7 @@ func (o *StepVerifyEnvironmentsOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	log.Logger().Infof("the git repositories for the environments look good\n")
+	log.Logger().Infof("Environment git repositories look good\n")
 	fmt.Println()
 	return nil
 }

--- a/pkg/cmd/step/verify/step_verify_git.go
+++ b/pkg/cmd/step/verify/step_verify_git.go
@@ -46,7 +46,7 @@ func NewCmdStepVerifyGit(commonOpts *opts.CommonOptions) *cobra.Command {
 
 // Run implements this command
 func (o *StepVerifyGitOptions) Run() error {
-	log.Logger().Infof("verifying the git Secrets\n")
+	log.Logger().Infof("Verifying the git Secrets\n")
 
 	secrets, err := o.LoadPipelineSecrets(kube.ValueKindGit, "")
 	if err != nil {
@@ -55,7 +55,7 @@ func (o *StepVerifyGitOptions) Run() error {
 
 	info := util.ColorInfo
 	for _, secret := range secrets.Items {
-		log.Logger().Infof("verifying git Secret %s\n", info(secret.Name))
+		log.Logger().Infof("Verifying git Secret %s\n", info(secret.Name))
 		annotations := secret.Annotations
 		data := secret.Data
 		if annotations == nil {
@@ -99,7 +99,7 @@ func (o *StepVerifyGitOptions) Run() error {
 	for _, server := range servers {
 		for _, userAuth := range server.Users {
 
-			log.Logger().Infof("verifying username %s at git server %s at %s\n", info(userAuth.Username), info(server.Name), info(server.URL))
+			log.Logger().Infof("Verifying username %s at git server %s at %s\n", info(userAuth.Username), info(server.Name), info(server.URL))
 
 			provider, err := gits.CreateProvider(server, userAuth, o.Git())
 			if err != nil {
@@ -120,7 +120,7 @@ func (o *StepVerifyGitOptions) Run() error {
 				orgNames = append(orgNames, org.Login)
 			}
 			sort.Strings(orgNames)
-			log.Logger().Infof("found %d organisations in git server %s: %s\n", len(orgs), info(server.URL), info(strings.Join(orgNames, ", ")))
+			log.Logger().Infof("Found %d organisations in git server %s: %s\n", len(orgs), info(server.URL), info(strings.Join(orgNames, ", ")))
 			if config.PipeLineServer == server.URL && config.PipeLineUsername == userAuth.Username {
 				pipeUserValid = true
 			}
@@ -133,6 +133,6 @@ func (o *StepVerifyGitOptions) Run() error {
 		return errors.Errorf("pipeline user %s on git server %s not valid", util.ColorError(config.PipeLineUsername), util.ColorError(config.PipeLineServer))
 	}
 
-	log.Logger().Infof("git tokens seem to be setup correctly\n")
+	log.Logger().Infof("Git tokens seem to be setup correctly\n")
 	return nil
 }

--- a/pkg/cmd/step/verify/step_verify_install.go
+++ b/pkg/cmd/step/verify/step_verify_install.go
@@ -108,6 +108,6 @@ func (o *StepVerifyInstallOptions) Run() error {
 			}
 		}
 	}
-	log.Logger().Infof("installation is currently looking: %s\n", util.ColorInfo("GOOD"))
+	log.Logger().Infof("Installation is currently looking: %s\n", util.ColorInfo("GOOD"))
 	return nil
 }

--- a/pkg/cmd/step/verify/step_verify_packages.go
+++ b/pkg/cmd/step/verify/step_verify_packages.go
@@ -78,8 +78,6 @@ func NewCmdStepVerifyPackages(commonOpts *opts.CommonOptions) *cobra.Command {
 
 // Run implements this command
 func (o *StepVerifyPackagesOptions) Run() error {
-	log.Logger().Infof("verifying the CLI packages\n")
-
 	packages, table := o.GetPackageVersions(o.Namespace, o.HelmTLS)
 
 	verifyMap := map[string]string{}
@@ -94,7 +92,7 @@ func (o *StepVerifyPackagesOptions) Run() error {
 	vs := requirements.VersionStream
 	u := vs.URL
 	ref := vs.Ref
-	log.Logger().Infof("verifying the CLI package using version stream URL: %s and git ref: %s\n", u, vs.Ref)
+	log.Logger().Infof("Verifying the CLI packages using version stream URL: %s and git ref: %s\n", u, vs.Ref)
 
 	resolver, err := o.CreateVersionResolver(u, ref)
 	if err != nil {
@@ -113,9 +111,7 @@ func (o *StepVerifyPackagesOptions) Run() error {
 		return err
 	}
 
-	log.Logger().Infof("the CLI packages seem to be setup correctly %s\n", util.ColorInfo(strings.Join(o.Packages, ", ")))
-	log.Logger().Infof("\n")
-
+	log.Logger().Infof("CLI packages %s seem to be setup correctly", util.ColorInfo(strings.Join(o.Packages, ", ")))
 	table.Render()
 
 	return nil

--- a/pkg/cmd/step/verify/step_verify_pod_ready.go
+++ b/pkg/cmd/step/verify/step_verify_pod_ready.go
@@ -89,7 +89,7 @@ func (o *StepVerifyPodReadyOptions) Run() error {
 			return err
 		}
 		log.Logger().Warnf("%s\n", err.Error())
-		log.Logger().Infof("\nWaiting %s for the pods to become Ready...\n\n", o.WaitDuration.String())
+		log.Logger().Infof("\nWaiting %s for the pods to become ready...\n\n", o.WaitDuration.String())
 
 		err = o.RetryQuietlyUntilTimeout(o.WaitDuration, time.Second*10, func() error {
 			var err error
@@ -172,7 +172,7 @@ func (o *StepVerifyPodReadyOptions) waitForReadyPods(kubeClient kubernetes.Inter
 		for k, list := range notReadyPhases {
 			phaseSlice = append(phaseSlice, fmt.Sprintf("%s: %s", k, strings.Join(list, ", ")))
 		}
-		return table, fmt.Errorf("the following pods are not Ready:\n%s", strings.Join(phaseSlice, "\n"))
+		return table, fmt.Errorf("the following pods are not ready:\n%s", strings.Join(phaseSlice, "\n"))
 	}
 	return table, nil
 }

--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -119,18 +119,17 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 
 	o.SetDevNamespace(ns)
 
-	log.Logger().Infof("verifying the kubernetes cluster before we try to boot Jenkins X in namespace: %s", info(ns))
+	log.Logger().Infof("Verifying the kubernetes cluster before we try to boot Jenkins X in namespace: %s", info(ns))
 	if o.LazyCreate {
-		log.Logger().Infof("we will try to lazily create any missing resources to get the current cluster ready to boot Jenkins X")
+		log.Logger().Infof("Trying to lazily create any missing resources to get the current cluster ready to boot Jenkins X")
 	} else {
-		log.Logger().Warn("lazy create of cloud resources is disabled")
-
+		log.Logger().Warn("Lazy create of cloud resources is disabled")
 	}
 
 	err = o.verifyDevNamespace(kubeClient, ns)
 	if err != nil {
 		if o.LazyCreate {
-			log.Logger().Infof("attempting to lazily create the deploy namespace %s", info(ns))
+			log.Logger().Infof("Attempting to lazily create the deploy namespace %s", info(ns))
 
 			err = kube.EnsureDevNamespaceCreatedWithoutEnvironment(kubeClient, ns)
 			if err != nil {
@@ -152,11 +151,11 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 	no := &namespace.NamespaceOptions{}
 	no.CommonOptions = o.CommonOptions
 	no.Args = []string{ns}
-	log.Logger().Infof("setting the local kubernetes context to the deploy namespace %s", info(ns))
 	err = no.Run()
 	if err != nil {
 		return err
 	}
+	log.Logger().Info("\n")
 
 	po := &StepVerifyPackagesOptions{}
 	po.CommonOptions = o.CommonOptions
@@ -165,6 +164,7 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 	if err != nil {
 		return err
 	}
+	log.Logger().Info("\n")
 
 	err = o.VerifyInstallConfig(kubeClient, ns, requirements, requirementsFileName)
 	if err != nil {
@@ -175,6 +175,7 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 	if err != nil {
 		return err
 	}
+	log.Logger().Info("\n")
 
 	if !o.DisableVerifyHelm {
 		err = o.verifyHelm(ns)
@@ -185,7 +186,7 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 
 	if requirements.Kaniko {
 		if requirements.Cluster.Provider == cloud.GKE {
-			log.Logger().Infof("validating the kaniko secret in namespace %s", info(ns))
+			log.Logger().Infof("Validating Kaniko secret in namespace %s", info(ns))
 
 			err = o.validateKaniko(ns)
 			if err != nil {
@@ -203,17 +204,18 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 			if err != nil {
 				return err
 			}
+			log.Logger().Info("\n")
 		}
 	}
 
 	if vns := requirements.Velero.Namespace; vns != "" {
 		if requirements.Cluster.Provider == cloud.GKE {
-			log.Logger().Infof("validating the velero secret in namespace %s", info(vns))
+			log.Logger().Infof("Validating the velero secret in namespace %s", info(vns))
 
 			err = o.validateVelero(vns)
 			if err != nil {
 				if o.LazyCreate {
-					log.Logger().Infof("attempting to lazily create the deploy namespace %s", info(vns))
+					log.Logger().Infof("Attempting to lazily create the deploy namespace %s", info(vns))
 
 					err = o.lazyCreateVeleroSecret(requirements, vns)
 					if err != nil {
@@ -226,6 +228,7 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 			if err != nil {
 				return err
 			}
+			log.Logger().Info("\n")
 		}
 	}
 
@@ -239,7 +242,7 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 
 	if requirements.Cluster.Provider == cloud.EKS && o.LazyCreate {
 		if !cluster.IsInCluster() {
-			log.Logger().Info("attempting to lazily create the IAM Role for Service Accounts permissions")
+			log.Logger().Info("Attempting to lazily create the IAM Role for Service Accounts permissions")
 			err = amazon.EnableIRSASupportInCluster(requirements)
 			if err != nil {
 				return errors.Wrap(err, "error enabling IRSA in cluster")
@@ -255,7 +258,7 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 
 	// Lets update the TeamSettings with the VersionStream data from the jx-requirements.yaml file so we make sure
 	// we are upgrading with the latest versions
-	log.Logger().Infof("the cluster looks good, you are ready to '%s' now!", info("jx boot"))
+	log.Logger().Infof("Cluster looks good, you are ready to '%s' now!", info("jx boot"))
 	fmt.Println()
 	return nil
 }
@@ -285,14 +288,14 @@ func (o *StepVerifyPreInstallOptions) verifyHelm(ns string) error {
 	if err != nil {
 		return errors.Wrapf(err, "initializing helm with config: %v", cfg)
 	}
-	log.Logger().Infof("helm client is setup")
 
 	o.EnableRemoteKubeCluster()
+
 	_, err = o.AddHelmBinaryRepoIfMissing(kube.DefaultChartMuseumURL, kube.DefaultChartMuseumJxRepoName, "", "")
 	if err != nil {
 		return errors.Wrapf(err, "adding '%s' helm charts repository", kube.DefaultChartMuseumURL)
 	}
-	log.Logger().Infof("ensure we have the helm repository %s", kube.DefaultChartMuseumURL)
+	log.Logger().Infof("Ensuring Helm chart repository %s is configured\n", kube.DefaultChartMuseumURL)
 
 	return nil
 }
@@ -304,10 +307,10 @@ func (o *StepVerifyPreInstallOptions) verifyDevNamespace(kubeClient kubernetes.I
 		return err
 	}
 	if ns == "" {
-		return fmt.Errorf("No dev namespace name found")
+		return fmt.Errorf("no dev namespace name found")
 	}
 	if envName == "" {
-		return fmt.Errorf("Namespace %s has no team label", ns)
+		return fmt.Errorf("namespace %s has no team label", ns)
 	}
 	return nil
 }
@@ -504,7 +507,6 @@ func (o *StepVerifyPreInstallOptions) gatherRequirements(requirements *config.Re
 				return nil, errors.Wrapf(err, "")
 			}
 			if currentClusterName != "" && currentProject != "" && currentZone != "" {
-				log.Logger().Infof("")
 				log.Logger().Infof("Currently connected cluster is %s in %s in project %s", util.ColorInfo(currentClusterName), util.ColorInfo(currentZone), util.ColorInfo(currentProject))
 				autoAcceptDefaults = util.Confirm(fmt.Sprintf("Do you want to jx boot the %s cluster?", util.ColorInfo(currentClusterName)), true, "Enter Y to use the currently connected cluster or enter N to specify a different cluster", o.GetIOFileHandles())
 			} else {
@@ -684,7 +686,7 @@ func (o *StepVerifyPreInstallOptions) verifyPrivateRepos(requirements *config.Re
 
 // verifyStorage verifies the associated buckets exist or if enabled lazily create them
 func (o *StepVerifyPreInstallOptions) verifyStorage(requirements *config.RequirementsConfig, requirementsFileName string) error {
-	log.Logger().Debug("Verifying Storage...")
+	log.Logger().Info("Verifying Storage...")
 	storage := &requirements.Storage
 	err := o.verifyStorageEntry(requirements, requirementsFileName, &storage.Logs, "logs", "Long term log storage")
 	if err != nil {
@@ -702,7 +704,7 @@ func (o *StepVerifyPreInstallOptions) verifyStorage(requirements *config.Require
 	if err != nil {
 		return err
 	}
-	log.Logger().Infof("the storage looks good")
+	log.Logger().Infof("Storage configuration looks good\n")
 	return nil
 }
 
@@ -873,16 +875,17 @@ func (o *StepVerifyPreInstallOptions) verifyConfigMapExists(kubeClient kubernete
 }
 
 func (o *StepVerifyPreInstallOptions) verifyIngress(requirements *config.RequirementsConfig, requirementsFileName string) error {
-	log.Logger().Debug("Verifying Ingress...")
+	log.Logger().Info("Verifying Ingress...")
 	domain := requirements.Ingress.Domain
 	if requirements.Ingress.IsAutoDNSDomain() {
-		log.Logger().Infof("clearing the domain %s as when using auto-DNS domains we need to regenerate to ensure its always accurate in case the cluster or ingress service is recreated", util.ColorInfo(domain))
+		log.Logger().Infof("Clearing the domain %s as when using auto-DNS domains we need to regenerate to ensure its always accurate in case the cluster or ingress service is recreated", util.ColorInfo(domain))
 		requirements.Ingress.Domain = ""
 		err := requirements.SaveConfig(requirementsFileName)
 		if err != nil {
 			return errors.Wrapf(err, "failed to save changes to file: %s", requirementsFileName)
 		}
 	}
+	log.Logger().Info("\n")
 	return nil
 }
 

--- a/pkg/cmd/step/verify/step_verify_requirements.go
+++ b/pkg/cmd/step/verify/step_verify_requirements.go
@@ -87,7 +87,8 @@ func (o *StepVerifyRequirementsOptions) Run() error {
 		return errors.Wrapf(err, "failed to load boot requirements")
 	}
 	vs := requirements.VersionStream
-	log.Logger().Infof("verifying the helm requirements versions in dir: %s using version stream URL: %s and git ref: %s\n", o.Dir, vs.URL, vs.Ref)
+
+	log.Logger().Debugf("Verifying the helm requirements versions in dir: %s using version stream URL: %s and git ref: %s\n", o.Dir, vs.URL, vs.Ref)
 
 	resolver, err := o.CreateVersionResolver(vs.URL, vs.Ref)
 	if err != nil {
@@ -145,7 +146,7 @@ func (o *StepVerifyRequirementsOptions) verifyRequirementsYAML(resolver *version
 			}
 			dep.Version = newVersion
 			modified = true
-			log.Logger().Infof("adding version %s to dependency %s in file %s", newVersion, name, fileName)
+			log.Logger().Debugf("adding version %s to dependency %s in file %s", newVersion, name, fileName)
 		}
 	}
 

--- a/pkg/kube/secrets.go
+++ b/pkg/kube/secrets.go
@@ -83,6 +83,6 @@ func ValidateSecret(kubeClient kubernetes.Interface, secretName, key, ns string)
 	if secret.Data == nil || len(secret.Data[key]) == 0 {
 		return fmt.Errorf("the Secret %s in the namespace: %s does not have a key: %s", secretName, ns, key)
 	}
-	log.Logger().Infof("valid: there is a Secret: %s in namespace: %s\n", util.ColorInfo(secretName), util.ColorInfo(ns))
+	log.Logger().Debugf("valid: there is a Secret: %s in namespace: %s\n", util.ColorInfo(secretName), util.ColorInfo(ns))
 	return nil
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -102,6 +102,11 @@ func SetLevel(s string) error {
 	return nil
 }
 
+// GetLevel gets the current log level
+func GetLevel() string {
+	return logrus.GetLevel().String()
+}
+
 // GetLevels returns the list of valid log levels
 func GetLevels() []string {
 	var levels []string

--- a/pkg/versionstream/versionstreamrepo/gitrepo.go
+++ b/pkg/versionstream/versionstreamrepo/gitrepo.go
@@ -60,7 +60,7 @@ func cloneJXVersionsRepo(versionRepository string, versionRef string, settings *
 	}
 
 	log.Logger().Debugf("Current configuration dir: %s", configDir)
-	log.Logger().Debugf("versionRepository: %s git ref: %s", versionRepository, versionRef)
+	log.Logger().Debugf("VersionRepository: %s git ref: %s", versionRepository, versionRef)
 
 	// If the repo already exists let's try to fetch the latest version
 	if exists, err := util.DirExists(wrkDir); err == nil && exists {
@@ -160,7 +160,7 @@ func cloneJXVersionsRepo(versionRepository string, versionRef string, settings *
 }
 
 func deleteAndReClone(wrkDir string, versionRepository string, referenceName string, gitter gits.Gitter, fw terminal.FileWriter) (string, error) {
-	log.Logger().Info("Deleting and cloning the Jenkins X versions repo")
+	log.Logger().Debug("Deleting and cloning the Jenkins X versions repo")
 	err := os.RemoveAll(wrkDir)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to delete dir %s: %s\n", wrkDir, err.Error())
@@ -183,10 +183,10 @@ func clone(wrkDir string, versionRepository string, referenceName string, gitter
 		if strings.HasPrefix(referenceName, "PR-") {
 			prNumber := strings.TrimPrefix(referenceName, "PR-")
 
-			log.Logger().Infof("Cloning the Jenkins X versions repo %s with PR: %s to %s", util.ColorInfo(versionRepository), util.ColorInfo(referenceName), util.ColorInfo(wrkDir))
+			log.Logger().Debugf("Cloning the Jenkins X versions repo %s with PR: %s to %s", util.ColorInfo(versionRepository), util.ColorInfo(referenceName), util.ColorInfo(wrkDir))
 			return "", shallowCloneGitRepositoryToDir(wrkDir, versionRepository, prNumber, "", gitter)
 		}
-		log.Logger().Infof("Cloning the Jenkins X versions repo %s with revision %s to %s", util.ColorInfo(versionRepository), util.ColorInfo(referenceName), util.ColorInfo(wrkDir))
+		log.Logger().Debugf("Cloning the Jenkins X versions repo %s with revision %s to %s", util.ColorInfo(versionRepository), util.ColorInfo(referenceName), util.ColorInfo(wrkDir))
 
 		err := gitter.Clone(versionRepository, wrkDir)
 		if err != nil {


### PR DESCRIPTION
fixes #5927

You get a more verbose output which contains most of the original output of `jx boot` via:

```
$ jx --verbose boot
# or
$ JX_LOG_LEVEL=debug jx boot
```

Still room for improvement, but imo the default output is a bit saner.

Would love to separate default UI output (to stdout) from logging. It really is unfortunate that we use the logger for both.