### PR TITLE
feat: if using self signed certs from letsencrypt (typically during C…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2019-10-24T10:26:44Z",
+  "generated_at": "2019-10-26T13:43:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -416,7 +416,7 @@
       {
         "hashed_secret": "2ace62c1befa19e3ea37dd52be9f6d508c5163e6",
         "is_secret": false,
-        "line_number": 1298,
+        "line_number": 1303,
         "type": "Secret Keyword"
       }
     ],
@@ -530,7 +530,7 @@
       {
         "hashed_secret": "5d5c1ff72d4d96c765976e44f54b2ca3c2376330",
         "is_secret": false,
-        "line_number": 256,
+        "line_number": 260,
         "type": "Secret Keyword"
       }
     ],
@@ -654,7 +654,7 @@
       {
         "hashed_secret": "2ee489d9ee5e2ab410b713e784e474d98cf08c54",
         "is_secret": false,
-        "line_number": 521,
+        "line_number": 528,
         "type": "Secret Keyword"
       }
     ],

--- a/pkg/cmd/controller/controller_enviornmentcontroller.go
+++ b/pkg/cmd/controller/controller_enviornmentcontroller.go
@@ -539,13 +539,18 @@ func (o *ControllerEnvironmentOptions) registerWebHook(webhookURL string, secret
 			return errors.Wrapf(err, "failed to create git provider for git URL %s", gitURL)
 		}
 	}
+	isInsecureSSL, err := o.IsInsecureSSLWebhooks()
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if we need to setup insecure SSL webhook")
+	}
 	webHookData := &gits.GitWebHookArguments{
 		Owner: o.GitOwner,
 		Repo: &gits.GitRepository{
 			Name: o.GitRepo,
 		},
-		URL:    webhookURL,
-		Secret: string(secret),
+		URL:         webhookURL,
+		Secret:      string(secret),
+		InsecureSSL: isInsecureSSL,
 	}
 	err = provider.CreateWebHook(webHookData)
 	if err != nil {

--- a/pkg/cmd/opts/import.go
+++ b/pkg/cmd/opts/import.go
@@ -199,11 +199,17 @@ func (o *CommonOptions) ImportProject(gitURL string, dir string, jenkinsfile str
 	if jenkBaseURL == "" {
 		jenkBaseURL = jenk.BaseURL()
 	}
+	isInsecureSSL, err := o.IsInsecureSSLWebhooks()
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if we need to setup insecure SSL webhook")
+	}
+
 	webhookUrl := util.UrlJoin(jenkBaseURL, suffix)
 	webhook := &gits.GitWebHookArguments{
-		Owner: gitInfo.Organisation,
-		Repo:  gitInfo,
-		URL:   webhookUrl,
+		Owner:       gitInfo.Organisation,
+		Repo:        gitInfo,
+		URL:         webhookUrl,
+		InsecureSSL: isInsecureSSL,
 	}
 	return gitProvider.CreateWebHook(webhook)
 }

--- a/pkg/cmd/opts/install.go
+++ b/pkg/cmd/opts/install.go
@@ -1195,11 +1195,16 @@ func (o *CommonOptions) CreateWebhookProw(gitURL string, gitProvider gits.GitPro
 	if err != nil {
 		return err
 	}
+	isInsecureSSL, err := o.IsInsecureSSLWebhooks()
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if we need to setup insecure SSL webhook")
+	}
 	webhook := &gits.GitWebHookArguments{
-		Owner:  gitInfo.Organisation,
-		Repo:   gitInfo,
-		URL:    webhookUrl,
-		Secret: string(hmacToken.Data["hmac"]),
+		Owner:       gitInfo.Organisation,
+		Repo:        gitInfo,
+		URL:         webhookUrl,
+		Secret:      string(hmacToken.Data["hmac"]),
+		InsecureSSL: isInsecureSSL,
 	}
 	return gitProvider.CreateWebHook(webhook)
 }

