### PR TITLE
fix: exclude env vars from build pack if passed in

### DIFF
--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
@@ -35,6 +35,8 @@ items:
       env:
       - name: FRUIT
         value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
@@ -46,8 +48,6 @@ items:
         value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
@@ -35,6 +35,8 @@ items:
       env:
       - name: FRUIT
         value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
@@ -46,8 +48,6 @@ items:
         value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/jenkins-x.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/jenkins-x.yml
@@ -1,0 +1,1 @@
+buildPack: javascript

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipeline.yml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: build-pack
+    build: "1"
+    owner: abayer
+    jenkins.io/pipelineType: build
+    repository: js-test-repo
+  name: abayer-js-test-repo-build-pack-1
+  namespace: jx
+spec:
+  params:
+  - default: 0.0.1
+    description: the version number for this pipeline which is used as a tag on docker
+      images and helm charts
+    name: version
+  resources:
+  - name: abayer-js-test-repo-build-pack
+    type: git
+  tasks:
+  - name: from-build-pack
+    params:
+    - name: version
+      value: ${params.version}
+    resources:
+      inputs:
+      - name: workspace
+        resource: abayer-js-test-repo-build-pack
+    taskRef:
+      name: abayer-js-test-repo-build-pack-from-build-pack-1
+status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipelineresources.yml
@@ -1,0 +1,15 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    creationTimestamp: null
+    name: abayer-js-test-repo-build-pack
+  spec:
+    params:
+    - name: revision
+      value: v0.0.1
+    - name: url
+      value: https://github.com/abayer/js-test-repo
+    type: git
+  status: {}
+metadata: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipelinerun.yml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: build-pack
+    build: "1"
+    owner: abayer
+    jenkins.io/pipelineType: build
+    repository: js-test-repo
+  name: abayer-js-test-repo-build-pack-1
+spec:
+  params:
+  - name: version
+    value: 0.0.1
+  pipelineRef:
+    apiVersion: tekton.dev/v1alpha1
+    name: abayer-js-test-repo-build-pack-1
+  resources:
+  - name: abayer-js-test-repo-build-pack
+    resourceRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: abayer-js-test-repo-build-pack
+  serviceAccount: tekton-bot
+  timeout: 240h0m0s
+status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/structure.yml
@@ -1,0 +1,15 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: build-pack
+    build: "1"
+    owner: abayer
+    jenkins.io/pipelineType: build
+    repository: js-test-repo
+  name: abayer-js-test-repo-build-pack-1
+pipelineRef: null
+pipelineRunRef: null
+stages:
+- depth: 0
+  name: from-build-pack
+  taskRef: abayer-js-test-repo-build-pack-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/tasks.yml
@@ -4,13 +4,13 @@ items:
   metadata:
     creationTimestamp: null
     labels:
-      branch: master
+      branch: build-pack
       build: "1"
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
       jenkins.io/pipelineType: build
-      repository: jx-demo-qs
-    name: abayer-jx-demo-qs-master-from-build-pack-1
+      repository: js-test-repo
+    name: abayer-js-test-repo-build-pack-from-build-pack-1
     namespace: jx
   spec:
     inputs:
@@ -33,10 +33,6 @@ items:
       command:
       - jx
       env:
-      - name: FRUIT
-        value: BANANA
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
@@ -48,16 +44,14 @@ items:
         value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -65,13 +59,13 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
+        value: abayer/js-test-repo/build-pack
       - name: APP_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: BRANCH_NAME
-        value: master
+        value: build-pack
       - name: JX_BATCH_MODE
         value: "true"
       - name: VERSION
@@ -91,12 +85,8 @@ items:
         name: workspace-volume
       - mountPath: /var/run/docker.sock
         name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
       - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
+        name: volume-0
       - mountPath: /etc/podinfo
         name: podinfo
         readOnly: true
@@ -114,12 +104,10 @@ items:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
-        value: somebodyelse
+        value: jenkins-x-bot
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
@@ -128,10 +116,6 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -139,20 +123,20 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
+        value: abayer/js-test-repo/build-pack
       - name: APP_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: BRANCH_NAME
