### PR TITLE
chore: Refactor applications commands

### DIFF
--- a/pkg/applications/applications.go
+++ b/pkg/applications/applications.go
@@ -1,0 +1,165 @@
+package applications
+
+import (
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/cmd/clients"
+	"github.com/jenkins-x/jx/pkg/flagger"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/services"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+	"k8s.io/api/apps/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Deployment represents an application deployment in a single environment
+type Deployment struct {
+	*v1beta1.Deployment
+}
+
+// Environment represents an environment in which an application has been
+// deployed
+type Environment struct {
+	v1.Environment
+	Deployments []Deployment
+}
+
+// Application represents an application in jx
+type Application struct {
+	*v1.SourceRepository
+	Environments map[string]Environment
+}
+
+// List is a collection of applications
+type List struct {
+	Items []Application
+}
+
+// Environments loops through all applications in a list and returns a map with
+// all the unique environments
+func (al List) Environments() map[string]v1.Environment {
+	envs := make(map[string]v1.Environment)
+
+	for _, a := range al.Items {
+		for name, env := range a.Environments {
+			if _, ok := envs[name]; !ok {
+				envs[name] = env.Environment
+			}
+		}
+	}
+
+	return envs
+}
+
+// Name returns the application name
+func (a Application) Name() string {
+	return a.SourceRepository.Spec.Repo
+}
+
+// IsPreview returns true if the environment is a preview environment
+func (e Environment) IsPreview() bool {
+	return e.Environment.Spec.Kind == v1.EnvironmentKindTypePreview
+}
+
+// Version returns the deployment version
+func (d Deployment) Version() string {
+	return kube.GetVersion(&d.Deployment.ObjectMeta)
+}
+
+// Pods returns the ratio of pods that are ready/replicas
+func (d Deployment) Pods() string {
+	pods := ""
+	ready := d.Deployment.Status.ReadyReplicas
+
+	if d.Deployment.Spec.Replicas != nil && ready > 0 {
+		replicas := util.Int32ToA(*d.Deployment.Spec.Replicas)
+		pods = util.Int32ToA(ready) + "/" + replicas
+	}
+
+	return pods
+}
+
+// URL returns a deployment URL
+func (d Deployment) URL(kc kubernetes.Interface, a Application) string {
+	url, _ := services.FindServiceURL(kc, d.Deployment.Namespace, a.Name())
+	return url
+}
+
+// GetApplications fetches all Applications
+func GetApplications(factory clients.Factory) (List, error) {
+	list := List{
+		Items: make([]Application, 0),
+	}
+
+	client, namespace, err := factory.CreateJXClient()
+	if err != nil {
+		return list, errors.Wrap(err, "failed to create a jx client from applications.GetApplications")
+	}
+
+	// fetch ALL repositories
+	srList, err := client.JenkinsV1().SourceRepositories(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return list, errors.Wrapf(err, "failed to find any SourceRepositories in namespace %s", namespace)
+	}
+
+	// fetch all environments
+	envMap, _, err := kube.GetOrderedEnvironments(client, namespace)
+	if err != nil {
+		return list, errors.Wrapf(err, "failed to fetch environments in namespace %s", namespace)
+	}
+
+	// only keep permanent environments
+	permanentEnvsMap := map[string]*v1.Environment{}
+	for _, env := range envMap {
+		if env.Spec.Kind.IsPermanent() {
+			permanentEnvsMap[env.Spec.Namespace] = env
+		}
+	}
+
+	// copy repositories that aren't environments to our applications list
+	for _, sr := range srList.Items {
+		if !kube.IsIncludedInTheGivenEnvs(permanentEnvsMap, &sr) {
+			srCopy := sr
+			list.Items = append(list.Items, Application{&srCopy, make(map[string]Environment)})
+		}
+	}
+
+	kubeClient, _, err := factory.CreateKubeClient()
+
+	// fetch deployments by environment (excluding dev)
+	deployments := make(map[string]map[string]v1beta1.Deployment)
+	for _, env := range permanentEnvsMap {
+		if env.Spec.Kind != v1.EnvironmentKindTypeDevelopment {
+			envDeployments, err := kube.GetDeployments(kubeClient, env.Spec.Namespace)
+			if err != nil {
+				return list, err
+			}
+
+			deployments[env.Spec.Namespace] = envDeployments
+		}
+	}
+
+	// fetch deployment app name and match it against application names
+	for _, app := range list.Items {
+		for envName, env := range permanentEnvsMap {
+			for _, dep := range deployments[envName] {
+				labels, err := metav1.LabelSelectorAsMap(dep.Spec.Selector)
+				if err != nil {
+					return list, err
+				}
+
+				depAppName := kube.GetAppName(labels["app"], env.Spec.Namespace)
+				if depAppName == app.SourceRepository.Spec.Repo && !flagger.IsCanaryAuxiliaryDeployment(dep) {
+					depCopy := dep
+					app.Environments[env.Name] = Environment{
+						*env,
+						[]Deployment{{&depCopy}},
+					}
+				}
+			}
+		}
+	}
+
+	return list, nil
+}

--- a/pkg/applications/applications_test.go
+++ b/pkg/applications/applications_test.go
@@ -1,0 +1,159 @@
+package applications
+
+import (
+	"testing"
+
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/apps/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAppendMatchingDeployments(t *testing.T) {
+	tests := []struct {
+		name             string
+		list             List
+		environments     map[string]*v1.Environment
+		deployments      map[string]map[string]v1beta1.Deployment
+		wantApplications int
+		wantEnvironments int
+		wantDeployments  int
+	}{
+		{
+			"No source repositories found",
+			List{},
+			make(map[string]*v1.Environment),
+			make(map[string]map[string]v1beta1.Deployment),
+			0, 0, 0,
+		},
+		{
+			"Source repository doesn't have a matching deployment",
+			List{
+				[]Application{
+					{
+						&v1.SourceRepository{
+							Spec: v1.SourceRepositorySpec{
+								Repo: "my-repo-name",
+							},
+						},
+						make(map[string]Environment),
+					},
+				},
+			},
+			make(map[string]*v1.Environment),
+			make(map[string]map[string]v1beta1.Deployment),
+			1, 0, 0,
+		},
+		{
+			"Source repository matches a single deployment",
+			List{
+				[]Application{
+					{
+						&v1.SourceRepository{
+							Spec: v1.SourceRepositorySpec{
+								Repo: "my-repo-name",
+							},
+						},
+						make(map[string]Environment),
+					},
+				},
+			},
+			map[string]*v1.Environment{
+				"staging": {
+					Spec: v1.EnvironmentSpec{
+						Namespace: "jx-staging",
+						Kind:      v1.EnvironmentKindTypePermanent,
+					},
+				},
+			},
+			map[string]map[string]v1beta1.Deployment{
+				"staging": {
+					"jx-staging": v1beta1.Deployment{
+						Spec: v1beta1.DeploymentSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "my-repo-name",
+								},
+							},
+						},
+					},
+				},
+			},
+			1, 1, 1,
+		},
+		{
+			"Source repository matches multiple deployments",
+			List{
+				[]Application{
+					{
+						&v1.SourceRepository{
+							Spec: v1.SourceRepositorySpec{
+								Repo: "my-repo-name",
+							},
+						},
+						make(map[string]Environment),
+					},
+				},
+			},
+			map[string]*v1.Environment{
+				"staging": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "staging",
+					},
+					Spec: v1.EnvironmentSpec{
+						Namespace: "jx-staging",
+						Kind:      v1.EnvironmentKindTypePermanent,
+					},
+				},
+				"production": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "production",
+					},
+					Spec: v1.EnvironmentSpec{
+						Namespace: "jx-production",
+						Kind:      v1.EnvironmentKindTypePermanent,
+					},
+				},
+			},
+			map[string]map[string]v1beta1.Deployment{
+				"staging": {
+					"jx-staging": v1beta1.Deployment{
+						Spec: v1beta1.DeploymentSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "jx-my-repo-name",
+								},
+							},
+						},
+					},
+				},
+				"production": {
+					"jx-production": v1beta1.Deployment{
+						Spec: v1beta1.DeploymentSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "jx-my-repo-name",
+								},
+							},
+						},
+					},
+				},
+			},
+			1, 2, 1,
+		},
+	}
+
+	for _, test := range tests {
+		err := test.list.appendMatchingDeployments(test.environments, test.deployments)
+
+		assert.NoError(t, err, test.name)
+		assert.Equal(t, test.wantApplications, len(test.list.Items), test.name)
+
+		envs := test.list.Environments()
+		assert.Equal(t, test.wantEnvironments, len(envs), test.name)
+
+		for env := range envs {
+			assert.Equal(t, test.wantDeployments, len(test.list.Items[0].Environments[env].Deployments), test.name)
+		}
+	}
+}

