### PR TITLE
fix: allow passing in of a git repo or PR URL for `jx get build log/pod`

### DIFF
--- a/pkg/builds/build_info_test.go
+++ b/pkg/builds/build_info_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/builds"
 	"github.com/jenkins-x/jx/pkg/tests"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -31,6 +32,41 @@ func TestCreateBuildPodInfo(t *testing.T) {
 		assert.Equal(t, "b662eb177fdd4252220399aa8da809411d87b8ed", b.LastCommitSHA, "LastCommitSHA")
 		assert.Equal(t, "https://github.com/jenkins-x/jenkins-x-serverless.git", b.GitURL, "GitURL")
 		assert.Equal(t, "jenkinsxio/jenkins-cwp:0.1.33", b.FirstStepImage, "FirstStepImage")
+	}
+}
+
+func TestBuildInfoFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		GitURL         string
+		ExpectedOwner  string
+		ExpectedRepo   string
+		ExpectedBranch string
+	}{
+		{
+			GitURL:         "https://github.com/jenkins-x/jenkins-x-platform/pull/6504",
+			ExpectedOwner:  "jenkins-x",
+			ExpectedRepo:   "jenkins-x-platform",
+			ExpectedBranch: "PR-6504",
+		},
+		{
+			GitURL:        "https://github.com/jenkins-x/jx.git",
+			ExpectedOwner: "jenkins-x",
+			ExpectedRepo:  "jx",
+		},
+	}
+
+	for _, tt := range tests {
+		filter := builds.BuildPodInfoFilter{
+			GitURL: tt.GitURL,
+		}
+		err := filter.Validate()
+		require.NoError(t, err, "failed to validate filter with URL %s", tt.GitURL)
+		assert.Equal(t, tt.ExpectedOwner, filter.Owner, "filter.Owner")
+		assert.Equal(t, tt.ExpectedRepo, filter.Repository, "filter.Repository")
+		assert.Equal(t, tt.ExpectedBranch, filter.Branch, "filter.Branch")
+		t.Logf("filter on GitURL %s populated %s/%s branch %s", filter.GitURL, filter.Owner, filter.Repository, filter.Branch)
 	}
 }
 

--- a/pkg/cmd/get/get_build_logs.go
+++ b/pkg/cmd/get/get_build_logs.go
@@ -110,6 +110,7 @@ func NewCmdGetBuildLogs(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.BuildFilter.Branch, "branch", "", "", "Filters the branch")
 	cmd.Flags().StringVarP(&options.BuildFilter.Build, "build", "", "", "The build number to view")
 	cmd.Flags().StringVarP(&options.BuildFilter.Pod, "pod", "", "", "The pod name to view")
+	cmd.Flags().StringVarP(&options.BuildFilter.GitURL, "giturl", "g", "", "The git URL to filter on. If you specify a link to a github repository or PR we can filter the query of build pods accordingly")
 	cmd.Flags().StringVarP(&options.BuildFilter.Context, "context", "", "", "Filters the context of the build")
 	cmd.Flags().BoolVarP(&options.CurrentFolder, "current", "c", false, "Display logs using current folder as repo name, and parent folder as owner")
 	options.JenkinsSelector.AddFlags(cmd)
@@ -120,6 +121,10 @@ func NewCmdGetBuildLogs(commonOpts *opts.CommonOptions) *cobra.Command {
 
 // Run implements this command
 func (o *GetBuildLogsOptions) Run() error {
+	err := o.BuildFilter.Validate()
+	if err != nil {
+		return err
+	}
 	jxClient, ns, err := o.JXClientAndDevNamespace()
 	if err != nil {
 		return err

--- a/pkg/cmd/get/get_build_pods.go
+++ b/pkg/cmd/get/get_build_pods.go
@@ -74,11 +74,16 @@ func NewCmdGetBuildPods(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.BuildFilter.Branch, "branch", "", "", "Filters the branch")
 	cmd.Flags().StringVarP(&options.BuildFilter.Build, "build", "", "", "Filter a specific build number")
 	cmd.Flags().StringVarP(&options.BuildFilter.Context, "context", "", "", "Filters the context of the build")
+	cmd.Flags().StringVarP(&options.BuildFilter.GitURL, "giturl", "g", "", "The git URL to filter on. If you specify a link to a github repository or PR we can filter the query of build pods accordingly")
 	return cmd
 }
 
 // Run implements this command
 func (o *GetBuildPodsOptions) Run() error {
+	err := o.BuildFilter.Validate()
+	if err != nil {
+		return err
+	}
 	kubeClient, ns, err := o.KubeClientAndDevNamespace()
 	if err != nil {
 		return err


### PR DESCRIPTION
so its easier to view the logs of a repo or PR by copy/pasting the git URL

Signed-off-by: James Strachan <james.strachan@gmail.com>