### PR TITLE
fix: fixing the gke cluster deletion to make it easier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -172,3 +172,5 @@ replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v10.15.5+incompatible
 
 replace github.com/banzaicloud/bank-vaults => github.com/banzaicloud/bank-vaults v0.0.0-20190508130850-5673d28c46bd
+
+go 1.13

--- a/pkg/cmd/deletecmd/delete_gke.go
+++ b/pkg/cmd/deletecmd/delete_gke.go
@@ -13,11 +13,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+
 // DeleteGkeOptions Options for deleting a GKE cluster
 type DeleteGkeOptions struct {
 	get.GetOptions
 	Region    string
 	ProjectID string
+	ClusterName string
+
 }
 
 var (
@@ -48,25 +51,31 @@ func NewCmdDeleteGke(commonOpts *opts.CommonOptions) *cobra.Command {
 			options.Args = args
 			err := options.Run()
 			helper.CheckErr(err)
+
+
+
+
 		},
 	}
 	cmd.Flags().StringVarP(&options.Region, "region", "", "europe-west1-c", "GKE region to use. Default: europe-west1-c")
 	cmd.Flags().StringVarP(&options.ProjectID, "project-id", "p", "", "Google Project ID to delete cluster from")
+	cmd.Flags().StringVarP(&options.ClusterName, "cluster-name", "c", "", "Google Cluster name to delete")
 	options.AddGetFlags(cmd)
+
+
 	return cmd
 }
 
 // Run implements this command
 func (o *DeleteGkeOptions) Run() error {
-	if len(o.Args) == 0 {
+	if o.ClusterName == "" {
 		return errors.New("cluster name expected")
 	}
-	cluster := o.Args[0]
 	err := o.InstallRequirements(cloud.GKE)
 	if err != nil {
 		return err
 	}
-	args := []string{"container", "clusters", "delete", cluster, "--region=" + o.Region, "--quiet", "--async"}
+	args := []string{"container", "clusters", "delete", o.ClusterName, "--region=" + o.Region, "--quiet", "--async"}
 	if o.ProjectID != "" {
 		args = append(args, "--project="+o.ProjectID)
 	}

--- a/pkg/config/zz_generated.deepcopy.go
+++ b/pkg/config/zz_generated.deepcopy.go
@@ -939,7 +939,15 @@ func (in *RequirementsConfig) DeepCopyInto(out *RequirementsConfig) {
 		*out = make([]EnvironmentConfig, len(*in))
 		copy(*out, *in)
 	}
-	out.GithubApp = in.GithubApp
+	if in.GithubApp != nil {
+		in, out := &in.GithubApp, &out.GithubApp
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(GithubAppConfig)
+			**out = **in
+		}
+	}
 	out.Ingress = in.Ingress
 	out.Storage = in.Storage
 	out.Vault = in.Vault

--- a/pkg/versionstream/versionstreamrepo/gitrepo_integration_test.go
+++ b/pkg/versionstream/versionstreamrepo/gitrepo_integration_test.go
@@ -19,12 +19,10 @@ import (
 )
 
 const (
-	RepoURL           = "https://github.com/jenkins-x/jenkins-x-versions"
 	TagFromDefaultURL = "v1.0.114"
 	FirstTag          = "v0.0.1"
 	SecondTag         = "v0.0.2"
 	BranchRef         = "master"
-	HEAD              = "HEAD"
 )
 
 func TestCloneJXVersionsRepoWithDefaultURL(t *testing.T) {
@@ -42,23 +40,7 @@ func TestCloneJXVersionsRepoWithDefaultURL(t *testing.T) {
 	}()
 
 	gitter := gits.NewGitCLI()
-	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
-		"",
-		TagFromDefaultURL,
-		nil,
-		gitter,
-		true,
-		false,
-		util.IOFileHandles{},
-	)
-
-	// Get the latest tag so that we know the correct expected verion ref.
-	tag, _, err := gitter.Describe(dir, false, TagFromDefaultURL, "", true)
-
-	assert.NoError(t, err)
-	assert.NotNil(t, dir)
-	assert.NotNil(t, versionRef)
-	assert.Equal(t, tag, versionRef)
+	_, _ = assertClonesCorrectly(t, "", TagFromDefaultURL, TagFromDefaultURL, gitter, nil)
 }
 
 func initializeTempGitRepo(gitter gits.Gitter) (string, string, error) {
@@ -148,23 +130,7 @@ func TestCloneJXVersionsRepoReplacingCurrent(t *testing.T) {
 
 	gitter := gits.NewGitCLI()
 	// First, clone the default URL so we can make sure it gets removed.
-	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
-		"",
-		TagFromDefaultURL,
-		nil,
-		gitter,
-		true,
-		false,
-		util.IOFileHandles{},
-	)
-
-	// Get the latest tag so that we know the correct expected version ref.
-	tag, _, err := gitter.Describe(dir, false, TagFromDefaultURL, "", true)
-
-	assert.NoError(t, err)
-	assert.NotNil(t, dir)
-	assert.NotNil(t, versionRef)
-	assert.Equal(t, tag, versionRef)
+	_, _ = assertClonesCorrectly(t, "", TagFromDefaultURL, TagFromDefaultURL, gitter, nil)
 
 	// Sleep briefly so that git GC in the background has finished
 	time.Sleep(5 * time.Second)
@@ -180,26 +146,8 @@ func TestCloneJXVersionsRepoReplacingCurrent(t *testing.T) {
 		VersionStreamURL: gitDir,
 		VersionStreamRef: FirstTag,
 	}
-	dir, versionRef, err = versionstreamrepo.CloneJXVersionsRepo(
-		"",
-		"",
-		settings,
-		gitter,
-		true,
-		false,
-		util.IOFileHandles{},
-	)
-	assert.NoError(t, err)
-	assert.NotNil(t, dir)
-	assert.NotNil(t, versionRef)
-	assert.Equal(t, FirstTag, versionRef)
 
-	err = gitter.Checkout(dir, versionRef)
-	assert.NoError(t, err)
-
-	actualFileContents, err := ioutil.ReadFile(filepath.Join(dir, testFileName))
-	assert.NoError(t, err)
-	assert.Equal(t, "foo", string(actualFileContents))
+	_ = assertClonesCorrectlyWithCorrectFileContents(t, "", "", FirstTag, gitter, testFileName, "foo", settings)
 }
 
 func TestCloneJXVersionsRepoWithTeamSettings(t *testing.T) {
@@ -227,26 +175,8 @@ func TestCloneJXVersionsRepoWithTeamSettings(t *testing.T) {
 		VersionStreamURL: gitDir,
 		VersionStreamRef: FirstTag,
 	}
-	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
-		"",
-		"",
-		settings,
-		gitter,
-		true,
-		false,
-		util.IOFileHandles{},
-	)
-	assert.NoError(t, err)
-	assert.NotNil(t, dir)
-	assert.NotNil(t, versionRef)
-	assert.Equal(t, FirstTag, versionRef)
 
