### PR TITLE
fix: can't install an app with version containing letters like *SNAPSHOT*

### DIFF
--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -695,7 +695,7 @@ func IsUnadvertisedObjectError(err error) bool {
 
 // IsCouldntFindRemoteRefError returns true if the error is due to the remote ref not being found
 func IsCouldntFindRemoteRefError(err error, ref string) bool {
-	return strings.Contains(strings.ToLower(err.Error()), fmt.Sprintf("couldn't find remote ref %s", ref))
+	return strings.Contains(strings.ToLower(err.Error()), strings.ToLower(fmt.Sprintf("couldn't find remote ref %s", ref)))
 }
 
 // IsCouldNotPopTheStashError returns true if the error is due to the stash not being able to be popped, often because

--- a/pkg/gits/helpers_test.go
+++ b/pkg/gits/helpers_test.go
@@ -2394,3 +2394,9 @@ func commitCount(t *testing.T, repoDir string) int {
 	assert.NoError(t, err)
 	return count
 }
+
+func TestIsCouldntFindRemoteRefErrorHandlesUppercaseRef(t *testing.T) {
+	error := errors.New(" fatal: couldn't find remote ref add-app-your-app-0.0.0-SNAPSHOT-PR-1234-1:")
+	ref := "add-app-your-app-0.0.0-SNAPSHOT-PR-1234-1"
+	assert.True(t, gits.IsCouldntFindRemoteRefError(error, ref))
+}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
**Fixing the following issue:**
It's not possible to install an app with a version containing capital letters like SNAPSHOT which can be useful for development and test purposes.
eg: `jx add app your-app --version=0.0.1-SNAPSHOT ` would fail with the following error:
```
error: adding app your-app version 0.0.1-SNAPSHOT with alias  using gitops: creating pr for your-app: pulling environment repo https://github.com/xxxx/environment-xxx-dev.git into /Users/xxx/.jx/environments: fetching origin add-app-your-app-0.0.1-SNAPSHOT: git output: fatal: couldn't find remote ref add-app-your-app-0.0.1-SNAPSHOT: failed to run 'git fetch https://xxx:xxxx@github.com/xxxx/environment-xxx-dev.git add-app-your-app-0.0.1-SNAPSHOT:xxxxxxx' command in directory '/Users/xxxx/.jx/environments/dev', output: 'fatal: couldn't find remote ref add-app-your-app-0.0.1-SNAPSHOT'

```