-        value: master
+        value: build-pack
       - name: JX_BATCH_MODE
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
+      image: jenkinsxio/builder-nodejs:0.1.235
       name: setup-jx-git-credentials
       resources:
         requests:
@@ -165,18 +149,14 @@ items:
         name: workspace-volume
       - mountPath: /var/run/docker.sock
         name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
       - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
+        name: volume-0
       - mountPath: /etc/podinfo
         name: podinfo
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - echo hi there
+      - npm install
       command:
       - /bin/sh
       - -c
@@ -188,12 +168,10 @@ items:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
-        value: somebodyelse
+        value: jenkins-x-bot
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
@@ -202,10 +180,6 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -213,21 +187,21 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
+        value: abayer/js-test-repo/build-pack
       - name: APP_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: BRANCH_NAME
-        value: master
+        value: build-pack
       - name: JX_BATCH_MODE
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
-      name: build-step3
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: build-npm-install
       resources:
         requests:
           cpu: 400m
@@ -239,18 +213,14 @@ items:
         name: workspace-volume
       - mountPath: /var/run/docker.sock
         name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
       - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
+        name: volume-0
       - mountPath: /etc/podinfo
         name: podinfo
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - mvn clean deploy
+      - CI=true DISPLAY=:99 npm test
       command:
       - /bin/sh
       - -c
@@ -262,12 +232,10 @@ items:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
-        value: somebodyelse
+        value: jenkins-x-bot
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
@@ -276,10 +244,6 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -287,21 +251,21 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
+        value: abayer/js-test-repo/build-pack
       - name: APP_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: BRANCH_NAME
-        value: master
+        value: build-pack
       - name: JX_BATCH_MODE
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
-      name: build-mvn-deploy
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: build-npm-test
       resources:
         requests:
           cpu: 400m
@@ -313,20 +277,16 @@ items:
         name: workspace-volume
       - mountPath: /var/run/docker.sock
         name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
       - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
+        name: volume-0
       - mountPath: /etc/podinfo
         name: podinfo
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - skaffold version
+      - /kaniko/executor --cache=true --cache-dir=/workspace --context=/workspace/source --dockerfile=/workspace/source/Dockerfile --destination=gcr.io/abayer/js-test-repo:${inputs.params.version} --cache-repo=gcr.io//cache
       command:
-      - /bin/sh
+      - /busybox/sh
       - -c
       env:
       - name: DOCKER_CONFIG
@@ -336,12 +296,10 @@ items:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
-        value: somebodyelse
+        value: jenkins-x-bot
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
@@ -350,10 +308,6 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -361,94 +315,22 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
+        value: abayer/js-test-repo/build-pack
       - name: APP_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: BRANCH_NAME
-        value: master
+        value: build-pack
       - name: JX_BATCH_MODE
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /kaniko-secret/secret.json
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
-      name: build-skaffold-version
-      resources:
-        requests:
-          cpu: 400m
-          memory: 512Mi
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - mountPath: /home/jenkins
-        name: workspace-volume
-      - mountPath: /var/run/docker.sock
-        name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
-      - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
-      - mountPath: /etc/podinfo
-        name: podinfo
-        readOnly: true
-      workingDir: /workspace/source
-    - args:
-      - skaffold build -f skaffold.yaml
-      command:
-      - /bin/sh
-      - -c
-      env:
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
-      - name: DOCKER_REGISTRY
-        valueFrom:
-          configMapKeyRef:
-            key: docker.registry
-            name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
-      - name: GIT_AUTHOR_EMAIL
-        value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
-      - name: GIT_COMMITTER_EMAIL
-        value: jenkins-x@googlegroups.com
-      - name: GIT_COMMITTER_NAME
-        value: jenkins-x-bot
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: XDG_CONFIG_HOME
-        value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
-      - name: BUILD_NUMBER
-        value: "1"
-      - name: PIPELINE_KIND
-        value: release
-      - name: REPO_OWNER
-        value: abayer
-      - name: REPO_NAME
-        value: jx-demo-qs
-      - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
-      - name: APP_NAME
-        value: jx-demo-qs
-      - name: BRANCH_NAME
-        value: master
-      - name: JX_BATCH_MODE
-        value: "true"
-      - name: VERSION
-        value: ${inputs.params.version}
-      - name: PREVIEW_VERSION
-        value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
+      image: gcr.io/kaniko-project/executor:debug-9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
       name: build-container-build
       resources:
         requests:
