### PR TITLE
feat: Bring history for step split monorepo

### DIFF
--- a/pkg/cmd/deprecation/deprecated.go
+++ b/pkg/cmd/deprecation/deprecated.go
@@ -195,9 +195,6 @@ var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
 		date: "01-04-2020",
 		info: "This replaced by Tekton's mounted secrets",
 	},
-	"step split monorepo": {
-		date: "01-02-2020",
-	},
 	"step nexus drop": {
 		date: "01-02-2020",
 	},

--- a/pkg/cmd/step/step_split_monorepo_test.go
+++ b/pkg/cmd/step/step_split_monorepo_test.go
@@ -47,35 +47,3 @@ func TestStepSplitMonorepo(t *testing.T) {
 		filepath.Join(tempDir, "bar", "charts", "bar", "templates", "deployment.yaml"))
 }
 
-func TestStepSplitMonorepoGetLastGitCommit(t *testing.T) {
-	t.Parallel()
-	testData := filepath.Join("test_data", "split_monorepo")
-
-	tempDir, err := ioutil.TempDir("", "test_split_monorepo")
-	assert.NoError(t, err)
-
-	options := &step.StepSplitMonorepoOptions{
-		StepOptions: step2.StepOptions{
-			CommonOptions: &opts.CommonOptions{},
-		},
-		Organisation: "dummy",
-		Glob:         "*",
-		Dir:          testData,
-		OutputDir:    tempDir,
-		RepoName:     "test",
-		NoGit:        true,
-	}
-
-	err = options.Run()
-	assert.NoError(t, err, "Failed to run split monorepo on source %s output %s", testData, tempDir)
-
-	tests.Debugf("Generated split repos in: %s\n", tempDir)
-	log.Logger().Infof("Generated split repos in: %s", tempDir)
-
-	tests.AssertFilesExist(t, true, filepath.Join(tempDir, "bar"), filepath.Join(tempDir, "foo"))
-	tests.AssertFilesExist(t, false, filepath.Join(tempDir, "kubernetes"))
-
-	tests.AssertFilesExist(t, true,
-		filepath.Join(tempDir, "bar", "charts", "bar", "Chart.yaml"),
-		filepath.Join(tempDir, "bar", "charts", "bar", "templates", "deployment.yaml"))
-}

--- a/pkg/cmd/step/step_split_monorepo_test.go
+++ b/pkg/cmd/step/step_split_monorepo_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	step2 "github.com/jenkins-x/jx/pkg/cmd/opts/step"
+	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
 
 	"github.com/jenkins-x/jx/pkg/cmd/step"
 
@@ -32,6 +33,7 @@ func TestStepSplitMonorepo(t *testing.T) {
 		OutputDir:    tempDir,
 		NoGit:        true,
 	}
+	testhelpers.ConfigureTestOptions(options.CommonOptions, nil, nil)
 
 	err = options.Run()
 	assert.NoError(t, err, "Failed to run split monorepo on source %s output %s", testData, tempDir)
@@ -46,4 +48,3 @@ func TestStepSplitMonorepo(t *testing.T) {
 		filepath.Join(tempDir, "bar", "charts", "bar", "Chart.yaml"),
 		filepath.Join(tempDir, "bar", "charts", "bar", "templates", "deployment.yaml"))
 }
-

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -949,6 +949,11 @@ func (g *GitCLI) FilterTags(dir string, filter string) ([]string, error) {
 	return split, nil
 }
 
