### PR TITLE
fix(boot): Exclude all pipeline pods from pod ready check

### DIFF
--- a/pkg/cmd/step/verify/step_verify_pod_ready.go
+++ b/pkg/cmd/step/verify/step_verify_pod_ready.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jenkins-x/jx/pkg/builds"
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
 
 	"os"
@@ -107,7 +108,7 @@ func (o *StepVerifyPodReadyOptions) waitForReadyPods(kubeClient kubernetes.Inter
 	var listOptions metav1.ListOptions
 	if o.ExcludeBuildPods {
 		listOptions = metav1.ListOptions{
-			LabelSelector: "created-by-prow != true",
+			LabelSelector: fmt.Sprintf("!%s", builds.LabelPipelineRunName),
 		}
 	} else {
 		listOptions = metav1.ListOptions{}

--- a/pkg/cmd/step/verify/step_verify_pod_ready_test.go
+++ b/pkg/cmd/step/verify/step_verify_pod_ready_test.go
@@ -1,23 +1,113 @@
-package verify_test
+package verify
 
 import (
 	"io/ioutil"
 	"os"
 	"testing"
 
-	"github.com/jenkins-x/jx/pkg/cmd/step/verify"
+	"github.com/jenkins-x/jx/pkg/builds"
 	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	gits_test "github.com/jenkins-x/jx/pkg/gits/mocks"
 	helm_test "github.com/jenkins-x/jx/pkg/helm/mocks"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestStepVerifyPod_WaitForReadyPods(t *testing.T) {
+	t.Parallel()
+
+	options := StepVerifyPodReadyOptions{
+		ExcludeBuildPods: true,
+	}
+	commonOpts := opts.NewCommonOptionsWithFactory(nil)
+	options.CommonOptions = &commonOpts
+
+	labels := make(map[string]string)
+	labels[builds.LabelPipelineRunName] = "some-pipeline"
+
+	podList := &corev1.PodList{
+		Items: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "web",
+				Namespace: "jx",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "web",
+						Image: "nginx:1.12",
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "http",
+								Protocol:      corev1.ProtocolTCP,
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-pipeline",
+				Labels:    labels,
+				Namespace: "jx",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "web",
+						Image: "nginx:1.12",
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "http",
+								Protocol:      corev1.ProtocolTCP,
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionFalse,
+						Reason: "Some container not ready",
+					},
+				},
+			},
+		}},
+	}
+
+	testhelpers.ConfigureTestOptionsWithResources(options.CommonOptions, []runtime.Object{podList}, nil, gits_test.NewMockGitter(), nil, helm_test.NewMockHelmer(), nil)
+
+	kubeClient, err := options.KubeClient()
+	assert.NoError(t, err)
+	table, err := options.waitForReadyPods(kubeClient, "jx")
+	assert.NoError(t, err, "Command failed: %#v", options)
+
+	rows := table.Rows
+	assert.Equal(t, 2, len(rows))
+}
 
 func TestStepVerifyPod(t *testing.T) {
 	t.Parallel()
 
-	options := verify.StepVerifyPodReadyOptions{}
+	options := StepVerifyPodReadyOptions{}
 	// fake the output stream to be checked later
 	r, fakeStdout, _ := os.Pipe()
 	commonOpts := opts.NewCommonOptionsWithFactory(nil)
@@ -40,7 +130,7 @@ func TestStepVerifyPod(t *testing.T) {
 func TestStepVerifyPodDebug(t *testing.T) {
 	t.Parallel()
 
-	options := verify.StepVerifyPodReadyOptions{Debug: true}
+	options := StepVerifyPodReadyOptions{Debug: true}
 	// fake the output stream to be checked later
 	r, fakeStdout, _ := os.Pipe()
 	commonOpts := opts.NewCommonOptionsWithFactory(nil)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

`jx start pipeline` doesn't seem to add the `created-by-prow` label, so let's check for the presence of `tekton.dev/pipelineRun` when we're excluding build pods instead.

#### Special notes for the reviewer(s)

/assign @daveconde 
/assign @warrenbailey 

#### Which issue this PR fixes

fixes #6085
