### PR TITLE
fix: Don't use config.DefaultVersionsURL outside of version stream cloning logic

### DIFF
--- a/pkg/cmd/create/create_addon_environment_controller.go
+++ b/pkg/cmd/create/create_addon_environment_controller.go
@@ -5,10 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jenkins-x/jx/pkg/cmd/initcmd"
-	config2 "github.com/jenkins-x/jx/pkg/config"
-
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/jenkins-x/jx/pkg/cmd/initcmd"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/helm"
@@ -268,14 +266,13 @@ func (o *CreateAddonEnvironmentControllerOptions) Run() error {
 
 	log.Logger().Infof("installing the Environment Controller with values: %s", util.ColorInfo(strings.Join(setValues, ",")))
 	helmOptions := helm.InstallChartOptions{
-		Chart:          "environment-controller",
-		ReleaseName:    o.ReleaseName,
-		Version:        o.Version,
-		Ns:             o.Namespace,
-		SetValues:      setValues,
-		HelmUpdate:     true,
-		Repository:     kube.DefaultChartMuseumURL,
-		VersionsGitURL: config2.DefaultVersionsURL,
+		Chart:       "environment-controller",
+		ReleaseName: o.ReleaseName,
+		Version:     o.Version,
+		Ns:          o.Namespace,
+		SetValues:   setValues,
+		HelmUpdate:  true,
+		Repository:  kube.DefaultChartMuseumURL,
 	}
 	err = o.InstallChartWithOptions(helmOptions)
 	if err != nil {

--- a/pkg/cmd/create/create_vault.go
+++ b/pkg/cmd/create/create_vault.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts/upgrade"
-	"github.com/jenkins-x/jx/pkg/config"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
@@ -251,7 +250,7 @@ func (o *CreateVaultOptions) dockerImages() (map[string]string, error) {
 		kubevault.VaultImage:      "",
 	}
 
-	resolver, err := o.CreateVersionResolver(config.DefaultVersionsURL, "")
+	resolver, err := o.CreateVersionResolver("", "")
 	if err != nil {
 		return images, errors.Wrap(err, "creating the docker image version resolver")
 	}

--- a/pkg/cmd/get/get_stream.go
+++ b/pkg/cmd/get/get_stream.go
@@ -3,7 +3,6 @@ package get
 import (
 	"strings"
 
-	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/versionstream"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
@@ -66,7 +65,7 @@ func NewCmdGetStream(commonOpts *opts.CommonOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&options.Kind, "kind", "k", "docker", "The kind of version. Possible values: "+strings.Join(versionstream.KindStrings, ", "))
-	cmd.Flags().StringVarP(&options.VersionsRepository, "repo", "r", config.DefaultVersionsURL, "Jenkins X versions Git repo")
+	cmd.Flags().StringVarP(&options.VersionsRepository, "repo", "r", "", "Jenkins X versions Git repo")
 	cmd.Flags().StringVarP(&options.VersionsGitRef, "versions-ref", "", "", "Jenkins X versions Git repository reference (tag, branch, sha etc)")
 	return cmd
 }

--- a/pkg/cmd/scan_cluster.go
+++ b/pkg/cmd/scan_cluster.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
-	"github.com/jenkins-x/jx/pkg/config"
-
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -162,7 +160,7 @@ func (o *ScanClusterOptions) hunterContainer() *v1.Container {
 
 func (o *ScanClusterOptions) hunterImage() string {
 	defaultImage := kubeHunterImage + ":latest"
-	resolver, err := o.CreateVersionResolver(config.DefaultVersionsURL, "")
+	resolver, err := o.CreateVersionResolver("", "")
 	if err != nil {
 		return defaultImage
 	}

--- a/pkg/cmd/step/get/step_get_version_changeset.go
+++ b/pkg/cmd/step/get/step_get_version_changeset.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
-	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/versionstream"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
@@ -67,7 +66,7 @@ func NewCmdStepGetVersionChangeSet(commonOpts *opts.CommonOptions) *cobra.Comman
 			helper.CheckErr(err)
 		},
 	}
-	cmd.Flags().StringVarP(&options.VersionsRepository, "repo", "r", config.DefaultVersionsURL, "Jenkins X versions Git repo")
+	cmd.Flags().StringVarP(&options.VersionsRepository, "repo", "r", "", "Jenkins X versions Git repo")
 	cmd.Flags().StringVarP(&options.VersionsGitRef, "versions-ref", "", "", "Jenkins X versions Git repository reference (tag, branch, sha etc)")
 	cmd.Flags().StringVarP(&options.StableBranch, "stable-branch", "", defaultStableVersionBranch, "the versions git repository branch to compare against")
 	cmd.Flags().StringVarP(&options.TestingBranch, "testing-branch", "", defaultStableVersionBranch, "the versions git repository branch to clone")


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We shouldn't have been doing this in the first place, but definitely not now that we've changed `config.DefaultVersionsURL` to be overridable, and we've got a standard API for cloning the version stream. So change places that were previously using `config.DefaultVersionsURL` to use an empty string instead, which will result in the team settings-provided version stream URL being used instead.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a