### PR TITLE
fix: override env vars from build pack if passed in

### DIFF
--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
@@ -33,17 +33,15 @@ items:
       command:
       - jx
       env:
-      - name: FRUIT
-        value: BANANA
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
+      - name: FRUIT
+        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -52,6 +50,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
@@ -33,17 +33,15 @@ items:
       command:
       - jx
       env:
-      - name: FRUIT
-        value: BANANA
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
+      - name: FRUIT
+        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -52,6 +50,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
@@ -33,17 +33,15 @@ items:
       command:
       - jx
       env:
-      - name: FRUIT
-        value: BANANA
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
+      - name: FRUIT
+        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -52,6 +50,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
@@ -33,15 +33,13 @@ items:
       command:
       - jx
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -50,6 +48,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: BUILD_NUMBER

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/jenkins-x.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/jenkins-x.yml
@@ -1,0 +1,1 @@
+buildPack: javascript

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipeline.yml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: build-pack
+    build: "1"
+    owner: abayer
+    jenkins.io/pipelineType: build
+    repository: js-test-repo
+  name: abayer-js-test-repo-build-pack-1
+  namespace: jx
+spec:
+  params:
+  - default: 0.0.1
+    description: the version number for this pipeline which is used as a tag on docker
+      images and helm charts
+    name: version
+  resources:
+  - name: abayer-js-test-repo-build-pack
+    type: git
+  tasks:
+  - name: from-build-pack
+    params:
+    - name: version
+      value: ${params.version}
+    resources:
+      inputs:
+      - name: workspace
+        resource: abayer-js-test-repo-build-pack
+    taskRef:
+      name: abayer-js-test-repo-build-pack-from-build-pack-1
+status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipelineresources.yml
@@ -1,0 +1,15 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    creationTimestamp: null
+    name: abayer-js-test-repo-build-pack
+  spec:
+    params:
+    - name: revision
+      value: v0.0.1
+    - name: url
+      value: https://github.com/abayer/js-test-repo
+    type: git
+  status: {}
+metadata: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/pipelinerun.yml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: build-pack
+    build: "1"
+    owner: abayer
+    jenkins.io/pipelineType: build
+    repository: js-test-repo
+  name: abayer-js-test-repo-build-pack-1
+spec:
+  params:
+  - name: version
+    value: 0.0.1
+  pipelineRef:
+    apiVersion: tekton.dev/v1alpha1
+    name: abayer-js-test-repo-build-pack-1
+  resources:
+  - name: abayer-js-test-repo-build-pack
+    resourceRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: abayer-js-test-repo-build-pack
+  serviceAccount: tekton-bot
+  timeout: 240h0m0s
+status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/structure.yml
@@ -1,0 +1,15 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    branch: build-pack
+    build: "1"
+    owner: abayer
+    jenkins.io/pipelineType: build
+    repository: js-test-repo
+  name: abayer-js-test-repo-build-pack-1
+pipelineRef: null
+pipelineRunRef: null
+stages:
+- depth: 0
+  name: from-build-pack
+  taskRef: abayer-js-test-repo-build-pack-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/tasks.yml
@@ -1,0 +1,625 @@
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    creationTimestamp: null
+    labels:
+      branch: build-pack
+      build: "1"
+      jenkins.io/task-stage-name: from-build-pack
+      owner: abayer
+      jenkins.io/pipelineType: build
+      repository: js-test-repo
+    name: abayer-js-test-repo-build-pack-from-build-pack-1
+    namespace: jx
+  spec:
+    inputs:
+      params:
+      - default: 0.0.1
+        description: the version number for this pipeline which is used as a tag on
+          docker images and helm charts
+        name: version
+      resources:
+      - name: workspace
+        outputImageDir: ""
+        targetPath: source
+        type: git
+    steps:
+    - args:
+      - step
+      - git
+      - merge
+      - --verbose
+      command:
+      - jx
+      env:
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/jenkinsxio/builder-jx:0.1.527
+      name: git-merge
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - jx step git credentials
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: setup-jx-git-credentials
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - npm install
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: build-npm-install
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - CI=true DISPLAY=:99 npm test
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: build-npm-test
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - /kaniko/executor --cache=true --cache-dir=/workspace --context=/workspace/source --dockerfile=/workspace/source/Dockerfile --destination=gcr.io/abayer/js-test-repo:${inputs.params.version} --cache-repo=gcr.io//cache
+      command:
+      - /busybox/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /kaniko-secret/secret.json
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: gcr.io/kaniko-project/executor:debug-9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+      name: build-container-build
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:${VERSION}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: build-post-build
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - cd /workspace/source/charts/js-test-repo && jx step changelog --batch-mode
+        --version v${VERSION}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: promote-changelog
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - cd /workspace/source/charts/js-test-repo && jx step helm release
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: promote-helm-release
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    - args:
+      - cd /workspace/source/charts/js-test-repo && jx promote -b --all-auto --timeout
+        1h --version ${VERSION}
+      command:
+      - /bin/sh
+      - -c
+      env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
+      - name: DOCKER_REGISTRY
+        valueFrom:
+          configMapKeyRef:
+            key: docker.registry
+            name: jenkins-x-docker-registry
+      - name: GIT_AUTHOR_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_AUTHOR_NAME
+        value: jenkins-x-bot
+      - name: GIT_COMMITTER_EMAIL
+        value: jenkins-x@googlegroups.com
+      - name: GIT_COMMITTER_NAME
+        value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
+      - name: XDG_CONFIG_HOME
+        value: /workspace/xdg_config
+      - name: BUILD_NUMBER
+        value: "1"
+      - name: PIPELINE_KIND
+        value: release
+      - name: REPO_OWNER
+        value: abayer
+      - name: REPO_NAME
+        value: js-test-repo
+      - name: JOB_NAME
+        value: abayer/js-test-repo/build-pack
+      - name: APP_NAME
+        value: js-test-repo
+      - name: BRANCH_NAME
+        value: build-pack
+      - name: JX_BATCH_MODE
+        value: "true"
+      - name: VERSION
+        value: ${inputs.params.version}
+      - name: PREVIEW_VERSION
+        value: ${inputs.params.version}
+      image: jenkinsxio/builder-nodejs:0.1.235
+      name: promote-jx-promote
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/jenkins
+        name: workspace-volume
+      - mountPath: /var/run/docker.sock
+        name: docker-daemon
+      - mountPath: /home/jenkins/.docker
+        name: volume-0
+      - mountPath: /etc/podinfo
+        name: podinfo
+        readOnly: true
+      workingDir: /workspace/source
+    volumes:
+    - hostPath:
+        path: /var/run/docker.sock
+      name: docker-daemon
+    - name: volume-0
+      secret:
+        secretName: jenkins-docker-cfg
+    - emptyDir: {}
+      name: workspace-volume
+    - downwardAPI:
+        items:
+        - fieldRef:
+            fieldPath: metadata.labels
+          path: labels
+      name: podinfo
+metadata: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
@@ -33,17 +33,15 @@ items:
       command:
       - jx
       env:
