### PR TITLE
fix: boot upgrade cloning using GitHub apps

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2019-12-02T12:12:04Z",
+  "generated_at": "2019-12-03T15:54:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -338,19 +338,19 @@
       {
         "hashed_secret": "4d55af37dbbb6a42088d917caa1ca25428ec42c9",
         "is_secret": false,
-        "line_number": 2423,
+        "line_number": 2426,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "ad5add064d262229c5ae13ba1b42b9dc0078f649",
         "is_secret": false,
-        "line_number": 2658,
+        "line_number": 2661,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "740b5066431be9b197b7688eed6a867cfebaf0e3",
         "is_secret": false,
-        "line_number": 3101,
+        "line_number": 3104,
         "type": "Secret Keyword"
       }
     ],

--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -474,13 +474,8 @@ func (o *ControllerBuildOptions) getGithubProvider(gitInfo *gits.GitRepository) 
 		return o.gitHubProvider, nil
 	}
 
-	ghOwner, err := o.GetGitHubAppOwner(gitInfo)
-	if err != nil {
-		return nil, err
-	}
-
 	// production code always goes this way
-	server, userAuth, err := o.GetPipelineGitAuth(ghOwner)
+	server, userAuth, err := o.GetPipelineGitAuthForRepo(gitInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/create/create_addon_prow.go
+++ b/pkg/cmd/create/create_addon_prow.go
@@ -95,7 +95,7 @@ func (o *CreateAddonProwOptions) Run() error {
 
 	isGitOps, _ := o.GetDevEnv()
 
-	_, pipelineUser, err := o.GetPipelineGitAuth("")
+	_, pipelineUser, err := o.GetPipelineGitAuth()
 	if err != nil {
 		return errors.Wrap(err, "retrieving the pipeline Git Auth")
 	}

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -1139,7 +1139,7 @@ func (options *InstallOptions) installPlatformGitOpsMode(gitOpsEnvDir string, gi
 func (options *InstallOptions) configureAndInstallProw(namespace string, gitOpsEnvDir string, valuesFiles []string) error {
 	options.SetCurrentNamespace(namespace)
 	if options.Flags.Prow {
-		_, pipelineUser, err := options.GetPipelineGitAuth("")
+		_, pipelineUser, err := options.GetPipelineGitAuth()
 		if err != nil || pipelineUser == nil {
 			return errors.Wrap(err, "retrieving the pipeline Git Auth")
 		}

--- a/pkg/cmd/upgrade/upgrade_addon_prow.go
+++ b/pkg/cmd/upgrade/upgrade_addon_prow.go
@@ -173,7 +173,7 @@ func (o *UpgradeAddonProwOptions) Upgrade() error {
 
 	gitOpsEnvDir := ""
 
-	_, pipelineUser, err := o.GetPipelineGitAuth("")
+	_, pipelineUser, err := o.GetPipelineGitAuth()
 	if err != nil {
 		return errors.Wrap(err, "retrieving the pipeline Git Auth")
 	}

--- a/pkg/cmd/upgrade/upgrade_boot.go
+++ b/pkg/cmd/upgrade/upgrade_boot.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/blang/semver"
 
-	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/boot"
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
@@ -488,8 +487,7 @@ func (o *UpgradeBootOptions) cloneDevEnv() error {
 	}
 
 	gitInfo, err := gits.ParseGitURL(devEnvURL)
-
-	_, userAuth, err := o.pipelineUserAuth(gitInfo)
+	_, userAuth, err := o.GetPipelineGitAuthForRepo(gitInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed to get pipeline user auth")
 	}
@@ -505,14 +503,6 @@ func (o *UpgradeBootOptions) cloneDevEnv() error {
 
 	o.Dir = cloneDir
 	return nil
-}
-
-func (o *UpgradeBootOptions) pipelineUserAuth(gitInfo *gits.GitRepository) (*auth.AuthServer, *auth.UserAuth, error) {
-	ghOwner, err := o.GetGitHubAppOwner(gitInfo)
-	if err != nil {
-		return nil, nil, err
-	}
-	return o.GetPipelineGitAuth(ghOwner)
 }
 
 func (o *UpgradeBootOptions) updatePipelineBuilderImage(resolver *versionstream.VersionResolver) error {


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

`jx upgrade boot` is failing to clone dev env repository when using GitHub apps. This change determines if GitHub App is enabled and configured so that the appropriate token can be used.

If no GitHub App owner is found then the auth flow continues as before.

fixes #6276 
