### PR TITLE
fix: use correct chart repo URL when promoting with bucketrepo

### DIFF
--- a/pkg/cmd/controller/controller_workflow.go
+++ b/pkg/cmd/controller/controller_workflow.go
@@ -357,7 +357,7 @@ func (o *ControllerWorkflowOptions) createPromoteOptions(repoName string, envNam
 		Version:           version,
 		NoPoll:            true,
 		IgnoreLocalFiles:  true,
-		HelmRepositoryURL: o.DefaultChartRepositoryUrl(),
+		HelmRepositoryURL: o.DefaultChartRepositoryURL(),
 		LocalHelmRepoName: kube.LocalHelmRepoName,
 		Namespace:         o.Namespace,
 	}

--- a/pkg/cmd/controller/controller_workflow.go
+++ b/pkg/cmd/controller/controller_workflow.go
@@ -17,7 +17,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	typev1 "github.com/jenkins-x/jx/pkg/client/clientset/versioned/typed/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/gits"
-	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/jenkins-x/jx/pkg/workflow"
@@ -358,7 +357,7 @@ func (o *ControllerWorkflowOptions) createPromoteOptions(repoName string, envNam
 		Version:           version,
 		NoPoll:            true,
 		IgnoreLocalFiles:  true,
-		HelmRepositoryURL: helm.InClusterHelmRepositoryURL,
+		HelmRepositoryURL: o.DefaultChartRepositoryUrl(),
 		LocalHelmRepoName: kube.LocalHelmRepoName,
 		Namespace:         o.Namespace,
 	}

