### PR TITLE
fix: only use /busybox/sh for the official kaniko image

### DIFF
--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/jenkins-x.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/jenkins-x.yml
@@ -22,15 +22,15 @@ pipelineConfig:
                 args: ['--help']
 
               - name: build-and-push-image
-                image: rawlingsj/executor:dev40
+                image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args: ['--dockerfile=/workspace/source/Dockerfile','--destination=docker.io/jenkinsxio/jx:A_VERSION','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
               - name: build-and-push-nodejs
-                image: rawlingsj/executor:dev40
+                image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=docker.io/jenkinsxio/builder-nodejs:A_VERSION','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
               - name: build-and-push-maven
-                image: rawlingsj/executor:dev40
+                image: gcr.io/kaniko-project/executor:debug-9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=docker.io/jenkinsxio/builder-maven:A_VERSION','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
               - name: build-and-push-go

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
@@ -165,7 +165,7 @@ items:
     - args:
       - /kaniko/executor --dockerfile=/workspace/source/Dockerfile --destination=docker.io/jenkinsxio/jx:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /busybox/sh
+      - /bin/sh
       - -c
       env:
       - name: BASE_WORKSPACE
@@ -199,7 +199,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:debug-dev40
+      image: rawlingsj/executor:dev40
       name: build-and-push-image
       resources: {}
       volumeMounts:
@@ -210,7 +210,7 @@ items:
     - args:
       - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-nodejs --destination=docker.io/jenkinsxio/builder-nodejs:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /busybox/sh
+      - /bin/sh
       - -c
       env:
       - name: BASE_WORKSPACE
@@ -244,7 +244,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:debug-dev40
+      image: rawlingsj/executor:dev40
       name: build-and-push-nodejs
       resources: {}
       volumeMounts:
@@ -255,7 +255,7 @@ items:
     - args:
       - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-maven --destination=docker.io/jenkinsxio/builder-maven:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /busybox/sh
+      - /bin/sh
       - -c
       env:
       - name: BASE_WORKSPACE
@@ -289,7 +289,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:debug-dev40
+      image: rawlingsj/executor:dev40
       name: build-and-push-maven
       resources: {}
       volumeMounts:
@@ -300,7 +300,7 @@ items:
     - args:
       - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-go --destination=docker.io/jenkinsxio/builder-go:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /busybox/sh
+      - /bin/sh
       - -c
       env:
       - name: BASE_WORKSPACE
@@ -334,7 +334,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:debug-dev40
+      image: rawlingsj/executor:dev40
       name: build-and-push-go
       resources: {}
       volumeMounts:

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
@@ -165,7 +165,7 @@ items:
     - args:
       - /kaniko/executor --dockerfile=/workspace/source/Dockerfile --destination=docker.io/jenkinsxio/jx:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /bin/sh
+      - /busybox/sh
       - -c
       env:
       - name: BASE_WORKSPACE
@@ -199,7 +199,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:dev40
+      image: gcr.io/kaniko-project/executor:debug-9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
       name: build-and-push-image
       resources: {}
       volumeMounts:
@@ -210,7 +210,7 @@ items:
     - args:
       - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-nodejs --destination=docker.io/jenkinsxio/builder-nodejs:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /bin/sh
+      - /busybox/sh
       - -c
       env:
       - name: BASE_WORKSPACE
@@ -244,7 +244,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:dev40
+      image: gcr.io/kaniko-project/executor:debug-9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
       name: build-and-push-nodejs
       resources: {}
       volumeMounts:
@@ -255,7 +255,7 @@ items:
     - args:
       - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-maven --destination=docker.io/jenkinsxio/builder-maven:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
-      - /bin/sh
+      - /busybox/sh
       - -c
       env:
       - name: BASE_WORKSPACE
@@ -289,7 +289,7 @@ items:
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: rawlingsj/executor:dev40
+      image: gcr.io/kaniko-project/executor:debug-9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
       name: build-and-push-maven
       resources: {}
       volumeMounts:

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -1552,8 +1552,10 @@ func generateSteps(params generateStepsParams) ([]corev1.Container, map[string]c
 			c.Args = params.step.Arguments
 		} else {
 			// If it's /kaniko/executor, use /busybox/sh instead of /bin/sh, and use the debug image
-			if strings.HasPrefix(params.step.GetCommand(), "/kaniko/executor") {
-				c.Image = strings.Replace(c.Image, "/executor:", "/executor:debug-", 1)
+			if strings.HasPrefix(params.step.GetCommand(), "/kaniko/executor") && strings.Contains(c.Image, "gcr.io/kaniko-project") {
+				if !strings.Contains(c.Image, "debug") {
+					c.Image = strings.Replace(c.Image, "/executor:", "/executor:debug-", 1)
+				}
 				c.Command = []string{"/busybox/sh", "-c"}
 			}
 			cmdStr := params.step.GetCommand()


### PR DESCRIPTION
if the debug image is already specified, don't prepend debug