### PR TITLE
WIP - chore: Support force pushing a tag

### DIFF
--- a/pkg/cmd/step/step_tag.go
+++ b/pkg/cmd/step/step_tag.go
@@ -45,6 +45,7 @@ type StepTagFlags struct {
 	ChartsDir            string
 	ChartValueRepository string
 	NoApply              bool
+	ForcePush            bool
 }
 
 var (
@@ -94,7 +95,7 @@ func NewCmdStepTag(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Flags.ChartValueRepository, "charts-value-repository", "r", "", "the fully qualified image name without the version tag. e.g. 'dockerregistry/myorg/myapp'")
 
 	cmd.Flags().BoolVarP(&options.Flags.NoApply, "no-apply", "", false, "Do not push the tag to the server, this is used for example in dry runs")
-
+	cmd.Flags().BoolVarP(&options.Flags.ForcePush, "force-push", "", false, "force push the tag to the server")
 	return cmd
 }
 
@@ -156,7 +157,7 @@ func (o *StepTagOptions) Run() error {
 	} else {
 
 		log.Logger().Debugf("pushing git tag %s", tag)
-		err = o.Git().PushTag("", tag)
+		err = o.Git().PushTag("", tag, o.Flags.ForcePush)
 		if err != nil {
 			return err
 		}

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -432,8 +432,8 @@ func (g *GitCLI) PushMaster(dir string) error {
 }
 
 // Pushtag pushes the given tag into the origin
-func (g *GitCLI) PushTag(dir string, tag string) error {
-	return g.Push(dir, "origin", false, tag)
+func (g *GitCLI) PushTag(dir string, tag string, force bool) error {
+	return g.Push(dir, "origin", force, tag)
 }
 
 // Add does a git add for all the given arguments

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -153,7 +153,7 @@ func (g *GitFake) PushMaster(dir string) error {
 }
 
 // PushTag pushes a tag
-func (g *GitFake) PushTag(dir string, tag string) error {
+func (g *GitFake) PushTag(dir string, tag string, force bool) error {
 	return nil
 }
 

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -180,8 +180,8 @@ func (g *GitLocal) PushMaster(dir string) error {
 
 // PushTag pushes the given tag into the origin
 // Faked out
-func (g *GitLocal) PushTag(dir string, tag string) error {
-	return g.GitFake.PushTag(dir, tag)
+func (g *GitLocal) PushTag(dir string, tag string, force bool) error {
+	return g.GitFake.PushTag(dir, tag, force)
 }
 
 // Add does a git add for all the given arguments

--- a/pkg/gits/helpers_test.go
+++ b/pkg/gits/helpers_test.go
@@ -1421,7 +1421,7 @@ func TestDuplicateGitRepoFromCommitish(t *testing.T) {
 	err = gitter.Push(dir, "origin", false, "HEAD")
 	assert.NoError(t, err)
 
-	err = gitter.PushTag(dir, "v1.0.0")
+	err = gitter.PushTag(dir, "v1.0.0", false)
 	assert.NoError(t, err)
 	type args struct {
 		toOrg         string

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -204,7 +204,7 @@ type Gitter interface {
 	IsShallow(dir string) (bool, error)
 	Push(dir string, remote string, force bool, refspec ...string) error
 	PushMaster(dir string) error
-	PushTag(dir string, tag string) error
+	PushTag(dir string, tag string, force bool) error
 	// CreateAuthenticatedURL adds username and password into the specified git URL.
 	CreateAuthenticatedURL(url string, userAuth *auth.UserAuth) (string, error)
 	ForcePushBranch(dir string, localBranch string, remoteBranch string) error

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -1185,11 +1185,11 @@ func (mock *MockGitter) PushMirror(_param0 string, _param1 string) error {
 	return ret0
 }
 
-func (mock *MockGitter) PushTag(_param0 string, _param1 string) error {
+func (mock *MockGitter) PushTag(_param0 string, _param1 string, _param2 bool) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
 	}
-	params := []pegomock.Param{_param0, _param1}
+	params := []pegomock.Param{_param0, _param1, _param2}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("PushTag", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
@@ -3772,8 +3772,8 @@ func (c *MockGitter_PushMirror_OngoingVerification) GetAllCapturedArguments() (_
 	return
 }
 
-func (verifier *VerifierMockGitter) PushTag(_param0 string, _param1 string) *MockGitter_PushTag_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1}
+func (verifier *VerifierMockGitter) PushTag(_param0 string, _param1 string, _param2 bool) *MockGitter_PushTag_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "PushTag", params, verifier.timeout)
 	return &MockGitter_PushTag_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -3783,12 +3783,12 @@ type MockGitter_PushTag_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockGitter_PushTag_OngoingVerification) GetCapturedArguments() (string, string) {
-	_param0, _param1 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+func (c *MockGitter_PushTag_OngoingVerification) GetCapturedArguments() (string, string, bool) {
+	_param0, _param1, _param2 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1]
 }
 
-func (c *MockGitter_PushTag_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
+func (c *MockGitter_PushTag_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []bool) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(c.methodInvocations))
@@ -3798,6 +3798,10 @@ func (c *MockGitter_PushTag_OngoingVerification) GetAllCapturedArguments() (_par
 		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
+		}
+		_param2 = make([]bool, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(bool)
 		}
 	}
 	return


### PR DESCRIPTION
Fixes: #6071 and also adds support for updating an existing PR during `jx create pr` For example: `jx create pr -l my-pr --update-existing=true`