### PR TITLE
fix: upgrades using branch ref

### DIFF
--- a/pkg/cmd/upgrade/upgrade_boot.go
+++ b/pkg/cmd/upgrade/upgrade_boot.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/blang/semver"
-
 	"github.com/jenkins-x/jx/pkg/boot"
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
@@ -219,21 +217,10 @@ func (o *UpgradeBootOptions) upgradeAvailable(versionStreamURL string, versionSt
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to get latest tag at %s", o.Dir)
 		}
-		// if version stream is currently set to a sha
-	} else if len(versionStreamRef) == 40 {
+	} else {
 		upgradeRef, err = o.Git().GetCommitPointedToByTag(versionsDir, upgradeRef)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to get commit pointed to by %s", upgradeRef)
-		}
-	} else {
-		// if version stream is currently tagged version
-		versionText := strings.TrimPrefix(versionStreamRef, "v")
-		_, err = semver.Parse(versionText)
-		if err == nil {
-			_, upgradeRef, err = o.Git().GetCommitPointedToByLatestTag(versionsDir)
-			if err != nil {
-				return "", errors.Wrapf(err, "failed to get latest tag at %s", o.Dir)
-			}
 		}
 	}
 

--- a/pkg/cmd/upgrade/upgrade_boot_integration_test.go
+++ b/pkg/cmd/upgrade/upgrade_boot_integration_test.go
@@ -30,11 +30,12 @@ func TestUpgradeAvailable(t *testing.T) {
 		latestRelease    bool
 		wantSha          bool
 		wantTag          bool
+		upgradeVSRef     string
 	}{
 		{
 			name:             "TestUpgradeAvailableFromTaggedVersion",
 			versionStreamRef: "v1.0.35",
-			wantTag:          true,
+			wantSha:          true,
 		},
 		{
 			name:             "TestUpgradeAvailableFromSha",


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

When the UpgradeVersionStreamRef is set to a branch the upgradeRef was being set to a tagged release, rather than looking up the commit.

This PR removes some of the recently added code which was trying to determine whether we should upgrade to a tagged release or a SHA. 

The `LatestRelease` will now be required to upgrade to the latest tagged release
