### PR TITLE
chore: update golang image version to 1.12.4

### DIFF
--- a/jenkins-x-bdd.yml
+++ b/jenkins-x-bdd.yml
@@ -47,12 +47,12 @@ pipelineConfig:
                     mountPath: /secrets
             steps:
               - name: build-binary
-                image: docker.io/golang:1.11.5
+                image: docker.io/golang:1.12.4
                 command: make
                 args: ['linux']
 
               - name: validate-binary
-                image: docker.io/golang:1.11.5
+                image: docker.io/golang:1.12.4
                 command: "./build/linux/jx"
                 args: ['help']
                 # Supported when we upgrade

--- a/jenkins-x-boot-vault.yml
+++ b/jenkins-x-boot-vault.yml
@@ -50,12 +50,12 @@ pipelineConfig:
 
             steps:
               - name: build-binary
-                image: docker.io/golang:1.11.5
+                image: docker.io/golang:1.12.4
                 command: make
                 args: ['linux']
 
               - name: validate-binary
-                image: docker.io/golang:1.11.5
+                image: docker.io/golang:1.12.4
                 command: "./build/linux/jx"
                 args: ['help']
 

--- a/jenkins-x-images.yml
+++ b/jenkins-x-images.yml
@@ -45,12 +45,12 @@ pipelineConfig:
                     memory: 3072Mi
             steps:
               - name: build-binary
-                image: docker.io/golang:1.11.5
+                image: docker.io/golang:1.12.4
                 command: make
                 args: ['linux']
 
               - name: validate-binary
-                image: docker.io/golang:1.11.5
+                image: docker.io/golang:1.12.4
                 command: "./build/linux/jx"
                 args: ['help']
 

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -50,12 +50,12 @@ pipelineConfig:
 
             steps:
               - name: build-binary
-                image: docker.io/golang:1.11.5
+                image: docker.io/golang:1.12.4
                 command: make
                 args: ['linux']
 
               - name: validate-binary
-                image: docker.io/golang:1.11.5
+                image: docker.io/golang:1.12.4
                 command: "./build/linux/jx"
                 args: ['help']
 


### PR DESCRIPTION
Signed-off-by: Cai Cooper <caicooper82@gmail.com>

Since our builder images are using golang 1.12.4, lets update the docker golang images  within our pipelines to 1.12.4 too

Contributes towards #6345 
