### PR TITLE
feat: boot - attempt restore from existing dev repository

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -47,6 +47,8 @@ type BootOptions struct {
 
 	// RequirementsFile provided by the user to override the default requirements file from repository
 	RequirementsFile string
+
+	EnvironmentRepo string
 }
 
 var (
@@ -98,6 +100,7 @@ func NewCmdBoot(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.EndStep, "end-step", "e", "", "the step in the pipeline to end at")
 	cmd.Flags().StringVarP(&options.HelmLogLevel, "helm-log", "v", "", "sets the helm logging level from 0 to 9. Passed into the helm CLI via the '-v' argument. Useful to diagnose helm related issues")
 	cmd.Flags().StringVarP(&options.RequirementsFile, "requirements", "r", "", "requirements file which will overwrite the default requirements file")
+	cmd.Flags().StringVarP(&options.EnvironmentRepo, "environment-repository-url", "n", "", "the  dev environment url repository to boot from")
 
 	return cmd
 }
@@ -112,6 +115,13 @@ func (o *BootOptions) Run() error {
 	}
 
 	o.overrideSteps()
+
+	if o.EnvironmentRepo != "" {
+		err = o.cloneDevEnvironment()
+		if err != nil {
+			return err
+		}
+	}
 
 	projectConfig, pipelineFile, err := config.LoadProjectConfig(o.Dir)
 	if err != nil {
@@ -342,6 +352,34 @@ func (o *BootOptions) Run() error {
 	no.CommonOptions = o.CommonOptions
 	no.Args = []string{requirements.Cluster.Namespace}
 	return no.Run()
+}
+
+func (o *BootOptions) cloneDevEnvironment() error {
+	log.Logger().Infof("dev environment url specified %s ", o.EnvironmentRepo)
+	gitURL := o.EnvironmentRepo
+	gitInfo, err := gits.ParseGitURL(gitURL)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse git URL %s", gitURL)
+	}
+
+	repo := gitInfo.Name
+	cloneDir := filepath.Join(o.Dir, repo)
+
+	err = os.MkdirAll(cloneDir, util.DefaultWritePermissions)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create directory: %s", cloneDir)
+	}
+
+	err = o.Git().Clone(gitURL, cloneDir)
+	if err != nil {
+		log.Logger().Errorf("error %v", err)
+		return errors.Wrapf(err, "failed to clone git URL %s to directory: %s", gitURL, cloneDir)
+	}
+	err = os.Chdir(cloneDir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to change into new directory: %s", cloneDir)
+	}
+	return nil
 }
 
 func (o *BootOptions) updateBootCloneIfOutOfDate(gitRef string) error {

--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/versionstream"
 
 	"github.com/jenkins-x/jx/pkg/boot"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -48,7 +48,7 @@ type BootOptions struct {
 	// RequirementsFile provided by the user to override the default requirements file from repository
 	RequirementsFile string
 
-	EnvironmentRepo bool
+	AttemptRestore bool
 }
 
 var (
@@ -100,7 +100,7 @@ func NewCmdBoot(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.EndStep, "end-step", "e", "", "the step in the pipeline to end at")
 	cmd.Flags().StringVarP(&options.HelmLogLevel, "helm-log", "v", "", "sets the helm logging level from 0 to 9. Passed into the helm CLI via the '-v' argument. Useful to diagnose helm related issues")
 	cmd.Flags().StringVarP(&options.RequirementsFile, "requirements", "r", "", "requirements file which will overwrite the default requirements file")
-	cmd.Flags().BoolVarP(&options.EnvironmentRepo, "dev-env-repo", "", false, "attempt to boot from the dev environment repository")
+	cmd.Flags().BoolVarP(&options.AttemptRestore, "attempt-restore", "a", false, "attempt to boot from an existing dev environment repository")
 
 	return cmd
 }
@@ -116,8 +116,8 @@ func (o *BootOptions) Run() error {
 
 	o.overrideSteps()
 
-	if o.EnvironmentRepo {
-		err := o.bootFromDevEnvRepo()
+	if o.AttemptRestore {
+		err := o.restoreFromDevEnvRepo()
 		if err != nil {
 			return err
 		}
@@ -354,7 +354,7 @@ func (o *BootOptions) Run() error {
 	return no.Run()
 }
 
-func (o *BootOptions) bootFromDevEnvRepo() error {
+func (o *BootOptions) restoreFromDevEnvRepo() error {
 	url := o.determineDevEnvironmentUrl()
 	if url != "" {
 		cloned, dir, err := o.cloneDevEnvironment(url)
@@ -376,7 +376,6 @@ func (o *BootOptions) bootFromDevEnvRepo() error {
 }
 
 func (o *BootOptions) determineDevEnvironmentUrl() string {
-
 	gitProvider := os.Getenv("JX_VALUE_GITPROVIDER")
 	gitOwner := os.Getenv(config.RequirementEnvGitOwner)
 	clusterName := os.Getenv(config.RequirementClusterName)
@@ -391,7 +390,7 @@ func (o *BootOptions) determineDevEnvironmentUrl() string {
 }
 
 func (o *BootOptions) cloneDevEnvironment(gitURL string) (bool, string, error) {
-	log.Logger().Infof("dev environment url specified %t ", o.EnvironmentRepo)
+	log.Logger().Infof("dev environment url specified %t ", o.AttemptRestore)
 	gitInfo, err := gits.ParseGitURL(gitURL)
 	if err != nil {
 		return false, "", errors.Wrapf(err, "failed to parse git URL %s", gitURL)

--- a/pkg/cmd/boot/boot_test.go
+++ b/pkg/cmd/boot/boot_test.go
@@ -67,7 +67,7 @@ func TestDetermineGitRef_GitURLNotInVersionStream(t *testing.T) {
 	assert.Equal(t, "master", gitRef, "determineGitRef")
 }
 
-func TestConeDevEnvironment(t *testing.T) {
+func TestCloneDevEnvironment(t *testing.T) {
 
 	url := "https://github.com/jenkins-x/jenkins-x-boot-config"
 	o := TestBootOptions{}

--- a/pkg/cmd/boot/boot_test.go
+++ b/pkg/cmd/boot/boot_test.go
@@ -72,23 +72,13 @@ func TestCloneDevEnvironment(t *testing.T) {
 	url := "https://github.com/jenkins-x/jenkins-x-boot-config"
 	o := TestBootOptions{}
 	o.setup(defaultBootRequirements)
-	o.EnvironmentRepo = url
 
-	dirBefore, err := os.Getwd()
+	cloned, dir, err := o.cloneDevEnvironment(url)
 	assert.Nil(t, err, "error should not be nil")
-	assert.NotNil(t, dirBefore, "current directory should not be nil")
+	cwd, err := os.Getwd()
 
-	err = o.cloneDevEnvironment()
-	assert.Nil(t, err, "error should not be nil")
-	dirAfter, err := os.Getwd()
-
-	assert.NotEqual(t, dirBefore, dirAfter, "working directory should have been changed")
-
-	assert.Equal(t, dirAfter, filepath.Join(dirBefore, "jenkins-x-boot-config"), "working directory should have jenkins-x-boot-config appended")
-
-	//finally switch back the working dir
-	err = os.Chdir(dirBefore)
-	assert.Nil(t, err, "error should not be nil")
+	assert.True(t, cloned)
+	assert.Equal(t, filepath.Join(cwd, "/jenkins-x-boot-config"), dir, "cloned dir is ")
 }
 
 func TestCloneDevEnvironmentIncorrectParam(t *testing.T) {
@@ -96,11 +86,12 @@ func TestCloneDevEnvironmentIncorrectParam(t *testing.T) {
 
 	o := TestBootOptions{}
 	o.setup(defaultBootRequirements)
-	o.EnvironmentRepo = "not-a-url"
+	url := "not-a-url"
 
-	err := o.cloneDevEnvironment()
-
+	cloned, dir, err := o.cloneDevEnvironment(url)
 	assert.NotNil(t, err, "error should not be nil")
+	assert.False(t, cloned)
+	assert.Empty(t, dir)
 }
 
 func (o *TestBootOptions) createTmpRequirements(t *testing.T) string {

--- a/pkg/cmd/boot/boot_test.go
+++ b/pkg/cmd/boot/boot_test.go
@@ -75,10 +75,9 @@ func TestCloneDevEnvironment(t *testing.T) {
 
 	cloned, dir, err := o.cloneDevEnvironment(url)
 	assert.Nil(t, err, "error should not be nil")
-	cwd, err := os.Getwd()
 
 	assert.True(t, cloned)
-	assert.Equal(t, filepath.Join(cwd, "/jenkins-x-boot-config"), dir, "cloned dir is ")
+	assert.Equal(t, "jenkins-x-boot-config", dir, "cloned dir is incorrect")
 }
 
 func TestCloneDevEnvironmentIncorrectParam(t *testing.T) {

--- a/pkg/cmd/boot/boot_test.go
+++ b/pkg/cmd/boot/boot_test.go
@@ -67,6 +67,42 @@ func TestDetermineGitRef_GitURLNotInVersionStream(t *testing.T) {
 	assert.Equal(t, "master", gitRef, "determineGitRef")
 }
 
+func TestConeDevEnvironment(t *testing.T) {
+
+	url := "https://github.com/jenkins-x/jenkins-x-boot-config"
+	o := TestBootOptions{}
+	o.setup(defaultBootRequirements)
+	o.EnvironmentRepo = url
+
+	dirBefore, err := os.Getwd()
+	assert.Nil(t, err, "error should not be nil")
+	assert.NotNil(t, dirBefore, "current directory should not be nil")
+
+	err = o.cloneDevEnvironment()
+	assert.Nil(t, err, "error should not be nil")
+	dirAfter, err := os.Getwd()
+
+	assert.NotEqual(t, dirBefore, dirAfter, "working directory should have been changed")
+
+	assert.Equal(t, dirAfter, filepath.Join(dirBefore, "jenkins-x-boot-config"), "working directory should have jenkins-x-boot-config appended")
+
+	//finally switch back the working dir
+	err = os.Chdir(dirBefore)
+	assert.Nil(t, err, "error should not be nil")
+}
+
+func TestCloneDevEnvironmentIncorrectParam(t *testing.T) {
+	t.Parallel()
+
+	o := TestBootOptions{}
+	o.setup(defaultBootRequirements)
+	o.EnvironmentRepo = "not-a-url"
+
+	err := o.cloneDevEnvironment()
+
+	assert.NotNil(t, err, "error should not be nil")
+}
+
 func (o *TestBootOptions) createTmpRequirements(t *testing.T) string {
 	from, err := os.Open(o.RequirementsFile)
 	require.NoError(t, err, "unable to open test jx-requirements")


### PR DESCRIPTION
Adding a parameter to jx boot that allows you to boot from an existing dev repository

Signed-off-by: warrenbailey <warren@warrenbailey.net>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
