### PR TITLE
fix: GitHubProvider#asGitHubCommit should extract author name and email from commit

### DIFF
--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -782,13 +782,13 @@ func (p *GitHubProvider) asGitHubCommit(commit *github.RepositoryCommit) GitComm
 		log.Logger().Warnf("No Commit object for for commit: %s", commit.GetSHA())
 	}
 	var author *GitUser
-	if commit.Commit.Author != nil {
+	if commit.Author != nil {
 		author = &GitUser{
-			Login:     commit.Commit.Author.GetLogin(),
+			Login:     commit.Author.GetLogin(),
 			Email:     commit.Commit.Author.GetEmail(),
 			Name:      commit.Commit.Author.GetName(),
-			URL:       commit.Commit.Author.GetURL(),
-			AvatarURL: commit.Commit.Author.GetAvatarURL(),
+			URL:       commit.Author.GetURL(),
+			AvatarURL: commit.Author.GetAvatarURL(),
 		}
 	} else {
 		log.Logger().Warnf("No author for commit: %s", commit.GetSHA())

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -782,13 +782,13 @@ func (p *GitHubProvider) asGitHubCommit(commit *github.RepositoryCommit) GitComm
 		log.Logger().Warnf("No Commit object for for commit: %s", commit.GetSHA())
 	}
 	var author *GitUser
-	if commit.Author != nil {
+	if commit.Commit.Author != nil {
 		author = &GitUser{
-			Login:     commit.Author.GetLogin(),
-			Email:     commit.Author.GetEmail(),
-			Name:      commit.Author.GetName(),
-			URL:       commit.Author.GetURL(),
-			AvatarURL: commit.Author.GetAvatarURL(),
+			Login:     commit.Commit.Author.GetLogin(),
+			Email:     commit.Commit.Author.GetEmail(),
+			Name:      commit.Commit.Author.GetName(),
+			URL:       commit.Commit.Author.GetURL(),
+			AvatarURL: commit.Commit.Author.GetAvatarURL(),
 		}
 	} else {
 		log.Logger().Warnf("No author for commit: %s", commit.GetSHA())


### PR DESCRIPTION
fixes #5726

asGithubCommit should extract author name and email from commit using commit.Commit.Author to get author name and email specified in the commit instead of getting them from commit.Author.