### PR TITLE
fix: ask user to validate discovered app name

### DIFF
--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -523,8 +523,6 @@ func (o *CommonOptions) DiscoverAppName() (string, error) {
 	}
 	answer = gitInfo.Name
 
-	if answer == "" {
-	}
 	return answer, nil
 }
 


### PR DESCRIPTION
This PR introduces the function `EnsureApplicationNameIsDefined()` which is used to make sure that the application name is set when running the `jx promote` command. This functionality was extracted from the `Run()` function and additionally added a check for the user to confirm whether the name of the app is correct when we guessed it.

Some things to consider:

- I decided to export it, to make it easier to test without having to do a lot of test preparation.
- Because the process to figure out the app name is tightly coupled to to other function in the promote and helm packages I decided to pass those functions as parameters so it's easier to provide fake functions in the tests. I think this should be ok because the functionality being tested is not the one from figuring out the application name itself.

fixes #5883