### PR TITLE
feat: Add support for specifying node tolerations in pipeline syntax and specifying arbitrary labels for pipeline pods

### DIFF
--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -665,7 +665,8 @@ func (o *StepCreateTaskOptions) generateTektonCRDs(effectiveProjectConfig *confi
 			return nil, errors.Wrapf(err, "parsing of pipeline timeout failed")
 		}
 	}
-	run := tekton.CreatePipelineRun(resources, pipeline.Name, pipeline.APIVersion, o.labels, o.ServiceAccount, o.pipelineParams, timeout, effectivePipeline.GetPossibleAffinityPolicy(pipeline.Name), effectivePipeline.GetTolerations())
+	prLabels := util.MergeMaps(o.labels, effectivePipeline.GetPodLabels())
+	run := tekton.CreatePipelineRun(resources, pipeline.Name, pipeline.APIVersion, prLabels, o.ServiceAccount, o.pipelineParams, timeout, effectivePipeline.GetPossibleAffinityPolicy(pipeline.Name), effectivePipeline.GetTolerations())
 
 	tektonCRDs, err := tekton.NewCRDWrapper(pipeline, tasks, resources, structure, run)
 	if err != nil {

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -665,7 +665,7 @@ func (o *StepCreateTaskOptions) generateTektonCRDs(effectiveProjectConfig *confi
 			return nil, errors.Wrapf(err, "parsing of pipeline timeout failed")
 		}
 	}
-	run := tekton.CreatePipelineRun(resources, pipeline.Name, pipeline.APIVersion, o.labels, o.ServiceAccount, o.pipelineParams, timeout, effectivePipeline.GetPossibleAffinityPolicy(pipeline.Name))
+	run := tekton.CreatePipelineRun(resources, pipeline.Name, pipeline.APIVersion, o.labels, o.ServiceAccount, o.pipelineParams, timeout, effectivePipeline.GetPossibleAffinityPolicy(pipeline.Name), effectivePipeline.GetTolerations())
 
 	tektonCRDs, err := tekton.NewCRDWrapper(pipeline, tasks, resources, structure, run)
 	if err != nil {

--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -354,6 +354,14 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			kind:                  "release",
 			effectiveProjectError: errors.New("no pipeline defined for kind release"),
 		},
+		{
+			name:         "tolerations",
+			language:     "none",
+			repoName:     "js-test-repo",
+			organization: "abayer",
+			branch:       "really-long",
+			kind:         "release",
+		},
 	}
 
 	k8sObjects := []runtime.Object{

--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -362,6 +362,15 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			branch:       "really-long",
 			kind:         "release",
 		},
