### PR TITLE
fix: git remote add fix

### DIFF
--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -266,7 +266,14 @@ func (g *GitCLI) ResetToUpstream(dir string, branch string) error {
 
 // AddRemote adds a remote repository at the given URL and with the given name
 func (g *GitCLI) AddRemote(dir string, name string, url string) error {
-	return g.gitCmd(dir, "remote", "add", name, url)
+	err := g.gitCmd(dir, "remote", "add", name, url)
+	if err != nil {
+		err = g.gitCmd(dir, "remote", "set-url", name, url)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // UpdateRemote updates the URL of the remote repository


### PR DESCRIPTION
lets not fail if we try and add a git remote if one already exists

Signed-off-by: James Strachan <james.strachan@gmail.com>