### PR TITLE
fix(build logs): allow to filter by `build_id`

### DIFF
--- a/pkg/builds/build_info.go
+++ b/pkg/builds/build_info.go
@@ -211,6 +211,9 @@ func (o *BuildPodInfoFilter) LabelSelectorsForActivity() []string {
 	if o.Context != "" {
 		labelSelectors = append(labelSelectors, fmt.Sprintf("%s=%s", v1.LabelContext, o.Context))
 	}
+	if o.Build != "" {
+		labelSelectors = append(labelSelectors, fmt.Sprintf("%s=%s", v1.LabelBuild, o.Build))
+	}
 	return labelSelectors
 }
 


### PR DESCRIPTION
Build logs support filtering by `build_id`

Fixes https://github.com/jenkins-x/jx/issues/5656