-      - name: FRUIT
-        value: BANANA
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
+      - name: FRUIT
+        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -52,6 +50,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
@@ -33,17 +33,15 @@ items:
       command:
       - jx
       env:
-      - name: FRUIT
-        value: BANANA
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
+      - name: FRUIT
+        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -52,6 +50,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
@@ -33,15 +33,13 @@ items:
       command:
       - jx
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -50,6 +48,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: BUILD_NUMBER

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
@@ -33,17 +33,15 @@ items:
       command:
       - jx
       env:
-      - name: FRUIT
-        value: BANANA
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
+      - name: FRUIT
+        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -52,6 +50,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
@@ -33,15 +33,13 @@ items:
       command:
       - jx
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -50,6 +48,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: BUILD_NUMBER

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
@@ -33,15 +33,13 @@ items:
       command:
       - jx
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -50,6 +48,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: BUILD_NUMBER

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
@@ -33,17 +33,15 @@ items:
       command:
       - jx
       env:
-      - name: FRUIT
-        value: BANANA
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
+      - name: FRUIT
+        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -52,6 +50,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
@@ -33,17 +33,15 @@ items:
       command:
       - jx
       env:
-      - name: FRUIT
-        value: BANANA
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
+      - name: FRUIT
+        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -52,6 +50,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
@@ -33,15 +33,13 @@ items:
       command:
       - jx
       env:
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -50,6 +48,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: BUILD_NUMBER

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
@@ -33,17 +33,15 @@ items:
       command:
       - jx
       env:
-      - name: FRUIT
-        value: BANANA
+      - name: DOCKER_CONFIG
+        value: /home/jenkins/.docker/
       - name: DOCKER_REGISTRY
         valueFrom:
           configMapKeyRef:
             key: docker.registry
             name: jenkins-x-docker-registry
