### PR TITLE
chore: Add builder-go-nodejs, switch BDD tests to use that image

### DIFF
--- a/Dockerfile.builder-go-nodejs
+++ b/Dockerfile.builder-go-nodejs
@@ -1,0 +1,4 @@
+# this is used for testing jx inside a cluster in development
+FROM gcr.io/jenkinsxio/builder-go-nodejs:latest
+
+COPY build/linux/jx /usr/bin/jx

--- a/jenkins-x-boot-vault.yml
+++ b/jenkins-x-boot-vault.yml
@@ -75,6 +75,10 @@ pipelineConfig:
                 command: /kaniko/executor
                 args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
+              - name: build-and-push-go-nodejs
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go-nodejs','--destination=gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
           - name: e2e-tests
             options:
               volumes:
@@ -117,7 +121,7 @@ pipelineConfig:
                     key: password
             steps:
               - name: boot-vault-e2e-tests
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}
                 command: ./jx/bdd/boot-vault/ci.sh
 
               - name: generate-report

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -75,6 +75,10 @@ pipelineConfig:
                 command: /kaniko/executor
                 args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
+              - name: build-and-push-go-nodejs
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go-nodejs','--destination=gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
           - name: e2e-tests
             options:
               volumes:
@@ -118,7 +122,7 @@ pipelineConfig:
 
             steps:
               - name: tekton-e2e-tests
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}
                 command: ./jx/bdd/tekton/ci.sh
 
               - name: generate-report

--- a/pkg/cmd/step/create/pr/step_create_pr_versions.go
+++ b/pkg/cmd/step/create/pr/step_create_pr_versions.go
@@ -153,7 +153,7 @@ func (o *StepCreatePullRequestVersionsOptions) Run() error {
 			pro.AuthorName = authorName
 			pro.AuthorEmail = authorEmail
 		}
-		fn, err := operations.CreatePullRequestRegexFn(builderImageVersion, "gcr.io/jenkinsxio/builder-(?:maven|go|terraform):(?P<versions>.+)", "jenkins-x*.yml")
+		fn, err := operations.CreatePullRequestRegexFn(builderImageVersion, "gcr.io/jenkinsxio/builder-(?:maven|go|terraform|go-nodejs):(?P<versions>.+)", "jenkins-x*.yml")
 		if err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This will enable us to use Cypress tests within BDD tests.

We also add support for updating the `jenkins-x*.yml`s in `jenkins-x-versions` to use the latest `builder-go-nodejs` image, since we'll be switching them to use that builder as well. Once this merges and gets through builders, I'll update the image used in the version stream update cronjob.

#### Special notes for the reviewer(s)

/assign @daveconde 
/assign @romainverduci 

#### Which issue this PR fixes

n/a