### PR TITLE
fix: don’t create default factory in tekton logging code

### DIFF
--- a/pkg/cmd/get/get_build_logs.go
+++ b/pkg/cmd/get/get_build_logs.go
@@ -338,7 +338,11 @@ func (o *GetBuildLogsOptions) getTektonLogs(kubeClient kubernetes.Interface, tek
 	}
 
 	if pa.Spec.BuildLogsURL != "" {
-		return false, o.TektonLogger.StreamPipelinePersistentLogs(pa.Spec.BuildLogsURL, o.CommonOptions)
+		authSvc, err := o.GitAuthConfigService()
+		if err != nil {
+			return false, err
+		}
+		return false, o.TektonLogger.StreamPipelinePersistentLogs(pa.Spec.BuildLogsURL, jxClient, ns, authSvc)
 	}
 
 	log.Logger().Infof("Build logs for %s", util.ColorInfo(name))

--- a/pkg/logs/tekton_logging_test.go
+++ b/pkg/logs/tekton_logging_test.go
@@ -355,7 +355,11 @@ func TestStreamPipelinePersistentLogsNotInBucket(t *testing.T) {
 		assert.NoError(t, err)
 	}))
 
-	err := tl.StreamPipelinePersistentLogs(server.URL, &commonOptions)
+	jxClient, ns, err := commonOptions.JXClient()
+	assert.NoError(t, err)
+	authSvc, err := commonOptions.GitAuthConfigService()
+	assert.NoError(t, err)
+	err = tl.StreamPipelinePersistentLogs(server.URL, jxClient, ns, authSvc)
 	assert.NoError(t, err)
 
 	assert.Contains(t, tl.LogWriter.(*TestWriter).StreamLinesLogged[0], "This is an example log line")
@@ -373,7 +377,11 @@ func TestStreamPipelinePersistentLogsInUnsupportedBucketProvider(t *testing.T) {
 		},
 	}
 
-	err := tl.StreamPipelinePersistentLogs("azblob://nonSupportedBucket", &commonOptions)
+	jxClient, ns, err := commonOptions.JXClient()
+	assert.NoError(t, err)
+	authSvc, err := commonOptions.GitAuthConfigService()
+	assert.NoError(t, err)
+	err = tl.StreamPipelinePersistentLogs("azblob://nonSupportedBucket", jxClient, ns, authSvc)
 	assert.NoError(t, err)
 	assert.Contains(t, tl.LogWriter.(*TestWriter).StreamLinesLogged[0], "The provided logsURL scheme is not supported: azblob")
 }


### PR DESCRIPTION
This was a bug we discovered when trying to reuse this code. I copied it and fixed it where I was using it for now but this fixes it here too

fixes #6337 