-      - name: TILLER_NAMESPACE
-        value: kube-system
-      - name: DOCKER_CONFIG
-        value: /home/jenkins/.docker/
+      - name: FRUIT
+        value: BANANA
       - name: GIT_AUTHOR_EMAIL
         value: jenkins-x@googlegroups.com
       - name: GIT_AUTHOR_NAME
@@ -52,6 +50,8 @@ items:
         value: jenkins-x@googlegroups.com
       - name: GIT_COMMITTER_NAME
         value: jenkins-x-bot
+      - name: TILLER_NAMESPACE
+        value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS

--- a/pkg/cmd/step/syntax/step_syntax_effective.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective.go
@@ -449,12 +449,8 @@ func (o *StepSyntaxEffectiveOptions) createPipelineForKind(kind string, lifecycl
 	}
 
 	// lets override any container options env vars from any custom injected env vars from the metapipeline client
-	for _, e := range pipelineConfig.Env {
-		for i, e2 := range parsed.Options.ContainerOptions.Env {
-			if e.Name == e2.Name {
-				parsed.Options.ContainerOptions.Env[i] = e
-			}
-		}
+	if parsed != nil && parsed.Options != nil && parsed.Options.ContainerOptions != nil {
+		parsed.Options.ContainerOptions.Env = syntax.ScopedEnv(pipelineConfig.Env, parsed.Options.ContainerOptions.Env)
 	}
 	return parsed, nil
 }

--- a/pkg/cmd/step/syntax/step_syntax_effective.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective.go
@@ -448,6 +448,14 @@ func (o *StepSyntaxEffectiveOptions) createPipelineForKind(kind string, lifecycl
 		return nil, errors.Wrapf(validateErr, "validation failed for Pipeline")
 	}
 
+	// lets override any container options env vars from any custom injected env vars from the metapipeline client
+	for _, e := range pipelineConfig.Env {
+		for i, e2 := range parsed.Options.ContainerOptions.Env {
+			if e.Name == e2.Name {
+				parsed.Options.ContainerOptions.Env[i] = e
+			}
+		}
+	}
 	return parsed, nil
 }
 

--- a/pkg/cmd/step/syntax/step_syntax_effective.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective.go
@@ -450,7 +450,7 @@ func (o *StepSyntaxEffectiveOptions) createPipelineForKind(kind string, lifecycl
 
 	// lets override any container options env vars from any custom injected env vars from the metapipeline client
 	if parsed != nil && parsed.Options != nil && parsed.Options.ContainerOptions != nil {
-		parsed.Options.ContainerOptions.Env = syntax.ScopedEnv(pipelineConfig.Env, parsed.Options.ContainerOptions.Env)
+		parsed.Options.ContainerOptions.Env = syntax.CombineEnv(pipelineConfig.Env, parsed.Options.ContainerOptions.Env)
 	}
 	return parsed, nil
 }

--- a/pkg/cmd/step/syntax/step_syntax_effective_test.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective_test.go
@@ -69,8 +69,147 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 		repoName     string
 		organization string
 		branch       string
