### PR TITLE
fix: jx upgrade boot should use set-in-binary version stream ref as default

### DIFF
--- a/pkg/cmd/upgrade/upgrade_boot.go
+++ b/pkg/cmd/upgrade/upgrade_boot.go
@@ -45,8 +45,7 @@ var (
 )
 
 const (
-	defaultUpgradeVersionStreamRef = "master"
-	builderImage                   = "gcr.io/jenkinsxio/builder-go"
+	builderImage = "gcr.io/jenkinsxio/builder-go"
 )
 
 // NewCmdUpgradeBoot creates the command
@@ -67,7 +66,7 @@ func NewCmdUpgradeBoot(commonOpts *opts.CommonOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&options.Dir, "dir", "d", "", "the directory to look for the Jenkins X Pipeline and requirements")
-	cmd.Flags().StringVarP(&options.UpgradeVersionStreamRef, "upgrade-version-stream-ref", "", defaultUpgradeVersionStreamRef, "a version stream ref to use to upgrade to")
+	cmd.Flags().StringVarP(&options.UpgradeVersionStreamRef, "upgrade-version-stream-ref", "", config.DefaultVersionsRef, "a version stream ref to use to upgrade to")
 
 	return cmd
 }


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

We shouldn't be using a hardcoded `master` here, we should be using `config.DefaultVersionsRef`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a