### PR TITLE
fix: Add build number when displaying pipelines to stop

### DIFF
--- a/pkg/cmd/stop/stop_pipeline.go
+++ b/pkg/cmd/stop/stop_pipeline.go
@@ -173,6 +173,7 @@ func (o *StopPipelineOptions) cancelPipelineRun() error {
 			repo := labels[tekton.LabelRepo]
 			branch := labels[tekton.LabelBranch]
 			context := labels[tekton.LabelContext]
+			buildNumber := labels[tekton.LabelBuild]
 
 			if owner == "" {
 				log.Logger().Warnf("missing label %s on PipelineRun %s has labels %#v", tekton.LabelOwner, pr.Name, labels)
@@ -187,7 +188,8 @@ func (o *StopPipelineOptions) cancelPipelineRun() error {
 				continue
 			}
 
-			name := fmt.Sprintf("%s/%s/%s", owner, repo, branch)
+			name := fmt.Sprintf("%s/%s/%s #%s", owner, repo, branch, buildNumber)
+
 			if context != "" {
 				name = fmt.Sprintf("%s-%s", name, context)
 			}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Prior to this PR, when a user ran `jx stop pipeline`, we'd display
the pipelines that could be stopped without the build number. This
commit adds the build number so it's easy to see which build would be
stopped when a user stops a pipeline.


#### Which issue this PR fixes

fixes #5626 
