### PR TITLE
fix: allow chartmusem to be replaced with bucketrepo

### DIFF
--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/io/secrets"
 	"github.com/jenkins-x/jx/pkg/versionstream"
 
@@ -771,6 +772,19 @@ func (o *CommonOptions) ReleaseChartMuseumUrl() string {
 		return ""
 	}
 	chartRepo := os.Getenv("CHART_REPOSITORY")
+	if chartRepo == "" {
+		teamSettings, err := o.TeamSettings()
+		if err != nil {
+			log.Logger().Warnf("failed to get the team settings: %s", err.Error())
+		} else {
+			requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+			if err != nil {
+				log.Logger().Warnf("failed to get the requiremnets from team settings: %s", err.Error())
+			} else {
+				chartRepo = requirements.Cluster.ChartRepository
+			}
+		}
+	}
 	if chartRepo == "" {
 		if o.factory.IsInCDPipeline() {
 			chartRepo = DefaultChartRepo

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -779,8 +779,8 @@ func (o *CommonOptions) ReleaseChartMuseumUrl() string {
 		} else {
 			requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
 			if err != nil {
-				log.Logger().Warnf("failed to get the requiremnets from team settings: %s", err.Error())
-			} else {
+				log.Logger().Warnf("failed to get the requirements from team settings: %s", err.Error())
+			} else if requirements != nil {
 				chartRepo = requirements.Cluster.ChartRepository
 			}
 		}

--- a/pkg/cmd/step/helm/step_helm_release.go
+++ b/pkg/cmd/step/helm/step_helm_release.go
@@ -115,7 +115,10 @@ func (o *StepHelmReleaseOptions) Run() error {
 		}
 		secret, err := client.CoreV1().Secrets(ns).Get(kube.SecretJenkinsChartMuseum, metav1.GetOptions{})
 		if err != nil {
-			log.Logger().Warnf("Could not load Secret %s in namespace %s: %s", kube.SecretJenkinsChartMuseum, ns, err)
+			secret, err = client.CoreV1().Secrets(ns).Get(kube.SecretBucketRepo, metav1.GetOptions{})
+		}
+		if err != nil {
+			log.Logger().Warnf("Could not load Secret %s or %s in namespace %s: %s", kube.SecretJenkinsChartMuseum, kube.SecretBucketRepo, ns, err)
 		} else {
 			if secret != nil && secret.Data != nil {
 				if userName == "" {

--- a/pkg/cmd/step/step_override_requirements.go
+++ b/pkg/cmd/step/step_override_requirements.go
@@ -67,6 +67,12 @@ func (o *StepOverrideRequirementsOptions) overrideRequirements(requirements *con
 	if "" != os.Getenv(config.RequirementZone) {
 		requirements.Cluster.Zone = os.Getenv(config.RequirementZone)
 	}
+	if "" != os.Getenv(config.RequirementChartRepository) {
+		requirements.Cluster.ChartRepository = os.Getenv(config.RequirementChartRepository)
+	}
+	if "" != os.Getenv(config.RequirementRegistry) {
+		requirements.Cluster.Registry = os.Getenv(config.RequirementRegistry)
+	}
 	if "" != os.Getenv(config.RequirementEnvGitOwner) {
 		requirements.Cluster.EnvironmentGitOwner = os.Getenv(config.RequirementEnvGitOwner)
 	}

--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -912,7 +912,7 @@ func (o *StepVerifyPreInstallOptions) ValidateRequirements(requirements *config.
 		}
 	}
 	if requirements.Repository == config.RepositoryTypeBucketRepo && requirements.Cluster.ChartRepository == "" {
-		requirements.Cluster.ChartRepository = "http://bucketrepo/bucketrepo/"
+		requirements.Cluster.ChartRepository = "http://bucketrepo/bucketrepo/charts/"
 		err := requirements.SaveConfig(fileName)
 		if err != nil {
 			return errors.Wrapf(err, "failed to save changes to file: %s", fileName)

--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -911,6 +911,13 @@ func (o *StepVerifyPreInstallOptions) ValidateRequirements(requirements *config.
 			return fmt.Errorf("invalid requirements in file %s cannot use prow as a webhook for git kind: %s server: %s. Please try using lighthouse instead", fileName, kind, server)
 		}
 	}
+	if requirements.Repository == config.RepositoryTypeBucketRepo && requirements.Cluster.ChartRepository == "" {
+		requirements.Cluster.ChartRepository = "http://bucketrepo/bucketrepo/"
+		err := requirements.SaveConfig(fileName)
+		if err != nil {
+			return errors.Wrapf(err, "failed to save changes to file: %s", fileName)
+		}
+	}
 	return nil
 }
 

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -75,6 +75,10 @@ const (
 	RequirementKaniko = "JX_REQUIREMENT_KANIKO"
 	// RequirementIngressTLSProduction use the lets encrypt production server
 	RequirementIngressTLSProduction = "JX_REQUIREMENT_INGRESS_TLS_PRODUCTION"
+	// RequirementChartRepository the helm chart repository for jx
+	RequirementChartRepository = "JX_REQUIREMENT_CHART_REPOSITORY"
+	// RequirementRegistry the container registry for jx
+	RequirementRegistry = "JX_REQUIREMENT_REGISTRY"
 	// RequirementRepository the artifact repository for jx
 	RequirementRepository = "JX_REQUIREMENT_REPOSITORY"
 	// RequirementWebhook the webhook handler for jx
@@ -276,6 +280,8 @@ type GKEConfig struct {
 type ClusterConfig struct {
 	// AzureConfig the azure specific configuration
 	AzureConfig *AzureConfig `json:"azure,omitempty"`
+	// ChartRepository the repository URL to deploy charts to
+	ChartRepository string `json:"chartRepository,omitempty"`
 	// GKEConfig the gke specific configuration
 	GKEConfig *GKEConfig `json:"gke,omitempty"`
 	// EnvironmentGitOwner the default git owner for environment repositories if none is specified explicitly

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -326,7 +326,12 @@ func (p *GitHubProvider) DeleteRepository(org string, name string) error {
 }
 
 func toGitHubRepo(name string, org string, repo *github.Repository) *GitRepository {
+	var id int64
+	if repo.ID != nil {
+		id = *repo.ID
+	}
 	return &GitRepository{
+		ID:               id,
 		Name:             name,
 		AllowMergeCommit: util.DereferenceBool(repo.AllowMergeCommit),
 		CloneURL:         asText(repo.CloneURL),

--- a/pkg/gits/provider.go
+++ b/pkg/gits/provider.go
@@ -18,6 +18,7 @@ type GitOrganisation struct {
 }
 
 type GitRepository struct {
+	ID               int64
 	Name             string
 	AllowMergeCommit bool
 	HTMLURL          string

--- a/pkg/kube/constants.go
+++ b/pkg/kube/constants.go
@@ -94,6 +94,9 @@ const (
 	// SecretJenkinsChartMuseum the chart museum secret
 	SecretJenkinsChartMuseum = "jenkins-x-chartmuseum"
 
+	// SecretBucketRepo the bucket repo secret if using it as a chart repositoru
+	SecretBucketRepo = "jenkins-x-bucketrepo"
+
 	// SecretJenkinsReleaseGPG the GPG secrets for doing releases
 	SecretJenkinsReleaseGPG = "jenkins-release-gpg"
 


### PR DESCRIPTION
if folks are running bucketrepo then there's not a huge point to using chartmuseum as well; we may as well use a single artifact repository for both

fixes: #6005
Signed-off-by: James Strachan <james.strachan@gmail.com>