### PR TITLE
fix: Output language of git

### DIFF
--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -530,6 +530,8 @@ func (g *GitCLI) gitCmd(dir string, args ...string) error {
 		Name: "git",
 		Args: args,
 	}
+	// Ensure that error output is in English so parsing work
+	cmd.Env = map[string]string{"LC_ALL": "C"}
 	output, err := cmd.RunWithoutRetry()
 	return errors.Wrapf(err, "git output: %s", output)
 }
@@ -540,6 +542,8 @@ func (g *GitCLI) gitCmdWithOutput(dir string, args ...string) (string, error) {
 		Name: "git",
 		Args: args,
 	}
+	// Ensure that error output is in English so parsing work
+	cmd.Env = map[string]string{"LC_ALL": "C"}
 	return cmd.RunWithoutRetry()
 }
 


### PR DESCRIPTION
#### Description

Since jx is assuming the output of git is is in English it should tell git to output English.

As it is now commands can fail because jx doesn't recognise the output of git when locale isn't specifying English language. For example in the case of promote:

```
error: pulling environment repo https://github.com/foo/environment.git into /Users/bar/.jx/environments: fetching origin promote-fubar-0.0.9: git output: fatal: Kunde inte hitta fjärr-referensen promote-fubar-0.0.9: failed to run 'git fetch origin promote-fubar-0.0.9' command in directory '/Users/bar/.jx/environments/production', output: 'fatal: Kunde inte hitta fjärr-referensen promote-fubar-0.0.9'
```

jx looks for the string `couldn't find remote ref` in method IsCouldntFindRemoteRefError. In thes same file (pkg/gits/helpers.go) there are other examples out string that jx checks for from git.


fixes #6052