### PR TITLE
test: Use boot config release from version stream in boot-vault test

### DIFF
--- a/jx/bdd/boot-vault/ci.sh
+++ b/jx/bdd/boot-vault/ci.sh
@@ -12,6 +12,8 @@ export GINKGO_ARGS="-v"
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"
 
+BOOT_CONFIG_FROM_VERSION_STREAM=v$(jx step get dependency-version --host=github.com --owner=jenkins-x --repo=jenkins-x-boot-config | sed 's/.*: \(.*\)/\1/')
+
 JX_HOME="/tmp/jxhome"
 KUBECONFIG="/tmp/jxhome/config"
 
@@ -42,9 +44,11 @@ export JX_VALUE_PROW_HMACTOKEN="$GH_ACCESS_TOKEN"
 export JX_BATCH_MODE="true"
 
 git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
-cp jx/bdd/boot-vault/jx-requirements.yml boot-source
-cp jx/bdd/boot-vault/parameters.yaml boot-source/env
 cd boot-source
+git fetch --tags
+git checkout ${BOOT_CONFIG_FROM_VERSION_STREAM}
+cp ../jx/bdd/boot-vault/jx-requirements.yml .
+cp ../jx/bdd/boot-vault/parameters.yaml env
 
 cp env/jenkins-x-platform/values.tmpl.yaml tmp.yaml
 cat tmp.yaml ../boot-vault.platform.yaml > env/jenkins-x-platform/values.tmpl.yaml


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This is needed due to #5949 causing `jx boot` to fail out if you clone a newer version of `jenkins-x-boot-config` than is in the version stream and then run `jx boot` from in that newer clone.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a