### PR TITLE
fix: allow jx get vault-config to work with clusters that don't have …

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2019-12-06T14:35:25Z",
+  "generated_at": "2019-12-11T12:27:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -341,19 +341,19 @@
       {
         "hashed_secret": "4d55af37dbbb6a42088d917caa1ca25428ec42c9",
         "is_secret": false,
-        "line_number": 2407,
+        "line_number": 2528,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "ad5add064d262229c5ae13ba1b42b9dc0078f649",
         "is_secret": false,
-        "line_number": 2642,
+        "line_number": 2763,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "740b5066431be9b197b7688eed6a867cfebaf0e3",
         "is_secret": false,
-        "line_number": 3085,
+        "line_number": 3206,
         "type": "Secret Keyword"
       }
     ],
@@ -773,31 +773,31 @@
       {
         "hashed_secret": "d95b56ce41a2e1ac4cecdd398defd7414407cc08",
         "is_secret": false,
-        "line_number": 21,
+        "line_number": 25,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "eb3591cac1239f323ddb46e0ef040587c69e2edc",
         "is_secret": false,
-        "line_number": 23,
+        "line_number": 27,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "6d1c5d0d239886008e9a89b16c73c5c01b7626d7",
         "is_secret": false,
-        "line_number": 25,
+        "line_number": 29,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "f519bce8b0ae84d8dbbc0a793bf6a180043be855",
         "is_secret": false,
-        "line_number": 27,
+        "line_number": 31,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "e4e810466669889f6d245e182e0f85b41a760695",
         "is_secret": false,
-        "line_number": 29,
+        "line_number": 33,
         "type": "Secret Keyword"
       }
     ],

--- a/pkg/cmd/clients/factory.go
+++ b/pkg/cmd/clients/factory.go
@@ -518,6 +518,23 @@ func (f *factory) CreateVaultClient(name string, namespace string) (vault.Client
 		return nil, errors.Wrapf(err, "checking if vault ingress should be used in namespace %q", devNamespace)
 	}
 