--- a/pkg/cmd/controller/controller_workflow_integration_test.go
+++ b/pkg/cmd/controller/controller_workflow_integration_test.go
@@ -322,7 +322,7 @@ func TestWorkflowManualPromote(t *testing.T) {
 		Version:           version,
 		NoPoll:            true,
 		IgnoreLocalFiles:  true,
-		HelmRepositoryURL: helm.InClusterHelmRepositoryURL,
+		HelmRepositoryURL: "http://jenkins-x-chartmuseum:8080",
 		LocalHelmRepoName: kube.LocalHelmRepoName,
 		Namespace:         "jx",
 	}

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -558,7 +558,7 @@ func (o *CommonOptions) AddChartRepos(dir string, helmBinary string, chartRepos 
 		if requirements != nil {
 			changed := false
 			// lets replace the release chart museum URL if required
-			chartRepoURL := o.ReleaseChartMuseumUrl()
+			chartRepoURL := o.ReleaseChartRepositoryURL()
 			if chartRepoURL != "" && chartRepoURL != DefaultChartRepo {
 				for i := range requirements.Dependencies {
 					if requirements.Dependencies[i].Repository == DefaultChartRepo {
@@ -757,7 +757,7 @@ func (o *CommonOptions) HelmInitRecursiveDependencyBuild(dir string, chartRepos 
 
 // DefaultReleaseCharts returns the default release charts
 func (o *CommonOptions) DefaultReleaseCharts() []string {
-	releasesURL := o.ReleaseChartMuseumUrl()
+	releasesURL := o.ReleaseChartRepositoryURL()
 	answer := []string{
 		kube.DefaultChartMuseumURL,
 	}
@@ -768,16 +768,16 @@ func (o *CommonOptions) DefaultReleaseCharts() []string {
 }
 
 // DefaultChartMuseumUrl returns the default chart repository URL
-func (o *CommonOptions) DefaultChartRepositoryUrl() string {
-	answer := o.ReleaseChartMuseumUrl()
+func (o *CommonOptions) DefaultChartRepositoryURL() string {
+	answer := o.ReleaseChartRepositoryURL()
 	if answer == "" {
 		answer = DefaultChartRepo
 	}
 	return answer
 }
 
-// ReleaseChartMuseumUrl returns the chart museum URL for releases
-func (o *CommonOptions) ReleaseChartMuseumUrl() string {
+// ReleaseChartRepositoryURL returns the chart repository URL for releases
+func (o *CommonOptions) ReleaseChartRepositoryURL() string {
 	if o.RemoteCluster {
 		return ""
 	}

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -767,6 +767,16 @@ func (o *CommonOptions) DefaultReleaseCharts() []string {
 	return answer
 }
 
+// DefaultChartMuseumUrl returns the default chart repository URL
+func (o *CommonOptions) DefaultChartRepositoryUrl() string {
+	answer := o.ReleaseChartMuseumUrl()
+	if answer == "" {
+		answer = DefaultChartRepo
+	}
+	return answer
+}
+
+// ReleaseChartMuseumUrl returns the chart museum URL for releases
 func (o *CommonOptions) ReleaseChartMuseumUrl() string {
 	if o.RemoteCluster {
 		return ""

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -767,7 +767,7 @@ func (o *CommonOptions) DefaultReleaseCharts() []string {
 	return answer
 }
 
-// DefaultChartMuseumUrl returns the default chart repository URL
+// DefaultChartRepositoryURL returns the default chart repository URL
 func (o *CommonOptions) DefaultChartRepositoryURL() string {
 	answer := o.ReleaseChartRepositoryURL()
 	if answer == "" {

--- a/pkg/cmd/promote/promote.go
+++ b/pkg/cmd/promote/promote.go
@@ -204,7 +204,7 @@ func (o *PromoteOptions) Run() error {
 	}
 
 	if o.HelmRepositoryURL == "" {
-		o.HelmRepositoryURL = o.DefaultChartRepositoryUrl()
+		o.HelmRepositoryURL = o.DefaultChartRepositoryURL()
 	}
 	if o.Environment == "" && !o.BatchMode {
 		names := []string{}

--- a/pkg/cmd/promote/promote.go
+++ b/pkg/cmd/promote/promote.go
@@ -151,7 +151,7 @@ func (options *PromoteOptions) AddPromoteOptions(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&options.Build, "build", "", "", "The Build number which is used to update the PipelineActivity. If not specified its defaulted from  the '$BUILD_NUMBER' environment variable")
 	cmd.Flags().StringVarP(&options.Version, "version", "v", "", "The Version to promote")
 	cmd.Flags().StringVarP(&options.LocalHelmRepoName, "helm-repo-name", "r", kube.LocalHelmRepoName, "The name of the helm repository that contains the app")
-	cmd.Flags().StringVarP(&options.HelmRepositoryURL, "helm-repo-url", "u", helm.InClusterHelmRepositoryURL, "The Helm Repository URL to use for the App")
+	cmd.Flags().StringVarP(&options.HelmRepositoryURL, "helm-repo-url", "u", "", "The Helm Repository URL to use for the App")
 	cmd.Flags().StringVarP(&options.ReleaseName, "release", "", "", "The name of the helm release")
 	cmd.Flags().StringVarP(&options.Timeout, opts.OptionTimeout, "t", "1h", "The timeout to wait for the promotion to succeed in the underlying Environment. The command fails if the timeout is exceeded or the promotion does not complete")
 	cmd.Flags().StringVarP(&options.PullRequestPollTime, optionPullRequestPollTime, "", "20s", "Poll time when waiting for a Pull Request to merge")
@@ -203,6 +203,9 @@ func (o *PromoteOptions) Run() error {
 		o.NoWaitForUpdatePipeline = true
 	}
 
+	if o.HelmRepositoryURL == "" {
+		o.HelmRepositoryURL = o.DefaultChartRepositoryUrl()
+	}
 	if o.Environment == "" && !o.BatchMode {
 		names := []string{}
 		m, allEnvNames, err := kube.GetOrderedEnvironments(jxClient, ns)

--- a/pkg/cmd/step/bdd/step_bdd.go
+++ b/pkg/cmd/step/bdd/step_bdd.go
@@ -383,6 +383,9 @@ func (o *StepBDDOptions) teamNameSuffix() string {
 }
 
 func (o *StepBDDOptions) runTests(gopath string) error {
+	// clear the CHART_REPOSITORY env repo to avoid passing in a bogus chart repo to manual `jx promote` commands
+	os.Unsetenv("CHART_REPOSITORY")
+
 	gitURL := o.Flags.TestRepoGitCloneUrl
 	gitRepository, err := gits.ParseGitURL(gitURL)
 	if err != nil {

--- a/pkg/cmd/step/helm/step_helm_release.go
+++ b/pkg/cmd/step/helm/step_helm_release.go
@@ -103,7 +103,7 @@ func (o *StepHelmReleaseOptions) Run() error {
 	}
 	defer os.Remove(tarball)
 
-	chartRepo := o.ReleaseChartMuseumUrl()
+	chartRepo := o.ReleaseChartRepositoryURL()
 
 	userName := os.Getenv("CHARTMUSEUM_CREDS_USR")
 	password := os.Getenv("CHARTMUSEUM_CREDS_PSW")

--- a/pkg/cmd/step/step_release.go
+++ b/pkg/cmd/step/step_release.go
@@ -305,7 +305,7 @@ func (o *StepReleaseOptions) releaseAndPromoteChart(dir string) error {
 	}
 
 	if o.HelmRepositoryURL == "" {
-		o.HelmRepositoryURL = o.DefaultChartRepositoryUrl()
+		o.HelmRepositoryURL = o.DefaultChartRepositoryURL()
 	}
 
 	stepHelmReleaseOptions := &helm_cmd.StepHelmReleaseOptions{

--- a/pkg/cmd/step/step_release.go
+++ b/pkg/cmd/step/step_release.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	helm_cmd "github.com/jenkins-x/jx/pkg/cmd/step/helm"
-	"github.com/jenkins-x/jx/pkg/helm"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -77,7 +76,7 @@ func NewCmdStepRelease(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Timeout, opts.OptionTimeout, "t", "1h", "The timeout to wait for the promotion to succeed in the underlying Environment. The command fails if the timeout is exceeded or the promotion does not complete")
 	cmd.Flags().StringVarP(&options.PullRequestPollTime, optionPullRequestPollTime, "", "20s", "Poll time when waiting for a Pull Request to merge")
 	cmd.Flags().StringVarP(&options.LocalHelmRepoName, "helm-repo-name", "", kube.LocalHelmRepoName, "The name of the helm repository that contains the app")
-	cmd.Flags().StringVarP(&options.HelmRepositoryURL, "helm-repo-url", "", helm.InClusterHelmRepositoryURL, "The Helm Repository URL to use for the App")
+	cmd.Flags().StringVarP(&options.HelmRepositoryURL, "helm-repo-url", "", "", "The Helm Repository URL to use for the App")
 	cmd.Flags().StringVarP(&options.Build, "build", "", "", "The Build number which is used to update the PipelineActivity. If not specified its defaulted from  the '$BUILD_NUMBER' environment variable")
 
 	return cmd
@@ -303,6 +302,10 @@ func (o *StepReleaseOptions) releaseAndPromoteChart(dir string) error {
 	err = stepChangelogOptions.Run()
 	if err != nil {
 		return fmt.Errorf("Failed to generate changelog: %s", err)
+	}
+
+	if o.HelmRepositoryURL == "" {
+		o.HelmRepositoryURL = o.DefaultChartRepositoryUrl()
 	}
 
 	stepHelmReleaseOptions := &helm_cmd.StepHelmReleaseOptions{

--- a/pkg/helm/helm_helpers.go
+++ b/pkg/helm/helm_helpers.go
@@ -51,9 +51,6 @@ const (
 	// inlined if not a secret which can be referenced from a 'values.yaml` file via a `{{ .Parameters.foo.bar }}` expression
 	ParametersYAMLFile = "parameters.yaml"
 
-	// InClusterHelmRepositoryURL is the default cluster local helm repo
-	InClusterHelmRepositoryURL = "http://jenkins-x-chartmuseum:8080"
-
 	// FakeChartmusuem is the url for the fake chart museum used in tests
 	FakeChartmusuem = "http://fake.chartmuseum"
 


### PR DESCRIPTION
as before this PR we were hard coding to use the chart museum URL

Signed-off-by: James Strachan <james.strachan@gmail.com>