### PR TITLE
fix: check also the commands which have children for deprecation

### DIFF
--- a/pkg/cmd/deprecation/deprecated.go
+++ b/pkg/cmd/deprecation/deprecated.go
@@ -40,11 +40,11 @@ type deprecationInfo struct {
 // DeprecateCommands runs recursively over all commands and set the deprecation message
 // on every command defined the deprecated commands map.
 func DeprecateCommands(cmd *cobra.Command) {
+	path := commandPath(cmd)
+	if deprecation, ok := deprecatedCommands[path]; ok {
+		cmd.Deprecated = deprecationMessage(deprecation)
+	}
 	if !cmd.HasSubCommands() {
-		path := commandPath(cmd)
-		if deprecation, ok := deprecatedCommands[path]; ok {
-			cmd.Deprecated = deprecationMessage(deprecation)
-		}
 		return
 	}
 	for _, c := range cmd.Commands() {


### PR DESCRIPTION
There are commands such as install which has children but still implements its own
functionality. We want to deprecate also in this case the command.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->