@@ -461,12 +343,8 @@ items:
         name: workspace-volume
       - mountPath: /var/run/docker.sock
         name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
       - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
+        name: volume-0
       - mountPath: /etc/podinfo
         name: podinfo
         readOnly: true
@@ -484,12 +362,10 @@ items:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
-        value: somebodyelse
+        value: jenkins-x-bot
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
@@ -498,10 +374,6 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -509,20 +381,20 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
+        value: abayer/js-test-repo/build-pack
       - name: APP_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: BRANCH_NAME
-        value: master
+        value: build-pack
       - name: JX_BATCH_MODE
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
+      image: jenkinsxio/builder-nodejs:0.1.235
       name: build-post-build
       resources:
         requests:
@@ -535,18 +407,15 @@ items:
         name: workspace-volume
       - mountPath: /var/run/docker.sock
         name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
       - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
+        name: volume-0
       - mountPath: /etc/podinfo
         name: podinfo
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - echo goodbye
+      - cd /workspace/source/charts/js-test-repo && jx step changelog --batch-mode
+        --version v${VERSION}
       command:
       - /bin/sh
       - -c
@@ -558,12 +427,10 @@ items:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
-        value: somebodyelse
+        value: jenkins-x-bot
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
@@ -572,10 +439,6 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -583,168 +446,20 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
+        value: abayer/js-test-repo/build-pack
       - name: APP_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: BRANCH_NAME
-        value: master
+        value: build-pack
       - name: JX_BATCH_MODE
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
-      name: build-step8
-      resources:
-        requests:
-          cpu: 400m
-          memory: 512Mi
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - mountPath: /home/jenkins
-        name: workspace-volume
-      - mountPath: /var/run/docker.sock
-        name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
-      - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
-      - mountPath: /etc/podinfo
-        name: podinfo
-        readOnly: true
-      workingDir: /workspace/source
-    - args:
-      - echo wait why am i here
-      command:
-      - /bin/sh
-      - -c
-      env:
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
-      - name: DOCKER_REGISTRY
-        valueFrom:
-          configMapKeyRef:
-            key: docker.registry
-            name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
-      - name: GIT_AUTHOR_EMAIL
-        value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
-      - name: GIT_COMMITTER_EMAIL
-        value: jenkins-x@googlegroups.com
-      - name: GIT_COMMITTER_NAME
-        value: jenkins-x-bot
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: XDG_CONFIG_HOME
-        value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
-      - name: BUILD_NUMBER
-        value: "1"
-      - name: PIPELINE_KIND
-        value: release
-      - name: REPO_OWNER
-        value: abayer
-      - name: REPO_NAME
-        value: jx-demo-qs
-      - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
-      - name: APP_NAME
-        value: jx-demo-qs
-      - name: BRANCH_NAME
-        value: master
-      - name: JX_BATCH_MODE
-        value: "true"
-      - name: VERSION
-        value: ${inputs.params.version}
-      - name: PREVIEW_VERSION
-        value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
-      name: build-step9
-      resources:
-        requests:
-          cpu: 400m
-          memory: 512Mi
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - mountPath: /home/jenkins
-        name: workspace-volume
-      - mountPath: /var/run/docker.sock
-        name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
-      - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
-      - mountPath: /etc/podinfo
-        name: podinfo
-        readOnly: true
-      workingDir: /workspace/source
-    - args:
-      - cd /workspace/source/charts/jx-demo-qs && jx step changelog --version v${VERSION}
-      command:
-      - /bin/sh
-      - -c
-      env:
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
-      - name: DOCKER_REGISTRY
-        valueFrom:
-          configMapKeyRef:
-            key: docker.registry
-            name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
-      - name: GIT_AUTHOR_EMAIL
-        value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
-      - name: GIT_COMMITTER_EMAIL
-        value: jenkins-x@googlegroups.com
-      - name: GIT_COMMITTER_NAME
-        value: jenkins-x-bot
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: XDG_CONFIG_HOME
-        value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
-      - name: BUILD_NUMBER
-        value: "1"
-      - name: PIPELINE_KIND
-        value: release
-      - name: REPO_OWNER
-        value: abayer
-      - name: REPO_NAME
-        value: jx-demo-qs
-      - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
-      - name: APP_NAME
-        value: jx-demo-qs
-      - name: BRANCH_NAME
-        value: master
-      - name: JX_BATCH_MODE
-        value: "true"
-      - name: VERSION
-        value: ${inputs.params.version}
-      - name: PREVIEW_VERSION
-        value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
+      image: jenkinsxio/builder-nodejs:0.1.235
       name: promote-changelog
       resources:
         requests:
