### PR TITLE
fix(boot): Try to update local boot clone to config ref from versions

### DIFF
--- a/pkg/cmd/boot/boot_integration_test.go
+++ b/pkg/cmd/boot/boot_integration_test.go
@@ -1,0 +1,228 @@
+// +build integration
+
+package boot
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/acarl005/stripansi"
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	FirstTag  = "v1.0.0"
+	SecondTag = "v2.0.0"
+
+	testFileName = "some-file"
+)
+
+func TestUpdateBootCloneIfOutOfDate_Conflicts(t *testing.T) {
+	gitter := gits.NewGitCLI()
+
+	repoDir, err := initializeTempGitRepo(gitter)
+	assert.NoError(t, err)
+
+	defer func() {
+		err := os.RemoveAll(repoDir)
+		assert.NoError(t, err)
+	}()
+
+	testDir, err := ioutil.TempDir("", "update-local-boot-clone-test-clone-")
+	assert.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(testDir)
+		assert.NoError(t, err)
+	}()
+
+	err = gitter.Clone(repoDir, testDir)
+	assert.NoError(t, err)
+
+	err = gitter.FetchTags(testDir)
+	assert.NoError(t, err)
+
+	err = gitter.Reset(testDir, FirstTag, true)
+	assert.NoError(t, err)
+
+	conflictingContent := []byte("something else")
+	err = ioutil.WriteFile(filepath.Join(testDir, testFileName), conflictingContent, util.DefaultWritePermissions)
+	assert.NoError(t, err)
+
+	o := &BootOptions{
+		CommonOptions: &opts.CommonOptions{},
+		Dir:           testDir,
+	}
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+	o.CommonOptions.Out = fakeStdout
+
+	err = o.updateBootCloneIfOutOfDate(SecondTag)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Could not update local boot clone due to conflicts between local changes and v2.0.0.")
+
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	output := stripansi.Strip(string(outBytes))
+	assert.Contains(t, output, "It is based on v1.0.0, but the version stream is using v2.0.0.")
+}
+
+func TestUpdateBootCloneIfOutOfDate_NoConflicts(t *testing.T) {
+	gitter := gits.NewGitCLI()
+
+	repoDir, err := initializeTempGitRepo(gitter)
+	assert.NoError(t, err)
+
+	defer func() {
+		err := os.RemoveAll(repoDir)
+		assert.NoError(t, err)
+	}()
+
+	testDir, err := ioutil.TempDir("", "update-local-boot-clone-test-clone-")
+	assert.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(testDir)
+		assert.NoError(t, err)
+	}()
+
+	err = gitter.Clone(repoDir, testDir)
+	assert.NoError(t, err)
+
+	err = gitter.FetchTags(testDir)
+	assert.NoError(t, err)
+
+	err = gitter.Reset(testDir, FirstTag, true)
+	assert.NoError(t, err)
+
+	conflictingContent := []byte("something else")
+	err = ioutil.WriteFile(filepath.Join(testDir, "some-other-file"), conflictingContent, util.DefaultWritePermissions)
+	assert.NoError(t, err)
+
+	o := &BootOptions{
+		CommonOptions: &opts.CommonOptions{},
+		Dir:           testDir,
+	}
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+	o.CommonOptions.Out = fakeStdout
+
+	err = o.updateBootCloneIfOutOfDate(SecondTag)
+	assert.NoError(t, err)
+
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	output := stripansi.Strip(string(outBytes))
+	assert.Contains(t, output, "It is based on v1.0.0, but the version stream is using v2.0.0.")
+}
+
+func TestUpdateBootCloneIfOutOfDate_UpToDate(t *testing.T) {
+	gitter := gits.NewGitCLI()
+
+	repoDir, err := initializeTempGitRepo(gitter)
+	assert.NoError(t, err)
+
+	defer func() {
+		err := os.RemoveAll(repoDir)
+		assert.NoError(t, err)
+	}()
+
+	testDir, err := ioutil.TempDir("", "update-local-boot-clone-test-clone-")
+	assert.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(testDir)
+		assert.NoError(t, err)
+	}()
+
+	err = gitter.Clone(repoDir, testDir)
+	assert.NoError(t, err)
+
+	err = gitter.FetchTags(testDir)
+	assert.NoError(t, err)
+
+	err = gitter.Reset(testDir, SecondTag, true)
+	assert.NoError(t, err)
+
+	conflictingContent := []byte("something else")
+	err = ioutil.WriteFile(filepath.Join(testDir, "some-other-file"), conflictingContent, util.DefaultWritePermissions)
+	assert.NoError(t, err)
+
+	o := &BootOptions{
+		CommonOptions: &opts.CommonOptions{},
+		Dir:           testDir,
+	}
+	r, fakeStdout, _ := os.Pipe()
+	log.SetOutput(fakeStdout)
+	o.CommonOptions.Out = fakeStdout
+
+	err = o.updateBootCloneIfOutOfDate(SecondTag)
+	assert.NoError(t, err)
+
+	fakeStdout.Close()
+	outBytes, _ := ioutil.ReadAll(r)
+	r.Close()
+	output := stripansi.Strip(string(outBytes))
+	assert.Equal(t, "", output)
+}
+
+func initializeTempGitRepo(gitter gits.Gitter) (string, error) {
+	dir, err := ioutil.TempDir("", "update-local-boot-clone-test-repo-")
+	if err != nil {
+		return "", err
+	}
+
+	err = gitter.Init(dir)
+	if err != nil {
+		return "", err
+	}
+
+	err = gitter.AddCommit(dir, "Initial Commit")
+	if err != nil {
+		return "", err
+	}
+
+	testFile := filepath.Join(dir, testFileName)
+	testFileContents := []byte("foo")
+	err = ioutil.WriteFile(testFile, testFileContents, util.DefaultWritePermissions)
+	if err != nil {
+		return "", err
+	}
+
+	err = gitter.Add(dir, ".")
+	if err != nil {
+		return "", err
+	}
+	err = gitter.AddCommit(dir, "Adding foo")
+	if err != nil {
+		return "", err
+	}
+
+	err = gitter.CreateTag(dir, FirstTag, "First Tag")
+	if err != nil {
+		return "", err
+	}
+
+	testFileContents = []byte("bar")
+	err = ioutil.WriteFile(testFile, testFileContents, util.DefaultWritePermissions)
+	if err != nil {
+		return "", err
+	}
+
+	err = gitter.AddCommit(dir, "Adding bar")
+	if err != nil {
+		return "", err
+	}
+
+	err = gitter.CreateTag(dir, SecondTag, "Second Tag")
+	if err != nil {
+		return "", err
+	}
+
+	return dir, nil
+}

