### PR TITLE
fix: Use debug image and /busybox/sh for /kaniko/executor

### DIFF
--- a/boot-vault.prow.yaml.template
+++ b/boot-vault.prow.yaml.template
@@ -1,5 +1,9 @@
 # override the pipelinerunner image
 pipelinerunner:
+  args:
+  - controller
+  - pipelinerunner
+  - --meta-pipeline-image=gcr.io/jenkinsxio/builder-maven:$VERSION
   enabled: true
   image:
     repository: gcr.io/jenkinsxio/builder-maven

--- a/myvalues.yaml.tekton.template
+++ b/myvalues.yaml.tekton.template
@@ -26,6 +26,10 @@ pipelinerunner:
   image:
     repository: gcr.io/jenkinsxio/builder-maven
     tag: $VERSION
+  args:
+    - controller
+    - pipelinerunner
+    - --meta-pipeline-image=gcr.io/jenkinsxio/builder-maven:$VERSION
   env:
     GIT_AUTHOR_NAME: "jenkins-x-bot"
     GIT_AUTHOR_EMAIL: "jenkins-x@googlegroups.com"

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
@@ -284,14 +284,10 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - --cache=true
-      - --cache-dir=/workspace
-      - --context=/workspace/source
-      - --dockerfile=/workspace/source/Dockerfile
-      - --destination=gcr.io/abayer/js-test-repo:${inputs.params.version}
-      - --cache-repo=gcr.io//cache
+      - /kaniko/executor --cache=true --cache-dir=/workspace --context=/workspace/source --dockerfile=/workspace/source/Dockerfile --destination=gcr.io/abayer/js-test-repo:${inputs.params.version} --cache-repo=gcr.io//cache
       command:
-      - /kaniko/executor
+      - /busybox/sh
+      - -c
       env:
       - name: DOCKER_CONFIG
         value: /home/jenkins/.docker/
@@ -334,7 +330,7 @@ items:
         value: /kaniko-secret/secret.json
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+      image: gcr.io/kaniko-project/executor:debug-9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
       name: build-container-build
       resources:
         requests:

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
@@ -163,15 +163,10 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - --dockerfile=/workspace/source/Dockerfile
-      - --destination=docker.io/jenkinsxio/jx:A_VERSION
-      - --context=/workspace/source
-      - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
-      - --cache=true
-      - --cache-dir=/workspace
-      - --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
+      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile --destination=docker.io/jenkinsxio/jx:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /kaniko/executor
+      - /busybox/sh
+      - -c
       env:
       - name: BASE_WORKSPACE
         value: /workspace/source
@@ -204,7 +199,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:dev40
+      image: rawlingsj/executor:debug-dev40
       name: build-and-push-image
       resources: {}
       volumeMounts:
@@ -213,15 +208,10 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - --dockerfile=/workspace/source/Dockerfile.builder-nodejs
-      - --destination=docker.io/jenkinsxio/builder-nodejs:A_VERSION
-      - --context=/workspace/source
-      - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
-      - --cache=true
-      - --cache-dir=/workspace
-      - --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
+      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-nodejs --destination=docker.io/jenkinsxio/builder-nodejs:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /kaniko/executor
+      - /busybox/sh
+      - -c
       env:
       - name: BASE_WORKSPACE
         value: /workspace/source
@@ -254,7 +244,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:dev40
+      image: rawlingsj/executor:debug-dev40
       name: build-and-push-nodejs
       resources: {}
       volumeMounts:
@@ -263,15 +253,10 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - --dockerfile=/workspace/source/Dockerfile.builder-maven
-      - --destination=docker.io/jenkinsxio/builder-maven:A_VERSION
-      - --context=/workspace/source
-      - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
-      - --cache=true
-      - --cache-dir=/workspace
-      - --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
+      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-maven --destination=docker.io/jenkinsxio/builder-maven:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /kaniko/executor
+      - /busybox/sh
+      - -c
       env:
       - name: BASE_WORKSPACE
         value: /workspace/source
@@ -304,7 +289,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:dev40
+      image: rawlingsj/executor:debug-dev40
       name: build-and-push-maven
       resources: {}
       volumeMounts:
@@ -313,15 +298,10 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - --dockerfile=/workspace/source/Dockerfile.builder-go
-      - --destination=docker.io/jenkinsxio/builder-go:A_VERSION
-      - --context=/workspace/source
-      - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
-      - --cache=true
-      - --cache-dir=/workspace
-      - --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
+      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-go --destination=docker.io/jenkinsxio/builder-go:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /kaniko/executor
+      - /busybox/sh
+      - -c
       env:
       - name: BASE_WORKSPACE
         value: /workspace/source
@@ -354,7 +334,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:dev40
+      image: rawlingsj/executor:debug-dev40
       name: build-and-push-go
       resources: {}
       volumeMounts:


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

/bin/sh doesn't exist on Kaniko's `executor` or `warmer` images, which is why we've been special-casing them all along. But that ends up creating a number of other problems. There is a `debug-...` image for every `executor` image, with `/busybox/sh`, so let's try using the `debug-...` image with `/busybox/sh -c` as the command when we see `/kaniko/executor` as the step command.

This should also allow environment variables to be used in kaniko step arguments.

#### Special notes for the reviewer(s)

/assign @garethjevans 

#### Which issue this PR fixes

fixes #6197
fixes #6058
