### PR TITLE
fix: Make pipeline CRD names always have the unique suffix

### DIFF
--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -303,8 +303,8 @@ func (o *StepCreateTaskOptions) Run() error {
 	}
 
 	// resourceName is shared across all builds of a branch, while the pipelineName is unique for each build.
-	resourceName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline.String(), nil, "")
-	pipelineName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline.String(), tektonClient, ns)
+	resourceName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline.String(), false)
+	pipelineName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline.String(), true)
 
 	exists, err = o.effectiveProjectConfigExists()
 	if err != nil {

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-dfq8f-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-golang-qs-test-master
     taskRef:
-      name: abayer-golang-qs-test-master-from-build-pack-1
+      name: abayer-golang-qs-test-master-dfq8f-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-dfq8f-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-golang-qs-test-master-1
+    name: abayer-golang-qs-test-master-dfq8f-1
   resources:
   - name: abayer-golang-qs-test-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-dfq8f-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-golang-qs-test-master-from-build-pack-1
+  taskRef: abayer-golang-qs-test-master-dfq8f-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: golang-qs-test
-    name: abayer-golang-qs-test-master-from-build-pack-1
+    name: abayer-golang-qs-test-master-dfq8f-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-h42ks-1
   namespace: jx
 spec:
   params:
@@ -32,7 +32,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-h42ks-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -46,5 +46,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-h42ks-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-h42ks-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-h42ks-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-h42ks-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-h42ks-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-h42ks-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-h42ks-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -237,11 +237,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-h42ks-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-tbl2p-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-jx-demo-qs-master
     taskRef:
-      name: abayer-jx-demo-qs-master-from-build-pack-1
+      name: abayer-jx-demo-qs-master-tbl2p-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-tbl2p-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-jx-demo-qs-master-1
+    name: abayer-jx-demo-qs-master-tbl2p-1
   resources:
   - name: abayer-jx-demo-qs-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-tbl2p-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master-from-build-pack-1
+  taskRef: abayer-jx-demo-qs-master-tbl2p-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: jx-demo-qs
-    name: abayer-jx-demo-qs-master-from-build-pack-1
+    name: abayer-jx-demo-qs-master-tbl2p-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-vt9mj-1
   namespace: jx
 spec:
   params:
@@ -33,7 +33,7 @@ spec:
         resource: abayer-js-test-repo-really-long
     retries: 5
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-vt9mj-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -47,5 +47,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-vt9mj-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-vt9mj-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-vt9mj-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-vt9mj-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-vt9mj-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-vt9mj-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-vt9mj-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -173,11 +173,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-vt9mj-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-b5j7r-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-jx-demo-qs-master
     taskRef:
-      name: abayer-jx-demo-qs-master-from-build-pack-1
+      name: abayer-jx-demo-qs-master-b5j7r-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-b5j7r-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-jx-demo-qs-master-1
+    name: abayer-jx-demo-qs-master-b5j7r-1
   resources:
   - name: abayer-jx-demo-qs-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-b5j7r-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master-from-build-pack-1
+  taskRef: abayer-jx-demo-qs-master-b5j7r-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: jx-demo-qs
-    name: abayer-jx-demo-qs-master-from-build-pack-1
+    name: abayer-jx-demo-qs-master-b5j7r-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-hvpvf-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-jx-demo-qs-master
     taskRef:
-      name: abayer-jx-demo-qs-master-from-build-pack-1
+      name: abayer-jx-demo-qs-master-hvpvf-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-hvpvf-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-jx-demo-qs-master-1
+    name: abayer-jx-demo-qs-master-hvpvf-1
   resources:
   - name: abayer-jx-demo-qs-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-hvpvf-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master-from-build-pack-1
+  taskRef: abayer-jx-demo-qs-master-hvpvf-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: jx-demo-qs
-    name: abayer-jx-demo-qs-master-from-build-pack-1
+    name: abayer-jx-demo-qs-master-hvpvf-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-fzfnf-1
   namespace: jx
 spec:
   params:
@@ -32,7 +32,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-fzfnf-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -46,5 +46,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-fzfnf-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-fzfnf-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-fzfnf-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-fzfnf-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-fzfnf-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-fzfnf-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-fzfnf-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -237,11 +237,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-fzfnf-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-sn8zf-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-golang-qs-test-master
     taskRef:
-      name: abayer-golang-qs-test-master-from-build-pack-1
+      name: abayer-golang-qs-test-master-sn8zf-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-sn8zf-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-golang-qs-test-master-1
+    name: abayer-golang-qs-test-master-sn8zf-1
   resources:
   - name: abayer-golang-qs-test-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-sn8zf-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-golang-qs-test-master-from-build-pack-1
+  taskRef: abayer-golang-qs-test-master-sn8zf-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: golang-qs-test
-    name: abayer-golang-qs-test-master-from-build-pack-1
+    name: abayer-golang-qs-test-master-sn8zf-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-mjxbm-1
   namespace: jx
 spec:
   params:
@@ -32,7 +32,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-mjxbm-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -46,5 +46,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-mjxbm-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-mjxbm-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-mjxbm-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-mjxbm-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-mjxbm-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-mjxbm-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-mjxbm-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -237,11 +237,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-mjxbm-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-m97mw-1
   namespace: jx
 spec:
   params:
@@ -32,7 +32,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-m97mw-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -46,5 +46,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-m97mw-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipelinerun.yml
@@ -7,27 +7,27 @@ metadata:
     build: "1"
     foo: bar
     fruit: apple
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
     way-too-long-a-label-seriously-this-just-goes-on-for-so-many-ch: this-hasinvalidcharacters
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-m97mw-1
 spec:
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchLabels:
-              foo: bar
-              fruit: apple
-              way-too-long-a-label-seriously-this-just-goes-on-for-so-many-ch: this-hasinvalidcharacters
-          topologyKey: kubernetes.io/hostname
+      - labelSelector:
+          matchLabels:
+            foo: bar
+            fruit: apple
+            way-too-long-a-label-seriously-this-just-goes-on-for-so-many-ch: this-hasinvalidcharacters
+        topologyKey: kubernetes.io/hostname
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-m97mw-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-m97mw-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-m97mw-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-m97mw-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-m97mw-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -237,11 +237,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-m97mw-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-shnql-1
   namespace: jx
 spec:
   params:
@@ -32,7 +32,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-shnql-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -46,5 +46,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-shnql-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelinerun.yml
@@ -5,24 +5,24 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-shnql-1
 spec:
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchLabels:
-              tekton.dev/pipelineRun: abayer-js-test-repo-really-long-1
-          topologyKey: kubernetes.io/hostname
+      - labelSelector:
+          matchLabels:
+            tekton.dev/pipelineRun: abayer-js-test-repo-really-long-shnql-1
+        topologyKey: kubernetes.io/hostname
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-shnql-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-shnql-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-shnql-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-shnql-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-shnql-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -237,11 +237,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-shnql-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-mssqb-1
   namespace: jx
 spec:
   params:
@@ -32,7 +32,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-mssqb-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -46,5 +46,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-mssqb-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-mssqb-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-mssqb-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-mssqb-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-mssqb-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-mssqb-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-mssqb-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -237,11 +237,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-mssqb-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: build-pack
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-build-pack-1
+  name: abayer-js-test-repo-build-pack-9l9zj-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-build-pack
     taskRef:
-      name: abayer-js-test-repo-build-pack-from-build-pack-1
+      name: abayer-js-test-repo-build-pack-9l9zj-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: build-pack
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-build-pack-1
+  name: abayer-js-test-repo-build-pack-9l9zj-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-build-pack-1
+    name: abayer-js-test-repo-build-pack-9l9zj-1
   resources:
   - name: abayer-js-test-repo-build-pack
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: build-pack
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-build-pack-1
+  name: abayer-js-test-repo-build-pack-9l9zj-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-js-test-repo-build-pack-from-build-pack-1
+  taskRef: abayer-js-test-repo-build-pack-9l9zj-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: build-pack
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-build-pack-from-build-pack-1
+    name: abayer-js-test-repo-build-pack-9l9zj-from-build-pack-1
     namespace: jx
   spec:
     inputs:
@@ -284,7 +284,9 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - /kaniko/executor --cache=true --cache-dir=/workspace --context=/workspace/source --dockerfile=/workspace/source/Dockerfile --destination=gcr.io/abayer/js-test-repo:${inputs.params.version} --cache-repo=gcr.io//cache
+      - /kaniko/executor --cache=true --cache-dir=/workspace --context=/workspace/source
+        --dockerfile=/workspace/source/Dockerfile --destination=gcr.io/abayer/js-test-repo:${inputs.params.version}
+        --cache-repo=gcr.io//cache
       command:
       - /busybox/sh
       - -c

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
@@ -8,7 +8,7 @@ metadata:
     jenkins.io/pipelineType: build
     owner: jenkins-x
     repository: jx
-  name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
+  name: jenkins-x-jx-fix-kaniko-special-6nl7g-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: jenkins-x-jx-fix-kaniko-special
     taskRef:
-      name: jenkins-x-jx-fix-kaniko-special-9l9zj-ci-1
+      name: jenkins-x-jx-fix-kaniko-special-6nl7g-ci-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
@@ -8,14 +8,14 @@ metadata:
     jenkins.io/pipelineType: build
     owner: jenkins-x
     repository: jx
-  name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
+  name: jenkins-x-jx-fix-kaniko-special-6nl7g-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
+    name: jenkins-x-jx-fix-kaniko-special-6nl7g-1
   resources:
   - name: jenkins-x-jx-fix-kaniko-special
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/structure.yml
@@ -6,10 +6,10 @@ metadata:
     jenkins.io/pipelineType: build
     owner: jenkins-x
     repository: jx
-  name: jenkins-x-jx-fix-kaniko-special-9l9zj-1
+  name: jenkins-x-jx-fix-kaniko-special-6nl7g-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: ci
-  taskRef: jenkins-x-jx-fix-kaniko-special-9l9zj-ci-1
+  taskRef: jenkins-x-jx-fix-kaniko-special-6nl7g-ci-1

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
@@ -10,7 +10,7 @@ items:
       jenkins.io/task-stage-name: ci
       owner: jenkins-x
       repository: jx
-    name: jenkins-x-jx-fix-kaniko-special-9l9zj-ci-1
+    name: jenkins-x-jx-fix-kaniko-special-6nl7g-ci-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-mnq6l-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-jx-demo-qs-master
     taskRef:
-      name: abayer-jx-demo-qs-master-from-build-pack-1
+      name: abayer-jx-demo-qs-master-mnq6l-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-mnq6l-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-jx-demo-qs-master-1
+    name: abayer-jx-demo-qs-master-mnq6l-1
   resources:
   - name: abayer-jx-demo-qs-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-mnq6l-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master-from-build-pack-1
+  taskRef: abayer-jx-demo-qs-master-mnq6l-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: jx-demo-qs
-    name: abayer-jx-demo-qs-master-from-build-pack-1
+    name: abayer-jx-demo-qs-master-mnq6l-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-mz4c7-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-jx-demo-qs-master
     taskRef:
-      name: abayer-jx-demo-qs-master-from-build-pack-1
+      name: abayer-jx-demo-qs-master-mz4c7-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-mz4c7-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-jx-demo-qs-master-1
+    name: abayer-jx-demo-qs-master-mz4c7-1
   resources:
   - name: abayer-jx-demo-qs-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-mz4c7-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master-from-build-pack-1
+  taskRef: abayer-jx-demo-qs-master-mz4c7-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: jx-demo-qs
-    name: abayer-jx-demo-qs-master-from-build-pack-1
+    name: abayer-jx-demo-qs-master-mz4c7-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: override-default-agent
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-override-de-1
+  name: abayer-js-test-repo-override-de-vr6ds-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-override-de
     taskRef:
-      name: abayer-js-test-repo-override-de-from-build-pack-1
+      name: abayer-js-test-repo-override-de-vr6ds-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: override-default-agent
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-override-de-1
+  name: abayer-js-test-repo-override-de-vr6ds-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-override-de-1
+    name: abayer-js-test-repo-override-de-vr6ds-1
   resources:
   - name: abayer-js-test-repo-override-de
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: override-default-agent
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-override-de-1
+  name: abayer-js-test-repo-override-de-vr6ds-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-js-test-repo-override-de-from-build-pack-1
+  taskRef: abayer-js-test-repo-override-de-vr6ds-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: override-default-agent
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-override-de-from-build-pack-1
+    name: abayer-js-test-repo-override-de-vr6ds-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-klrgx-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-golang-qs-test-master
     taskRef:
-      name: abayer-golang-qs-test-master-from-build-pack-1
+      name: abayer-golang-qs-test-master-klrgx-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-klrgx-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-golang-qs-test-master-1
+    name: abayer-golang-qs-test-master-klrgx-1
   resources:
   - name: abayer-golang-qs-test-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-klrgx-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-golang-qs-test-master-from-build-pack-1
+  taskRef: abayer-golang-qs-test-master-klrgx-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: golang-qs-test
-    name: abayer-golang-qs-test-master-from-build-pack-1
+    name: abayer-golang-qs-test-master-klrgx-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-kbptp-1
   namespace: jx
 spec:
   params:
@@ -32,7 +32,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-kbptp-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -46,5 +46,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-kbptp-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-kbptp-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-kbptp-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-kbptp-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-kbptp-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-kbptp-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-kbptp-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -237,11 +237,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-kbptp-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-l22wn-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-jx-demo-qs-master
     taskRef:
-      name: abayer-jx-demo-qs-master-from-build-pack-1
+      name: abayer-jx-demo-qs-master-l22wn-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-l22wn-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-jx-demo-qs-master-1
+    name: abayer-jx-demo-qs-master-l22wn-1
   resources:
   - name: abayer-jx-demo-qs-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-l22wn-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master-from-build-pack-1
+  taskRef: abayer-jx-demo-qs-master-l22wn-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: jx-demo-qs
-    name: abayer-jx-demo-qs-master-from-build-pack-1
+    name: abayer-jx-demo-qs-master-l22wn-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-twkr2-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-golang-qs-test-master
     taskRef:
-      name: abayer-golang-qs-test-master-from-build-pack-1
+      name: abayer-golang-qs-test-master-twkr2-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-twkr2-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-golang-qs-test-master-1
+    name: abayer-golang-qs-test-master-twkr2-1
   resources:
   - name: abayer-golang-qs-test-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-twkr2-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-golang-qs-test-master-from-build-pack-1
+  taskRef: abayer-golang-qs-test-master-twkr2-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: golang-qs-test
-    name: abayer-golang-qs-test-master-from-build-pack-1
+    name: abayer-golang-qs-test-master-twkr2-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-78c5n-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-golang-qs-test-master
     taskRef:
-      name: abayer-golang-qs-test-master-from-build-pack-1
+      name: abayer-golang-qs-test-master-78c5n-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-78c5n-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-golang-qs-test-master-1
+    name: abayer-golang-qs-test-master-78c5n-1
   resources:
   - name: abayer-golang-qs-test-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: golang-qs-test
-  name: abayer-golang-qs-test-master-1
+  name: abayer-golang-qs-test-master-78c5n-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-golang-qs-test-master-from-build-pack-1
+  taskRef: abayer-golang-qs-test-master-78c5n-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: golang-qs-test
-    name: abayer-golang-qs-test-master-from-build-pack-1
+    name: abayer-golang-qs-test-master-78c5n-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-j9gz7-1
   namespace: jx
 spec:
   params:
@@ -32,7 +32,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-j9gz7-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -46,5 +46,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-j9gz7-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-j9gz7-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-j9gz7-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-j9gz7-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-j9gz7-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-j9gz7-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-j9gz7-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -237,11 +237,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-j9gz7-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-x9hlq-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-x9hlq-build-a-really-long-sta-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-x9hlq-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-x9hlq-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-x9hlq-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-x9hlq-build-a-really-long-sta-1

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-x9hlq-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-l72kq-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-jx-demo-qs-master
     taskRef:
-      name: abayer-jx-demo-qs-master-from-build-pack-1
+      name: abayer-jx-demo-qs-master-l72kq-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-l72kq-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-jx-demo-qs-master-1
+    name: abayer-jx-demo-qs-master-l72kq-1
   resources:
   - name: abayer-jx-demo-qs-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-l72kq-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master-from-build-pack-1
+  taskRef: abayer-jx-demo-qs-master-l72kq-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: jx-demo-qs
-    name: abayer-jx-demo-qs-master-from-build-pack-1
+    name: abayer-jx-demo-qs-master-l72kq-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-62hjz-1
   namespace: jx
 spec:
   params:
@@ -32,7 +32,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-62hjz-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -46,5 +46,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-62hjz-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-62hjz-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-62hjz-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-62hjz-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-62hjz-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-62hjz-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-62hjz-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -237,11 +237,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-62hjz-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-mxcdj-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-jx-demo-qs-master
     taskRef:
-      name: abayer-jx-demo-qs-master-from-build-pack-1
+      name: abayer-jx-demo-qs-master-mxcdj-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-mxcdj-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-jx-demo-qs-master-1
+    name: abayer-jx-demo-qs-master-mxcdj-1
   resources:
   - name: abayer-jx-demo-qs-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-mxcdj-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master-from-build-pack-1
+  taskRef: abayer-jx-demo-qs-master-mxcdj-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: jx-demo-qs
-    name: abayer-jx-demo-qs-master-from-build-pack-1
+    name: abayer-jx-demo-qs-master-mxcdj-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: no-default-agent
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-no-default-1
+  name: abayer-js-test-repo-no-default-j2tds-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-no-default
     taskRef:
-      name: abayer-js-test-repo-no-default-from-build-pack-1
+      name: abayer-js-test-repo-no-default-j2tds-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: no-default-agent
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-no-default-1
+  name: abayer-js-test-repo-no-default-j2tds-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-no-default-1
+    name: abayer-js-test-repo-no-default-j2tds-1
   resources:
   - name: abayer-js-test-repo-no-default
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: no-default-agent
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-no-default-1
+  name: abayer-js-test-repo-no-default-j2tds-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-js-test-repo-no-default-from-build-pack-1
+  taskRef: abayer-js-test-repo-no-default-j2tds-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: no-default-agent
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-no-default-from-build-pack-1
+    name: abayer-js-test-repo-no-default-j2tds-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-xw5r5-1
   namespace: jx
 spec:
   params:
@@ -32,7 +32,7 @@ spec:
       - name: workspace
         resource: abayer-js-test-repo-really-long
     taskRef:
-      name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+      name: abayer-js-test-repo-really-long-xw5r5-build-a-really-long-sta-1
   - name: second
     params:
     - name: version
@@ -46,5 +46,5 @@ spec:
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:
-      name: abayer-js-test-repo-really-long-second-1
+      name: abayer-js-test-repo-really-long-xw5r5-second-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-xw5r5-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-js-test-repo-really-long-1
+    name: abayer-js-test-repo-really-long-xw5r5-1
   resources:
   - name: abayer-js-test-repo-really-long
     resourceRef:
@@ -24,7 +24,7 @@ spec:
   serviceAccount: tekton-bot
   timeout: 240h0m0s
   tolerations:
-  - key: "some-key"
-    operator: "Exists"
-    effect: "NoSchedule"
+  - effect: NoSchedule
+    key: some-key
+    operator: Exists
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/structure.yml
@@ -3,17 +3,17 @@ metadata:
   labels:
     branch: really-long
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: js-test-repo
-  name: abayer-js-test-repo-really-long-1
+  name: abayer-js-test-repo-really-long-xw5r5-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+  taskRef: abayer-js-test-repo-really-long-xw5r5-build-a-really-long-sta-1
 - depth: 0
   name: Second
   previous: Build-a-really-long-stage-name-please-but-not-too-long-thanks
-  taskRef: abayer-js-test-repo-really-long-second-1
+  taskRef: abayer-js-test-repo-really-long-xw5r5-second-1

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: build-a-really-long-stage-name-please-but-not-too-long-thanks
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-build-a-really-long-stage-nam-1
+    name: abayer-js-test-repo-really-long-xw5r5-build-a-really-long-sta-1
     namespace: jx
   spec:
     inputs:
@@ -237,11 +237,11 @@ items:
     labels:
       branch: really-long
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: second
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: js-test-repo
-    name: abayer-js-test-repo-really-long-second-1
+    name: abayer-js-test-repo-really-long-xw5r5-second-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipeline.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-lxm9g-1
   namespace: jx
 spec:
   params:
@@ -29,5 +29,5 @@ spec:
       - name: workspace
         resource: abayer-jx-demo-qs-master
     taskRef:
-      name: abayer-jx-demo-qs-master-from-build-pack-1
+      name: abayer-jx-demo-qs-master-lxm9g-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelinerun.yml
@@ -5,17 +5,17 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-lxm9g-1
 spec:
   params:
   - name: version
     value: 0.0.1
   pipelineRef:
     apiVersion: tekton.dev/v1alpha1
-    name: abayer-jx-demo-qs-master-1
+    name: abayer-jx-demo-qs-master-lxm9g-1
   resources:
   - name: abayer-jx-demo-qs-master
     resourceRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/structure.yml
@@ -3,13 +3,13 @@ metadata:
   labels:
     branch: master
     build: "1"
-    owner: abayer
     jenkins.io/pipelineType: build
+    owner: abayer
     repository: jx-demo-qs
-  name: abayer-jx-demo-qs-master-1
+  name: abayer-jx-demo-qs-master-lxm9g-1
 pipelineRef: null
 pipelineRunRef: null
 stages:
 - depth: 0
   name: from-build-pack
-  taskRef: abayer-jx-demo-qs-master-from-build-pack-1
+  taskRef: abayer-jx-demo-qs-master-lxm9g-from-build-pack-1

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
@@ -6,11 +6,11 @@ items:
     labels:
       branch: master
       build: "1"
+      jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      jenkins.io/pipelineType: build
       repository: jx-demo-qs
-    name: abayer-jx-demo-qs-master-from-build-pack-1
+    name: abayer-jx-demo-qs-master-lxm9g-from-build-pack-1
     namespace: jx
   spec:
     inputs:

--- a/pkg/tekton/metapipeline/clientfactory.go
+++ b/pkg/tekton/metapipeline/clientfactory.go
@@ -106,8 +106,8 @@ func (c *clientFactory) Create(param PipelineCreateParam) (kube.PromoteStepActiv
 	}
 
 	// resourceName is shared across all builds of a branch, while the pipelineName is unique for each build.
-	resourceName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String(), nil, "")
-	pipelineName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String(), c.tektonClient, c.ns)
+	resourceName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String(), false)
+	pipelineName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String(), true)
 	buildNumber, err := tekton.GenerateNextBuildNumber(c.tektonClient, c.jxClient, c.ns, gitInfo, branchIdentifier, retryDuration, param.Context, param.UseActivityForNextBuildNumber)
 	if err != nil {
 		return kube.PromoteStepActivityKey{}, tekton.CRDWrapper{}, errors.Wrap(err, "unable to determine next build number")

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -152,7 +152,7 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 	}
 
 	pri := &PipelineRunInfo{
-		Name:        PipelineResourceName(pr.Labels[LabelOwner], pr.Labels[LabelRepo], pr.Labels[LabelBranch], pr.Labels[LabelContext], pr.Labels[LabelType], nil, "") + "-" + pr.Labels[LabelBuild],
+		Name:        PipelineResourceName(pr.Labels[LabelOwner], pr.Labels[LabelRepo], pr.Labels[LabelBranch], pr.Labels[LabelContext], pr.Labels[LabelType], false) + "-" + pr.Labels[LabelBuild],
 		PipelineRun: pr.Name,
 		Pipeline:    pr.Spec.PipelineRef.Name,
 		Type:        pipelineType.String(),

--- a/pkg/tekton/pipelines.go
+++ b/pkg/tekton/pipelines.go
@@ -369,12 +369,12 @@ func CreateOrUpdatePipeline(tektonClient tektonclient.Interface, ns string, crea
 }
 
 // PipelineResourceNameFromGitInfo returns the pipeline resource name for the given git repository, branch and context
-func PipelineResourceNameFromGitInfo(gitInfo *gits.GitRepository, branch string, context string, pipelineType string, tektonClient tektonclient.Interface, ns string) string {
-	return PipelineResourceName(gitInfo.Organisation, gitInfo.Name, branch, context, pipelineType, tektonClient, ns)
+func PipelineResourceNameFromGitInfo(gitInfo *gits.GitRepository, branch string, context string, pipelineType string, forceUnique bool) string {
+	return PipelineResourceName(gitInfo.Organisation, gitInfo.Name, branch, context, pipelineType, forceUnique)
 }
 
 // PipelineResourceName returns the pipeline resource name for the given git org, repo name, branch and context
-func PipelineResourceName(organisation string, name string, branch string, context string, pipelineType string, tektonClient tektonclient.Interface, ns string) string {
+func PipelineResourceName(organisation string, name string, branch string, context string, pipelineType string, forceUnique bool) string {
 	dirtyName := organisation + "-" + name + "-" + branch
 	if context != "" {
 		dirtyName += "-" + context
@@ -385,11 +385,8 @@ func PipelineResourceName(organisation string, name string, branch string, conte
 	}
 	resourceName := naming.ToValidNameTruncated(dirtyName, 31)
 
-	if tektonClient != nil {
-		_, err := tektonClient.TektonV1alpha1().PipelineResources(ns).Get(resourceName, metav1.GetOptions{})
-		if err == nil {
-			return resourceName + "-" + rand.String(5)
-		}
+	if forceUnique {
+		return resourceName + "-" + rand.String(5)
 	}
 	return resourceName
 }


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We already were making them unique, but there's a whacky race condition where if the first PR build and first release build of a repo get kicked off in very rapid succession (like, 3-5 seconds apart), the `PipelineResource` for the repo isn't yet retrievable via `Get` and so our logic thinks "hey, this base name is unique, let's use it". So...let's always throw the suffix on to absolutely guarantee uniqueness.

#### Special notes for the reviewer(s)

/assign @romainverduci 

#### Which issue this PR fixes

fixes #6320 
