### PR TITLE
fix: gke cluser deletion with option

### DIFF
--- a/pkg/cmd/deletecmd/delete_gke.go
+++ b/pkg/cmd/deletecmd/delete_gke.go
@@ -13,11 +13,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+
 // DeleteGkeOptions Options for deleting a GKE cluster
 type DeleteGkeOptions struct {
 	get.GetOptions
 	Region    string
 	ProjectID string
+	ClusterName string
+
 }
 
 var (
@@ -48,25 +51,31 @@ func NewCmdDeleteGke(commonOpts *opts.CommonOptions) *cobra.Command {
 			options.Args = args
 			err := options.Run()
 			helper.CheckErr(err)
+
+
+
+
 		},
 	}
 	cmd.Flags().StringVarP(&options.Region, "region", "", "europe-west1-c", "GKE region to use. Default: europe-west1-c")
 	cmd.Flags().StringVarP(&options.ProjectID, "project-id", "p", "", "Google Project ID to delete cluster from")
+	cmd.Flags().StringVarP(&options.ClusterName, "cluster-name", "c", "", "Google Cluster name to delete")
 	options.AddGetFlags(cmd)
+
+
 	return cmd
 }
 
 // Run implements this command
 func (o *DeleteGkeOptions) Run() error {
-	if len(o.Args) == 0 {
+	if o.ClusterName == "" {
 		return errors.New("cluster name expected")
 	}
-	cluster := o.Args[0]
 	err := o.InstallRequirements(cloud.GKE)
 	if err != nil {
 		return err
 	}
-	args := []string{"container", "clusters", "delete", cluster, "--region=" + o.Region, "--quiet", "--async"}
+	args := []string{"container", "clusters", "delete", o.ClusterName, "--region=" + o.Region, "--quiet", "--async"}
 	if o.ProjectID != "" {
 		args = append(args, "--project="+o.ProjectID)
 	}


### PR DESCRIPTION
Signed-off-by: Evan Haston <ehaston@darkmatterit.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Switched gke delete to use option instead of arg. It's easier to understand 

#### Special notes for the reviewer(s)

We may want to do this with eks too 

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