@@ -757,18 +472,14 @@ items:
         name: workspace-volume
       - mountPath: /var/run/docker.sock
         name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
       - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
+        name: volume-0
       - mountPath: /etc/podinfo
         name: podinfo
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - cd /workspace/source/charts/jx-demo-qs && jx step helm release
+      - cd /workspace/source/charts/js-test-repo && jx step helm release
       command:
       - /bin/sh
       - -c
@@ -780,12 +491,10 @@ items:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
-        value: somebodyelse
+        value: jenkins-x-bot
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
@@ -794,10 +503,6 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -805,20 +510,20 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
+        value: abayer/js-test-repo/build-pack
       - name: APP_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: BRANCH_NAME
-        value: master
+        value: build-pack
       - name: JX_BATCH_MODE
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
+      image: jenkinsxio/builder-nodejs:0.1.235
       name: promote-helm-release
       resources:
         requests:
@@ -831,18 +536,14 @@ items:
         name: workspace-volume
       - mountPath: /var/run/docker.sock
         name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
       - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
+        name: volume-0
       - mountPath: /etc/podinfo
         name: podinfo
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - cd /workspace/source/charts/jx-demo-qs && jx promote -b --all-auto --timeout
+      - cd /workspace/source/charts/js-test-repo && jx promote -b --all-auto --timeout
         1h --version ${VERSION}
       command:
       - /bin/sh
@@ -855,12 +556,10 @@ items:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: FRUIT
-        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
-        value: somebodyelse
+        value: jenkins-x-bot
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
@@ -869,10 +568,6 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
-      - name: _JAVA_OPTIONS
-        value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
-          -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
-          -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -880,20 +575,20 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: JOB_NAME
-        value: abayer/jx-demo-qs/master
+        value: abayer/js-test-repo/build-pack
       - name: APP_NAME
-        value: jx-demo-qs
+        value: js-test-repo
       - name: BRANCH_NAME
-        value: master
+        value: build-pack
       - name: JX_BATCH_MODE
         value: "true"
       - name: VERSION
         value: ${inputs.params.version}
       - name: PREVIEW_VERSION
         value: ${inputs.params.version}
-      image: jenkinsxio/builder-maven-java11:0.1.235
+      image: jenkinsxio/builder-nodejs:0.1.235
       name: promote-jx-promote
       resources:
         requests:
@@ -906,12 +601,8 @@ items:
         name: workspace-volume
       - mountPath: /var/run/docker.sock
         name: docker-daemon
-      - mountPath: /root/.m2/
-        name: volume-0
       - mountPath: /home/jenkins/.docker
-        name: volume-1
-      - mountPath: /home/jenkins/.gnupg
-        name: volume-2
+        name: volume-0
       - mountPath: /etc/podinfo
         name: podinfo
         readOnly: true
@@ -922,13 +613,7 @@ items:
       name: docker-daemon
     - name: volume-0
       secret:
