### PR TITLE
fix: "jx import"-created source repositories in dev env should be valid

### DIFF
--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	jenkinsio "github.com/jenkins-x/jx/pkg/apis/jenkins.io"
 	"github.com/jenkins-x/jx/pkg/cmd/step/create/pr"
 	"github.com/jenkins-x/jx/pkg/maven"
 
@@ -1018,6 +1019,10 @@ func (options *ImportOptions) addProwConfig(gitURL string, gitKind string) error
 				fileName := filepath.Join(outDir, sr.Name+"-sr.yaml")
 				// lets clear the fields we don't need to save
 				clearSourceRepositoryMetadata(&sr.ObjectMeta)
+				// Ensure it has the type information it needs
+				sr.APIVersion = jenkinsio.GroupName + "/" + jenkinsio.Version
+				sr.Kind = "SourceRepository"
+
 				data, err := yaml.Marshal(&sr)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to marshal SourceRepository %s to yaml", sr.Name)

--- a/pkg/kube/sourcerepositories.go
+++ b/pkg/kube/sourcerepositories.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	jenkinsio "github.com/jenkins-x/jx/pkg/apis/jenkins.io"
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/kube/naming"
@@ -61,6 +62,10 @@ func GetOrCreateSourceRepositoryCallback(jxClient versioned.Interface, ns string
 
 	labels := map[string]string{}
 	sr := &v1.SourceRepository{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SourceRepository",
+			APIVersion: jenkinsio.GroupName + "/" + jenkinsio.Version,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   resourceName,
 			Labels: labels,
@@ -149,6 +154,10 @@ func CreateSourceRepository(client versioned.Interface, namespace string, name, 
 	resourceName := naming.ToValidName(organisation + "-" + name)
 
 	repository := &v1.SourceRepository{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SourceRepository",
+			APIVersion: jenkinsio.GroupName + "/" + jenkinsio.Version,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: resourceName,
 		},


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We need to add `TypeMeta` to the serialized form of `SourceRepository`s added by `jx import` in the dev env repo, so let's just add that `TypeMeta` whenever we're creating a `SourceRepository`. It's cleaner that way anyway.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6016
