### PR TITLE
feat: podAnnotations on jx pod

### DIFF
--- a/charts/jx/templates/cronjob.yaml
+++ b/charts/jx/templates/cronjob.yaml
@@ -20,6 +20,10 @@ spec:
           labels:
             app: {{ template "jx.name" . }}
             release: {{ .Release.Name }}
+    {{- if .Values.podAnnotations }}
+          annotations:
+{{ toYaml .Values.podAnnotations | indent 12 }}
+    {{- end }}
         spec:
     {{- if .Values.restartPolicy }}
           restartPolicy: {{ .Values.restartPolicy }}

--- a/charts/jx/templates/daemonset.yaml
+++ b/charts/jx/templates/daemonset.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         app: {{ template "jx.name" . }}
         release: {{ .Release.Name }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
     spec:
 {{- if .Values.restartPolicy }}
       restartPolicy: {{ .Values.restartPolicy }}

--- a/charts/jx/templates/deployment.yaml
+++ b/charts/jx/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app: {{ template "jx.name" . }}
         release: {{ .Release.Name }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
     spec:
 {{- if .Values.restartPolicy }}
       restartPolicy: {{ .Values.restartPolicy }}

--- a/charts/jx/templates/job.yaml
+++ b/charts/jx/templates/job.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         app: {{ template "jx.name" . }}
         release: {{ .Release.Name }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
     spec:
 {{- if .Values.restartPolicy }}
       restartPolicy: {{ .Values.restartPolicy }}

--- a/charts/jx/values.yaml
+++ b/charts/jx/values.yaml
@@ -17,6 +17,8 @@ daemonset:
 job:
   enabled: false
 
+podAnnotations: {}
+
 cronjob:
   enabled: false
   schedule: "* * * * *"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is covered by existing or new tests.

#### Description

Adds support for setting podAnnotations in jx chart.

#### Special notes for the reviewer(s)

The reason I needed this was that gcactivities stopped working when I enabled istio for the namespace. With the annotation sidecar.istio.io/inject: "false" on the pod it would have worked. But now there is no way to add this annotation via the chart.

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
