### PR TITLE
feat: fixes for GitHub Apps and also only use local gitAuth.yaml when importing and creating quickstarts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2019-11-25T11:30:02Z",
+  "generated_at": "2019-11-27T13:41:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -663,7 +663,7 @@
       {
         "hashed_secret": "2ee489d9ee5e2ab410b713e784e474d98cf08c54",
         "is_secret": false,
-        "line_number": 538,
+        "line_number": 539,
         "type": "Secret Keyword"
       }
     ],

--- a/jx/bdd/boot-vault/ci.sh
+++ b/jx/bdd/boot-vault/ci.sh
@@ -15,15 +15,20 @@ export BUILD_NUMBER="$BUILD_ID"
 JX_HOME="/tmp/jxhome"
 KUBECONFIG="/tmp/jxhome/config"
 
-mkdir -p $JX_HOME
+# lets avoid the git/credentials causing confusion during the test
+export XDG_CONFIG_HOME=$JX_HOME
+
+mkdir -p $JX_HOME/git
 
 jx --version
-jx step git credentials
+
+# replace the credentials file with a single user entry
+echo "https://$GH_USERNAME:$GH_ACCESS_TOKEN@github.com" > $JX_HOME/git/credentials
 
 gcloud auth activate-service-account --key-file $GKE_SA
 
 # lets setup git 
-git config --global --add user.name JenkinsXBot
+git config --global --add user.name jenkins-x-bot-test
 git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
