### PR TITLE
chore: correctly clean down bdd iam bindings with deleted members

### DIFF
--- a/pkg/cmd/gc/gc_gke.go
+++ b/pkg/cmd/gc/gc_gke.go
@@ -567,8 +567,9 @@ func (o *GCGKEOptions) determineUnusedIamBindings(policy iamPolicy) ([]string, e
 	}
 	for _, b := range policy.Bindings {
 		for _, m := range b.Members {
-			if strings.HasPrefix(m, "serviceAccount:") {
-				saName := strings.TrimPrefix(m, "serviceAccount:")
+			if strings.HasPrefix(m, "deleted:serviceAccount:") || strings.HasPrefix(m, "serviceAccount:") {
+				saName := strings.TrimPrefix(m, "deleted:")
+				saName = strings.TrimPrefix(saName, "serviceAccount:")
 				displayName := saName[:strings.IndexByte(saName, '@')]
 
 				if isServiceAccount(displayName) {


### PR DESCRIPTION
Signed-off-by: David Conde <dconde@cloudbees.com>

Deletes bindings that have deleted members starting with deleted:
