### PR TITLE
fix: making sure naming.ToValidName is called before creating a new CRD

### DIFF
--- a/pkg/users/git.go
+++ b/pkg/users/git.go
@@ -86,7 +86,7 @@ func (r *GitUserResolver) Resolve(user *gits.GitUser) (*jenkinsv1.User, error) {
 			}
 		}
 		new := r.GitUserToUser(gitUser)
-		id = gitUser.Login
+		id = naming.ToValidName(gitUser.Login)
 		// Check if the user id is available, if not append "-<n>" where <n> is some integer
 		for i := 0; true; i++ {
 			_, err := r.JXClient.JenkinsV1().Users(r.Namespace).Get(id, v1.GetOptions{})

--- a/pkg/users/git_test.go
+++ b/pkg/users/git_test.go
@@ -27,9 +27,11 @@ func TestFindUserByLabel(t *testing.T) {
 	t.Parallel()
 	resolver, _, err := prepare(t)
 	assert.NoError(t, err)
+
 	gituserIDUUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	gituserID := gituserIDUUID.String()
+
 	// Create the user
 	labeleduserID, err := createUniqueDummyUser(resolver, true, gituserID)
 	defer func() {
@@ -44,6 +46,7 @@ func TestFindUserByLabel(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 	assert.NoError(t, err)
+
 	gitUser := gits.GitUser{
 		Login: gituserID,
 	}
@@ -57,9 +60,11 @@ func TestFindUserBySignature(t *testing.T) {
 	t.Parallel()
 	resolver, _, err := prepare(t)
 	assert.NoError(t, err)
+
 	gituserIDUUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	gituserID := gituserIDUUID.String()
+
 	// Create the user
 	userID, err := createUniqueDummyUser(resolver, true, gituserID)
 	defer func() {
@@ -67,7 +72,7 @@ func TestFindUserBySignature(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 	assert.NoError(t, err)
-	assert.NoError(t, err)
+
 	signature := object.Signature{
 		Email: fmt.Sprintf("%s@test.com", userID),
 		Name:  userID,
@@ -82,12 +87,15 @@ func TestFindUserByAccountReference(t *testing.T) {
 	t.Parallel()
 	resolver, _, err := prepare(t)
 	assert.NoError(t, err)
+
 	gituserID1UUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	gituserID1 := gituserID1UUID.String()
+
 	gituserID2UUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	gituserID2 := gituserID2UUID.String()
+
 	// Create the user
 	userID1, err := createUniqueDummyUser(resolver, false, gituserID1)
 	defer func() {
@@ -102,6 +110,7 @@ func TestFindUserByAccountReference(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 	assert.NoError(t, err)
+
 	gitUser := gits.GitUser{
 		Login: gituserID1,
 	}
@@ -119,18 +128,22 @@ func TestFindUserByFromGitProvider(t *testing.T) {
 	t.Parallel()
 	resolver, fakeProvider, err := prepare(t)
 	assert.NoError(t, err)
+
 	gituserID1UUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	gituserID1 := gituserID1UUID.String()
+
 	gituserID2UUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	gituserID2 := gituserID2UUID.String()
+
 	nameUUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	name := nameUUID.String()
 	emailUUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	email := emailUUID.String()
+
 	// Create the user
 	gitUser1 := &gits.GitUser{
 		Name:  name,
@@ -168,12 +181,15 @@ func TestFindUserByFromGitProviderWithNoEmail(t *testing.T) {
 	t.Parallel()
 	resolver, fakeProvider, err := prepare(t)
 	assert.NoError(t, err)
+
 	gituserID1UUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	gituserID1 := gituserID1UUID.String()
+
 	gituserID2UUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	gituserID2 := gituserID2UUID.String()
+
 	nameUUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	name := nameUUID.String()
@@ -208,9 +224,11 @@ func TestFindUserWithDifferentEmailButSameGitLogin(t *testing.T) {
 	t.Parallel()
 	resolver, fakeProvider, err := prepare(t)
 	assert.NoError(t, err)
+
 	userID1UUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	userID := userID1UUID.String()
+
 	nameUUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	name := nameUUID.String()
@@ -241,13 +259,13 @@ func TestFindUserWithDifferentEmailButSameGitLogin(t *testing.T) {
 	for _, u := range users.Items {
 		userIds = append(userIds, u.Name)
 	}
-	t.Logf("Found two users: %v", userIds)
 }
 
 func TestFindUserWithNoEmailButSameGitLogin(t *testing.T) {
 	t.Parallel()
 	resolver, fakeProvider, err := prepare(t)
 	assert.NoError(t, err)
+
 	userID1UUID, err := uuid.NewV4()
 	assert.NoError(t, err)
 	userID := userID1UUID.String()
@@ -277,6 +295,41 @@ func TestFindUserWithNoEmailButSameGitLogin(t *testing.T) {
 	users, err := resolver.JXClient.JenkinsV1().Users(resolver.Namespace).List(metav1.ListOptions{})
 	assert.NoError(t, err)
 	assert.Len(t, users.Items, 2)
+}
+
+func TestFindUserByUpperCaseGitUserName(t *testing.T) {
+	t.Parallel()
+	resolver, _, err := prepare(t)
+	assert.NoError(t, err)
+	assert.NoError(t, err)
+
+	gitUser := gits.GitUser{
+		Login: "foo",
+		Name:  "John",
+		Email: "john@acme.com",
+	}
+
+	user, err := resolver.Resolve(&gitUser)
+	assert.NoError(t, err)
+	assert.NotNil(t, user)
+	assert.Equal(t, user.Spec.Login, "foo")
+	assert.Contains(t, user.Labels, "jenkins.io/git-fakegit-userid")
+	assert.Equal(t, user.Spec.Name, "John")
+	assert.Equal(t, user.Spec.Email, "john@acme.com")
+
+	gitUser = gits.GitUser{
+		Login: "Foo",
+		Name:  "Jane",
+		Email: "jane@acme.com",
+	}
+
+	user, err = resolver.Resolve(&gitUser)
+	assert.NoError(t, err)
+	assert.NotNil(t, user)
+	assert.Contains(t, user.Labels, "jenkins.io/git-fakegit-userid")
+	assert.Equal(t, user.Spec.Login, "Foo")
+	assert.Equal(t, user.Spec.Name, "Jane")
+	assert.Equal(t, user.Spec.Email, "jane@acme.com")
 }
 
 func prepare(t *testing.T) (*users.GitUserResolver, *gits.FakeProvider, error) {


### PR DESCRIPTION
When creating a new name for the new Jenkins X User CRD we need to make sure
the name is a valid Kubernetes resource name.

This is the minimal change necessary to move forward. The current design of the code needs imo to be refactored. See also #6365. This would, however, also require to change the code in the Slack App. To move this forward let's do the minimal amount of work for now.

fixes #5727