+		customEnvs   []string
 		expected     *config.ProjectConfig
 	}{{
+		name:         "js_build_pack_with_yaml",
+		pack:         "javascript",
+		repoName:     "js-test-repo",
+		organization: "abayer",
+		branch:       "build-pack",
+		customEnvs:   []string{"DOCKER_REGISTRY=gcr.io"},
+		expected: &config.ProjectConfig{
+			BuildPack: "javascript",
+			PipelineConfig: &jenkinsfile.PipelineConfig{
+				Agent: &jxsyntax.Agent{
+					Container: "nodejs",
+					Label:     "jenkins-nodejs",
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "DOCKER_REGISTRY",
+						Value: "gcr.io",
+					},
+				},
+				Extends: &jenkinsfile.PipelineExtends{
+					File:   "javascript/pipeline.yaml",
+					Import: "classic",
+				},
+				Pipelines: jenkinsfile.Pipelines{
+					Post: &jenkinsfile.PipelineLifecycle{
+						Steps:    []*jxsyntax.Step{},
+						PreSteps: []*jxsyntax.Step{},
+					},
+					PullRequest: &jenkinsfile.PipelineLifecycles{
+						Pipeline: sht.ParsedPipeline(
+							sht.PipelineEnvVar("DOCKER_REGISTRY", "gcr.io"),
+							sht.PipelineOptions(
+								sht.PipelineContainerOptions(
+									sht.ContainerResourceRequests("400m", "512Mi"),
+									sht.EnvVar("DOCKER_REGISTRY", "gcr.io"),
+									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
+									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
+									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
+									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
+									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
+									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
+									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
+									tb.EnvVar("XDG_CONFIG_HOME", "/home/jenkins"),
+									sht.ContainerSecurityContext(true),
+									tb.VolumeMount("workspace-volume", "/home/jenkins"),
+									tb.VolumeMount("docker-daemon", "/var/run/docker.sock"),
+									tb.VolumeMount("volume-0", "/home/jenkins/.docker"),
+								),
+							),
+							sht.PipelineStage("from-build-pack",
+								sht.StageAgent("nodejs"),
+								sht.StageStep(sht.StepCmd("npm install"), sht.StepDir("/workspace/source"),
+									sht.StepImage("nodejs"), sht.StepName("build-npm-install")),
+								sht.StageStep(sht.StepCmd("CI=true DISPLAY=:99 npm test"), sht.StepDir("/workspace/source"),
+									sht.StepImage("nodejs"), sht.StepName("build-step3")),
+								sht.StageStep(sht.StepCmd("/kaniko/executor"), sht.StepDir("/workspace/source"),
+									sht.StepImage(jxsyntax.KanikoDockerImage), sht.StepName("build-container-build"),
+									sht.StepArg("--cache=true"), sht.StepArg("--cache-dir=/workspace"),
+									sht.StepArg("--context=/workspace/source"), sht.StepArg("--dockerfile=/workspace/source/Dockerfile"),
+									sht.StepArg("--destination=gcr.io/abayer/js-test-repo:${inputs.params.version}"),
+									sht.StepArg("--cache-repo=gcr.io//cache")),
+								sht.StageStep(sht.StepCmd("jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"),
+									sht.StepDir("/workspace/source"), sht.StepImage("nodejs"), sht.StepName("postbuild-post-build")),
+								sht.StageStep(sht.StepCmd("make preview"), sht.StepDir("/workspace/source/charts/preview"),
+									sht.StepImage("nodejs"), sht.StepName("promote-make-preview")),
+								sht.StageStep(sht.StepCmd("jx preview --app $APP_NAME --dir ../.."), sht.StepDir("/workspace/source/charts/preview"),
+									sht.StepImage("nodejs"), sht.StepName("promote-jx-preview")),
+							),
+						),
+					},
+					Release: &jenkinsfile.PipelineLifecycles{
+						Pipeline: sht.ParsedPipeline(
+							sht.PipelineEnvVar("DOCKER_REGISTRY", "gcr.io"),
+							sht.PipelineOptions(
+								sht.PipelineContainerOptions(
+									sht.ContainerResourceRequests("400m", "512Mi"),
+									sht.EnvVar("DOCKER_REGISTRY", "gcr.io"),
+									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
+									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
+									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
+									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
+									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
+									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
+									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
+									tb.EnvVar("XDG_CONFIG_HOME", "/home/jenkins"),
+									sht.ContainerSecurityContext(true),
+									tb.VolumeMount("workspace-volume", "/home/jenkins"),
+									tb.VolumeMount("docker-daemon", "/var/run/docker.sock"),
+									tb.VolumeMount("volume-0", "/home/jenkins/.docker"),
+								),
+							),
+							sht.PipelineStage("from-build-pack",
+								sht.StageAgent("nodejs"),
+								sht.StageStep(sht.StepCmd("jx step git credentials"), sht.StepDir("/workspace/source"),
+									sht.StepImage("nodejs"), sht.StepName("setup-jx-git-credentials")),
+								sht.StageStep(sht.StepCmd("npm install"), sht.StepDir("/workspace/source"),
+									sht.StepImage("nodejs"), sht.StepName("build-npm-install")),
+								sht.StageStep(sht.StepCmd("CI=true DISPLAY=:99 npm test"), sht.StepDir("/workspace/source"),
+									sht.StepImage("nodejs"), sht.StepName("build-npm-test")),
+								sht.StageStep(sht.StepCmd("/kaniko/executor"), sht.StepDir("/workspace/source"),
+									sht.StepImage(jxsyntax.KanikoDockerImage), sht.StepName("build-container-build"),
+									sht.StepArg("--cache=true"), sht.StepArg("--cache-dir=/workspace"),
+									sht.StepArg("--context=/workspace/source"), sht.StepArg("--dockerfile=/workspace/source/Dockerfile"),
+									sht.StepArg("--destination=gcr.io/abayer/js-test-repo:${inputs.params.version}"),
+									sht.StepArg("--cache-repo=gcr.io//cache")),
+								sht.StageStep(sht.StepCmd("jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:${VERSION}"),
+									sht.StepDir("/workspace/source"), sht.StepImage("nodejs"), sht.StepName("build-post-build")),
+								sht.StageStep(sht.StepCmd("jx step changelog --batch-mode --version v${VERSION}"),
+									sht.StepDir("/workspace/source/charts/js-test-repo"), sht.StepImage("nodejs"),
+									sht.StepName("promote-changelog")),
+								sht.StageStep(sht.StepCmd("jx step helm release"), sht.StepDir("/workspace/source/charts/js-test-repo"),
+									sht.StepImage("nodejs"), sht.StepName("promote-helm-release")),
+								sht.StageStep(sht.StepCmd("jx promote -b --all-auto --timeout 1h --version ${VERSION}"),
+									sht.StepDir("/workspace/source/charts/js-test-repo"),
+									sht.StepImage("nodejs"), sht.StepName("promote-jx-promote")),
+							),
+						),
+						SetVersion: &jenkinsfile.PipelineLifecycle{
+							Steps: []*jxsyntax.Step{{
+								Image: "nodejs",
+								Steps: []*jxsyntax.Step{{
+									Comment: "so we can retrieve the version in later steps",
+									Name:    "next-version",
+									Sh:      "echo \\$(jx-release-version) > VERSION",
+									Steps:   []*jxsyntax.Step{},
+								}, {
+									Name:  "tag-version",
+									Sh:    "jx step tag --version \\$(cat VERSION)",
+									Steps: []*jxsyntax.Step{},
+								}},
+							}},
+							PreSteps: []*jxsyntax.Step{},
+						},
+					},
+				},
+			},
+		},
+	}, /*{
 		name:         "js_build_pack",
 		pack:         "javascript",
 		repoName:     "js-test-repo",
@@ -541,7 +680,7 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 				},
 			},
 		},
-	}}
+	}*/}
 
 	k8sObjects := []runtime.Object{
 		&corev1.ConfigMap{
@@ -578,6 +717,7 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 
 			createCanonical := &syntax.StepSyntaxEffectiveOptions{
 				Pack:         tt.pack,
+				CustomEnvs:   tt.customEnvs,
 				DefaultImage: "maven",
 				KanikoImage:  "gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6",
 				UseKaniko:    true,

--- a/pkg/cmd/step/syntax/step_syntax_effective_test.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective_test.go
@@ -209,7 +209,7 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 				},
 			},
 		},
