### PR TITLE
fix: GC ProwJobs in gc_activities

### DIFF
--- a/pkg/cmd/clients/factory.go
+++ b/pkg/cmd/clients/factory.go
@@ -48,6 +48,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	prowjobclient "k8s.io/test-infra/prow/client/clientset/versioned"
+
 	"github.com/jenkins-x/jx/pkg/jxfactory"
 )
 
@@ -615,6 +617,23 @@ func (f *factory) CreateKnativeServeClient() (kserve.Interface, string, error) {
 	}
 	ns := kube.CurrentNamespace(kubeConfig)
 	client, err := kserve.NewForConfig(config)
+	if err != nil {
+		return nil, ns, err
+	}
+	return client, ns, err
+}
+
+func (f *factory) CreateProwJobClient() (prowjobclient.Interface, string, error) {
+	config, err := f.CreateKubeConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	kubeConfig, _, err := f.jxFactory.KubeConfig().LoadConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	ns := kube.CurrentNamespace(kubeConfig)
+	client, err := prowjobclient.NewForConfig(config)
 	if err != nil {
 		return nil, ns, err
 	}

--- a/pkg/cmd/clients/fake/fake_factory.go
+++ b/pkg/cmd/clients/fake/fake_factory.go
@@ -41,6 +41,8 @@ import (
 	"k8s.io/client-go/rest"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
 	fake_metricsclient "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+	prowjobclient "k8s.io/test-infra/prow/client/clientset/versioned"
+	fake_prowjobclient "k8s.io/test-infra/prow/client/clientset/versioned/fake"
 )
 
 // FakeFactory points to a fake factory implementation
@@ -56,12 +58,13 @@ type FakeFactory struct {
 	offline         bool
 
 	// cached fake clients
-	apiClient    apiextensionsclientset.Interface
-	buildClient  build.Interface
-	jxClient     versioned.Interface
-	kubeClient   kubernetes.Interface
-	kserveClient kserve.Interface
-	tektonClient tektonclient.Interface
+	apiClient     apiextensionsclientset.Interface
+	buildClient   build.Interface
+	jxClient      versioned.Interface
+	kubeClient    kubernetes.Interface
+	kserveClient  kserve.Interface
+	tektonClient  tektonclient.Interface
+	prowJobClient prowjobclient.Interface
 }
 
 var _ clients.Factory = (*FakeFactory)(nil)
@@ -272,6 +275,14 @@ func (f *FakeFactory) CreateKnativeBuildClient() (build.Interface, string, error
 		f.buildClient = buildfake.NewSimpleClientset()
 	}
 	return f.buildClient, f.namespace, nil
+}
+
+// CreateProwJobClient creates a new Kubernetes client for ProwJob resources
+func (f *FakeFactory) CreateProwJobClient() (prowjobclient.Interface, string, error) {
+	if f.prowJobClient == nil {
+		f.prowJobClient = fake_prowjobclient.NewSimpleClientset()
+	}
+	return f.prowJobClient, f.namespace, nil
 }
 
 // CreateKnativeServeClient create a new Kubernetes client for Knative serve resources

--- a/pkg/cmd/clients/interface.go
+++ b/pkg/cmd/clients/interface.go
@@ -26,6 +26,7 @@ import (
 	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
+	prowjobclient "k8s.io/test-infra/prow/client/clientset/versioned"
 
 	// this is so that we load the auth plugins so we can connect to, say, GCP
 
@@ -122,6 +123,9 @@ type Factory interface {
 
 	// CreateTektonClient create a new Kubernetes client for Tekton resources
 	CreateTektonClient() (tektonclient.Interface, string, error)
+
+	// CreateProwJobClient creates a new Kubernetes client for ProwJob resources
+	CreateProwJobClient() (prowjobclient.Interface, string, error)
 
 	// CreateKnativeBuildClient create a new Kubernetes client for Knative Build resources
 	CreateKnativeBuildClient() (buildclient.Interface, string, error)

--- a/pkg/cmd/clients/mocks/factory.go
+++ b/pkg/cmd/clients/mocks/factory.go
@@ -30,6 +30,7 @@ import (
 	kubernetes "k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"
 	versioned5 "k8s.io/metrics/pkg/client/clientset/versioned"
+	versioned6 "k8s.io/test-infra/prow/client/clientset/versioned"
 )
 
 type MockFactory struct {
@@ -479,6 +480,29 @@ func (mock *MockFactory) CreateMetricsClient() (versioned5.Interface, error) {
 		}
 	}
 	return ret0, ret1
+}
+
+func (mock *MockFactory) CreateProwJobClient() (versioned6.Interface, string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockFactory().")
+	}
+	params := []pegomock.Param{}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateProwJobClient", params, []reflect.Type{reflect.TypeOf((*versioned6.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 versioned6.Interface
+	var ret1 string
+	var ret2 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(versioned6.Interface)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(string)
+		}
+		if result[2] != nil {
+			ret2 = result[2].(error)
+		}
+	}
+	return ret0, ret1, ret2
 }
 
 func (mock *MockFactory) CreateSystemVaultClient(_param0 string) (vault.Client, error) {
@@ -1328,6 +1352,23 @@ func (c *MockFactory_CreateMetricsClient_OngoingVerification) GetCapturedArgumen
 }
 
 func (c *MockFactory_CreateMetricsClient_OngoingVerification) GetAllCapturedArguments() {
+}
+
+func (verifier *VerifierMockFactory) CreateProwJobClient() *MockFactory_CreateProwJobClient_OngoingVerification {
+	params := []pegomock.Param{}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CreateProwJobClient", params, verifier.timeout)
+	return &MockFactory_CreateProwJobClient_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockFactory_CreateProwJobClient_OngoingVerification struct {
+	mock              *MockFactory
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockFactory_CreateProwJobClient_OngoingVerification) GetCapturedArguments() {
+}
+
+func (c *MockFactory_CreateProwJobClient_OngoingVerification) GetAllCapturedArguments() {
 }
 
 func (verifier *VerifierMockFactory) CreateSystemVaultClient(_param0 string) *MockFactory_CreateSystemVaultClient_OngoingVerification {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We're already GCing `PipelineActivity` and `PipelineRun` directly,
which also results in the downstream CRDs
`Pipeline`/`Task`/`TaskRun`/`PipelineStructure` all getting GCed too,
but until now, we're not doing anything about `ProwJob`s, so they can
get out of control and cause performance and OOM issues on the various
Prow pods. So let's GC `ProwJob`s too.

The default is to keep a week of `ProwJob`s - even on prod, I haven't
seen issues caused by excesses of `ProwJob`s until it's been at least
two weeks of regular rates of creation, so a week seems fine.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6094