+		{
+			name:             "distribute-parallel-across-nodes-with-labels",
+			language:         "none",
+			repoName:         "js-test-repo",
+			organization:     "abayer",
+			branch:           "really-long",
+			kind:             "release",
+			branchAsRevision: true,
+		},
 	}
 
 	k8sObjects := []runtime.Object{

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/jenkins-x.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/jenkins-x.yml
@@ -1,0 +1,46 @@
+pipelineConfig:
+  env:
+    - name: FRUIT
+      value: BANANA
+  pipelines:
+    release:
+      pipeline:
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: somebodyelse
+        options:
+          distributeParallelAcrossNodes: true
+          containerOptions:
+            resources:
+              requests:
+                cpu: 0.1
+                memory: 64Mi
+          podLabels:
+            foo: bar
+            fruit: apple
+            way-too-long-a-label-seriously-this-just-goes-on-for-so-many-characters: this%-hasinvalid^characters
+        agent:
+          image: nodejs
+        stages:
+          - name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+            steps:
+              - command: echo
+                args:
+                  - hello world
+              - command: ls
+                args:
+                  - -la
+                env:
+                  - name: ANOTHER_VAR
+                    value: Another value
+          - name: Second
+            steps:
+              - command: echo
+                args:
+                  - hi ${FRUIT}
+            options:
+              containerOptions:
+                resources:
+                  limits:
+                    cpu: 0.4
+                    memory: 256Mi

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipeline.yml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: really-long
+    build: "1"
+    owner: abayer
+    jenkins.io/pipelineType: build
+    repository: js-test-repo
+  name: abayer-js-test-repo-really-long-1
+  namespace: jx
+spec:
+  params:
+  - default: 0.0.1
+    description: the version number for this pipeline which is used as a tag on docker
+      images and helm charts
+    name: version
+  resources:
+  - name: abayer-js-test-repo-really-long
+    type: git
+  tasks:
+  - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+    params:
+    - name: version
+      value: ${params.version}
+    resources:
+      inputs:
+      - name: workspace
+        resource: abayer-js-test-repo-really-long
+      outputs:
+      - name: workspace
+        resource: abayer-js-test-repo-really-long
+    taskRef:
+      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  - name: second
+    params:
+    - name: version
+      value: ${params.version}
+    resources:
+      inputs:
+      - from:
+        - build-a-really-long-stage-name-please-but-not-too-long-thanks
+        name: workspace
+        resource: abayer-js-test-repo-really-long
+    runAfter:
+    - build-a-really-long-stage-name-please-but-not-too-long-thanks
+    taskRef:
+      name: abayer-js-test-repo-really-long-second-1
+status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipelineresources.yml
@@ -1,0 +1,15 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    creationTimestamp: null
+    name: abayer-js-test-repo-really-long
+  spec:
+    params:
+    - name: revision
+      value: really-long
+    - name: url
+      value: https://github.com/abayer/js-test-repo
+    type: git
+  status: {}
+metadata: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipelinerun.yml
@@ -5,9 +5,12 @@ metadata:
   labels:
     branch: really-long
     build: "1"
+    foo: bar
+    fruit: apple
     owner: abayer
     jenkins.io/pipelineType: build
     repository: js-test-repo
+    way-too-long-a-label-seriously-this-just-goes-on-for-so-many-ch: this-hasinvalidcharacters
   name: abayer-js-test-repo-really-long-1
 spec:
   affinity:
@@ -15,7 +18,9 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchLabels:
-              tekton.dev/pipelineRun: abayer-js-test-repo-really-long-1
+              foo: bar
+              fruit: apple
+              way-too-long-a-label-seriously-this-just-goes-on-for-so-many-ch: this-hasinvalidcharacters
           topologyKey: kubernetes.io/hostname
   params:
   - name: version

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/structure.yml
@@ -1,0 +1,19 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: really-long
+    build: "1"
+    owner: abayer
+    jenkins.io/pipelineType: build
+    repository: js-test-repo
+  name: abayer-js-test-repo-really-long-1
+pipelineRef: null
+pipelineRunRef: null
+stages:
+- depth: 0
+  name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+- depth: 0
+  name: Second
+  previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+  taskRef: abayer-js-test-repo-really-long-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/tasks.yml
@@ -1,0 +1,343 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: null
+    labels:
+      branch: really-long
+      build: "1"
+      jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+      owner: abayer
+      jenkins.io/pipelineType: build
+      repository: js-test-repo
+    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    namespace: jx
+  spec:
+    inputs:
+      params:
+      - default: 0.0.1
+        description: the version number for this pipeline which is used as a tag on
+          docker images and helm charts
+        name: version
+      resources:
+      - name: workspace
+        outputImageDir: ""
+        targetPath: source
+        type: git
+    outputs:
+      resources:
+      - name: workspace
+        outputImageDir: ""
+        targetPath: ""
+        type: git
+    steps:
+    - args:
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - jx
+      env:
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: DOCKER_REGISTRY
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-jx:0.1.527
+      name: git-merge
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      volumeMounts:
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - echo hello world
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step2
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - ls -la
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: ANOTHER_VAR
+        value: Another value
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step3
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: null
+    labels:
+      branch: really-long
+      build: "1"
+      jenkins.io/task-stage-name: second
+      owner: abayer
+      jenkins.io/pipelineType: build
+      repository: js-test-repo
+    name: abayer-js-test-repo-really-long-second-1
+    namespace: jx
+  spec:
+    inputs:
+      params:
+      - default: 0.0.1
+        description: the version number for this pipeline which is used as a tag on
+          docker images and helm charts
+        name: version
+      resources:
+      - name: workspace
+        outputImageDir: ""
+        targetPath: source
+        type: git
+    steps:
+    - args:
+      - echo hi ${FRUIT}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step2
+      resources:
+        limits:
+          cpu: 400m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+metadata: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/jenkins-x.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/jenkins-x.yml
@@ -1,0 +1,45 @@
+pipelineConfig:
+  env:
+    - name: FRUIT
+      value: BANANA
+  pipelines:
+    release:
+      pipeline:
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: somebodyelse
+        options:
+          containerOptions:
+            resources:
+              requests:
+                cpu: 0.1
+                memory: 64Mi
+          tolerations:
+            - key: "some-key"
+              operator: "Exists"
+              effect: "NoSchedule"
+        agent:
+          image: nodejs
+        stages:
+          - name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+            steps:
+              - command: echo
+                args:
+                  - hello world
+              - command: ls
+                args:
+                  - -la
+                env:
+                  - name: ANOTHER_VAR
+                    value: Another value
+          - name: Second
+            steps:
+              - command: echo
+                args:
+                  - hi ${FRUIT}
+            options:
+              containerOptions:
+                resources:
+                  limits:
+                    cpu: 0.4
+                    memory: 256Mi

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipeline.yml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: really-long
+    build: "1"
+    owner: abayer
+    jenkins.io/pipelineType: build
+    repository: js-test-repo
+  name: abayer-js-test-repo-really-long-1
+  namespace: jx
+spec:
+  params:
+  - default: 0.0.1
+    description: the version number for this pipeline which is used as a tag on docker
+      images and helm charts
+    name: version
+  resources:
+  - name: abayer-js-test-repo-really-long
+    type: git
+  tasks:
+  - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+    params:
+    - name: version
+      value: ${params.version}
+    resources:
+      inputs:
+      - name: workspace
+        resource: abayer-js-test-repo-really-long
+      outputs:
+      - name: workspace
+        resource: abayer-js-test-repo-really-long
+    taskRef:
+      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  - name: second
+    params:
+    - name: version
+      value: ${params.version}
+    resources:
+      inputs:
+      - from:
+        - build-a-really-long-stage-name-please-but-not-too-long-thanks
+        name: workspace
+        resource: abayer-js-test-repo-really-long
+    runAfter:
+    - build-a-really-long-stage-name-please-but-not-too-long-thanks
+    taskRef:
+      name: abayer-js-test-repo-really-long-second-1
+status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipelineresources.yml
@@ -1,0 +1,15 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    creationTimestamp: null
+    name: abayer-js-test-repo-really-long
+  spec:
+    params:
+    - name: revision
+      value: v0.0.1
+    - name: url
+      value: https://github.com/abayer/js-test-repo
+    type: git
+  status: {}
+metadata: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipelinerun.yml
@@ -10,13 +10,6 @@ metadata:
     repository: js-test-repo
   name: abayer-js-test-repo-really-long-1
 spec:
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchLabels:
-              tekton.dev/pipelineRun: abayer-js-test-repo-really-long-1
-          topologyKey: failure-domain.beta.kubernetes.io/zone
   params:
   - name: version
     value: 0.0.1
@@ -30,4 +23,8 @@ spec:
       name: abayer-js-test-repo-really-long
   serviceAccount: tekton-bot
   timeout: 240h0m0s
+  tolerations:
+  - key: "some-key"
+    operator: "Exists"
+    effect: "NoSchedule"
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/structure.yml
@@ -1,0 +1,19 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: really-long
+    build: "1"
+    owner: abayer
+    jenkins.io/pipelineType: build
+    repository: js-test-repo
+  name: abayer-js-test-repo-really-long-1
+pipelineRef: null
+pipelineRunRef: null
+stages:
+- depth: 0
+  name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+- depth: 0
+  name: Second
+  previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
+  taskRef: abayer-js-test-repo-really-long-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/tasks.yml
@@ -1,0 +1,343 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: null
+    labels:
+      branch: really-long
+      build: "1"
+      jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
+      owner: abayer
+      jenkins.io/pipelineType: build
+      repository: js-test-repo
+    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    namespace: jx
+  spec:
+    inputs:
+      params:
+      - default: 0.0.1
+        description: the version number for this pipeline which is used as a tag on
+          docker images and helm charts
+        name: version
+      resources:
+      - name: workspace
+        outputImageDir: ""
+        targetPath: source
+        type: git
+    outputs:
+      resources:
+      - name: workspace
+        outputImageDir: ""
+        targetPath: ""
+        type: git
+    steps:
+    - args:
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - jx
+      env:
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: DOCKER_REGISTRY
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-jx:0.1.527
+      name: git-merge
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      volumeMounts:
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - echo hello world
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step2
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - ls -la
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: ANOTHER_VAR
+        value: Another value
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step3
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: null
+    labels:
+      branch: really-long
+      build: "1"
+      jenkins.io/task-stage-name: second
+      owner: abayer
+      jenkins.io/pipelineType: build
+      repository: js-test-repo
+    name: abayer-js-test-repo-really-long-second-1
+    namespace: jx
+  spec:
+    inputs:
+      params:
+      - default: 0.0.1
+        description: the version number for this pipeline which is used as a tag on
+          docker images and helm charts
+        name: version
+      resources:
+      - name: workspace
+        outputImageDir: ""
+        targetPath: source
+        type: git
+    steps:
+    - args:
+      - echo hi ${FRUIT}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: FRUIT
+        value: BANANA
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/really-long
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: really-long
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: step2
+      resources:
+        limits:
+          cpu: 400m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+metadata: {}

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -97,7 +97,7 @@ func createMetaPipelineCRDs(params CRDCreationParameters) (*tekton.CRDWrapper, e
 		revision = params.PullRef.BaseBranch()
 	}
 	resources := []*pipelineapi.PipelineResource{tekton.GenerateSourceRepoResource(params.ResourceName, &params.GitInfo, revision)}
-	run := tekton.CreatePipelineRun(resources, pipeline.Name, pipeline.APIVersion, labels, params.ServiceAccount, nil, nil, nil)
+	run := tekton.CreatePipelineRun(resources, pipeline.Name, pipeline.APIVersion, labels, params.ServiceAccount, nil, nil, nil, nil)
 
 	tektonCRDs, err := tekton.NewCRDWrapper(pipeline, tasks, resources, structure, run)
 	if err != nil {

--- a/pkg/tekton/pipelines.go
+++ b/pkg/tekton/pipelines.go
@@ -286,7 +286,8 @@ func CreatePipelineRun(resources []*pipelineapi.PipelineResource,
 	serviceAccount string,
 	pipelineParams []pipelineapi.Param,
 	timeout *metav1.Duration,
-	affinity *corev1.Affinity) *pipelineapi.PipelineRun {
+	affinity *corev1.Affinity,
+	tolerations []corev1.Toleration) *pipelineapi.PipelineRun {
 	var resourceBindings []pipelineapi.PipelineResourceBinding
 	for _, resource := range resources {
 		resourceBindings = append(resourceBindings, pipelineapi.PipelineResourceBinding{
@@ -320,8 +321,9 @@ func CreatePipelineRun(resources []*pipelineapi.PipelineResource,
 			Resources: resourceBindings,
 			Params:    pipelineParams,
 			// TODO: We shouldn't have to set a default timeout in the first place. See https://github.com/tektoncd/pipeline/issues/978
-			Timeout:  timeout,
-			Affinity: affinity,
+			Timeout:     timeout,
+			Affinity:    affinity,
+			Tolerations: tolerations,
 		},
 	}
 

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -1327,6 +1327,10 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						Operator: "Exists",
 						Effect:   "NoSchedule",
 					}}),
+					sh.PipelinePodLabels(map[string]string{
+						"foo":   "bar",
+						"fruit": "apple",
+					}),
 				),
 				sh.PipelineStage("A Working Stage",
 					sh.StageStep(

--- a/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
+++ b/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
@@ -193,6 +193,13 @@ func PipelineContainerOptions(ops ...builder.ContainerOp) PipelineOptionsOp {
 	}
 }
 
+// PipelineTolerations sets the tolerations for the pipeline
+func PipelineTolerations(tolerations []corev1.Toleration) PipelineOptionsOp {
+	return func(options *syntax.RootOptions) {
+		options.Tolerations = append(options.Tolerations, tolerations...)
+	}
+}
+
 // StageContainerOptions sets the containerOptions for a stage
 func StageContainerOptions(ops ...builder.ContainerOp) StageOptionsOp {
 	return func(options *syntax.StageOptions) {

--- a/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
+++ b/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
@@ -3,6 +3,7 @@ package syntax_helpers_test
 import (
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/tekton/syntax"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
@@ -197,6 +198,13 @@ func PipelineContainerOptions(ops ...builder.ContainerOp) PipelineOptionsOp {
 func PipelineTolerations(tolerations []corev1.Toleration) PipelineOptionsOp {
 	return func(options *syntax.RootOptions) {
 		options.Tolerations = append(options.Tolerations, tolerations...)
+	}
+}
+
+// PipelinePodLabels sets the optional pod labels for the pipeline
+func PipelinePodLabels(labels map[string]string) PipelineOptionsOp {
+	return func(options *syntax.RootOptions) {
+		options.PodLabels = util.MergeMaps(options.PodLabels, labels)
 	}
 }
 

--- a/pkg/tekton/syntax/test_data/tolerations/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/tolerations/jenkins-x.yml
@@ -9,6 +9,9 @@ pipelineConfig:
             - key: "some-key"
               operator: "Exists"
               effect: "NoSchedule"
+          podLabels:
+            foo: bar
+            fruit: apple
         stages:
           - name: A Working Stage
             steps:

--- a/pkg/tekton/syntax/test_data/tolerations/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/tolerations/jenkins-x.yml
@@ -1,0 +1,19 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: some-image
+        options:
+          tolerations:
+            - key: "some-key"
+              operator: "Exists"
+              effect: "NoSchedule"
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such

--- a/pkg/tekton/syntax/zz_generated.deepcopy.go
+++ b/pkg/tekton/syntax/zz_generated.deepcopy.go
@@ -319,6 +319,20 @@ func (in *RootOptions) DeepCopyInto(out *RootOptions) {
 			}
 		}
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.PodLabels != nil {
+		in, out := &in.PodLabels, &out.PodLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

If said arbitrary label(s) are specified and `distributeParallelAcrossNodes` is true, then those label(s) will be used for the anti-affinity rather than the default of the `tekton.dev/pipelineRun` label+value. This will allow multiple runs of one or more pipelines to be on unique nodes, not just multiple pods of a single pipeline run.

Also switched the `distributeParallelAcrossNodes` behavior from `PreferredDuringSchedulingIgnoredDuringExecution` to `RequiredDuringSchedulingIgnoredDuringExecution`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a