+// FilterBranch clears the repository from anything not matching filterdir and branch
+func (g *GitCLI) FilterBranch(dir string, filterdir string, branch string) error {
+	return g.gitCmd(dir, "filter-branch", "--prune-empty", "--subdirectory-filter", filterdir, branch)
+}
+
 // CreateTag creates a tag with the given name and message in the repository at the given directory
 func (g *GitCLI) CreateTag(dir string, tag string, msg string) error {
 	return g.gitCmd(dir, "tag", "-fa", tag, "-m", msg)
@@ -1186,6 +1191,15 @@ func (g *GitCLI) CloneBare(dir string, url string) error {
 	err := g.gitCmd(dir, "clone", "--bare", url, dir)
 	if err != nil {
 		return errors.Wrapf(err, "running git clone --bare %s", url)
+	}
+	return nil
+}
+
+// LocalClone will create a clone for a specific branch from a local git repository
+func (g *GitCLI) LocalClone(origindir string, parentdir string, name string, branch string) error {
+	err := g.gitCmd(parentdir, "clone", "-b", branch, "--single-branch", "-q", origindir, name)
+	if err != nil {
+		return errors.Wrapf(err, "running git clone %s", origindir)
 	}
 	return nil
 }

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -142,6 +142,11 @@ func (g *GitFake) ShallowClone(dir string, url string, commitish string, pullReq
 	return nil
 }
 
+// LocalClone will create a clone for a specific branch from a local git repository
+func (g *GitFake) LocalClone(origindir string, parentdir string, name string, branch string) error {
+	return nil
+}
+
 // Push performs a git push
 func (g *GitFake) Push(dir string, remote string, force bool, refspec ...string) error {
 	return nil
@@ -531,6 +536,11 @@ func (g *GitFake) Tags(dir string) ([]string, error) {
 // FilterTags returns all tags from the repository at the given directory that match the filter
 func (g *GitFake) FilterTags(dir string, filter string) ([]string, error) {
 	return make([]string, 0), nil
+}
+
+// FilterBranch clears the repository from anything not matching filterdir and branch
+func (g *GitFake) FilterBranch(dir string, filterdir string, branch string) error {
+	return nil
 }
 
 // CreateTag creates a tag

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -195,6 +195,7 @@ type Gitter interface {
 	Init(dir string) error
 	Clone(url string, directory string) error
 	CloneBare(dir string, url string) error
+	LocalClone(origindir string, parentdir string, name string, branch string) error
 	PushMirror(dir string, url string) error
 
 	// ShallowCloneBranch TODO not sure if this method works any more - consider using ShallowClone(dir, url, branch, "")
@@ -273,6 +274,7 @@ type Gitter interface {
 	FetchRemoteTags(dir string, repo string) error
 	Tags(dir string) ([]string, error)
 	FilterTags(dir string, filter string) ([]string, error)
+	FilterBranch(dir string, filterdir string, branch string) error
 	CreateTag(dir string, tag string, msg string) error
 	GetLatestCommitSha(dir string) (string, error)
 	GetFirstCommitSha(dir string) (string, error)

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -4,14 +4,13 @@
 package gits_test
 
 import (
-	io "io"
-	"reflect"
-	"time"
-
 	auth "github.com/jenkins-x/jx/pkg/auth"
 	gits "github.com/jenkins-x/jx/pkg/gits"
 	pegomock "github.com/petergtz/pegomock"
 	config "gopkg.in/src-d/go-git.v4/config"
+	io "io"
+	"reflect"
+	"time"
 )
 
 type MockGitter struct {
@@ -598,6 +597,21 @@ func (mock *MockGitter) FetchUnshallow(_param0 string) error {
 	return ret0
 }
 
+func (mock *MockGitter) FilterBranch(_param0 string, _param1 string, _param2 string) error {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0, _param1, _param2}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("FilterBranch", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(error)
+		}
+	}
+	return ret0
+}
+
 func (mock *MockGitter) FilterTags(_param0 string, _param1 string) ([]string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -1071,6 +1085,21 @@ func (mock *MockGitter) LocalBranches(_param0 string) ([]string, error) {
 		}
 	}
 	return ret0, ret1
+}
+
+func (mock *MockGitter) LocalClone(_param0 string, _param1 string, _param2 string, _param3 string) error {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("LocalClone", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(error)
+		}
+	}
+	return ret0
 }
 
 func (mock *MockGitter) Merge(_param0 string, _param1 string) error {
@@ -2815,6 +2844,41 @@ func (c *MockGitter_FetchUnshallow_OngoingVerification) GetAllCapturedArguments(
 	return
 }
 
+func (verifier *VerifierMockGitter) FilterBranch(_param0 string, _param1 string, _param2 string) *MockGitter_FilterBranch_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "FilterBranch", params, verifier.timeout)
+	return &MockGitter_FilterBranch_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_FilterBranch_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_FilterBranch_OngoingVerification) GetCapturedArguments() (string, string, string) {
+	_param0, _param1, _param2 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1]
+}
+
+func (c *MockGitter_FilterBranch_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
+		}
+		_param2 = make([]string, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(string)
+		}
+	}
+	return
+}
+
 func (verifier *VerifierMockGitter) FilterTags(_param0 string, _param1 string) *MockGitter_FilterTags_OngoingVerification {
 	params := []pegomock.Param{_param0, _param1}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "FilterTags", params, verifier.timeout)
