### PR TITLE
fix: Communicate errors when resolve function can not operate

### DIFF
--- a/pkg/users/git.go
+++ b/pkg/users/git.go
@@ -60,8 +60,11 @@ func (r *GitUserResolver) GitUserSliceAsUserDetailsSlice(users []gits.GitUser) (
 // * making a call to the gitProvider
 // as often user info is not complete in a git response
 func (r *GitUserResolver) Resolve(user *gits.GitUser) (*jenkinsv1.User, error) {
-	if r == nil || user == nil {
-		return nil, nil
+	if r == nil {
+		return nil, errors.New("unable to resolve user on nil receiver")
+	}
+	if user == nil {
+		return nil, errors.New("unable to resolve when user is nil")
 	}
 	selectUsers := func(id string, users []jenkinsv1.User) (string, []jenkinsv1.User,
 		*jenkinsv1.User, error) {

--- a/pkg/users/git_test.go
+++ b/pkg/users/git_test.go
@@ -279,6 +279,23 @@ func TestFindUserWithNoEmailButSameGitLogin(t *testing.T) {
 	assert.Len(t, users.Items, 2)
 }
 
+func TestResolve(t *testing.T) {
+	t.Run("Unable to resolve on niled pointer receiver", func(t *testing.T) {
+		var resolver *users.GitUserResolver
+
+		_, err := resolver.Resolve(&gits.GitUser{})
+		assert.Error(t, err)
+	})
+
+	t.Run("Unable to resolve when user is niled", func(t *testing.T) {
+		resolver, _, err := prepare(t)
+		assert.NoError(t, err)
+
+		_, err = resolver.Resolve(nil)
+		assert.Error(t, err)
+	})
+}
+
 func prepare(t *testing.T) (*users.GitUserResolver, *gits.FakeProvider, error) {
 	testOrgName := "myorg"
 	testRepoName := "my-app"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description

The function resolve should handle edge cases like niled pointer receiver and niled user argument by providing information to the user.

#### Special notes for the reviewer(s)

The messages that resolve function returns are not very informative for the user of jx command-line tool, but developers could quickly identify a problem when the messages appears. 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
