### PR TITLE
feat: lock cert-manager version for jx install based clusters and block the use of upgrade ingress for boot clusters

### DIFF
--- a/pkg/cmd/opts/cert_manager.go
+++ b/pkg/cmd/opts/cert_manager.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const JXInstallCertManagerVersion = "0.9.1"
+
 // EnsureCertManager ensures cert-manager is installed
 func (o *CommonOptions) EnsureCertManager() error {
 	log.Logger().Infof("Looking for %q deployment in namespace %q...", pki.CertManagerDeployment, pki.CertManagerNamespace)
@@ -55,7 +57,7 @@ func (o *CommonOptions) EnsureCertManager() error {
 			err = o.InstallChartWithOptions(helm.InstallChartOptions{
 				ReleaseName: pki.CertManagerReleaseName,
 				Chart:       pki.CertManagerChart,
-				Version:     "",
+				Version:     JXInstallCertManagerVersion,
 				Ns:          pki.CertManagerNamespace,
 				HelmUpdate:  true,
 				SetValues:   values,

--- a/pkg/cmd/opts/cert_manager.go
+++ b/pkg/cmd/opts/cert_manager.go
@@ -11,7 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-const JXInstallCertManagerVersion = "0.9.1"
+// jxInstallCertManagerVersion is the locked cert-manager version to use for the old jenkins x install method
+const jxInstallCertManagerVersion = "0.9.1"
 
 // EnsureCertManager ensures cert-manager is installed
 func (o *CommonOptions) EnsureCertManager() error {
@@ -57,7 +58,7 @@ func (o *CommonOptions) EnsureCertManager() error {
 			err = o.InstallChartWithOptions(helm.InstallChartOptions{
 				ReleaseName: pki.CertManagerReleaseName,
 				Chart:       pki.CertManagerChart,
-				Version:     JXInstallCertManagerVersion,
+				Version:     jxInstallCertManagerVersion,
 				Ns:          pki.CertManagerNamespace,
 				HelmUpdate:  true,
 				SetValues:   values,

--- a/pkg/cmd/opts/upgrade/upgrade_ingress.go
+++ b/pkg/cmd/opts/upgrade/upgrade_ingress.go
@@ -55,6 +55,21 @@ func (o *UpgradeIngressOptions) Run() error {
 		return fmt.Errorf("cannot connect to Kubernetes cluster: %v", err)
 	}
 
+	jxClient, ns, err := o.JXClient()
+	if err != nil {
+		return errors.Wrap(err, "error obtaining the JX Client")
+	}
+
+	devEnv, err := jxClient.JenkinsV1().Environments(ns).Get("dev", metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "error obtaining the ")
+	}
+
+	if devEnv.Spec.TeamSettings.BootRequirements != "" {
+		return errors.New(`jx upgrade ingress shouldn't be used in a Jenkins X Boot cluster.
+For more documentation on Ingress configuration see: [https://jenkins-x.io/docs/getting-started/setup/boot/#ingress](https://jenkins-x.io/docs/getting-started/setup/boot/#ingress)`)
+	}
+
 	previousWebHookEndpoint := ""
 	if !o.SkipResourcesUpdate {
 		previousWebHookEndpoint, err = o.GetWebHookEndpoint()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Using a newer version of cert-manager was making the `jx upgrade ingress` command to fail due to different APIs being used.

After trying to upgrade the cert-manager dependency version in Jenkins X I found a problem with our dependencies and the inability to add new ones due to very old versions used for k8s dependencies.

As `jx upgrade ingress` is being deprecated soon, we are locking the cert-manager version to `0.9.0` so new versions are only applied to boot clusters.

Part of #5521 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
