### PR TITLE
chore: refactor `cmd` ginkgo tests

### DIFF
--- a/pkg/cmd/get/get_activity_test.go
+++ b/pkg/cmd/get/get_activity_test.go
@@ -24,34 +24,40 @@ func TestGetActivity(t *testing.T) {
 	RunSpecs(t, "Get Activity Suite")
 }
 
-type fakeOut struct {
-	content []byte
-}
-
-func (f *fakeOut) Write(p []byte) (int, error) {
-	f.content = append(f.content, p...)
-
-	return len(f.content), nil
-}
-
-func (f *fakeOut) Fd() uintptr {
-	return 0
-}
-
-func (f *fakeOut) GetOutput() string {
-	return string(f.content)
-}
-
 var _ = Describe("get activity", func() {
 	Describe("Run()", func() {
 		var (
+			originalRepoOwner  string
+			originalRepoName   string
+			originalJobName    string
+			originalBranchName string
+
 			sort   bool
 			err    error
-			stdout *fakeOut
+			stdout *testhelpers.FakeOut
 		)
 
+		BeforeEach(func() {
+			originalRepoOwner = os.Getenv("REPO_OWNER")
+			originalRepoName = os.Getenv("REPO_NAME")
+			originalJobName = os.Getenv("JOB_NAME")
+			originalBranchName = os.Getenv("BRANCH_NAME")
+
+			os.Setenv("REPO_OWNER", "jx-testing")
+			os.Setenv("REPO_NAME", "jx-testing")
+			os.Setenv("JOB_NAME", "job")
+			os.Setenv("BRANCH_NAME", "job")
+		})
+
+		AfterEach(func() {
+			os.Setenv("REPO_OWNER", originalRepoOwner)
+			os.Setenv("REPO_NAME", originalRepoName)
+			os.Setenv("JOB_NAME", originalJobName)
+			os.Setenv("BRANCH_NAME", originalBranchName)
+		})
+
 		JustBeforeEach(func() {
-			stdout = &fakeOut{}
+			stdout = &testhelpers.FakeOut{}
 			commonOpts := &opts.CommonOptions{
 				Out: stdout,
 			}
@@ -77,13 +83,6 @@ var _ = Describe("get activity", func() {
 			}
 
 			err = options.Run()
-		})
-
-		BeforeEach(func() {
-			os.Setenv("REPO_OWNER", "jx-testing")
-			os.Setenv("REPO_NAME", "jx-testing")
-			os.Setenv("JOB_NAME", "job")
-			os.Setenv("BRANCH_NAME", "job")
 		})
 
 		Context("Without flags", func() {

--- a/pkg/cmd/get/get_preview_test.go
+++ b/pkg/cmd/get/get_preview_test.go
@@ -42,14 +42,22 @@ var _ = Describe("get preview", func() {
 			stdout []byte
 		)
 
-		BeforeSuite(func() {
+		BeforeEach(func() {
 			originalRepoOwner = os.Getenv("REPO_OWNER")
 			originalRepoName = os.Getenv("REPO_NAME")
 			originalJobName = os.Getenv("JOB_NAME")
 			originalBranchName = os.Getenv("BRANCH_NAME")
+
+			os.Setenv("REPO_OWNER", "jx-testing")
+			os.Setenv("REPO_NAME", "jx-testing")
+			os.Setenv("JOB_NAME", "job")
+			os.Setenv("BRANCH_NAME", "job")
+
+			devEnv = kube.NewPreviewEnvironment("jx-testing-jx-testing-job")
+			devEnv.Spec.PreviewGitSpec.ApplicationURL = "http://example.com"
 		})
 
-		AfterSuite(func() {
+		AfterEach(func() {
 			os.Setenv("REPO_OWNER", originalRepoOwner)
 			os.Setenv("REPO_NAME", originalRepoName)
 			os.Setenv("JOB_NAME", originalJobName)
@@ -103,16 +111,6 @@ var _ = Describe("get preview", func() {
 				w.Close()
 			}()
 			stdout, _ = ioutil.ReadAll(r)
-		})
-
-		BeforeEach(func() {
-			devEnv = kube.NewPreviewEnvironment("jx-testing-jx-testing-job")
-			devEnv.Spec.PreviewGitSpec.ApplicationURL = "http://example.com"
-
-			os.Setenv("REPO_OWNER", "jx-testing")
-			os.Setenv("REPO_NAME", "jx-testing")
-			os.Setenv("JOB_NAME", "job")
-			os.Setenv("BRANCH_NAME", "job")
 		})
 
 		It("prints the preview url to stdout", func() {

--- a/pkg/cmd/testhelpers/cmd_test_helpers.go
+++ b/pkg/cmd/testhelpers/cmd_test_helpers.go
@@ -587,3 +587,25 @@ func dumpFailedActivity(activity *v1.PipelineActivity) {
 		log.Logger().Warnf("YAML: %s", string(data))
 	}
 }
+
+// FakeOut can be passed to the Common Options for ease of testing. It's also helpful so test output doesn't get polluted by all the printouts
+type FakeOut struct {
+	content []byte
+}
+
+// Write is used to fulfill the terminal Writer interface
+func (f *FakeOut) Write(p []byte) (int, error) {
+	f.content = append(f.content, p...)
+
+	return len(f.content), nil
+}
+
+// Fd is used to fulfill the terminal Writer interface
+func (f *FakeOut) Fd() uintptr {
+	return 0
+}
+
+// GetOutput returns the contents printed to FakeOut
+func (f *FakeOut) GetOutput() string {
+	return string(f.content)
+}


### PR DESCRIPTION
- Move FakeOut to be a helper
- Switch usage of BeforeSuite to BeforeEach so setup is visible on every
  test specifically and not just magically by the first test that
  introduced it