### PR TITLE
chore: allow escaping for code comments on PRs

### DIFF
--- a/pkg/cmd/step/pr/step_pr_comment.go
+++ b/pkg/cmd/step/pr/step_pr_comment.go
@@ -28,6 +28,7 @@ type StepPRCommentFlags struct {
 	Owner      string
 	Repository string
 	PR         string
+	Code       bool
 }
 
 // NewCmdStepPRComment Steps a command object for the "step pr comment" command
@@ -55,6 +56,7 @@ func NewCmdStepPRComment(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Flags.Owner, "owner", "o", "", "Git organisation / owner")
 	cmd.Flags().StringVarP(&options.Flags.Repository, "repository", "r", "", "Git repository")
 	cmd.Flags().StringVarP(&options.Flags.PR, "pull-request", "p", "", "Git Pull Request number")
+	cmd.Flags().BoolVarP(&options.Flags.Code, "code", "", false, "Treat the comment as code")
 
 	return cmd
 }
@@ -120,5 +122,12 @@ func (o *StepPRCommentOptions) Run() error {
 		Number: &prNumber,
 	}
 
+	if o.Flags.Code {
+		return provider.AddPRComment(&pr, escapeAsCode(o.Flags.Comment))
+	}
 	return provider.AddPRComment(&pr, o.Flags.Comment)
+}
+
+func escapeAsCode(comment string) string {
+	return "```\n" + comment
 }


### PR DESCRIPTION
--code can be used to turn on escaping

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->