### PR TITLE
fix(boot): Only update to version stream boot config if current is ancestor

### DIFF
--- a/jx/bdd/boot-vault/ci.sh
+++ b/jx/bdd/boot-vault/ci.sh
@@ -12,8 +12,6 @@ export GINKGO_ARGS="-v"
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"
 
-BOOT_CONFIG_FROM_VERSION_STREAM=v$(jx step get dependency-version --host=github.com --owner=jenkins-x --repo=jenkins-x-boot-config | sed 's/.*: \(.*\)/\1/')
-
 JX_HOME="/tmp/jxhome"
 KUBECONFIG="/tmp/jxhome/config"
 
@@ -45,8 +43,6 @@ export JX_BATCH_MODE="true"
 
 git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
 cd boot-source
-git fetch --tags
-git checkout ${BOOT_CONFIG_FROM_VERSION_STREAM}
 cp ../jx/bdd/boot-vault/jx-requirements.yml .
 cp ../jx/bdd/boot-vault/parameters.yaml env
 

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -1186,3 +1186,15 @@ func (g *GitCLI) Describe(dir string, contains bool, commitish string, abbrev st
 	}
 	return parts[0], "", nil
 }
+
+// IsAncestor checks if the possible ancestor commit-ish is an ancestor of the given commit-ish.
+func (g *GitCLI) IsAncestor(dir string, possibleAncestor string, commitish string) (bool, error) {
+	args := []string{"merge-base", "--is-ancestor", possibleAncestor, commitish}
+	_, err := g.gitCmdWithOutput(dir, args...)
+	if err != nil {
+		// Treat any error as meaning that it's not an ancestor. Switch this to use ExitError.ExitCode() when we move to go >=1.12
+		return false, err
+	}
+	// Default case is that this is an ancestor, since there's no error from the merge-base call.
+	return true, nil
+}

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -665,3 +665,8 @@ func (g *GitFake) CherryPickTheirs(dir string, commit string) error {
 func (g *GitFake) Describe(dir string, contains bool, commitish string, abbrev string, fallback bool) (string, string, error) {
 	return "", "", nil
 }
+
+// IsAncestor checks if the possible ancestor commit-ish is an ancestor of the given commit-ish.
+func (g *GitFake) IsAncestor(dir string, possibleAncestor string, commitish string) (bool, error) {
+	return false, nil
+}

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -519,3 +519,8 @@ func (g *GitLocal) CherryPickTheirs(dir string, commit string) error {
 func (g *GitLocal) Describe(dir string, contains bool, commitish string, abbrev string, fallback bool) (string, string, error) {
 	return g.GitCLI.Describe(dir, false, commitish, abbrev, fallback)
 }
+
+// IsAncestor checks if the possible ancestor commit-ish is an ancestor of the given commit-ish.
+func (g *GitLocal) IsAncestor(dir string, possibleAncestor string, commitish string) (bool, error) {
+	return g.GitCLI.IsAncestor(dir, possibleAncestor, commitish)
+}

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -278,6 +278,7 @@ type Gitter interface {
 	RevParse(dir string, rev string) (string, error)
 	GetCommitsNotOnAnyRemote(dir string, branch string) ([]GitCommit, error)
 	Describe(dir string, contains bool, commitish string, abbrev string, fallback bool) (string, string, error)
+	IsAncestor(dir string, possibleAncestor string, commitish string) (bool, error)
 
 	GetRevisionBeforeDate(dir string, t time.Time) (string, error)
 	GetRevisionBeforeDateText(dir string, dateText string) (string, error)

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -940,6 +940,25 @@ func (mock *MockGitter) Init(_param0 string) error {
 	return ret0
 }
 
+func (mock *MockGitter) IsAncestor(_param0 string, _param1 string, _param2 string) (bool, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0, _param1, _param2}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("IsAncestor", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 bool
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(bool)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockGitter) IsFork(_param0 string) (bool, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -3283,6 +3302,41 @@ func (c *MockGitter_Init_OngoingVerification) GetAllCapturedArguments() (_param0
 		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) IsAncestor(_param0 string, _param1 string, _param2 string) *MockGitter_IsAncestor_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "IsAncestor", params, verifier.timeout)
+	return &MockGitter_IsAncestor_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_IsAncestor_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_IsAncestor_OngoingVerification) GetCapturedArguments() (string, string, string) {
+	_param0, _param1, _param2 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1]
+}
+
+func (c *MockGitter_IsAncestor_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
+		}
+		_param2 = make([]string, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(string)
 		}
 	}
 	return


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This will let newer commits or tags in the boot config be used for the local boot clone.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6024
