### PR TITLE
fix: update urls for contributor guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!--  Thanks for sending a pull request!  Here are some tips for you:
-1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/contribute/
+1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
 2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
-3. Follow these instructions to write tests https://jenkins-x.io/contribute/development/#testing
+3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
 4. You can trigger the tests for your PR with /test bdd
 5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
 6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

--- a/docs/contributing/hacking.md
+++ b/docs/contributing/hacking.md
@@ -1,3 +1,3 @@
 # Contributing to Jenkins X
 
-Please visit the contributing guide for the documentation available at [Jenkins X website](https://jenkins-x.io/contribute/development/)
+Please visit the contributing guide for the documentation available at [Jenkins X website](https://jenkins-x.io/docs/contributing/code/)


### PR DESCRIPTION
Signed-off-by: Yuki Nagai <ynagai@r.recruit.co.jp>

fix: update urls for contributor guidelines

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
Update url in [this page](https://github.com/jenkins-x/jx/blob/master/docs/contributing/hacking.md).
Also, urls in pull_request_template.md are also outdated, so I fixed them.