### PR TITLE
feat: add '--merge' option when deleting branch

### DIFF
--- a/pkg/cmd/deletecmd/delete_branch.go
+++ b/pkg/cmd/deletecmd/delete_branch.go
@@ -46,6 +46,7 @@ type DeleteBranchOptions struct {
 	SelectFilter      string
 	SelectAllRepos    bool
 	SelectFilterRepos string
+	Merged            bool
 }
 
 // NewCmdDeleteBranch creates a command object for the "delete repo" command
@@ -79,12 +80,12 @@ func NewCmdDeleteBranch(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.SelectFilter, "filter", "f", "", "If selecting branches to remove this filters the list of repositories")
 	cmd.Flags().BoolVarP(&options.SelectAllRepos, "all-repos", "", false, "If selecting projects to remove branches this defaults to selecting them all")
 	cmd.Flags().StringVarP(&options.SelectFilterRepos, "filter-repos", "", "", "If selecting projects to remove brancehs this filters the list of repositories")
+	cmd.Flags().BoolVarP(&options.Merged, "merged", "", false, "If deleting merged branches in a repository")
 	return cmd
 }
 
 // Run implements the command
 func (o *DeleteBranchOptions) Run() error {
-	surveyOpts := survey.WithStdio(o.In, o.Out, o.Err)
 	authConfigSvc, err := o.GitAuthConfigService()
 	if err != nil {
 		return err
@@ -154,45 +155,86 @@ func (o *DeleteBranchOptions) Run() error {
 		if err != nil {
 			return errors.Wrapf(err, "Failed to pull remote branches for %s/%s", org, name)
 		}
-		branchNames, err := o.Git().RemoteBranchNames(dir, "remotes/origin/")
-		if err != nil {
-			return errors.Wrapf(err, "Failed to get remote branches for %s/%s", org, name)
-		}
 
-		branches, err := util.SelectNamesWithFilter(branchNames, "Which remote branches do you to to delete: ", o.SelectAll, o.SelectFilter, "", o.GetIOFileHandles())
-		if err != nil {
-			return err
-		}
-		if len(branches) == 0 {
-			return fmt.Errorf("No branches selected!")
-		}
-		if !o.BatchMode {
-			log.Logger().Warnf("You are about to delete these branches '%s' on the Git provider. This operation CANNOT be undone!",
-				strings.Join(branches, ","))
-
-			flag := false
-			prompt := &survey.Confirm{
-				Message: "Are you sure you want to delete these all these branches?",
-				Default: false,
+		if o.Merged {
+			branches, err := o.Git().RemoteMergedBranchNames(dir, "remotes/origin/")
+			if err != nil {
+				return errors.Wrapf(err, "fetching remote merged branches for %s/%s", org, name)
 			}
-			err = survey.AskOne(prompt, &flag, nil, surveyOpts)
+
+			if len(branches) == 0 {
+				return fmt.Errorf("no branches to remove")
+			}
+
+			if !o.BatchMode {
+				if !o.confirmDeletion(branches) {
+					return nil
+				}
+			}
+
+			if err := o.deleteRemoteBranches(branches, dir, org, name); err != nil {
+				return errors.Wrap(err, "deleting branches")
+			}
+		} else {
+			branchNames, err := o.Git().RemoteBranchNames(dir, "remotes/origin/")
+			if err != nil {
+				return errors.Wrapf(err, "fetching remote branches for %s/%s", org, name)
+			}
+
+			branches, err := util.SelectNamesWithFilter(branchNames, "Which remote branches do you to to delete: ", o.SelectAll, o.SelectFilter, "", o.GetIOFileHandles())
 			if err != nil {
 				return err
 			}
-			if !flag {
-				return nil
+
+			if len(branches) == 0 {
+				return fmt.Errorf("no branches selected")
 			}
+
+			if !o.BatchMode {
+				if !o.confirmDeletion(branches) {
+					return nil
+				}
+			}
+
+			if err := o.deleteRemoteBranches(branches, dir, org, name); err != nil {
+				return errors.Wrap(err, "deleting branches")
+			}
+		}
+	}
+	return nil
+}
+
+func (o *DeleteBranchOptions) confirmDeletion(branches []string) bool {
+	log.Logger().Warnf("You are about to delete these branches '%s' on the Git provider. This operation CANNOT be undone!",
+		strings.Join(branches, ","))
+
+	flag := false
+	prompt := &survey.Confirm{
+		Message: "Are you sure you want to delete these all these branches?",
+		Default: false,
+	}
+
+	surveyOpts := survey.WithStdio(o.In, o.Out, o.Err)
+	err := survey.AskOne(prompt, &flag, nil, surveyOpts)
+
+	if err != nil {
+		return false
+	}
+
+	return flag
+}
+
+func (o *DeleteBranchOptions) deleteRemoteBranches(branches []string, dir string, org string, name string) error {
+	for _, branch := range branches {
+		err := o.Git().DeleteRemoteBranch(dir, "origin", branch)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to delete remote branche %s from %s/%s", branch, org, name)
 		}
 
 		info := util.ColorInfo
-		for _, branch := range branches {
-			err := o.Git().DeleteRemoteBranch(dir, "origin", branch)
-			if err != nil {
-				return errors.Wrapf(err, "Failed to delete remote branche %s from %s/%s", branch, org, name)
-			}
-			log.Logger().Infof("Deleted branch in repo %s/%s branch: %s", info(org), info(name), info(branch))
-		}
+		log.Logger().Infof("Deleted branch in repo %s/%s branch: %s", info(org), info(name), info(branch))
 	}
+
 	return nil
 }
 

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -293,6 +293,11 @@ func (g *GitFake) RemoteBranchNames(dir string, prefix string) ([]string, error)
 	return remoteBranches, nil
 }
 
+// RemoteMergedBranchNames list the remote branch names that are merged
+func (g *GitFake) RemoteMergedBranchNames(dir string, prefix string) ([]string, error) {
+	return g.RemoteBranchNames(dir, prefix)
+}
+
 // GetRemoteUrl get the remote URL
 func (g *GitFake) GetRemoteUrl(config *gitcfg.Config, name string) string {
 	if len(g.GitRemotes) == 0 {

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -293,6 +293,11 @@ func (g *GitLocal) RemoteBranchNames(dir string, prefix string) ([]string, error
 	return g.GitCLI.RemoteBranchNames(dir, prefix)
 }
 
+// RemoteMergedBranchNames returns all remote branch names with the given prefix
+func (g *GitLocal) RemoteMergedBranchNames(dir string, prefix string) ([]string, error) {
+	return g.GitCLI.RemoteMergedBranchNames(dir, prefix)
+}
+
 // GetCommitPointedToByPreviousTag returns the previous git tag from the repository at the given directory
 func (g *GitLocal) GetCommitPointedToByPreviousTag(dir string) (string, string, error) {
 	return g.GitCLI.GetCommitPointedToByPreviousTag(dir)

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -223,6 +223,7 @@ type Gitter interface {
 	DiscoverUpstreamGitURL(gitConf string) (string, error)
 	RemoteBranches(dir string) ([]string, error)
 	RemoteBranchNames(dir string, prefix string) ([]string, error)
+	RemoteMergedBranchNames(dir string, prefix string) ([]string, error)
 	GetRemoteUrl(config *gitcfg.Config, name string) string
 	RemoteUpdate(dir string) error
 	LocalBranches(dir string) ([]string, error)

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -1272,6 +1272,25 @@ func (mock *MockGitter) RemoteBranches(_param0 string) ([]string, error) {
 	return ret0, ret1
 }
 
+func (mock *MockGitter) RemoteMergedBranchNames(_param0 string, _param1 string) ([]string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0, _param1}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("RemoteMergedBranchNames", params, []reflect.Type{reflect.TypeOf((*[]string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 []string
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].([]string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockGitter) RemoteUpdate(_param0 string) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -3945,6 +3964,37 @@ func (c *MockGitter_RemoteBranches_OngoingVerification) GetAllCapturedArguments(
 		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) RemoteMergedBranchNames(_param0 string, _param1 string) *MockGitter_RemoteMergedBranchNames_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "RemoteMergedBranchNames", params, verifier.timeout)
+	return &MockGitter_RemoteMergedBranchNames_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_RemoteMergedBranchNames_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_RemoteMergedBranchNames_OngoingVerification) GetCapturedArguments() (string, string) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+}
+
+func (c *MockGitter_RemoteMergedBranchNames_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
 		}
 	}
 	return


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Adds new `--merge` option to the `jx delete branch` command. Which will
delete all merged branches on a repository.

#### Which issue this PR fixes

fixes #2917