### PR TITLE
feat: implement a generic mechanism to deprecate commands and marked a few commands as deprecated

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/jenkins-x/jx/pkg/cmd/deprecation"
 	"github.com/jenkins-x/jx/pkg/cmd/profile"
 	"github.com/jenkins-x/jx/pkg/cmd/ui"
 	"github.com/spf13/viper"
@@ -232,6 +233,9 @@ func NewJXCommand(f clients.Factory, in terminal.FileReader, out terminal.FileWr
 	rootCommand.SetVersionTemplate("{{printf .Version}}\n")
 	rootCommand.AddCommand(NewCmdOptions(out))
 	rootCommand.AddCommand(NewCmdDiagnose(commonOpts))
+
+	// Mark the deprecated commands
+	deprecation.DeprecateCommands(rootCommand)
 
 	managedPlugins := &managedPluginHandler{
 		CommonOptions: commonOpts,

--- a/pkg/cmd/deprecation/deprecated.go
+++ b/pkg/cmd/deprecation/deprecated.go
@@ -1,0 +1,83 @@
+package deprecation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// deprecatedCommands list of deprecated commands along with some more deprecation details
+var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
+	"install": {
+		replacement: "boot",
+		date:        "01-02-2020",
+		info: fmt.Sprintf("Please check %s for more details.",
+			util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/")),
+	},
+	"upgrade platform": {
+		replacement: "boot",
+		date:        "01-02-2020",
+		info: fmt.Sprintf("Please check %s for more details.",
+			util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/")),
+	},
+	"upgrade ingress": {
+		replacement: "boot",
+		date:        "01-02-2020",
+		info: fmt.Sprintf("Please check %s for more details.",
+			util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/")),
+	},
+}
+
+// deprecateInfo keeps some deprecation details related to a command
+type deprecationInfo struct {
+	replacement string
+	date        string
+	info        string
+}
+
+// DeprecateCommands runs recursively over all commands and set the deprecation message
+// on every command defined the deprecated commands map.
+func DeprecateCommands(cmd *cobra.Command) {
+	if !cmd.HasSubCommands() {
+		path := commandPath(cmd)
+		if deprecation, ok := deprecatedCommands[path]; ok {
+			cmd.Deprecated = deprecationMessage(deprecation)
+		}
+		return
+	}
+	for _, c := range cmd.Commands() {
+		DeprecateCommands(c)
+	}
+}
+
+func deprecationMessage(dep deprecationInfo) string {
+	var date string
+	if dep.date != "" {
+		date = fmt.Sprintf("it will be removed on %s.", util.ColorInfo(dep.date))
+	} else {
+		date = "it will be soon removed."
+	}
+	var replacement string
+	if dep.replacement != "" {
+		replacement = fmt.Sprintf("We now highly recommend you use %s instead.", util.ColorInfo(dep.replacement))
+	}
+	msg := fmt.Sprintf("%s %s", date, replacement)
+	if dep.info != "" {
+		return fmt.Sprintf("%s %s", msg, dep.info)
+	}
+	return msg
+}
+
+func commandPath(cmd *cobra.Command) string {
+	parentText := ""
+	parent := cmd.Parent()
+	if parent != nil {
+		parentText = commandPath(parent)
+		if parentText != "" {
+			parentText += " "
+		}
+	}
+	return strings.TrimPrefix(parentText, "jx ") + cmd.Name()
+}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This generates a message such this before the command execution:
```
$x upgrade ingress
Command "ingress" is deprecated, it will be removed on 01-02-2020. We now highly recommend you use boot instead. Please check https://jenkins-x.io/docs/getting-started/setup/boot/ for more details.


```

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->