### PR TITLE
fix: Correct link to import documentation

### DIFF
--- a/pkg/cmd/create/create_branch_pattern.go
+++ b/pkg/cmd/create/create_branch_pattern.go
@@ -22,7 +22,7 @@ var (
 
 		The pattern should match all the branches you wish to automate CI/CD on when creating or importing projects.
 
-		For more documentation see: [https://jenkins-x.io/developing/import/#branch-patterns](https://jenkins-x.io/developing/import/#branch-patterns)
+		For more documentation see: [https://jenkins-x.io/docs/using-jx/creating/import/#branch-patterns](https://jenkins-x.io/docs/using-jx/creating/import/#branch-patterns)
 `)
 
 	createBranchPatternExample = templates.Examples(`

--- a/pkg/cmd/get/get_branchpattern.go
+++ b/pkg/cmd/get/get_branchpattern.go
@@ -16,7 +16,7 @@ var (
 	getBranchPatternLong = templates.LongDesc(`
 		Display the git branch patterns for the current Team used on creating and importing projects
 
-		For more documentation see: [https://jenkins-x.io/developing/import/#branch-patterns](https://jenkins-x.io/developing/import/#branch-patterns)
+		For more documentation see: [https://jenkins-x.io/docs/using-jx/creating/import/#branch-patterns](https://jenkins-x.io/docs/using-jx/creating/import/#branch-patterns)
 `)
 
 	getBranchPatternExample = templates.Examples(`

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -106,7 +106,7 @@ var (
 
 	    You can specify the git URL as an argument.
 	    
-		For more documentation see: [https://jenkins-x.io/developing/import/](https://jenkins-x.io/developing/import/)
+		For more documentation see: [https://jenkins-x.io/docs/using-jx/creating/import/](https://jenkins-x.io/docs/using-jx/creating/import/)
 	    
 ` + helper.SeeAlsoText("jx create project"))
 


### PR DESCRIPTION
Fixing that documentation has moved on the website making following links in command line help and also reference on website give 404.