-	}, /*{
+	}, {
 		name:         "js_build_pack",
 		pack:         "javascript",
 		repoName:     "js-test-repo",
@@ -680,7 +680,7 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 				},
 			},
 		},
-	}*/}
+	}}
 
 	k8sObjects := []runtime.Object{
 		&corev1.ConfigMap{

--- a/pkg/cmd/step/syntax/step_syntax_effective_test.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective_test.go
@@ -106,14 +106,14 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 							sht.PipelineOptions(
 								sht.PipelineContainerOptions(
 									sht.ContainerResourceRequests("400m", "512Mi"),
-									sht.EnvVar("DOCKER_REGISTRY", "gcr.io"),
-									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
 									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
+									sht.EnvVar("DOCKER_REGISTRY", "gcr.io"),
 									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
 									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
 									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
+									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
 									tb.EnvVar("XDG_CONFIG_HOME", "/home/jenkins"),
 									sht.ContainerSecurityContext(true),
 									tb.VolumeMount("workspace-volume", "/home/jenkins"),
@@ -148,14 +148,14 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 							sht.PipelineOptions(
 								sht.PipelineContainerOptions(
 									sht.ContainerResourceRequests("400m", "512Mi"),
-									sht.EnvVar("DOCKER_REGISTRY", "gcr.io"),
-									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
 									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
+									sht.EnvVar("DOCKER_REGISTRY", "gcr.io"),
 									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
 									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
 									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
+									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
 									tb.EnvVar("XDG_CONFIG_HOME", "/home/jenkins"),
 									sht.ContainerSecurityContext(true),
 									tb.VolumeMount("workspace-volume", "/home/jenkins"),
@@ -236,19 +236,19 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 							sht.PipelineOptions(
 								sht.PipelineContainerOptions(
 									sht.ContainerResourceRequests("400m", "512Mi"),
+									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
 									sht.EnvVarFrom("DOCKER_REGISTRY", &corev1.EnvVarSource{
 										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 											Key: "docker.registry",
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "jenkins-x-docker-registry",
 											}}}),
-									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
-									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
 									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
 									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
 									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
+									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
 									tb.EnvVar("XDG_CONFIG_HOME", "/home/jenkins"),
 									sht.ContainerSecurityContext(true),
 									tb.VolumeMount("workspace-volume", "/home/jenkins"),
@@ -282,19 +282,19 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 							sht.PipelineOptions(
 								sht.PipelineContainerOptions(
 									sht.ContainerResourceRequests("400m", "512Mi"),
+									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
 									sht.EnvVarFrom("DOCKER_REGISTRY", &corev1.EnvVarSource{
 										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 											Key: "docker.registry",
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "jenkins-x-docker-registry",
 											}}}),
-									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
-									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
 									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
 									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
 									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
+									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
 									tb.EnvVar("XDG_CONFIG_HOME", "/home/jenkins"),
 									sht.ContainerSecurityContext(true),
 									tb.VolumeMount("workspace-volume", "/home/jenkins"),
@@ -502,19 +502,20 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 							sht.PipelineEnvVar("GIT_AUTHOR_NAME", "somebodyelse"),
 							sht.PipelineOptions(
 								sht.PipelineContainerOptions(
+									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
 									sht.EnvVarFrom("DOCKER_REGISTRY", &corev1.EnvVarSource{
 										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 											Key: "docker.registry",
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "jenkins-x-docker-registry",
 											}}}),
-									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
-									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
+									tb.EnvVar("FRUIT", "BANANA"),
 									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
-									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
+									tb.EnvVar("GIT_AUTHOR_NAME", "somebodyelse"),
 									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
 									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
+									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
 									tb.EnvVar("XDG_CONFIG_HOME", "/home/jenkins"),
 									tb.EnvVar("_JAVA_OPTIONS", "-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m"),
 									sht.ContainerSecurityContext(true),
@@ -554,19 +555,20 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 							sht.PipelineEnvVar("GIT_AUTHOR_NAME", "somebodyelse"),
 							sht.PipelineOptions(
 								sht.PipelineContainerOptions(
+									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
 									sht.EnvVarFrom("DOCKER_REGISTRY", &corev1.EnvVarSource{
 										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 											Key: "docker.registry",
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "jenkins-x-docker-registry",
 											}}}),
-									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
-									tb.EnvVar("DOCKER_CONFIG", "/home/jenkins/.docker/"),
+									tb.EnvVar("FRUIT", "BANANA"),
 									tb.EnvVar("GIT_AUTHOR_EMAIL", "jenkins-x@googlegroups.com"),
-									tb.EnvVar("GIT_AUTHOR_NAME", "jenkins-x-bot"),
+									tb.EnvVar("GIT_AUTHOR_NAME", "somebodyelse"),
 									tb.EnvVar("GIT_COMMITTER_EMAIL", "jenkins-x@googlegroups.com"),
 									tb.EnvVar("GIT_COMMITTER_NAME", "jenkins-x-bot"),
 									tb.EnvVar("JENKINS_URL", "http://jenkins:8080"),
+									tb.EnvVar("TILLER_NAMESPACE", "kube-system"),
 									tb.EnvVar("XDG_CONFIG_HOME", "/home/jenkins"),
 									tb.EnvVar("_JAVA_OPTIONS", "-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m"),
 									sht.ContainerSecurityContext(true),

--- a/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
+++ b/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
@@ -279,6 +279,16 @@ func EnvVarFrom(name string, source *corev1.EnvVarSource) builder.ContainerOp {
 	}
 }
 
+// EnvVar adds an environment variable with a value to the container options
+func EnvVar(name string, value string) builder.ContainerOp {
+	return func(container *corev1.Container) {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+}
+
 // PipelineOptionsTimeout sets the timeout for the pipeline
 func PipelineOptionsTimeout(time int64, unit syntax.TimeoutUnit) PipelineOptionsOp {
 	return func(options *syntax.RootOptions) {


### PR DESCRIPTION
if we pass in custom env vars when creating an effective pipeline we should override any inherited env vars of the same name from the build pack to avoid creating invalid combined env var definitions in the pods which tekton + k8s cannot instantiate

fixes #6313

Signed-off-by: James Strachan <james.strachan@gmail.com>