--- a/pkg/cmd/update/update_webhooks.go
+++ b/pkg/cmd/update/update_webhooks.go
@@ -241,13 +241,17 @@ func (o *UpdateWebhooksOptions) updateRepoHook(git gits.GitProvider, owner strin
 	if err != nil {
 		log.Logger().Infof("no webhooks found repository %s/%s", util.ColorInfo(owner), util.ColorInfo(repoName))
 	}
-
+	isInsecureSSL, err := o.IsInsecureSSLWebhooks()
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if we need to setup insecure SSL webhook")
+	}
 	webHookArgs := &gits.GitWebHookArguments{
 		Owner: owner,
 		Repo: &gits.GitRepository{
 			Name: repoName,
 		},
-		URL: webhookURL,
+		URL:         webhookURL,
+		InsecureSSL: isInsecureSSL,
 	}
 	if userName != owner {
 		webHookArgs.Repo.Organisation = owner

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -431,9 +431,16 @@ func (p *GitHubProvider) CreateWebHook(data *GitWebHookArguments) error {
 			}
 		}
 	}
+	// 0 makes insecure SSL not enabled
+	insecureSSL := "0"
+	if data.InsecureSSL {
+		// this is insecure and should only be used in test scenarios
+		insecureSSL = "1"
+	}
 	config := map[string]interface{}{
 		"url":          webhookUrl,
 		"content_type": "json",
+		"insecure_ssl": insecureSSL,
 	}
 	if data.Secret != "" {
 		config["secret"] = data.Secret

--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -185,6 +185,7 @@ type GitWebHookArguments struct {
 	URL         string
 	ExistingURL string
 	Secret      string
+	InsecureSSL bool
 }
 
 type GitFileContent struct {

--- a/pkg/kube/certmanager.go
+++ b/pkg/kube/certmanager.go
@@ -1,0 +1,27 @@
+package kube
+
+import (
+	certmngclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const labelLetsencryptService = "jenkins.io/letsencrypt-service"
+
+// IsStagingCertificate looks at certmanager certificates to find if we are using staging or prod certs
+func IsStagingCertificate(client certmngclient.Interface, ns string) (bool, error) {
+	certs, err := client.CertmanagerV1alpha1().Certificates(ns).List(metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	// loop over certificates and look for a Jenkins X label to identify if we are using staging or prod certs
+	for _, cert := range certs.Items {
+		if cert.ObjectMeta.Labels[labelLetsencryptService] == "production" {
+			return false, nil
+		}
+		if cert.ObjectMeta.Labels[labelLetsencryptService] == "staging" {
+			return true, nil
+		}
+	}
+	return false, errors.New("no matching certificates found with letsencrypt-service label")
+}

--- a/pkg/kube/certmanager_test.go
+++ b/pkg/kube/certmanager_test.go
@@ -1,0 +1,65 @@
+package kube
+
+import (
+	"testing"
+
+	certmng "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/client/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsStagingCertificate(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset()
+
+	const name = "test"
+	const ns = "test"
+	cert := newCert(name, "staging")
+
+	_, err := client.Certmanager().Certificates(ns).Create(cert)
+	assert.NoError(t, err, "should create a test certificate whithout an error")
+
+	isStaging, err := IsStagingCertificate(client, ns)
+	assert.NoError(t, err, "should find a matching certificate")
+	assert.Equal(t, true, isStaging, "should gave found a staging certificate")
+}
+
+func TestIsNotStagingCertificate(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset()
+
+	const name = "test"
+	const ns = "test"
+	cert := newCert(name, "production")
+	_, err := client.Certmanager().Certificates(ns).Create(cert)
+	assert.NoError(t, err, "should create a test certificate whithout an error")
+
+	isStaging, err := IsStagingCertificate(client, ns)
+	assert.NoError(t, err, "should find a matching certificate")
+	assert.Equal(t, false, isStaging, "should gave found a production certificate")
+
+}
+
+func TestNoCertificate(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset()
+	const ns = "test"
+
+	_, err := IsStagingCertificate(client, ns)
+	assert.Error(t, err, "should find a matching certificate")
+}
+
+func newCert(name, service string) *certmng.Certificate {
+	labels := map[string]string{}
+	labels[labelLetsencryptService] = service
+	return &certmng.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}


### PR DESCRIPTION
…I tests) we need to enable insecure SSL when creating webhooks on GitHub. 

This change means we will be able to switch to staging self signed certs in our CI repos and still be able to run the BDD tests.