@@ -32,7 +37,7 @@ sed -e s/\$VERSION/${VERSION_PREFIX}${VERSION}/g -e s/\$CODECOV_TOKEN/${CODECOV_
 sed -e s/\$VERSION/${VERSION_PREFIX}${VERSION}/g -e s/\$CODECOV_TOKEN/${CODECOV_TOKEN}/g boot-vault.prow.yaml.template > boot-vault.prow.yaml
 
 # setup jx boot parameters
-export JX_VALUE_ADMINUSER_PASSWORD="$JENKINS_PASSWORD"
+export JX_VALUE_ADMINUSER_PASSWORD="$JENKINS_PASSWORD" # pragma: allowlist secret
 export JX_VALUE_PIPELINEUSER_USERNAME="$GH_USERNAME"
 export JX_VALUE_PIPELINEUSER_EMAIL="$GH_EMAIL"
 export JX_VALUE_PIPELINEUSER_TOKEN="$GH_ACCESS_TOKEN"

--- a/pkg/cmd/clients/factory.go
+++ b/pkg/cmd/clients/factory.go
@@ -386,6 +386,17 @@ func (f *factory) CreateAuthConfigService(fileName string, namespace string,
 	return nil, fmt.Errorf("no auth config found for secret %q", fileName)
 }
 
+// CreateLocalGitAuthConfigService creates a new service which loads/saves the auth config from/to a local file.
+func (f *factory) CreateLocalGitAuthConfigService() (auth.ConfigService, error) {
+
+	if authService, err := f.createAuthConfigServiceFile(auth.GitAuthConfigFile, kube.ValueKindGit); err == nil {
+		return authService, nil
+	}
+	log.Logger().Debugf("No auth config found in file %s", auth.GitAuthConfigFile)
+
+	return nil, fmt.Errorf("no auth config found for secret %q", auth.GitAuthConfigFile)
+}
+
 // SecretsLocation indicates the location where the secrets are stored
 func (f *factory) SecretsLocation() secrets.SecretsLocationKind {
 	client, namespace, err := f.CreateKubeClient()

--- a/pkg/cmd/clients/fake/fake_factory.go
+++ b/pkg/cmd/clients/fake/fake_factory.go
@@ -378,3 +378,9 @@ func (f *FakeFactory) CreateHelm(verbose bool,
 func (f *FakeFactory) CreateCertManagerClient() (certmngclient.Interface, error) {
 	return fake_certmngclient.NewSimpleClientset(), nil
 }
+
+
+// CreateLocalGitAuthConfigService creates a new service which loads/saves the auth config from/to a local file.
+func (f *FakeFactory) CreateLocalGitAuthConfigService() (auth.ConfigService, error) {
+	return  f.GetDelegateFactory().CreateLocalGitAuthConfigService()
+}

--- a/pkg/cmd/clients/fake/fake_factory.go
+++ b/pkg/cmd/clients/fake/fake_factory.go
@@ -379,8 +379,7 @@ func (f *FakeFactory) CreateCertManagerClient() (certmngclient.Interface, error)
 	return fake_certmngclient.NewSimpleClientset(), nil
 }
 
-
 // CreateLocalGitAuthConfigService creates a new service which loads/saves the auth config from/to a local file.
 func (f *FakeFactory) CreateLocalGitAuthConfigService() (auth.ConfigService, error) {
-	return  f.GetDelegateFactory().CreateLocalGitAuthConfigService()
+	return f.GetDelegateFactory().CreateLocalGitAuthConfigService()
 }

--- a/pkg/cmd/clients/interface.go
+++ b/pkg/cmd/clients/interface.go
@@ -55,7 +55,7 @@ type Factory interface {
 	// CreateGitAuthConfigService creates a new git authentication configuration service
 	CreateGitAuthConfigService(namespace string, serviceKind string) (auth.ConfigService, error)
 
-	// CreateLocalAuthConfigService creates a new service which loads/saves the auth config from/to a local file.
+	// CreateLocalGitAuthConfigService creates a new service which loads/saves Git auth config from/to a local file.
 	CreateLocalGitAuthConfigService() (auth.ConfigService, error)
 
 	// CreateJenkinsAuthConfigService creates a new Jenkins authentication configuration service

--- a/pkg/cmd/clients/interface.go
+++ b/pkg/cmd/clients/interface.go
@@ -55,6 +55,9 @@ type Factory interface {
 	// CreateGitAuthConfigService creates a new git authentication configuration service
 	CreateGitAuthConfigService(namespace string, serviceKind string) (auth.ConfigService, error)
 
+	// CreateLocalAuthConfigService creates a new service which loads/saves the auth config from/to a local file.
+	CreateLocalGitAuthConfigService() (auth.ConfigService, error)
+
 	// CreateJenkinsAuthConfigService creates a new Jenkins authentication configuration service
 	CreateJenkinsAuthConfigService(namespace string, jenkinsService string) (auth.ConfigService, error)
 

--- a/pkg/cmd/clients/mocks/factory.go
+++ b/pkg/cmd/clients/mocks/factory.go
@@ -443,6 +443,25 @@ func (mock *MockFactory) CreateKubeConfig() (*rest.Config, error) {
 	return ret0, ret1
 }
 
+func (mock *MockFactory) CreateLocalGitAuthConfigService() (auth.ConfigService, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockFactory().")
+	}
+	params := []pegomock.Param{}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateLocalGitAuthConfigService", params, []reflect.Type{reflect.TypeOf((*auth.ConfigService)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 auth.ConfigService
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(auth.ConfigService)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockFactory) CreateMetricsClient() (versioned5.Interface, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
@@ -1275,6 +1294,23 @@ func (c *MockFactory_CreateKubeConfig_OngoingVerification) GetCapturedArguments(
 }
 
 func (c *MockFactory_CreateKubeConfig_OngoingVerification) GetAllCapturedArguments() {
+}
+
+func (verifier *VerifierMockFactory) CreateLocalGitAuthConfigService() *MockFactory_CreateLocalGitAuthConfigService_OngoingVerification {
+	params := []pegomock.Param{}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CreateLocalGitAuthConfigService", params, verifier.timeout)
+	return &MockFactory_CreateLocalGitAuthConfigService_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockFactory_CreateLocalGitAuthConfigService_OngoingVerification struct {
+	mock              *MockFactory
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockFactory_CreateLocalGitAuthConfigService_OngoingVerification) GetCapturedArguments() {
+}
+
+func (c *MockFactory_CreateLocalGitAuthConfigService_OngoingVerification) GetAllCapturedArguments() {
 }
 
 func (verifier *VerifierMockFactory) CreateMetricsClient() *MockFactory_CreateMetricsClient_OngoingVerification {

--- a/pkg/cmd/create/create_quickstart.go
+++ b/pkg/cmd/create/create_quickstart.go
@@ -169,6 +169,7 @@ func (o *CreateQuickstartOptions) Run() error {
 			return err
 		}
 	}
+
 	genDir, err := o.createQuickstart(q, dir)
 	if err != nil {
 		return err

--- a/pkg/cmd/create/create_quickstart.go
+++ b/pkg/cmd/create/create_quickstart.go
@@ -169,7 +169,6 @@ func (o *CreateQuickstartOptions) Run() error {
 			return err
 		}
 	}
-
 	genDir, err := o.createQuickstart(q, dir)
 	if err != nil {
 		return err

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -949,8 +949,14 @@ func (options *ImportOptions) doImport() error {
 	if err != nil {
 		return err
 	}
+
+	githubAppMode, err := options.IsGitHubAppMode()
+	if err != nil {
+		return err
+	}
+
 	if isProw {
-		if !options.DisableWebhooks {
+		if !options.DisableWebhooks && !githubAppMode {
 			// register the webhook
 			err = options.CreateWebhookProw(gitURL, gitProvider)
 			if err != nil {

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -237,7 +237,7 @@ func (options *ImportOptions) Run() error {
 
 	var userAuth *auth.UserAuth
 	if options.GitProvider == nil {
-		authConfigSvc, err := options.GitAuthConfigService()
+		authConfigSvc, err := options.GitLocalAuthConfigService()
 		if err != nil {
 			return err
 		}
@@ -637,7 +637,7 @@ func (options *ImportOptions) GetOrganisation() string {
 
 // CreateNewRemoteRepository creates a new remote repository
 func (options *ImportOptions) CreateNewRemoteRepository() error {
-	authConfigSvc, err := options.GitAuthConfigService()
+	authConfigSvc, err := options.GitLocalAuthConfigService()
 	if err != nil {
 		return err
 	}
@@ -917,7 +917,7 @@ func (options *ImportOptions) doImport() error {
 		gitProvider = p
 	}
 
-	authConfigSvc, err := options.GitAuthConfigService()
+	authConfigSvc, err := options.GitLocalAuthConfigService()
 	if err != nil {
 		return err
 	}
@@ -1580,7 +1580,7 @@ func (options *ImportOptions) GetGitRepositoryDetails() (*gits.CreateRepoData, e
 	if err != nil {
 		return nil, err
 	}
-	authConfigSvc, err := options.GitAuthConfigService()
+	authConfigSvc, err := options.GitLocalAuthConfigService()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -1024,8 +1024,13 @@ func (options *ImportOptions) addProwConfig(gitURL string, gitKind string) error
 			return errors.Wrapf(err, "failed to get the git URL for SourceRepository %s", sr.Name)
 		}
 
+		gha, err := options.IsGitHubAppMode()
+		if err != nil {
+			return err
+		}
+
 		devGitURL := devEnv.Spec.Source.URL
-		if devGitURL != "" {
+		if devGitURL != "" && !gha {
 			// lets generate a PR
 			base := devEnv.Spec.Source.Ref
 			if base == "" {

--- a/pkg/cmd/opts/auth.go
+++ b/pkg/cmd/opts/auth.go
@@ -174,6 +174,8 @@ func (o *CommonOptions) GitAuthConfigServiceGitHubMode(gha bool, serviceKind str
 		return nil, errors.Wrap(err, "loading auth config from kubernetes secrets")
 	}
 	return authService, nil
+}
+
 // GitLocalAuthConfigService create a git auth config service using the local gitAuth.yaml file method only
 func (o *CommonOptions) GitLocalAuthConfigService() (auth.ConfigService, error) {
 	if o.factory == nil {

--- a/pkg/cmd/opts/auth.go
+++ b/pkg/cmd/opts/auth.go
@@ -174,4 +174,10 @@ func (o *CommonOptions) GitAuthConfigServiceGitHubMode(gha bool, serviceKind str
 		return nil, errors.Wrap(err, "loading auth config from kubernetes secrets")
 	}
 	return authService, nil
+// GitLocalAuthConfigService create a git auth config service using the local gitAuth.yaml file method only
+func (o *CommonOptions) GitLocalAuthConfigService() (auth.ConfigService, error) {
+	if o.factory == nil {
+		return nil, errors.New("command factory is not initialized")
+	}
+	return o.factory.CreateLocalGitAuthConfigService()
 }

--- a/pkg/cmd/opts/quickstarts.go
+++ b/pkg/cmd/opts/quickstarts.go
@@ -16,7 +16,7 @@ import (
 
 // LoadQuickStartsModel Load all quickstarts
 func (o *CommonOptions) LoadQuickStartsModel(gitHubOrganisations []string, ignoreTeam bool) (*quickstarts.QuickstartModel, error) {
-	authConfigSvc, err := o.GitAuthConfigService()
+	authConfigSvc, err := o.GitLocalAuthConfigService()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -297,6 +297,7 @@ func (p *GitHubProvider) CreateRepository(owner string, name string, private boo
 	}
 
 	org := owner
+
 	if org == p.Username {
 		log.Logger().Debugf("repository owner for %s is the authenticated user %s, setting org to the empty string '%s'", name, p.Username, org)
 		org = ""


### PR DESCRIPTION
Main motivation for this is to support GitHub Apps and also ensure we only ever use users local git auth credentials when creating or importing applications.  We don't want to be using an in cluster git secret.

fixes #6209