### PR TITLE
fix: Ignore tide context for last commit status on PRs

### DIFF
--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -902,7 +902,7 @@ func (p *GitHubProvider) PullRequestLastCommitStatus(pr *GitPullRequest) (string
 		return "", err
 	}
 	for _, result := range results {
-		if result.State != nil {
+		if result.State != nil && notNullString(result.Context) != "tide" {
 			return *result.State, nil
 		}
 	}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This should hopefully get `jx promote` and `jx delete app` to stop getting confused by `tide` contexts, blocking merging due to the `tide` context being, obviously, `pending`, and also first in the list. So this will make sure that we check the latest non-`tide` context with a state instead.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a