### PR TITLE
fix: Set `.Requirements.repository` by default to "nexus"

### DIFF
--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -739,6 +739,9 @@ func (c *RequirementsConfig) addDefaults() {
 			// c.Webhook = WebhookTypeLighthouse
 		}
 	}
+	if c.Repository == "" {
+		c.Repository = "nexus"
+	}
 }
 
 func (c *RequirementsConfig) handleDeprecation() {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

The helm charts in `jenkins-x-boot-config` need to check this value a bunch of times, so it'd be awkward to tweak them to always do a `hasKey` check first. So let's set this by default to `"nexus"` - can't go with `""` as the default because the field is `omitempty`.

Fixes version stream BDD failures like:
```
STEP: install-jenkins-x command: /bin/sh -c ** step helm apply --boot --remote --name jenkins-x --provider-values-dir ../kubeProviders in dir: /workspace/source/boot-source/env
Modified file /workspace/source/boot-source/env/Chart.yaml to set the chart to version 1
error: generating values.yaml for tree from /tmp/**-helm-apply-164375805/env: failed to execute Secrets template: /tmp/**-helm-apply-164375805/env/bucketrepo/values.tmpl.yaml: template: values.tmpl.yaml:1:23: executing "values.tmpl.yaml" at <.Requirements.repository>: map has no entry for key "repository"
error: failed to interpret pipeline file jenkins-x.yml: failed to run '/bin/sh -c ** step helm apply --boot --remote --name jenkins-x --provider-values-dir ../kubeProviders' command in directory 'env', output: ''
ERROR: Error: Command failed  ** boot -b
error: exit status 1
```

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6011