### PR TITLE
fix: create promote PR with labels

### DIFF
--- a/pkg/environments/gitops.go
+++ b/pkg/environments/gitops.go
@@ -68,21 +68,15 @@ func (o *EnvironmentPullRequestOptions) Create(env *jenkinsv1.Environment, envir
 		return nil, err
 	}
 	labels := make([]string, 0)
+	labels = append(labels, pullRequestDetails.Labels...)
 	labels = append(labels, o.Labels...)
 	if autoMerge {
 		labels = append(labels, gits.LabelUpdatebot)
 	}
+	pullRequestDetails.Labels = labels
 	prInfo, err := gits.PushRepoAndCreatePullRequest(dir, upstreamRepo, forkURL, base, pullRequestDetails, filter, true, pullRequestDetails.Message, true, false, o.Gitter, o.GitProvider)
 	if err != nil {
 		return nil, err
-	}
-
-	// this will be nil if no PR was created due to no real changes in source
-	if prInfo != nil {
-		err = gits.AddLabelsToPullRequest(prInfo, labels)
-		if err != nil {
-			return nil, err
-		}
 	}
 	return prInfo, nil
 }

--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -237,6 +237,7 @@ func PushRepoAndCreatePullRequest(dir string, upstreamRepo *GitRepository, forkR
 		Title:         prDetails.Title,
 		Body:          prDetails.Message,
 		Base:          base,
+		Labels:        prDetails.Labels,
 	}
 	var existingPr *GitPullRequest
 

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -294,6 +294,7 @@ type PullRequestDetails struct {
 	Message    string
 	BranchName string
 	Title      string
+	Labels     []string
 }
 
 func (p *PullRequestDetails) String() string {


### PR DESCRIPTION
rather than in 2 separate REST APIs so its faster and we avoid possible webhook complications in lighthouse; seems can we sometimes miss the PR open if we label a PR immediately after creating

fixes #6243

Signed-off-by: James Strachan <james.strachan@gmail.com>