### PR TITLE
fix: Correct command name in output

### DIFF
--- a/pkg/versionstream/resolver.go
+++ b/pkg/versionstream/resolver.go
@@ -37,7 +37,7 @@ func (v *VersionResolver) ResolveGitVersion(gitURL string) (string, error) {
 		path := GitURLToName(gitURL)
 		log.Logger().Warnf("could not find a stable version for git repository: %s in %s", gitURL, v.VersionsDir)
 		log.Logger().Warn("for background see: https://jenkins-x.io/architecture/version-stream/")
-		log.Logger().Infof("please lock this version down via the command: %s", util.ColorInfo(fmt.Sprintf("jx step create version pr -k git -n %s -v 1.2.3", path)))
+		log.Logger().Infof("please lock this version down via the command: %s", util.ColorInfo(fmt.Sprintf("jx step create pr versions -k git -n %s -v 1.2.3", path)))
 	}
 	return answer, nil
 }

--- a/pkg/versionstream/version_data.go
+++ b/pkg/versionstream/version_data.go
@@ -81,7 +81,7 @@ func (data *StableVersion) VerifyPackage(name string, currentVersion string, wor
 	version := convertToVersion(data.Version)
 	if version == "" {
 		log.Logger().Warnf("could not find a stable package version for %s from %s\nFor background see: https://jenkins-x.io/architecture/version-stream/", name, workDir)
-		log.Logger().Infof("Please lock this version down via the command: %s", util.ColorInfo(fmt.Sprintf("jx step create version pr -k package -n %s", name)))
+		log.Logger().Infof("Please lock this version down via the command: %s", util.ColorInfo(fmt.Sprintf("jx step create pr versions -k package -n %s", name)))
 		return nil
 	}
 
@@ -209,7 +209,7 @@ func LoadStableVersionNumber(wrkDir string, kind VersionKind, name string) (stri
 			return version, err
 		}
 		log.Logger().Warnf("could not find a stable version from %s of %s from %s\nFor background see: https://jenkins-x.io/architecture/version-stream/", string(kind), name, wrkDir)
-		log.Logger().Infof("Please lock this version down via the command: %s", util.ColorInfo(fmt.Sprintf("jx step create version pr -k %s -n %s", string(kind), name)))
+		log.Logger().Infof("Please lock this version down via the command: %s", util.ColorInfo(fmt.Sprintf("jx step create pr versions -k %s -n %s", string(kind), name)))
 	}
 	return version, err
 }
@@ -266,7 +266,7 @@ func ResolveDockerImage(versionsDir, image string) (string, error) {
 	if info.Version == "" {
 		log.Logger().Warnf("could not find a stable version for Docker image: %s in %s", image, versionsDir)
 		log.Logger().Warn("for background see: https://jenkins-x.io/architecture/version-stream/")
-		log.Logger().Infof("please lock this version down via the command: %s", util.ColorInfo(fmt.Sprintf("jx step create version pr -k docker -n %s -v 1.2.3", image)))
+		log.Logger().Infof("please lock this version down via the command: %s", util.ColorInfo(fmt.Sprintf("jx step create pr versions -k docker -n %s -v 1.2.3", image)))
 		return image, nil
 	}
 	prefix := strings.TrimSuffix(strings.TrimSpace(image), ":")


### PR DESCRIPTION
#### Description

Fix for faulty commands being output:

`jx step create version pr` -> jx step create pr versions`

#### Which issue this PR fixes

fixes #5724 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