-        secretName: jenkins-maven-settings
-    - name: volume-1
-      secret:
         secretName: jenkins-docker-cfg
-    - name: volume-2
-      secret:
-        secretName: jenkins-release-gpg
     - emptyDir: {}
       name: workspace-volume
     - downwardAPI:

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
@@ -35,6 +35,8 @@ items:
       env:
       - name: FRUIT
         value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
@@ -46,8 +48,6 @@ items:
         value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
@@ -35,6 +35,8 @@ items:
       env:
       - name: FRUIT
         value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
@@ -46,8 +48,6 @@ items:
         value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
@@ -35,6 +35,8 @@ items:
       env:
       - name: FRUIT
         value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
@@ -46,8 +48,6 @@ items:
         value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
@@ -35,6 +35,8 @@ items:
       env:
       - name: FRUIT
         value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
@@ -46,8 +48,6 @@ items:
         value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
@@ -35,6 +35,8 @@ items:
       env:
       - name: FRUIT
         value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
@@ -46,8 +48,6 @@ items:
         value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
@@ -35,6 +35,8 @@ items:
       env:
       - name: FRUIT
         value: BANANA
+      - name: GIT_AUTHOR_NAME
+        value: somebodyelse
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
@@ -46,8 +48,6 @@ items:
         value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
-      - name: GIT_AUTHOR_NAME
-        value: somebodyelse
       - name: GIT_COMMITTER_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME

--- a/pkg/cmd/step/syntax/step_syntax_effective.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective.go
@@ -466,6 +466,7 @@ func (o *StepSyntaxEffectiveOptions) createPipelineForKind(kind string, lifecycl
 	return parsed, nil
 }
 
