### PR TITLE
feat: Updated Helm install URL

### DIFF
--- a/pkg/cmd/opts/install.go
+++ b/pkg/cmd/opts/install.go
@@ -355,7 +355,7 @@ func (o *CommonOptions) InstallHelm() error {
 		return err
 	}
 
-	clientURL := fmt.Sprintf("https://storage.googleapis.com/kubernetes-helm/helm-v%s-%s-%s.tar.gz", stableVersion, runtime.GOOS, runtime.GOARCH)
+	clientURL := fmt.Sprintf("https://get.helm.sh/helm-v%s-%s-%s.tar.gz", stableVersion, runtime.GOOS, runtime.GOARCH)
 	fullPath := filepath.Join(binDir, fileName)
 	tarFile := fullPath + ".tgz"
 	err = packages.DownloadFile(clientURL, tarFile)


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Not only is there now Helm3 (which isn't yet supported by jx) but the binary download locations have changed as per https://helm.sh/blog/get-helm-sh/#where-are-we-now.  

#### Special notes for the reviewer(s)


#### Which issue this PR fixes
https://github.com/jenkins-x/jx/issues/6110