### PR TITLE
feat: allow project name to be overridden for tenant service call

### DIFF
--- a/pkg/cmd/step/get/step_get_subdomain.go
+++ b/pkg/cmd/step/get/step_get_subdomain.go
@@ -109,7 +109,12 @@ func (o *StepGetSubdomainOptions) discoverIngressDomain(requirements *config.Req
 	}
 
 	if requirements.Ingress.DomainIssuerURL != "" {
-		domain, err = o.getDomainFromIssuer(requirements.Ingress.DomainIssuerURL, requirements.Cluster.ProjectID, requirements.Cluster.ClusterName)
+		projectName := requirements.Cluster.ProjectID
+		if requirements.Cluster.ConsumerProjectID != "" {
+			projectName = requirements.Cluster.ConsumerProjectID
+			log.Logger().Infof("Overriding projectName with '%s' when getting domain", projectName)
+		}
+		domain, err = o.getDomainFromIssuer(requirements.Ingress.DomainIssuerURL, projectName, requirements.Cluster.ClusterName)
 		if err != nil {
 			return errors.Wrap(err, "issuing domain")
 		}

--- a/pkg/cmd/step/get/step_get_subdomain.go
+++ b/pkg/cmd/step/get/step_get_subdomain.go
@@ -109,12 +109,12 @@ func (o *StepGetSubdomainOptions) discoverIngressDomain(requirements *config.Req
 	}
 
 	if requirements.Ingress.DomainIssuerURL != "" {
-		projectName := requirements.Cluster.ProjectID
-		if requirements.Cluster.ConsumerProjectID != "" {
-			projectName = requirements.Cluster.ConsumerProjectID
-			log.Logger().Infof("Overriding projectName with '%s' when getting domain", projectName)
+		domainPrefix := requirements.Cluster.ProjectID
+		if requirements.Ingress.DomainPrefixOverride != "" {
+			domainPrefix = requirements.Ingress.DomainPrefixOverride
+			log.Logger().Infof("Overriding domainPrefix with '%s' when getting domain", domainPrefix)
 		}
-		domain, err = o.getDomainFromIssuer(requirements.Ingress.DomainIssuerURL, projectName, requirements.Cluster.ClusterName)
+		domain, err = o.getDomainFromIssuer(requirements.Ingress.DomainIssuerURL, domainPrefix, requirements.Cluster.ClusterName)
 		if err != nil {
 			return errors.Wrap(err, "issuing domain")
 		}

--- a/pkg/cmd/step/step_override_requirements.go
+++ b/pkg/cmd/step/step_override_requirements.go
@@ -64,6 +64,9 @@ func (o *StepOverrideRequirementsOptions) overrideRequirements(requirements *con
 	if "" != os.Getenv(config.RequirementProject) {
 		requirements.Cluster.ProjectID = os.Getenv(config.RequirementProject)
 	}
+	if "" != os.Getenv(config.RequirementConsumerProject) {
+		requirements.Cluster.ConsumerProjectID = os.Getenv(config.RequirementConsumerProject)
+	}
 	if "" != os.Getenv(config.RequirementZone) {
 		requirements.Cluster.Zone = os.Getenv(config.RequirementZone)
 	}

--- a/pkg/cmd/step/step_override_requirements.go
+++ b/pkg/cmd/step/step_override_requirements.go
@@ -64,8 +64,8 @@ func (o *StepOverrideRequirementsOptions) overrideRequirements(requirements *con
 	if "" != os.Getenv(config.RequirementProject) {
 		requirements.Cluster.ProjectID = os.Getenv(config.RequirementProject)
 	}
-	if "" != os.Getenv(config.RequirementConsumerProject) {
-		requirements.Cluster.ConsumerProjectID = os.Getenv(config.RequirementConsumerProject)
+	if "" != os.Getenv(config.RequirementDomainPrefixOverride) {
+		requirements.Ingress.DomainPrefixOverride = os.Getenv(config.RequirementDomainPrefixOverride)
 	}
 	if "" != os.Getenv(config.RequirementZone) {
 		requirements.Cluster.Zone = os.Getenv(config.RequirementZone)

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -43,6 +43,8 @@ const (
 	RequirementClusterName = "JX_REQUIREMENT_CLUSTER_NAME"
 	// RequirementProject is the cloudprovider project
 	RequirementProject = "JX_REQUIREMENT_PROJECT"
+	// RequirementConsumerProject is the name of the consumer project
+	RequirementConsumerProject = "JX_REQUIREMENT_CONSUMER_PROJECT"
 	// RequirementZone zone the cluster is in
 	RequirementZone = "JX_REQUIREMENT_ZONE"
 	// RequirementEnvGitOwner the default git owner for environment repositories if none is specified explicitly
@@ -302,6 +304,8 @@ type ClusterConfig struct {
 	Namespace string `json:"namespace,omitempty"`
 	// ProjectID the cloud project ID e.g. on GCP
 	ProjectID string `json:"project,omitempty"`
+	// ConsumerProjectID when binding to a domain issuer, this is the consumer project
+	ConsumerProjectID string `json:"consumerProjectId,omitempty"`
 	// ClusterName the logical name of the cluster
 	ClusterName string `json:"clusterName,omitempty"`
 	// VaultName the name of the vault if using vault for secrets

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -39,12 +39,12 @@ const (
 	RequirementDomainIssuerPassword = "JX_REQUIREMENT_DOMAIN_ISSUER_PASSWORD"
 	// RequirementDomainIssuerURL contains the URL to the service used when requesting a domain
 	RequirementDomainIssuerURL = "JX_REQUIREMENT_DOMAIN_ISSUER_URL"
+	// RequirementDomainPrefixOverride is the name of the prefix to be used rather than the project id
+	RequirementDomainPrefixOverride = "JX_REQUIREMENT_DOMAIN_PREFIX_OVERRIDE"
 	// RequirementClusterName is the cluster name
 	RequirementClusterName = "JX_REQUIREMENT_CLUSTER_NAME"
 	// RequirementProject is the cloudprovider project
 	RequirementProject = "JX_REQUIREMENT_PROJECT"
-	// RequirementConsumerProject is the name of the consumer project
-	RequirementConsumerProject = "JX_REQUIREMENT_CONSUMER_PROJECT"
 	// RequirementZone zone the cluster is in
 	RequirementZone = "JX_REQUIREMENT_ZONE"
 	// RequirementEnvGitOwner the default git owner for environment repositories if none is specified explicitly
@@ -230,6 +230,8 @@ type IngressConfig struct {
 	TLS TLSConfig `json:"tls"`
 	// DomainIssuerURL contains a URL used to retrieve a Domain
 	DomainIssuerURL string `json:"domainIssuerURL,omitempty"`
+	// DomainPrefixOverride when binding to a domain issuer, use this as the prefix rather than the project id
+	DomainPrefixOverride string `json:"domainPrefixOverride,omitempty"`
 }
 
 // TLSConfig contains TLS specific requirements
@@ -304,8 +306,6 @@ type ClusterConfig struct {
 	Namespace string `json:"namespace,omitempty"`
 	// ProjectID the cloud project ID e.g. on GCP
 	ProjectID string `json:"project,omitempty"`
-	// ConsumerProjectID when binding to a domain issuer, this is the consumer project
-	ConsumerProjectID string `json:"consumerProjectId,omitempty"`
 	// ClusterName the logical name of the cluster
 	ClusterName string `json:"clusterName,omitempty"`
 	// VaultName the name of the vault if using vault for secrets


### PR DESCRIPTION
allow boot to override the project name with the consumer project name when asking
the tenant service for a domain.