@@ -3553,6 +3617,45 @@ func (c *MockGitter_LocalBranches_OngoingVerification) GetAllCapturedArguments()
 		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) LocalClone(_param0 string, _param1 string, _param2 string, _param3 string) *MockGitter_LocalClone_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "LocalClone", params, verifier.timeout)
+	return &MockGitter_LocalClone_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_LocalClone_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_LocalClone_OngoingVerification) GetCapturedArguments() (string, string, string, string) {
+	_param0, _param1, _param2, _param3 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1]
+}
+
+func (c *MockGitter_LocalClone_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string, _param3 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
+		}
+		_param2 = make([]string, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(string)
+		}
+		_param3 = make([]string, len(c.methodInvocations))
+		for u, param := range params[3] {
+			_param3[u] = param.(string)
 		}
 	}
 	return

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -431,23 +431,6 @@ func DeleteDirContents(dir string) error {
 	return nil
 }
 
-func DeleteDirContentsExcept(dir string, exceptDir string) error {
-	files, err := filepath.Glob(filepath.Join(dir, "*"))
-	if err != nil {
-		return err
-	}
-	for _, file := range files {
-		// lets ignore the top level dir
-		if dir != file && !strings.HasSuffix(file, exceptDir) {
-			err = os.RemoveAll(file)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // DeleteDirContents removes all the contents of the given directory
 func RecreateDirs(dirs ...string) error {
 	for _, dir := range dirs {

--- a/pkg/util/files_test.go
+++ b/pkg/util/files_test.go
@@ -87,46 +87,6 @@ func TestDeleteDirContents(t *testing.T) {
 
 }
 
-func TestDeleteDirContentsExcept(t *testing.T) {
-	t.Parallel()
-
-	tmpDir, err := ioutil.TempDir("", "TestDeleteDirContents")
-	require.NoError(t, err, "Failed to create temporary directory.")
-	defer func() {
-		err = os.RemoveAll(tmpDir)
-	}()
-	fmt.Printf("tmpDir=%s\n", tmpDir)
-
-	// Various types
-	var testFileNames = []string{
-		"file1",
-		"file2.out",
-		"file.3.ex-tension",
-	}
-	for _, filename := range testFileNames {
-		//Validate filename deletion as a file, directory, and non-empty directory.
-		filePath := filepath.Join(tmpDir, filename)
-		ioutil.WriteFile(filePath, []byte(filename), os.ModePerm)
-		dirPath := filepath.Join(tmpDir, filename+"-dir")
-		os.Mkdir(dirPath, os.ModeDir)
-		fileInDirPath := filepath.Join(dirPath, filename)
-		ioutil.WriteFile(fileInDirPath, []byte(filename), os.ModePerm)
-	}
-
-	//delete contents
-	util.DeleteDirContentsExcept(tmpDir, "file1")
-
-	//check dir still exists.
-	_, err = os.Stat(tmpDir)
-	require.NoError(t, err, "Directory has been deleted.")
-
-	//check empty
-	remainingFiles, err := filepath.Glob(filepath.Join(tmpDir, "*"))
-	assert.Equal(t, 1, len(remainingFiles),
-		fmt.Sprintf("Expected tmp dir %s to be empty, but contains %v.", tmpDir, remainingFiles))
-
-}
-
 func TestToValidFileSystemName(t *testing.T) {
 	assert.Equal(t, util.ToValidFileSystemName("x.y/z"), "x_y_z")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
Various features and fixes for the command `jx step split monorepo` has been made:

Made git history come along to new repo. This made it tricky to support existing remote repos for the split out repos, so I removed that.
Removed some code related to earlier handling copying files and commit message.
Removed test that didn't test what it was supposed to.
When 

#### Special notes for the reviewer(s)

I think these fixes warrants removing the command from the deprecation list.
There are more things that should be done, but I didn't want to make this PR too big. Supporting other git provider than github and fetching git provider and organisation from configuration to let user choose from comes to mind.

#### Which issue this PR fixes

Actually fixes #1486 which was closed due to being rotten

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
