### PR TITLE
fix: Add kaniko secrets to all steps running `/kaniko/executor`

### DIFF
--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -51,7 +51,7 @@ type testCase struct {
 	kind                  string
 	generateError         error
 	effectiveProjectError error
-	useKaniko             bool
+	noKaniko              bool
 	pipelineUserName      string
 	pipelineUserEmail     string
 	branchAsRevision      bool
@@ -89,7 +89,6 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			organization: "abayer",
 			branch:       "build-pack",
 			kind:         "release",
-			useKaniko:    true,
 		},
 		{
 			name:         "maven_build_pack",
@@ -98,7 +97,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			organization: "abayer",
 			branch:       "master",
 			kind:         "release",
-			useKaniko:    false,
+			noKaniko:     true,
 		},
 		{
 			name:         "from_yaml",
@@ -158,7 +157,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			organization: "abayer",
 			branch:       "master",
 			kind:         "release",
-			useKaniko:    false,
+			noKaniko:     true,
 		},
 		{
 			name:         "override_block_step",
@@ -175,7 +174,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			organization: "abayer",
 			branch:       "master",
 			kind:         "release",
-			useKaniko:    false,
+			noKaniko:     true,
 		},
 		{
 			name:         "containeroptions-on-pipelineconfig",
@@ -184,7 +183,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			organization: "abayer",
 			branch:       "master",
 			kind:         "release",
-			useKaniko:    false,
+			noKaniko:     true,
 		},
 		{
 			name:         "default-in-jenkins-x-yml",
@@ -276,7 +275,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			organization: "abayer",
 			branch:       "master",
 			kind:         "release",
-			useKaniko:    false,
+			noKaniko:     true,
 		},
 		{
 			name:         "replace-stage-steps-in-jenkins-x-yml",
@@ -326,7 +325,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 			organization: "abayer",
 			branch:       "master",
 			kind:         "release",
-			useKaniko:    false,
+			noKaniko:     true,
 		},
 		{
 			name:         "volume-in-overrides",
@@ -444,7 +443,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 				Branch:              tt.branch,
 				UseBranchAsRevision: tt.branchAsRevision,
 				PipelineKind:        tt.kind,
-				NoKaniko:            !tt.useKaniko,
+				NoKaniko:            tt.noKaniko,
 				StepOptions: step.StepOptions{
 					CommonOptions: &opts.CommonOptions{
 						ServiceAccount: "tekton-bot",

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
@@ -5,8 +5,8 @@ metadata:
   labels:
     branch: fix-kaniko-special-casing
     build: "1"
-    owner: jenkins-x
     jenkins.io/pipelineType: build
+    owner: jenkins-x
     repository: jx
   name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
   namespace: jx

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
@@ -5,8 +5,8 @@ metadata:
   labels:
     branch: fix-kaniko-special-casing
     build: "1"
-    owner: jenkins-x
     jenkins.io/pipelineType: build
+    owner: jenkins-x
     repository: jx
   name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/structure.yml
@@ -3,8 +3,8 @@ metadata:
   labels:
     branch: fix-kaniko-special-casing
     build: "1"
-    owner: jenkins-x
     jenkins.io/pipelineType: build
+    owner: jenkins-x
     repository: jx
   name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
 pipelineRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
@@ -6,9 +6,9 @@ items:
     labels:
       branch: fix-kaniko-special-casing
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: ci
       owner: jenkins-x
-      jenkins.io/pipelineType: build
       repository: jx
     name: jenkins-x-jx-fix-kaniko-special-9l9zj-ci-1
     namespace: jx
@@ -163,7 +163,9 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile --destination=docker.io/jenkinsxio/jx:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
+      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile --destination=docker.io/jenkinsxio/jx:A_VERSION
+        --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
+        --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
       - /busybox/sh
       - -c
@@ -197,6 +199,8 @@ items:
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /kaniko-secret/secret.json
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
       image: gcr.io/kaniko-project/executor:debug-9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
@@ -208,7 +212,10 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-nodejs --destination=docker.io/jenkinsxio/builder-nodejs:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
+      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-nodejs
+        --destination=docker.io/jenkinsxio/builder-nodejs:A_VERSION --context=/workspace/source
+        --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true
+        --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
       - /busybox/sh
       - -c
@@ -242,6 +249,8 @@ items:
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /kaniko-secret/secret.json
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
       image: gcr.io/kaniko-project/executor:debug-9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
@@ -253,7 +262,9 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-maven --destination=docker.io/jenkinsxio/builder-maven:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
+      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-maven --destination=docker.io/jenkinsxio/builder-maven:A_VERSION
+        --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
+        --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
       - /busybox/sh
       - -c
@@ -287,6 +298,8 @@ items:
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /kaniko-secret/secret.json
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
       image: gcr.io/kaniko-project/executor:debug-9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
@@ -298,7 +311,9 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-go --destination=docker.io/jenkinsxio/builder-go:A_VERSION --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/ --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
+      - /kaniko/executor --dockerfile=/workspace/source/Dockerfile.builder-go --destination=docker.io/jenkinsxio/builder-go:A_VERSION
+        --context=/workspace/source --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
+        --cache=true --cache-dir=/workspace --skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000
       command:
       - /bin/sh
       - -c
@@ -332,6 +347,8 @@ items:
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /kaniko-secret/secret.json
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
       image: rawlingsj/executor:dev40


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Changes the logic determining whether to include kaniko secrets on a step to check whether it's running `/kaniko/executor`, not whether it's named `build-container-build`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6247
