### PR TITLE
feat: checkout to the ref instead of FETCH_HEAD if ref is a branch

### DIFF
--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -917,3 +917,17 @@ func GetGitInfoFromDirectory(dir string, gitter Gitter) (string, string, error) 
 
 	return g.HttpsURL(), currentBranch, nil
 }
+
+// RefIsBranch looks for remove branches in ORIGIN for the provided directory and returns true if ref is found
+func RefIsBranch(dir string, ref string, gitter Gitter) (bool, error) {
+	remoteBranches, err := gitter.RemoteBranches(dir)
+	if err != nil {
+		return false, errors.Wrapf(err, "error getting remote branches to find provided ref %s", ref)
+	}
+	for _, b := range remoteBranches {
+		if strings.Contains(b, ref) {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
We need to be able to use a branch as a versions stream ref in order to get our automated release system to work, if the ref is a branch it will look for it in the remote branches and then checkout to it if it is.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
