### PR TITLE
fix: lookup only the ingress when use ingress is setup

### DIFF
--- a/pkg/kube/services/services.go
+++ b/pkg/kube/services/services.go
@@ -91,45 +91,45 @@ func GetServiceURLFromMap(services map[string]*v1.Service, name string) string {
 }
 
 func FindServiceURL(client kubernetes.Interface, namespace string, name string) (string, error) {
-	log.Logger().Debugf("finding service url for %s in namespace %s", name, namespace)
+	log.Logger().Debugf("Finding service url for %s in namespace %s", name, namespace)
 	svc, err := client.CoreV1().Services(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		return "", errors.Wrapf(err, "finding the service %s in namespace %s", name, namespace)
 	}
 	answer := GetServiceURL(svc)
 	if answer != "" {
-		log.Logger().Debugf("found service url %s", answer)
+		log.Logger().Debugf("Found service url %s", answer)
 		return answer, nil
 	}
 
-	log.Logger().Debugf("couldn't find service url, attempting to look up via ingress")
+	log.Logger().Debugf("Couldn't find service url, attempting to look up via ingress")
 
 	// lets try find the service via Ingress
 	ing, err := client.ExtensionsV1beta1().Ingresses(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
-		log.Logger().Debugf("unable to finding ingress for %s in namespace %s - err %s", name, namespace, err)
+		log.Logger().Debugf("Unable to finding ingress for %s in namespace %s - err %s", name, namespace, err)
 		return "", errors.Wrapf(err, "getting ingress for service %q in namespace %s", name, namespace)
 	}
 
 	url := IngressURL(ing)
 	if url == "" {
-		log.Logger().Debugf("unable to find service url via ingress for %s in namespace %s", name, namespace)
+		log.Logger().Debugf("Unable to find service url via ingress for %s in namespace %s", name, namespace)
 	}
 	return url, nil
 }
 
 func FindIngressURL(client kubernetes.Interface, namespace string, name string) (string, error) {
-	log.Logger().Debugf("finding ingress url for %s in namespace %s", name, namespace)
+	log.Logger().Debugf("Finding ingress url for %s in namespace %s", name, namespace)
 	// lets try find the service via Ingress
 	ing, err := client.ExtensionsV1beta1().Ingresses(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
-		log.Logger().Errorf("error finding ingress for %s in namespace %s - err %s", name, namespace, err)
+		log.Logger().Debugf("Error finding ingress for %s in namespace %s - err %s", name, namespace, err)
 		return "", nil
 	}
 
 	url := IngressURL(ing)
 	if url == "" {
-		log.Logger().Debugf("unable to find url via ingress for %s in namespace %s", name, namespace)
+		log.Logger().Debugf("Unable to find url via ingress for %s in namespace %s", name, namespace)
 	}
 	return url, nil
 }

--- a/pkg/kube/vault/vault.go
+++ b/pkg/kube/vault/vault.go
@@ -435,22 +435,14 @@ func GetVaults(client kubernetes.Interface, vaultOperatorClient versioned.Interf
 		vaultName := v.Name
 		vaultAuthSaName := GetAuthSaName(v)
 
-		// default to using internal kubernetes service dns name
+		// default to using internal kubernetes service dns name for vault endpoint
 		vaultURL := fmt.Sprintf(defaultInternalVaultURL, vaultName)
-
-		// lookup the Ingress URL from the service if default behavior is overridden
 		if useIngressURL {
-			vaultURL, err = services.FindServiceURL(client, ns, vaultName)
-			if err != nil {
-				log.Logger().Warnf("error finding vault service url setting to empty string, err: %s", err)
-				vaultURL = ""
-			}
-			if vaultURL == "" {
-				vaultURL, err = services.FindIngressURL(client, ns, vaultName)
-				if err != nil {
-					log.Logger().Warnf("error finding vault ingress url setting to empty string, err: %s", err)
-					vaultURL = ""
-				}
+			vaultURL, err = services.FindIngressURL(client, ns, vaultName)
+			if err != nil || vaultURL == "" {
+				log.Logger().Debugf("Cannot finding the vault ingress url for vault %s", vaultName)
+				// skip this vault since cannot be used without the ingress
+				continue
 			}
 		}
 


### PR DESCRIPTION
Stop looking up the vault service, it is always available even when the vault ingress is not created.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->