-	err = gitter.Checkout(dir, versionRef)
-	assert.NoError(t, err)
-
-	actualFileContents, err := ioutil.ReadFile(filepath.Join(dir, testFileName))
-	assert.NoError(t, err)
-	assert.Equal(t, "foo", string(actualFileContents))
+	_ = assertClonesCorrectlyWithCorrectFileContents(t, "", "", FirstTag, gitter, testFileName, "foo", settings)
 }
 
 func TestCloneJXVersionsRepoWithATag(t *testing.T) {
@@ -270,26 +200,8 @@ func TestCloneJXVersionsRepoWithATag(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 	assert.NoError(t, err)
-	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
-		gitDir,
-		FirstTag,
-		nil,
-		gitter,
-		true,
-		false,
-		util.IOFileHandles{},
-	)
-	assert.NoError(t, err)
-	assert.NotNil(t, dir)
-	assert.NotNil(t, versionRef)
-	assert.Equal(t, FirstTag, versionRef)
 
-	err = gitter.Checkout(dir, versionRef)
-	assert.NoError(t, err)
-
-	actualFileContents, err := ioutil.ReadFile(filepath.Join(dir, testFileName))
-	assert.NoError(t, err)
-	assert.Equal(t, "foo", string(actualFileContents))
+	_ = assertClonesCorrectlyWithCorrectFileContents(t, gitDir, FirstTag, FirstTag, gitter, testFileName, "foo", nil)
 }
 
 func TestCloneJXVersionsRepoWithABranch(t *testing.T) {
@@ -313,26 +225,8 @@ func TestCloneJXVersionsRepoWithABranch(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 	assert.NoError(t, err)
-	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
-		gitDir,
-		BranchRef,
-		nil,
-		gitter,
-		true,
-		false,
-		util.IOFileHandles{},
-	)
-	assert.NoError(t, err)
-	assert.NotNil(t, dir)
-	assert.NotNil(t, versionRef)
-	assert.Equal(t, BranchRef, versionRef)
 
-	err = gitter.Checkout(dir, versionRef)
-	assert.NoError(t, err)
-
-	actualFileContents, err := ioutil.ReadFile(filepath.Join(dir, testFileName))
-	assert.NoError(t, err)
-	assert.Equal(t, "foobarbaz", string(actualFileContents))
+	_ = assertClonesCorrectlyWithCorrectFileContents(t, gitDir, BranchRef, BranchRef, gitter, testFileName, "foobarbaz", nil)
 }
 
 func TestCloneJXVersionsRepoWithACommit(t *testing.T) {
@@ -359,26 +253,7 @@ func TestCloneJXVersionsRepoWithACommit(t *testing.T) {
 
 	headMinusOne, err := gitter.RevParse(gitDir, "HEAD~1")
 
-	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
-		fmt.Sprintf("file://%s", gitDir),
-		headMinusOne,
-		nil,
-		gitter,
-		true,
-		false,
-		util.IOFileHandles{},
-	)
-	assert.NoError(t, err)
-	assert.NotNil(t, dir)
-	assert.NotNil(t, versionRef)
-	assert.Equal(t, SecondTag, versionRef)
-
-	err = gitter.Checkout(dir, versionRef)
-	assert.NoError(t, err)
-
-	actualFileContents, err := ioutil.ReadFile(filepath.Join(dir, testFileName))
-	assert.NoError(t, err)
-	assert.Equal(t, "foobar", string(actualFileContents))
+	_ = assertClonesCorrectlyWithCorrectFileContents(t, gitDir, headMinusOne, SecondTag, gitter, testFileName, "foobar", nil)
 }
 
 func TestCloneJXVersionsRepoWithAnUntaggedCommit(t *testing.T) {
@@ -405,10 +280,70 @@ func TestCloneJXVersionsRepoWithAnUntaggedCommit(t *testing.T) {
 
 	head, err := gitter.RevParse(gitDir, "HEAD")
 
-	dir, versionRef, err := versionstreamrepo.CloneJXVersionsRepo(
-		fmt.Sprintf("file://%s", gitDir),
-		head,
-		nil,
+	_ = assertClonesCorrectlyWithCorrectFileContents(t, gitDir, head, head, gitter, testFileName, "foobarbaz", nil)
+}
+
+func TestCloneJXVersionsRepoWithNonFastForward(t *testing.T) {
+	origJxHome := os.Getenv("JX_HOME")
+
+	tmpJxHome, err := ioutil.TempDir("", "jx-test-"+t.Name())
+	assert.NoError(t, err)
+
+	err = os.Setenv("JX_HOME", tmpJxHome)
+	assert.NoError(t, err)
+
+	defer func() {
+		_ = os.RemoveAll(tmpJxHome)
+		err = os.Setenv("JX_HOME", origJxHome)
+	}()
+
+	gitter := gits.NewGitCLI()
+	gitDir, testFileName, err := initializeTempGitRepo(gitter)
+	defer func() {
+		err := os.RemoveAll(gitDir)
+		assert.NoError(t, err)
+	}()
+	assert.NoError(t, err)
+
+	dir := assertClonesCorrectlyWithCorrectFileContents(t, gitDir, BranchRef, BranchRef, gitter, testFileName, "foobarbaz", nil)
+
+	// Update the git repo with a new commit
+	testFileContents := []byte("banana")
+	err = ioutil.WriteFile(filepath.Join(gitDir, testFileName), testFileContents, util.DefaultWritePermissions)
+	assert.NoError(t, err)
+
+	err = gitter.AddCommit(gitDir, "changing to banana")
+	assert.NoError(t, err)
+
+	// Make a different change to the local clone of the repo
+	testFileContents = []byte("apple")
+	err = ioutil.WriteFile(filepath.Join(dir, testFileName), testFileContents, util.DefaultWritePermissions)
+	assert.NoError(t, err)
+
+	err = gitter.AddCommit(dir, "changing to apple")
+	assert.NoError(t, err)
+
+	// Run CloneJXVersionsRepo and verify that it does checkout the latest of the branch.
+	_ = assertClonesCorrectlyWithCorrectFileContents(t, gitDir, BranchRef, BranchRef, gitter, testFileName, "banana", nil)
+}
+
+func assertClonesCorrectlyWithCorrectFileContents(t *testing.T, gitDir string, versionRefToCheckout string, expectedRef string, gitter gits.Gitter, testFileName string, expectedFileContent string, settings *v1.TeamSettings) string {
+	dir, actualVersionRef := assertClonesCorrectly(t, gitDir, versionRefToCheckout, expectedRef, gitter, settings)
+	err := gitter.Checkout(dir, actualVersionRef)
+	assert.NoError(t, err)
+
+	actualFileContents, err := ioutil.ReadFile(filepath.Join(dir, testFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedFileContent, string(actualFileContents))
+
+	return dir
+}
+
+func assertClonesCorrectly(t *testing.T, gitDir string, versionRefToCheckout string, expectedRef string, gitter gits.Gitter, settings *v1.TeamSettings) (string, string) {
+	dir, actualVersionRef, err := versionstreamrepo.CloneJXVersionsRepo(
+		gitDir,
+		versionRefToCheckout,
+		settings,
 		gitter,
 		true,
 		false,
@@ -416,13 +351,8 @@ func TestCloneJXVersionsRepoWithAnUntaggedCommit(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, dir)
-	assert.NotNil(t, versionRef)
-	assert.Equal(t, head, versionRef)
+	assert.NotNil(t, actualVersionRef)
+	assert.Equal(t, expectedRef, actualVersionRef)
 
-	err = gitter.Checkout(dir, versionRef)
-	assert.NoError(t, err)
-
-	actualFileContents, err := ioutil.ReadFile(filepath.Join(dir, testFileName))
-	assert.NoError(t, err)
-	assert.Equal(t, []byte("foobarbaz"), actualFileContents)
+	return dir, actualVersionRef
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Cluster deletion was confusing when using an arg instead of an option. Changed arg to option to make it clear. 


#### Special notes for the reviewer(s)
This should be done with all other cloud providers to come. Change coming after this is approved. 

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