+	if useIngressURL {
+		// does the ingress exist
+		_, err := kube.GetIngress(kubeClient, namespace, name)
+		if err != nil {
+			if os.Getenv("LOCAL_VAULT_ADDR") == "" {
+				log.Logger().Infof("Vault ingress is not present for '%s'", util.ColorInfo(name))
+				log.Logger().Info("It appears like you're attempting to access vault locally but the cluster isn't exposing Vault (which is good)")
+				log.Logger().Info("Execute the following in another terminal window:")
+				log.Logger().Infof(util.ColorInfo("\n\tkubectl port-forward -n %s %s-0 %s:%s\n"), namespace, name, vault.DefaultVaultPort, vault.DefaultVaultPort)
+				log.Logger().Info("Then execute the following:")
+				log.Logger().Infof(util.ColorInfo("\n\tLOCAL_VAULT_ADDR=http://localhost:%s jx get vault-config\n"), vault.DefaultVaultPort)
+				return nil, errors.Errorf("no local configuration set - follow the instructions above and try again")
+			}
+			useIngressURL = false
+		}
+	}
+
 	insecureSSLWebhook, err := f.useVaultInsecureSSL(namespace)
 	if err != nil {
 		// use secure SSL by default if cannot determine if it's insecure

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -253,8 +253,6 @@ This repository contains the source code for the Jenkins X Development Environme
 	prowFlagName            = "prow"
 	staticJenkinsFlagName   = "static-jenkins"
 	gitOpsFlagName          = "gitops"
-
-	exposedVaultPort = "8200"
 )
 
 var (
@@ -2475,7 +2473,7 @@ func (options *InstallOptions) exposeVault(vaultService string, namespace string
 	}
 	if svc.Annotations[kube.AnnotationExpose] == "" {
 		svc.Annotations[kube.AnnotationExpose] = "true"
-		svc.Annotations[kube.AnnotationExposePort] = exposedVaultPort
+		svc.Annotations[kube.AnnotationExposePort] = vault.DefaultVaultPort
 		svc, err = client.CoreV1().Services(namespace).Update(svc)
 		if err != nil {
 			return errors.Wrapf(err, "updating %s service annotations", vaultService)

--- a/pkg/cmd/create/vault/create_vault.go
+++ b/pkg/cmd/create/vault/create_vault.go
@@ -23,10 +23,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const (
-	exposedVaultPort = "8200"
-)
-
 var (
 	createVaultLong = templates.LongDesc(`
 		Creates a Vault using the vault-operator
@@ -295,7 +291,7 @@ func (o *CreateVaultOptions) exposeVault(vaultService string) error {
 	}
 	if svc.Annotations[kube.AnnotationExpose] == "" {
 		svc.Annotations[kube.AnnotationExpose] = "true"
-		svc.Annotations[kube.AnnotationExposePort] = exposedVaultPort
+		svc.Annotations[kube.AnnotationExposePort] = vault.DefaultVaultPort
 		svc, err = client.CoreV1().Services(o.Namespace).Update(svc)
 		if err != nil {
 			return errors.Wrapf(err, "updating %s service annotations", vaultService)

--- a/pkg/kube/vault/vault.go
+++ b/pkg/kube/vault/vault.go
@@ -44,7 +44,7 @@ const (
 
 	vaultSecretEngines      = "secrets"
 	defaultNumVaults        = 1
-	defaultInternalVaultURL = "http://%s:8200"
+	defaultInternalVaultURL = "http://%s:" + vault.DefaultVaultPort
 )
 
 // Vault stores some details of a Vault resource
@@ -321,11 +321,11 @@ func NewVaultCRD(kubeClient kubernetes.Interface, name string, ns string, images
 			ServiceType:     string(v1.ServiceTypeClusterIP),
 			ServiceAccount:  name,
 			Config: map[string]interface{}{
-				"api_addr":           fmt.Sprintf("http://%s.%s:8200", name, ns),
+				"api_addr":           fmt.Sprintf("http://%s.%s:%s", name, ns, vault.DefaultVaultPort),
 				"disable_clustering": true,
 				"listener": Listener{
 					Tcp: Tcp{
-						Address:    "0.0.0.0:8200",
+						Address:    fmt.Sprintf("0.0.0.0:%s", vault.DefaultVaultPort),
 						TlsDisable: true,
 					},
 				},

--- a/pkg/kube/vault/vault_factory.go
+++ b/pkg/kube/vault/vault_factory.go
@@ -2,10 +2,11 @@ package vault
 
 import (
 	"fmt"
-	"github.com/jenkins-x/jx/pkg/vault"
 	"io"
 	"os"
 	"time"
+
+	"github.com/jenkins-x/jx/pkg/vault"
 
 	"github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 	"github.com/hashicorp/vault/api"

--- a/pkg/kube/vault/vault_factory.go
+++ b/pkg/kube/vault/vault_factory.go
@@ -2,7 +2,9 @@ package vault
 
 import (
 	"fmt"
+	"github.com/jenkins-x/jx/pkg/vault"
 	"io"
+	"os"
 	"time"
 
 	"github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
@@ -139,6 +141,10 @@ func (v *VaultClientFactory) GetConfigData(name string, namespace string, useIng
 	vlt, err := v.Selector.GetVault(name, namespace, useIngressURL)
 	if err != nil {
 		return nil, "", "", err
+	}
+
+	if os.Getenv(vault.LocalVaultEnvVar) != "" && !useIngressURL {
+		vlt.URL = os.Getenv(vault.LocalVaultEnvVar)
 	}
 
 	serviceAccount, err := v.getServiceAccountFromVault(vlt)

--- a/pkg/kube/vault/vault_selector_test.go
+++ b/pkg/kube/vault/vault_selector_test.go
@@ -2,8 +2,9 @@ package vault_test
 
 import (
 	"fmt"
-	vault_const "github.com/jenkins-x/jx/pkg/vault"
 	"testing"
+
+	vault_const "github.com/jenkins-x/jx/pkg/vault"
 
 	expect "github.com/Netflix/go-expect"
 	kubevault "github.com/jenkins-x/jx/pkg/kube/vault"

--- a/pkg/kube/vault/vault_selector_test.go
+++ b/pkg/kube/vault/vault_selector_test.go
@@ -1,6 +1,8 @@
 package vault_test
 
 import (
+	"fmt"
+	vault_const "github.com/jenkins-x/jx/pkg/vault"
 	"testing"
 
 	expect "github.com/Netflix/go-expect"
@@ -34,7 +36,7 @@ func Test_GetVault_InclusterUsesInternalVaultURL(t *testing.T) {
 
 	assert.Equal(t, "myVault", vault.Name)
 	assert.Equal(t, "myVaultNamespace", vault.Namespace)
-	assert.Equal(t, "http://myVault:8200", vault.URL)
+	assert.Equal(t, fmt.Sprintf("http://myVault:%s", vault_const.DefaultVaultPort), vault.URL)
 	assert.Equal(t, "myVault-auth-sa", vault.AuthServiceAccountName)
 	assert.NoError(t, err)
 }

--- a/pkg/vault/constants.go
+++ b/pkg/vault/constants.go
@@ -11,6 +11,10 @@ const (
 	AdminSecretsPath = "admin/"
 	// AuthSecretsPath the path of auth secrets
 	AuthSecretsPath = "auth/"
+	// LocalVaultEnvVar defines the address to search for when using kubectl port-forward to access Vault without an ingress
+	LocalVaultEnvVar = "LOCAL_VAULT_ADDR"
+	//DefaultVaultPort defines the port to access vault
+	DefaultVaultPort = "8200"
 )
 
 // AdminSecret type for a vault admin secret


### PR DESCRIPTION
…a vault ingress

Signed-off-by: Cai Cooper <caicooper82@gmail.com>

Hopefully addresses https://github.com/jenkins-x/jx/issues/4925

```bash
🙅 developer ~/go-workspace/src/github.com/jenkins-x/jx(master)$ jx get vault-config 
Vault ingress is not present for 'shiftpickle'
It appears like you're attempting to access vault locally but the cluster isn't exposing Vault (which is good)
Execute the following in another terminal window:

        kubectl port-forward -n jx shiftpickle-0 8200:8200

Then execute the following:

        LOCAL_VAULT_ADDR=http://localhost:8200 jx get vault-config

error: no local configuration set - follow the instructions above and try again
----------------------------------Another terminal session--------------------------------
🙅 developer ~/go-workspace()$ kubectl port-forward -n jx shiftpickle-0 8200:8200
Forwarding from 127.0.0.1:8200 -> 8200
------------------------------------------------------------------------------------------
🙅 developer ~/go-workspace/src/github.com/jenkins-x/jx(master)$ LOCAL_VAULT_ADDR=http://localhost:8200 jx get vault-config
export VAULT_ADDR=http://localhost:8200
export VAULT_TOKEN=<redacted>
🙅 developer ~/go-workspace/src/github.com/jenkins-x/jx(master)$ export VAULT_ADDR=http://localhost:8200
🙅 developer ~/go-workspace/src/github.com/jenkins-x/jx(master)$ export VAULT_TOKEN=<redacted>
🙅 developer ~/go-workspace/src/github.com/jenkins-x/jx(master)$ safe tree
.
└── secret/
    ├── jx-write-check
    ├── shiftpickle
    └── shiftpickle/
        ├── adminUser
        ├── pipelineUser
        └── prow
```