--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -709,6 +709,24 @@ func IsNoStashEntriesError(err error) bool {
 	return strings.Contains(err.Error(), "No stash entries found.")
 }
 
+// GetSimpleIndentedStashPopErrorMessage gets the output of a failed git stash pop without duplication or additional content,
+// with each line indented four characters.
+func GetSimpleIndentedStashPopErrorMessage(err error) string {
+	errStr := err.Error()
+	idx := strings.Index(errStr, ": failed to run 'git stash pop'")
+	if idx > -1 {
+		errStr = errStr[:idx]
+	}
+
+	var indentedLines []string
+
+	for _, line := range strings.Split(errStr, "\n") {
+		indentedLines = append(indentedLines, "    "+line)
+	}
+
+	return strings.Join(indentedLines, "\n")
+}
+
 // FindTagForVersion will find a tag for a version number (first fetching the tags, then looking for a tag <version>
 // then trying the common convention v<version>). It will return the tag or an error if the tag can't be found.
 func FindTagForVersion(dir string, version string, gitter Gitter) (string, error) {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This will check if the boot clone isn't using the ref the desired tag points to, after cloning the boot config if needed. If the clone is using a different ref, it will try to stash any local changes, update the clone to use the appropriate ref, and unstash those local changes. If there are errors in the unstash due to conflicts, it'll report the `git stash pop` error message and tell the user what they need to do to fix it.

#### Special notes for the reviewer(s)

/assign @macox 
/assign @pmuir 
/assign @daveconde 
/assign @dgozalo 

#### Which issue this PR fixes

fixes #5929