--- a/pkg/cmd/get/get_applications.go
+++ b/pkg/cmd/get/get_applications.go
@@ -1,13 +1,13 @@
 package get
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/jenkins-x/jx/pkg/applications"
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
-	"github.com/jenkins-x/jx/pkg/kserving"
-	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/jenkins-x/jx/pkg/table"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
@@ -17,13 +17,9 @@ import (
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
-	"github.com/jenkins-x/jx/pkg/flagger"
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/jenkins-x/jx/pkg/util"
-	kserve "github.com/knative/serving/pkg/client/clientset/versioned"
 	"k8s.io/api/apps/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetApplicationsOptions containers the CLI options
@@ -35,18 +31,10 @@ type GetApplicationsOptions struct {
 	HideUrl     bool
 	HidePod     bool
 	Previews    bool
-
-	Results GetApplicationsResults
 }
 
-// GetApplicationsResults contains the data result from invoking this command
-type GetApplicationsResults struct {
-	EnvApps  []EnvApps
-	EnvNames []string
-
-	// Applications is a map indexed by the application name then the environment name
-	Applications map[string]map[string]*ApplicationEnvironmentInfo
-}
+// Applications is a map indexed by the application name then the environment name
+// Applications map[string]map[string]*ApplicationEnvironmentInfo
 
 // EnvApps contains data about app deployments in an environment
 type EnvApps struct {
@@ -63,11 +51,11 @@ type ApplicationEnvironmentInfo struct {
 }
 
 var (
-	get_version_long = templates.LongDesc(`
+	getVersionLong = templates.LongDesc(`
 		Display applications across environments.
 `)
 
-	get_version_example = templates.Examples(`
+	getVersionExample = templates.Examples(`
 		# List applications, their URL and pod counts for all environments
 		jx get applications
 
@@ -97,8 +85,8 @@ func NewCmdGetApplications(commonOpts *opts.CommonOptions) *cobra.Command {
 		Use:     "applications",
 		Short:   "Display one or more Applications and their versions",
 		Aliases: []string{"application", "version", "versions"},
-		Long:    get_version_long,
-		Example: get_version_example,
+		Long:    getVersionLong,
+		Example: getVersionExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Cmd = cmd
 			options.Args = args
@@ -116,232 +104,110 @@ func NewCmdGetApplications(commonOpts *opts.CommonOptions) *cobra.Command {
 
 // Run implements this command
 func (o *GetApplicationsOptions) Run() error {
+	if o.Previews {
+		fmt.Println("The `--preview` flag has been deprecated from this command, use instead `jx get previews`")
+		return nil
+	}
+
+	list, err := applications.GetApplications(o.CommonOptions.GetFactory())
+	if err != nil {
+		return errors.Wrap(err, "fetching applications")
+	}
+	if len(list.Items) == 0 {
+		log.Logger().Infof("No applications found")
+		return nil
+	}
+
 	kubeClient, err := o.KubeClient()
 	if err != nil {
 		return err
 	}
-	kserveClient, _, err := o.KnativeServeClient()
-	if err != nil {
-		return err
-	}
-
-	_, envApps, envNames, apps, err := o.getAppData(kubeClient)
-	if err != nil {
-		return err
-	}
-
-	if len(apps) == 0 {
-		log.Logger().Infof("No applications found in environments %s", strings.Join(envNames, ", "))
-		return nil
-	}
-	sort.Strings(apps)
-
-	o.Results.EnvApps = envApps
-	o.Results.EnvNames = envNames
-
-	table := o.generateTable(apps, envApps, kubeClient, kserveClient)
-
+	table := o.generateTable(kubeClient, list)
 	table.Render()
+
 	return nil
 }
 
-func (o *GetApplicationsOptions) generateTable(apps []string, envApps []EnvApps, kubeClient kubernetes.Interface, kserveClient kserve.Interface) table.Table {
-	table := o.generateTableHeaders(envApps)
+func (o *GetApplicationsOptions) generateTable(kubeClient kubernetes.Interface, list applications.List) table.Table {
+	table := o.generateTableHeaders(list)
 
-	appEnvMap := map[string]map[string]*ApplicationEnvironmentInfo{}
-	for _, appName := range apps {
-		row := []string{appName}
-		for _, ea := range envApps {
-			version := ""
-			d, ok := ea.Apps[appName]
-			if len(ea.Apps) > 0 {
-				if ok {
-					appMap := appEnvMap[appName]
-					if appMap == nil {
-						appMap = map[string]*ApplicationEnvironmentInfo{}
-						appEnvMap[appName] = appMap
-					}
-					version = kube.GetVersion(&d.ObjectMeta)
-					url := ""
-					if !o.HideUrl {
-						names := []string{appName}
-						if d.Name != appName {
-							names = append(names, d.Name)
-						}
-						for _, name := range names {
-							url, _ = services.FindServiceURL(kubeClient, d.Namespace, name)
-							if url != "" {
-								break
-							}
-							url2, svc, _ := kserving.FindServiceURL(kserveClient, kubeClient, d.Namespace, name)
-							if url2 != "" {
-								url = url2
-								if svc != nil {
-									svcVersion := kube.GetVersion(&svc.ObjectMeta)
-									if svcVersion != "" {
-										version = svcVersion
-									}
-								}
-								break
-							}
-						}
-						if url == "" {
-							// handle helm3
-							chart, ok := d.Labels["chart"]
-							if ok {
-								idx := strings.LastIndex(chart, "-")
-								if idx > 0 {
-									svcName := chart[0:idx]
-									if svcName != appName && svcName != d.Name {
-										url, _ = services.FindServiceURL(kubeClient, d.Namespace, svcName)
-									}
-								}
-							}
-						}
-					}
+	for _, a := range list.Items {
+		row := []string{}
+		name := a.Name()
 
-					appEnvInfo := &ApplicationEnvironmentInfo{
-						Deployment:  &d,
-						Environment: ea.Environment.DeepCopy(),
-						Version:     version,
-						URL:         url,
-					}
-					appMap[ea.Environment.Name] = appEnvInfo
+		for _, k := range o.sortedKeys(list.Environments()) {
 
-					if ea.Environment.Spec.Kind != v1.EnvironmentKindTypePreview {
-						row = append(row, version)
+			if ae, ok := a.Environments[k]; ok {
+				for _, d := range ae.Deployments {
+					name = kube.GetAppName(d.Deployment.Name, k)
+					if ae.Environment.Spec.Kind == v1.EnvironmentKindTypeEdit {
+						name = kube.GetEditAppName(name)
+					} else if ae.Environment.Spec.Kind == v1.EnvironmentKindTypePreview {
+						name = ae.Environment.Spec.PullRequestURL
+					}
+					if !ae.IsPreview() {
+						row = append(row, d.Version())
 					}
 					if !o.HidePod {
-						pods := ""
-						replicas := ""
-						ready := d.Status.ReadyReplicas
-						if d.Spec.Replicas != nil && ready > 0 {
-							replicas = formatInt32(*d.Spec.Replicas)
-							pods = formatInt32(ready) + "/" + replicas
-						}
-						row = append(row, pods)
+						row = append(row, d.Pods())
 					}
 					if !o.HideUrl {
-						row = append(row, url)
+						row = append(row, d.URL(kubeClient, a))
 					}
-				} else {
-					if ea.Environment.Spec.Kind != v1.EnvironmentKindTypePreview {
-						row = append(row, "")
-					}
-					if !o.HidePod {
-						row = append(row, "")
-					}
-					if !o.HideUrl {
-						row = append(row, "")
-					}
+				}
+			} else {
+				if !ae.IsPreview() {
+					row = append(row, "")
+				}
+				if !o.HidePod {
+					row = append(row, "")
+				}
+				if !o.HideUrl {
+					row = append(row, "")
 				}
 			}
 		}
+		row = append([]string{name}, row...)
 		table.AddRow(row...)
 	}
-	o.Results.Applications = appEnvMap
 	return table
 }
 
-func (o *GetApplicationsOptions) getAppData(kubeClient kubernetes.Interface) (namespaces []string, envApps []EnvApps, envNames, apps []string, err error) {
-	client, currentNs, err := o.JXClientAndDevNamespace()
-	if err != nil {
-		return nil, nil, nil, nil, errors.Wrap(err, "getting jx client")
-	}
-	username, err := o.GetUsername(o.Username)
-	if err != nil {
-		log.Logger().Warnf("could not find the current user name %s", err.Error())
+func envTitleName(e v1.Environment) string {
+	if e.Spec.Kind == v1.EnvironmentKindTypeEdit {
+		return "Edit"
 	}
 
-	ns, _, err := kube.GetDevNamespace(kubeClient, currentNs)
-	if err != nil {
-		return nil, nil, nil, nil, errors.Wrap(err, "getting current dev namespace")
-	}
-	envList, err := client.JenkinsV1().Environments(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return nil, nil, nil, nil, errors.Wrap(err, "listing environments")
-	}
-	kube.SortEnvironments(envList.Items)
-
-	namespaces, envNames, apps = []string{}, []string{}, []string{}
-	envApps = []EnvApps{}
-	for _, env := range envList.Items {
-		isPreview := env.Spec.Kind == v1.EnvironmentKindTypePreview
-		shouldShow := isPreview
-		if !o.Previews {
-			shouldShow = !shouldShow
-		}
-		if shouldShow &&
-			(o.Environment == "" || o.Environment == env.Name) &&
-			(o.Namespace == "" || o.Namespace == env.Spec.Namespace) {
-			ens := env.Spec.Namespace
-			namespaces = append(namespaces, ens)
-			if ens != "" && env.Name != kube.LabelValueDevEnvironment {
-				envNames = append(envNames, env.Name)
-				m, err := kube.GetDeployments(kubeClient, ens)
-				if err == nil {
-					envApp := EnvApps{
-						Environment: env,
-						Apps:        map[string]v1beta1.Deployment{},
-					}
-					envApps = append(envApps, envApp)
-					for k, d := range m {
-						// lets use the logical service name from kserve
-						if d.Labels != nil {
-							serviceName := d.Labels[kserving.ServiceLabel]
-							if serviceName != "" {
-								k = serviceName
-							}
-						}
-						appName := kube.GetAppName(k, ens)
-						if env.Spec.Kind == v1.EnvironmentKindTypeEdit {
-							if appName == kube.DeploymentExposecontrollerService || env.Spec.PreviewGitSpec.User.Username != username {
-								continue
-							}
-							appName = kube.GetEditAppName(appName)
-						} else if env.Spec.Kind == v1.EnvironmentKindTypePreview {
-							appName = env.Spec.PullRequestURL
-						}
-
-						// Ignore flagger canary auxiliary deployments
-						if flagger.IsCanaryAuxiliaryDeployment(d) {
-							continue
-						}
-
-						envApp.Apps[appName] = d
-						if util.StringArrayIndex(apps, appName) < 0 {
-							apps = append(apps, appName)
-						}
-					}
-				}
-			}
-		}
-	}
-	return
+	return e.Name
 }
 
-func (o *GetApplicationsOptions) generateTableHeaders(envApps []EnvApps) table.Table {
+func (o *GetApplicationsOptions) sortedKeys(envs map[string]v1.Environment) []string {
+	keys := make([]string, 0, len(envs))
+	for k, env := range envs {
+		if (o.Environment == "" || o.Environment == k) && (o.Namespace == "" || o.Namespace == env.Spec.Namespace) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+
+	return keys
+}
+
+func (o *GetApplicationsOptions) generateTableHeaders(list applications.List) table.Table {
 	t := o.CreateTable()
 	title := "APPLICATION"
-	if o.Previews {
-		title = "PULL REQUESTS"
-	}
 	titles := []string{title}
-	for _, ea := range envApps {
-		envName := ea.Environment.Name
-		if len(ea.Apps) > 0 {
-			if ea.Environment.Spec.Kind == v1.EnvironmentKindTypeEdit {
-				envName = "Edit"
-			}
-			if ea.Environment.Spec.Kind != v1.EnvironmentKindTypePreview {
-				titles = append(titles, strings.ToUpper(envName))
-			}
-			if !o.HidePod {
-				titles = append(titles, "PODS")
-			}
-			if !o.HideUrl {
-				titles = append(titles, "URL")
-			}
+
+	envs := list.Environments()
+
+	for _, k := range o.sortedKeys(envs) {
+		titles = append(titles, strings.ToUpper(envTitleName(envs[k])))
+
+		if !o.HidePod {
+			titles = append(titles, "PODS")
+		}
+		if !o.HideUrl {
+			titles = append(titles, "URL")
 		}
 	}
 	t.AddRow(titles...)

--- a/pkg/kube/sourcerepositories.go
+++ b/pkg/kube/sourcerepositories.go
@@ -194,3 +194,19 @@ func IsEnvironmentRepository(environments map[string]*v1.Environment, repository
 	}
 	return false
 }
+
+// IsIncludedInTheGivenEnvs returns true if the given repository is an environment repository
+func IsIncludedInTheGivenEnvs(environments map[string]*v1.Environment, repository *v1.SourceRepository) bool {
+	gitURL, err := GetRepositoryGitURL(repository)
+	if err != nil {
+		return false
+	}
+	u2 := gitURL + ".git"
+
+	for _, env := range environments {
+		if env.Spec.Source.URL == gitURL || env.Spec.Source.URL == u2 {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- Application command returns user applications and not K8s deployments
  (fixes jenkins-x#6099)
- Extract business logic outside of the get command into its own package
- Passing the --preview flag will return a message telling the user to
  use a different command in order to separate concerns (fixes jenkins-x#6271)