### PR TITLE
fix: Don't crash build controller for errors in labeling legacy resources

### DIFF
--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -188,12 +188,12 @@ func (o *ControllerBuildOptions) Run() error {
 
 	err = o.ensureSourceRepositoryHasLabels(jxClient, ns)
 	if err != nil {
-		return errors.Wrap(err, "failed to label the PipelineActivity resources")
+		log.Logger().Warnf("failed to label the legacy SourceRepository resources: %s", err)
 	}
 
 	err = o.ensurePipelineActivityHasLabels(jxClient, ns)
 	if err != nil {
-		return errors.Wrap(err, "failed to label the PipelineActivity resources")
+		log.Logger().Warnf("failed to label the legacy PipelineActivity resources: %s", err)
 	}
 
 	if tektonEnabled {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Just warn if a `SourceRepository` or `PipelineActivity` that doesn't already have its label populated is not able to be updated due to one or more of the label values being an invalid value for a k8s label.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #4049
