### PR TITLE
chore: Add ability to skip auto merging during `step create pr`

### DIFF
--- a/pkg/cmd/step/create/pr/step_create_pr.go
+++ b/pkg/cmd/step/create/pr/step_create_pr.go
@@ -20,16 +20,17 @@ import (
 //StepCreatePrOptions are the common options for all PR creation steps
 type StepCreatePrOptions struct {
 	step.StepCreateOptions
-	Results    *gits.PullRequestInfo
-	BranchName string
-	GitURLs    []string
-	Base       string
-	Fork       bool
-	SrcGitURL  string
-	Component  string
-	Version    string
-	DryRun     bool
-	SkipCommit bool
+	Results       *gits.PullRequestInfo
+	BranchName    string
+	GitURLs       []string
+	Base          string
+	Fork          bool
+	SrcGitURL     string
+	Component     string
+	Version       string
+	DryRun        bool
+	SkipCommit    bool
+	SkipAutoMerge bool
 }
 
 // NewCmdStepCreatePr Steps a command object for the "step" command
@@ -79,6 +80,7 @@ func AddStepCreatePrFlags(cmd *cobra.Command, o *StepCreatePrOptions) {
 	cmd.Flags().StringVarP(&o.Component, "component", "", "", "The component of the git repo which caused this change; useful if you have a complex or monorepo setup and want to differentiate between different components from the same repo")
 	cmd.Flags().StringVarP(&o.Version, "version", "v", "", "The version to change. If no version is supplied the latest version is found")
 	cmd.Flags().BoolVarP(&o.DryRun, "dry-run", "", false, "Perform a dry run, the change will be generated and committed, but not pushed or have a PR created")
+	cmd.Flags().BoolVarP(&o.SkipAutoMerge, "skip-auto-merge", "", false, "Disable auto merge of the PR if status checks pass")
 }
 
 // ValidateOptions validates the common options for all PR creation steps
@@ -141,6 +143,7 @@ func (o *StepCreatePrOptions) createPullRequestOperation() operations.PullReques
 		Component:     o.Component,
 		DryRun:        o.DryRun,
 		SkipCommit:    o.SkipCommit,
+		SkipAutoMerge: o.SkipAutoMerge,
 	}
 	authorName, authorEmail, err := gits.EnsureUserAndEmailSetup(o.Git())
 	if err != nil {

--- a/pkg/gits/operations/pull_request_op.go
+++ b/pkg/gits/operations/pull_request_op.go
@@ -37,16 +37,17 @@ import (
 // PullRequestOperation provides a way to execute a PullRequest operation using Git
 type PullRequestOperation struct {
 	*opts.CommonOptions
-	GitURLs     []string
-	SrcGitURL   string
-	Base        string
-	Component   string
-	BranchName  string
-	Version     string
-	DryRun      bool
-	SkipCommit  bool
-	AuthorName  string
-	AuthorEmail string
+	GitURLs       []string
+	SrcGitURL     string
+	Base          string
+	Component     string
+	BranchName    string
+	Version       string
+	DryRun        bool
+	SkipCommit    bool
+	AuthorName    string
+	AuthorEmail   string
+	SkipAutoMerge bool
 }
 
 // ChangeFilesFn is the function called to create the pull request
@@ -80,7 +81,10 @@ func (o *PullRequestOperation) CreatePullRequest(kind string, update ChangeFiles
 			return nil, errors.WithStack(err)
 		}
 
-		labels := []string{"updatebot"}
+		labels := []string{}
+		if !o.SkipAutoMerge {
+			labels = append(labels, "updatebot")
+		}
 		filter := &gits.PullRequestFilter{
 			Labels: labels,
 		}


### PR DESCRIPTION
This PR adds a flag called `--skip-auto-merge` that stops the updatebot label being added to a PR created with `jx step create pr`

fixes: #6157