### PR TITLE
fix: Don't require --version for step create pr repositories

### DIFF
--- a/pkg/cmd/step/create/pr/step_create_pr_repositories.go
+++ b/pkg/cmd/step/create/pr/step_create_pr_repositories.go
@@ -75,7 +75,7 @@ func (o *StepCreatePullRequestRepositoriesOptions) ValidateRepositoriesOptions()
 		}
 		o.GitURLs = []string{devEnv.Spec.Source.URL}
 	}
-	if err := o.ValidateOptions(false); err != nil {
+	if err := o.ValidateOptions(true); err != nil {
 		return errors.WithStack(err)
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is covered by existing or new tests.

#### Description

According to usage information `--version` is optional for `jx step create pullrequest respositories`, but ValidateOptions croaks if it is missing. I don't see that version is needed at all and it should certainly not be mandatory.
