### PR TITLE
feat: sort activities output

### DIFF
--- a/pkg/cmd/get/get_activity.go
+++ b/pkg/cmd/get/get_activity.go
@@ -32,6 +32,7 @@ type GetActivityOptions struct {
 	Filter      string
 	BuildNumber string
 	Watch       bool
+	Sort        bool
 }
 
 var (
@@ -72,6 +73,7 @@ func NewCmdGetActivity(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Filter, "filter", "f", "", "Text to filter the pipeline names")
 	cmd.Flags().StringVarP(&options.BuildNumber, "build", "", "", "The build number to filter on")
 	cmd.Flags().BoolVarP(&options.Watch, "watch", "w", false, "Whether to watch the activities for changes")
+	cmd.Flags().BoolVarP(&options.Sort, "sort", "s", false, "Sort activities by timestamp")
 	return cmd
 }
 
@@ -89,12 +91,6 @@ func (o *GetActivityOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	envList, err := client.JenkinsV1().Environments(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	kube.SortEnvironments(envList.Items)
-
 	table := o.CreateTable()
 	table.SetColumnAlign(1, util.ALIGN_RIGHT)
 	table.SetColumnAlign(2, util.ALIGN_RIGHT)
@@ -108,6 +104,10 @@ func (o *GetActivityOptions) Run() error {
 	if err != nil {
 		return err
 	}
+	if o.Sort {
+		kube.SortActivities(list.Items)
+	}
+
 	for _, activity := range list.Items {
 		o.addTableRow(&table, &activity)
 	}

--- a/pkg/cmd/get/get_activity_test.go
+++ b/pkg/cmd/get/get_activity_test.go
@@ -1,0 +1,113 @@
+package get_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jenkins-x/jx/pkg/cmd/get"
+
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
+	"github.com/jenkins-x/jx/pkg/gits"
+	helm_test "github.com/jenkins-x/jx/pkg/helm/mocks"
+	resources_test "github.com/jenkins-x/jx/pkg/kube/resources/mocks"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGetActivity(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Get Activity Suite")
+}
+
+type fakeOut struct {
+	content []byte
+}
+
+func (f *fakeOut) Write(p []byte) (int, error) {
+	f.content = append(f.content, p...)
+
+	return len(f.content), nil
+}
+
+func (f *fakeOut) Fd() uintptr {
+	return 0
+}
+
+func (f *fakeOut) GetOutput() string {
+	return string(f.content)
+}
+
+var _ = Describe("get activity", func() {
+	Describe("Run()", func() {
+		var (
+			sort   bool
+			err    error
+			stdout *fakeOut
+		)
+
+		JustBeforeEach(func() {
+			stdout = &fakeOut{}
+			commonOpts := &opts.CommonOptions{
+				Out: stdout,
+			}
+			commonOpts.SetDevNamespace("jx")
+
+			testhelpers.ConfigureTestOptionsWithResources(commonOpts,
+				[]runtime.Object{},
+				[]runtime.Object{},
+				&gits.GitFake{CurrentBranch: "job"},
+				&gits.FakeProvider{},
+				helm_test.NewMockHelmer(),
+				resources_test.NewMockInstaller(),
+			)
+
+			c, ns, _ := commonOpts.JXClient()
+
+			testhelpers.CreateTestPipelineActivityWithTime(c, ns, "jx-testing", "jx-testing", "job", "1", "workflow", v1.Date(2019, time.October, 10, 23, 0, 0, 0, time.UTC))
+			testhelpers.CreateTestPipelineActivityWithTime(c, ns, "jx-testing", "jx-testing", "job", "2", "workflow", v1.Date(2019, time.January, 10, 23, 0, 0, 0, time.UTC))
+
+			options := &get.GetActivityOptions{
+				CommonOptions: commonOpts,
+				Sort:          sort,
+			}
+
+			err = options.Run()
+		})
+
+		BeforeEach(func() {
+			os.Setenv("REPO_OWNER", "jx-testing")
+			os.Setenv("REPO_NAME", "jx-testing")
+			os.Setenv("JOB_NAME", "job")
+			os.Setenv("BRANCH_NAME", "job")
+		})
+
+		Context("Without flags", func() {
+			BeforeEach(func() {
+				sort = false
+			})
+
+			It("Prints a list of activities", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout.GetOutput()).To(HavePrefix(`STEP                         STARTED AGO DURATION STATUS
+jx-testing/jx-testing/job #1`))
+			})
+		})
+
+		Context("With  the sort flag", func() {
+			BeforeEach(func() {
+				sort = true
+			})
+
+			It("Prints a sorted list of activities", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout.GetOutput()).To(HavePrefix(`STEP                         STARTED AGO DURATION STATUS
+jx-testing/jx-testing/job #2`))
+			})
+		})
+	})
+})

--- a/pkg/kube/env.go
+++ b/pkg/kube/env.go
@@ -968,6 +968,31 @@ func SortEnvironments(environments []v1.Environment) {
 	sort.Sort(ByOrder(environments))
 }
 
+// ByTimestamp is used to fileter a list of PipelineActivities by their given timestamp
+type ByTimestamp []v1.PipelineActivity
+
+func (a ByTimestamp) Len() int      { return len(a) }
+func (a ByTimestamp) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByTimestamp) Less(i, j int) bool {
+	act1 := a[i]
+	act2 := a[j]
+	t1 := act1.Spec.StartedTimestamp
+	if t1 == nil {
+		return false
+	}
+	t2 := act2.Spec.StartedTimestamp
+	if t2 == nil {
+		return true
+	}
+
+	return t1.Before(t2)
+}
+
+// SortActivities sorts a list of PipelineActivities
+func SortActivities(activities []v1.PipelineActivity) {
+	sort.Sort(ByTimestamp(activities))
+}
+
 // NewPermanentEnvironment creates a new permanent environment for testing
 func NewPermanentEnvironment(name string) *v1.Environment {
 	return &v1.Environment{


### PR DESCRIPTION
This PR introduces the flag `--sort` to the get activities command which will return a sorted version of the activities by timestamp.

fixes #2910 