### PR TITLE
fix: Correct use of AWS credentials for vault

### DIFF
--- a/pkg/cmd/step/boot/step_boot_vault.go
+++ b/pkg/cmd/step/boot/step_boot_vault.go
@@ -145,7 +145,6 @@ func (o *StepBootVaultOptions) Run() error {
 			secretAccessKey := os.Getenv("VAULT_AWS_SECRET_ACCESS_KEY")
 			accessKeyId := os.Getenv("VAULT_AWS_ACCESS_KEY_ID")
 			if !awsConfig.AutoCreate && (checkRequiredResource("dynamoDBTable", awsConfig.DynamoDBTable) ||
-				checkRequiredResource("providedIAMUsername", awsConfig.ProvidedIAMUsername) ||
 				checkRequiredResource("secretAccessKey", secretAccessKey) ||
 				checkRequiredResource("accessKeyId", accessKeyId) ||
 				checkRequiredResource("kmsKeyId", awsConfig.KMSKeyID) ||
@@ -165,8 +164,8 @@ func (o *StepBootVaultOptions) Run() error {
 				AutoCreate:          awsConfig.AutoCreate,
 				DynamoDBTable:       awsConfig.DynamoDBTable,
 				DynamoDBRegion:      awsConfig.DynamoDBRegion,
-				AccessKeyID:         secretAccessKey,
-				SecretAccessKey:     accessKeyId,
+				AccessKeyID:         accessKeyId,
+				SecretAccessKey:     secretAccessKey,
 				ProvidedIAMUsername: awsConfig.ProvidedIAMUsername,
 			}
 		}

--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -503,7 +503,7 @@ func defineAppsChartOverridingError(chartName string, err error) error {
 func (o *StepHelmApplyOptions) fetchSecretFilesFromVault(dir string, store configio.ConfigStore) ([]string, error) {
 	log.Logger().Debugf("Fetching secrets from vault into directory %q", dir)
 	files := []string{}
-	client, err := o.SystemVaultClient(kube.DefaultNamespace)
+	client, err := o.SystemVaultClient("")
 	if err != nil {
 		return files, errors.Wrap(err, "retrieving the system Vault")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Correct use of AWS credentials for vault when creating cloud resources outside of jx

Allow use of system vault in other namespace than jx

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6218

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
