### PR TITLE
fix: Apply labels as part of pull req creation, not just after

### DIFF
--- a/pkg/gits/operations/pull_request_op.go
+++ b/pkg/gits/operations/pull_request_op.go
@@ -88,13 +88,10 @@ func (o *PullRequestOperation) CreatePullRequest(kind string, update ChangeFiles
 		filter := &gits.PullRequestFilter{
 			Labels: labels,
 		}
+		details.Labels = labels
 		result, err = gits.PushRepoAndCreatePullRequest(dir, upstreamInfo, forkInfo, o.Base, details, filter, !o.SkipCommit, commitMessage, true, o.DryRun, o.Git(), provider)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create PR for base %s and head branch %s from temp dir %s", o.Base, details.BranchName, dir)
-		}
-		err = gits.AddLabelsToPullRequest(result, labels)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to add labels %+v to PR %s", labels, result.PullRequest.URL)
 		}
 	}
 	return result, nil

--- a/pkg/gits/operations/pull_request_op_test.go
+++ b/pkg/gits/operations/pull_request_op_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/gits/operations"
 
-	"github.com/acarl005/stripansi"
 	"github.com/ghodss/yaml"
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -37,7 +36,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/gits"
 	gits_test "github.com/jenkins-x/jx/pkg/gits/mocks"
 	resources_test "github.com/jenkins-x/jx/pkg/kube/resources/mocks"
-	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/petergtz/pegomock"
 	"github.com/stretchr/testify/assert"
 	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -82,15 +80,13 @@ func TestCreatePullRequest(t *testing.T) {
 
 	pegomock.When(gitter.HasChanges(pegomock.AnyString())).ThenReturn(true, nil)
 
-	var results *gits.PullRequestInfo
-	logOutput := log.CaptureOutput(func() {
-		results, err = o.CreatePullRequest("test", func(dir string, gitInfo *gits.GitRepository) (strings []string, e error) {
-			return []string{"1.0.0", "v1.0.1", "2.0.0"}, nil
-		})
-		assert.NoError(t, err)
+	results, err := o.CreatePullRequest("test", func(dir string, gitInfo *gits.GitRepository) (strings []string, e error) {
+		return []string{"1.0.0", "v1.0.1", "2.0.0"}, nil
 	})
+	assert.NoError(t, err)
+	assert.NotNil(t, results)
 
-	assert.Contains(t, logOutput, "Added label updatebot to Pull Request https://fake.git/testowner/testrepo/pulls/1",
+	assert.Contains(t, results.PullRequestArguments.Labels, "updatebot",
 		"Updatebot label should be added to the PR")
 	assert.NotNil(t, results, "we must have results coming out of the PR creation")
 	assert.Equal(t, "chore(deps): bump testowner/testrepo from 1.0.0, 2.0.0 and v1.0.1 to 3.0.0",
@@ -203,15 +199,13 @@ func TestCreatePullRequestWithMatrixUpdatePaths(t *testing.T) {
 
 	pegomock.When(gitter.HasChanges(pegomock.AnyString())).ThenReturn(true, nil)
 
-	var results *gits.PullRequestInfo
-	logOutput := log.CaptureOutput(func() {
-		results, err = o.CreatePullRequest("test", func(dir string, gitInfo *gits.GitRepository) (strings []string, e error) {
-			return []string{"1.0.0", "v1.0.1", "2.0.0"}, nil
-		})
-		assert.NoError(t, err)
+	results, err := o.CreatePullRequest("test", func(dir string, gitInfo *gits.GitRepository) (strings []string, e error) {
+		return []string{"1.0.0", "v1.0.1", "2.0.0"}, nil
 	})
+	assert.NoError(t, err)
+	assert.NotNil(t, results)
 
-	assert.Contains(t, stripansi.Strip(logOutput), "Added label updatebot to Pull Request https://fake.git/testowner/testrepo/pulls/1",
+	assert.Contains(t, results.PullRequestArguments.Labels, "updatebot",
 		"Updatebot label should be added to the PR")
 	assert.NotNil(t, results, "we must have results coming out of the PR creation")
 	assert.Equal(t, "chore(deps): bump testowner/testrepo from 1.0.0, 2.0.0 and v1.0.1 to 3.0.0",


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Analogous to #6244 - gets us away from the nil pointer issue and cuts down on API calls a bit.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6210 
