### PR TITLE
chore: jx step report junit can handle both []<testsuite> and <testsuites> junit kind of reports

### DIFF
--- a/pkg/cmd/step/report/step_report_junit_test.go
+++ b/pkg/cmd/step/report/step_report_junit_test.go
@@ -55,6 +55,42 @@ func TestReportFromSingleFile(t *testing.T) {
 	assert.Equal(t, initialReportBytes, resultingReportBytes)
 }
 
+func TestReportFromTestSuites(t *testing.T) {
+	mock := reportingtools_test.NewMockXUnitClient(pegomock.WithT(t))
+
+	dirName, err := ioutil.TempDir("", uuid.New().String())
+	defer os.Remove(dirName)
+	assert.NoError(t, err, "there shouldn't be any problem creating a temp dir")
+
+	reportName := uuid.New().String() + ".html"
+	o := StepReportJUnitOptions{
+		XUnitClient:      mock,
+		ReportsDir:       filepath.Join("test_data", "junit", "testsuites_report"),
+		TargetReport:     "ui_smoke.junit.xml",
+		DeleteReportFn:   func(reportName string) (err error) { return },
+		OutputReportName: reportName,
+		StepReportOptions: StepReportOptions{
+			OutputDir: dirName,
+		},
+	}
+
+	err = o.Run()
+	assert.NoError(t, err)
+
+	mock.VerifyWasCalledOnce().EnsureXUnitViewer(AnyCommonOptions())
+	_, _, targetFileName := mock.VerifyWasCalledOnce().CreateHTMLReport(pegomock.EqString(filepath.Join(dirName,
+		reportName)), pegomock.EqString(""), pegomock.AnyString()).GetCapturedArguments()
+	defer util.DeleteFile(targetFileName)
+
+	resultingReportBytes, err := ioutil.ReadFile(targetFileName)
+	assert.NoError(t, err)
+
+	initialReportBytes, err := ioutil.ReadFile(filepath.Join(o.ReportsDir, o.TargetReport))
+	assert.NoError(t, err)
+
+	assert.Equal(t, initialReportBytes, resultingReportBytes)
+}
+
 func TestReportWithMultipleFiles(t *testing.T) {
 	mock := reportingtools_test.NewMockXUnitClient(pegomock.WithT(t))
 
@@ -88,13 +124,19 @@ func TestReportWithMultipleFiles(t *testing.T) {
 	err = xml.Unmarshal(reportBytes, &testSuites)
 	assert.NoError(t, err, "There shouldn't be an error Unmarshalling the resulting merged report")
 
-	assert.Len(t, testSuites.TestSuites, 2, "there should be two suites in the merged report")
+	assert.Len(t, testSuites.TestSuites, 4, "there should be two suites in the merged report")
 	knownSuitesNamesFound := 0
 	for _, v := range testSuites.TestSuites {
 		if v.Name == "Jenkins X E2E tests: create_quickstarts" {
 			knownSuitesNamesFound++
 		}
 		if v.Name == "Jenkins X E2E tests: import_applications" {
+			knownSuitesNamesFound++
+		}
+		if v.Name == "Jenkins X E2E tests: ui_smoke_can_list_projects" {
+			knownSuitesNamesFound++
+		}
+		if v.Name == "Jenkins X E2E tests: ui_smoke_can_list_builds" {
 			knownSuitesNamesFound++
 		}
 	}

--- a/pkg/cmd/step/report/test_data/junit/multiple_reports/ui_smoke.junit.xml
+++ b/pkg/cmd/step/report/test_data/junit/multiple_reports/ui_smoke.junit.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Jenkins X E2E tests: ui_smoke_can_list_projects" tests="1" failures="0" errors="0" time="1.309"></testsuite>
+  <testsuite name="Jenkins X E2E tests: ui_smoke_can_list_builds" tests="1" failures="0" errors="0" time="1.309"></testsuite>
+</testsuites>

--- a/pkg/cmd/step/report/test_data/junit/testsuites_report/ui_smoke.junit.xml
+++ b/pkg/cmd/step/report/test_data/junit/testsuites_report/ui_smoke.junit.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Jenkins X E2E tests: ui_smoke_can_list_projects" tests="1" failures="0" errors="0" time="1.309"></testsuite>
+  <testsuite name="Jenkins X E2E tests: ui_smoke_can_list_builds" tests="1" failures="0" errors="0" time="1.309"></testsuite>
+</testsuites>


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
`jx step report junit` is used to aggregate junit reports from different sources, it was only handling reports of this kind:
```
<testsuite>...</testsuite>
<testsuite>...</testsuite>
<testsuite>...</testsuite>
```

This change allows the step to handle as well:
```
<testsuites>
    <testsuite>...</testsuite>
    <testsuite>...</testsuite>
    <testsuite>...</testsuite>
</testsuites>
```