+// RemoveDuplicateEnvVars removes any duplicate env var definitions
 func RemoveDuplicateEnvVars(env []corev1.EnvVar) []corev1.EnvVar {
 	counts := map[string]int{}
 	for _, e := range env {

--- a/pkg/cmd/step/syntax/step_syntax_effective_test.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective_test.go
@@ -69,8 +69,145 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 		repoName     string
 		organization string
 		branch       string
+		customEnvs   []string
 		expected     *config.ProjectConfig
 	}{{
+		name:         "js_build_pack_with_yaml",
+		pack:         "javascript",
+		repoName:     "js-test-repo",
+		organization: "abayer",
+		branch:       "build-pack",
+		customEnvs:   []string{"DOCKER_REGISTRY=gcr.io"},
+		expected: &config.ProjectConfig{
+			BuildPack: "javascript",
+			PipelineConfig: &jenkinsfile.PipelineConfig{
+				Agent: &jxsyntax.Agent{
+					Container: "nodejs",
+					Label:     "jenkins-nodejs",
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "DOCKER_REGISTRY",
+						Value: "gcr.io",
+					},
+				},
+				Extends: &jenkinsfile.PipelineExtends{
+					File:   "javascript/pipeline.yaml",
+					Import: "classic",
+				},
+				Pipelines: jenkinsfile.Pipelines{
+					Post: &jenkinsfile.PipelineLifecycle{
+						Steps:    []*jxsyntax.Step{},
+						PreSteps: []*jxsyntax.Step{},
+					},
+					PullRequest: &jenkinsfile.PipelineLifecycles{
+						Pipeline: sht.ParsedPipeline(
+							sht.PipelineEnvVar("DOCKER_REGISTRY", "gcr.io"),
+							sht.PipelineOptions(
+								sht.PipelineContainerOptions(
+									sht.ContainerResourceRequests("400m", "512Mi"),
+									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
+									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
+									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
+									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
+									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
+									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
+									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
+									tb.EnvVar("XDG_CONFIG_HOME", "/home/jenkins"),
+									sht.ContainerSecurityContext(true),
+									tb.VolumeMount("workspace-volume", "/home/jenkins"),
+									tb.VolumeMount("docker-daemon", "/var/run/docker.sock"),
+									tb.VolumeMount("volume-0", "/home/jenkins/.docker"),
+								),
+							),
+							sht.PipelineStage("from-build-pack",
+								sht.StageAgent("nodejs"),
+								sht.StageStep(sht.StepCmd("npm install"), sht.StepDir("/workspace/source"),
+									sht.StepImage("nodejs"), sht.StepName("build-npm-install")),
+								sht.StageStep(sht.StepCmd("CI=true DISPLAY=:99 npm test"), sht.StepDir("/workspace/source"),
+									sht.StepImage("nodejs"), sht.StepName("build-step3")),
+								sht.StageStep(sht.StepCmd("/kaniko/executor"), sht.StepDir("/workspace/source"),
+									sht.StepImage(jxsyntax.KanikoDockerImage), sht.StepName("build-container-build"),
+									sht.StepArg("--cache=true"), sht.StepArg("--cache-dir=/workspace"),
+									sht.StepArg("--context=/workspace/source"), sht.StepArg("--dockerfile=/workspace/source/Dockerfile"),
+									sht.StepArg("--destination=gcr.io/abayer/js-test-repo:${inputs.params.version}"),
+									sht.StepArg("--cache-repo=gcr.io//cache")),
+								sht.StageStep(sht.StepCmd("jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"),
+									sht.StepDir("/workspace/source"), sht.StepImage("nodejs"), sht.StepName("postbuild-post-build")),
+								sht.StageStep(sht.StepCmd("make preview"), sht.StepDir("/workspace/source/charts/preview"),
+									sht.StepImage("nodejs"), sht.StepName("promote-make-preview")),
+								sht.StageStep(sht.StepCmd("jx preview --app $APP_NAME --dir ../.."), sht.StepDir("/workspace/source/charts/preview"),
+									sht.StepImage("nodejs"), sht.StepName("promote-jx-preview")),
+							),
+						),
+					},
+					Release: &jenkinsfile.PipelineLifecycles{
+						Pipeline: sht.ParsedPipeline(
+							sht.PipelineEnvVar("DOCKER_REGISTRY", "gcr.io"),
+							sht.PipelineOptions(
+								sht.PipelineContainerOptions(
+									sht.ContainerResourceRequests("400m", "512Mi"),
+									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
+									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
+									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
+									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
+									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
+									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
+									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
+									tb.EnvVar("XDG_CONFIG_HOME", "/home/jenkins"),
+									sht.ContainerSecurityContext(true),
+									tb.VolumeMount("workspace-volume", "/home/jenkins"),
+									tb.VolumeMount("docker-daemon", "/var/run/docker.sock"),
+									tb.VolumeMount("volume-0", "/home/jenkins/.docker"),
+								),
+							),
+							sht.PipelineStage("from-build-pack",
+								sht.StageAgent("nodejs"),
+								sht.StageStep(sht.StepCmd("jx step git credentials"), sht.StepDir("/workspace/source"),
+									sht.StepImage("nodejs"), sht.StepName("setup-jx-git-credentials")),
+								sht.StageStep(sht.StepCmd("npm install"), sht.StepDir("/workspace/source"),
+									sht.StepImage("nodejs"), sht.StepName("build-npm-install")),
+								sht.StageStep(sht.StepCmd("CI=true DISPLAY=:99 npm test"), sht.StepDir("/workspace/source"),
+									sht.StepImage("nodejs"), sht.StepName("build-npm-test")),
+								sht.StageStep(sht.StepCmd("/kaniko/executor"), sht.StepDir("/workspace/source"),
+									sht.StepImage(jxsyntax.KanikoDockerImage), sht.StepName("build-container-build"),
+									sht.StepArg("--cache=true"), sht.StepArg("--cache-dir=/workspace"),
+									sht.StepArg("--context=/workspace/source"), sht.StepArg("--dockerfile=/workspace/source/Dockerfile"),
+									sht.StepArg("--destination=gcr.io/abayer/js-test-repo:${inputs.params.version}"),
+									sht.StepArg("--cache-repo=gcr.io//cache")),
+								sht.StageStep(sht.StepCmd("jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:${VERSION}"),
+									sht.StepDir("/workspace/source"), sht.StepImage("nodejs"), sht.StepName("build-post-build")),
+								sht.StageStep(sht.StepCmd("jx step changelog --batch-mode --version v${VERSION}"),
+									sht.StepDir("/workspace/source/charts/js-test-repo"), sht.StepImage("nodejs"),
+									sht.StepName("promote-changelog")),
+								sht.StageStep(sht.StepCmd("jx step helm release"), sht.StepDir("/workspace/source/charts/js-test-repo"),
+									sht.StepImage("nodejs"), sht.StepName("promote-helm-release")),
+								sht.StageStep(sht.StepCmd("jx promote -b --all-auto --timeout 1h --version ${VERSION}"),
+									sht.StepDir("/workspace/source/charts/js-test-repo"),
+									sht.StepImage("nodejs"), sht.StepName("promote-jx-promote")),
+							),
+						),
+						SetVersion: &jenkinsfile.PipelineLifecycle{
+							Steps: []*jxsyntax.Step{{
+								Image: "nodejs",
+								Steps: []*jxsyntax.Step{{
+									Comment: "so we can retrieve the version in later steps",
+									Name:    "next-version",
+									Sh:      "echo \\$(jx-release-version) > VERSION",
+									Steps:   []*jxsyntax.Step{},
+								}, {
+									Name:  "tag-version",
+									Sh:    "jx step tag --version \\$(cat VERSION)",
+									Steps: []*jxsyntax.Step{},
+								}},
+							}},
+							PreSteps: []*jxsyntax.Step{},
+						},
+					},
+				},
+			},
+		},
+	}, {
 		name:         "js_build_pack",
 		pack:         "javascript",
 		repoName:     "js-test-repo",
@@ -372,7 +509,6 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
 									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
 									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
-									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
 									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
 									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
@@ -424,7 +560,6 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
 									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
 									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
-									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
 									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
 									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
@@ -578,6 +713,7 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 
 			createCanonical := &syntax.StepSyntaxEffectiveOptions{
 				Pack:         tt.pack,
+				CustomEnvs:   tt.customEnvs,
 				DefaultImage: "maven",
 				KanikoImage:  "gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6",
 				UseKaniko:    true,
@@ -610,6 +746,61 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRemoveDuplicateEnv(t *testing.T) {
+	t.Parallel()
+
+	env := []corev1.EnvVar{
+		{
+			Name:  "FRUIT",
+			Value: "banana",
+		},
+		{
+			Name:  "DOCKER_REGISTRY",
+			Value: "gcr.io",
+		},
+		{
+			Name:  "A",
+			Value: "1",
+		},
+		{
+			Name:  "DOCKER_REGISTRY",
+			Value: "gcr.io",
+		},
+		{
+			Name:  "B",
+			Value: "2",
+		},
+		{
+			Name:  "DOCKER_REGISTRY",
+			Value: "gcr.io",
+		},
+		{
+			Name:  "FRUIT",
+			Value: "banana",
+		},
+	}
+	actual := syntax.RemoveDuplicateEnvVars(env)
+	expected := []corev1.EnvVar{
+		{
+			Name:  "A",
+			Value: "1",
+		},
+		{
+			Name:  "B",
+			Value: "2",
+		},
+		{
+			Name:  "DOCKER_REGISTRY",
+			Value: "gcr.io",
+		},
+		{
+			Name:  "FRUIT",
+			Value: "banana",
+		},
+	}
+	assert.Equal(t, expected, actual, "remove duplicates failed")
 }
 
 func assertLoadPodTemplates(t *testing.T) map[string]*corev1.Pod {


### PR DESCRIPTION
if we pass in custom env vars when creating an effective pipeline we should remove any inherited env vars of the same name from the build pack to avoid creating invalid combined env var definitions in the pods which tekton + k8s cannot instantiate

fixes #6313

Signed-off-by: James Strachan <james.strachan@gmail.com>