### PR TITLE
fix: Don't include pipeline runs that failed/were retried by Prow in logs

### DIFF
--- a/pkg/logs/test_data/active_single_run/pipelineruns.yml
+++ b/pkg/logs/test_data/active_single_run/pipelineruns.yml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- metadata:
+    creationTimestamp: null
+    labels:
+      branch: fakebranch
+      context: fakecontext
+      owner: fakeowner
+      repository: fakerepo
+    name: PR1
+    namespace: jx
+  spec:
+    params:
+    - name: version
+      value: v1
+    - name: build_id
+      value: "1"
+    pipelineRef: {}
+    serviceAccount: ""
+  status:
+    taskRuns:
+      faketaskrun:
+        status:
+          podName: ""
+          steps:
+          - running:
+              startedAt: null
+- metadata:
+    creationTimestamp: null
+    labels:
+      branch: fakebranch
+      build: "2"
+      context: tekton
+      owner: fakeowner
+      repository: fakerepo
+    name: PR2
+    namespace: jx
+  spec:
+    pipelineRef: {}
+    serviceAccount: ""
+  status: {}
+kind: PipelineRunList
+metadata: {}

--- a/pkg/logs/test_data/failed_and_rerun/pipelineruns.yml
+++ b/pkg/logs/test_data/failed_and_rerun/pipelineruns.yml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineRun
+  metadata:
+    creationTimestamp: null
+    labels:
+      branch: fakebranch
+      context: fakecontext
+      owner: fakeowner
+      repository: fakerepo
+    name: PR1
+    namespace: jx
+  spec:
+    params:
+    - name: version
+      value: v1
+    - name: build_id
+      value: "1"
+    pipelineRef: {}
+    serviceAccount: ""
+  status:
+    conditions:
+    - lastTransitionTime: null
+      message: blah blah can't be found:pipeline.tekton.dev blah blah
+      status: "False"
+      type: Succeeded
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineRun
+  metadata:
+    creationTimestamp: null
+    labels:
+      branch: fakebranch
+      context: fakecontext
+      owner: fakeowner
+      repository: fakerepo
+    name: PR1_2
+    namespace: jx
+  spec:
+    params:
+    - name: version
+      value: v1
+    - name: build_id
+      value: "2"
+    pipelineRef: {}
+    serviceAccount: ""
+  status:
+    taskRuns:
+      faketaskrun:
+        status:
+          podName: ""
+          steps:
+          - running:
+              startedAt: null
+kind: PipelineRunList
+metadata: {}

--- a/pkg/logs/test_data/only_waiting_step/pipelineruns.yml
+++ b/pkg/logs/test_data/only_waiting_step/pipelineruns.yml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1alpha1
+items:
+- metadata:
+    creationTimestamp: null
+    labels:
+      branch: fakebranch
+      context: fakecontext
+      owner: fakeowner
+      repository: fakerepo
+    name: PR1
+    namespace: jx
+  spec:
+    params:
+    - name: version
+      value: v1
+    - name: build_id
+      value: "1"
+    pipelineRef: {}
+    serviceAccount: ""
+  status:
+    taskRuns:
+      faketaskrun:
+        status:
+          podName: ""
+          steps:
+          - waiting:
+              message: Pending
+- metadata:
+    creationTimestamp: null
+    labels:
+      branch: fakebranch
+      build: "2"
+      context: tekton
+      owner: fakeowner
+      repository: fakerepo
+    name: PR2
+    namespace: jx
+  spec:
+    pipelineRef: {}
+    serviceAccount: ""
+  status: {}
+kind: PipelineRunList
+metadata: {}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

The immediate impetus here is that BDD tests can fail in this scenario, because more than one pipeline is found for the filter - the one that failed, and the one that was retried. But this should just clean things up a bit anyway.

#### Special notes for the reviewer(s)

~~I'll come back and add tests for this later today.~~
EDIT: Test added.

/assign @dgozalo 

#### Which issue this PR fixes

fixes #6061
