### PR TITLE
fix: only commit requirement upgrade files if changed

### DIFF
--- a/pkg/cmd/upgrade/upgrade_boot.go
+++ b/pkg/cmd/upgrade/upgrade_boot.go
@@ -163,10 +163,16 @@ func (o *UpgradeBootOptions) Run() error {
 }
 
 func (o UpgradeBootOptions) createCommitForRequirements(requirementsFileName string) error {
-	err := o.Git().AddCommitFiles(o.Dir, "Merge jx-requirements.yml", []string{requirementsFileName})
+	changedFiles, err := o.Git().ListChangedFilesFromBranch(o.Dir, requirementsFileName)
 	if err != nil {
-		return errors.Wrapf(err, "error creating a commit with the merged jx-requirements.yml file from dir %s",
-			requirementsFileName)
+		return errors.Wrap(err, "failed to list changed files")
+	}
+	if strings.Contains(changedFiles, requirementsFileName) {
+		err := o.Git().AddCommitFiles(o.Dir, "Merge jx-requirements.yml", []string{requirementsFileName})
+		if err != nil {
+			return errors.Wrapf(err, "error creating a commit with the merged jx-requirements.yml file from dir %s",
+				requirementsFileName)
+		}
 	}
 	return nil
 }

--- a/pkg/cmd/upgrade/upgrade_boot.go
+++ b/pkg/cmd/upgrade/upgrade_boot.go
@@ -163,11 +163,11 @@ func (o *UpgradeBootOptions) Run() error {
 }
 
 func (o UpgradeBootOptions) createCommitForRequirements(requirementsFileName string) error {
-	changedFiles, err := o.Git().ListChangedFilesFromBranch(o.Dir, requirementsFileName)
+	reqsChanged, err := o.Git().HasFileChanged(o.Dir, requirementsFileName)
 	if err != nil {
 		return errors.Wrap(err, "failed to list changed files")
 	}
-	if strings.Contains(changedFiles, requirementsFileName) {
+	if reqsChanged {
 		err := o.Git().AddCommitFiles(o.Dir, "Merge jx-requirements.yml", []string{requirementsFileName})
 		if err != nil {
 			return errors.Wrapf(err, "error creating a commit with the merged jx-requirements.yml file from dir %s",

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -456,6 +456,16 @@ func (g *GitCLI) HasChanges(dir string) (bool, error) {
 	return len(text) > 0, nil
 }
 
+// HasFileChanged indicates if there are any changes to a file in the repository from the given directory
+func (g *GitCLI) HasFileChanged(dir string, fileName string) (bool, error) {
+	text, err := g.gitCmdWithOutput(dir, "status", "-s", fileName)
+	if err != nil {
+		return false, err
+	}
+	text = strings.TrimSpace(text)
+	return len(text) > 0, nil
+}
+
 // CommiIfChanges does a commit if there are any changes in the repository at the given directory
 func (g *GitCLI) CommitIfChanges(dir string, message string) error {
 	changed, err := g.HasChanges(dir)

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -445,6 +445,11 @@ func (g *GitFake) HasChanges(dir string) (bool, error) {
 	return g.Changes, nil
 }
 
+// HasFileChanged returns true if file has changes in git
+func (g *GitFake) HasFileChanged(dir string, fileName string) (bool, error) {
+	return g.Changes, nil
+}
+
 // GetCommitPointedToByPreviousTag returns the previous git tag SHA
 func (g *GitFake) GetCommitPointedToByPreviousTag(dir string) (string, string, error) {
 	len := len(g.Commits)

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -194,6 +194,11 @@ func (g *GitLocal) HasChanges(dir string) (bool, error) {
 	return g.GitCLI.HasChanges(dir)
 }
 
+// HasFileChanged returns true if file has changes in git
+func (g *GitLocal) HasFileChanged(dir string, fileName string) (bool, error) {
+	return g.GitCLI.HasFileChanged(dir, fileName)
+}
+
 // CommitIfChanges does a commit if there are any changes in the repository at the given directory
 func (g *GitLocal) CommitIfChanges(dir string, message string) error {
 	return g.GitCLI.CommitIfChanges(dir, message)

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -259,6 +259,7 @@ type Gitter interface {
 	AddCommit(dir string, msg string) error
 	AddCommitFiles(dir string, msg string, files []string) error
 	HasChanges(dir string) (bool, error)
+	HasFileChanged(dir string, fileName string) (bool, error)
 	Diff(dir string) (string, error)
 	ListChangedFilesFromBranch(dir string, branch string) (string, error)
 	LoadFileFromBranch(dir string, branch string, file string) (string, error)

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -906,6 +906,25 @@ func (mock *MockGitter) HasChanges(_param0 string) (bool, error) {
 	return ret0, ret1
 }
 
+func (mock *MockGitter) HasFileChanged(_param0 string, _param1 string) (bool, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0, _param1}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("HasFileChanged", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 bool
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(bool)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockGitter) Info(_param0 string) (*gits.GitRepository, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -3248,6 +3267,37 @@ func (c *MockGitter_HasChanges_OngoingVerification) GetAllCapturedArguments() (_
 		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) HasFileChanged(_param0 string, _param1 string) *MockGitter_HasFileChanged_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "HasFileChanged", params, verifier.timeout)
+	return &MockGitter_HasFileChanged_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_HasFileChanged_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_HasFileChanged_OngoingVerification) GetCapturedArguments() (string, string) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+}
+
+func (c *MockGitter_HasFileChanged_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
 		}
 	}
 	return


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This was trying to commit the requirements file even when there was no changes, and then failing.

fixes #6213 