### PR TITLE
fix: labels need to be added after PR creation

### DIFF
--- a/pkg/gits/operations/pull_request_op.go
+++ b/pkg/gits/operations/pull_request_op.go
@@ -88,10 +88,17 @@ func (o *PullRequestOperation) CreatePullRequest(kind string, update ChangeFiles
 		filter := &gits.PullRequestFilter{
 			Labels: labels,
 		}
-		details.Labels = labels
+
 		result, err = gits.PushRepoAndCreatePullRequest(dir, upstreamInfo, forkInfo, o.Base, details, filter, !o.SkipCommit, commitMessage, true, o.DryRun, o.Git(), provider)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create PR for base %s and head branch %s from temp dir %s", o.Base, details.BranchName, dir)
+		}
+		if result != nil {
+			err = gits.AddLabelsToPullRequest(result, labels)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to add labels %+v to PR %s", labels, result.PullRequest.URL)
+
+			}
 		}
 	}
 	return result, nil

--- a/pkg/gits/operations/pull_request_op_test.go
+++ b/pkg/gits/operations/pull_request_op_test.go
@@ -2,8 +2,6 @@ package operations_test
 
 import (
 	"fmt"
-	"github.com/acarl005/stripansi"
-	"github.com/jenkins-x/jx/pkg/log"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/acarl005/stripansi"
+	"github.com/jenkins-x/jx/pkg/log"
 
 	"github.com/jenkins-x/jx/pkg/kube"
 
@@ -85,7 +86,7 @@ func TestCreatePullRequest(t *testing.T) {
 	var results *gits.PullRequestInfo
 
 	logOutput := log.CaptureOutput(func() {
-		results, err := o.CreatePullRequest("test", func(dir string, gitInfo *gits.GitRepository) (strings []string, e error) {
+		results, err = o.CreatePullRequest("test", func(dir string, gitInfo *gits.GitRepository) (strings []string, e error) {
 			return []string{"1.0.0", "v1.0.1", "2.0.0"}, nil
 		})
 		assert.NoError(t, err)
@@ -209,7 +210,7 @@ func TestCreatePullRequestWithMatrixUpdatePaths(t *testing.T) {
 	var results *gits.PullRequestInfo
 
 	logOutput := log.CaptureOutput(func() {
-		results, err := o.CreatePullRequest("test", func(dir string, gitInfo *gits.GitRepository) (strings []string, e error) {
+		results, err = o.CreatePullRequest("test", func(dir string, gitInfo *gits.GitRepository) (strings []string, e error) {
 			return []string{"1.0.0", "v1.0.1", "2.0.0"}, nil
 		})
 		assert.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

updatebot label isn't getting added to PR's, seemingly labels need to be added using the GitHub issues API after PR creation https://developer.github.com/v3/pulls/#labels-assignees-and-milestones.

Essentially a revert of #6211 with a nil pointer check on the PR creation before applying labels
