### PR TITLE
[wip] fix: remove functionality to install jx on cluster with create cluste…

### DIFF
--- a/jx/bdd/static/ci.sh
+++ b/jx/bdd/static/ci.sh
@@ -51,7 +51,7 @@ cd boot-source
 
 # lets trigger the BDD tests in a clusterand git provider
 jx step bdd \
-  --config jx/bdd/static/cluster.yaml \
+  --config ../jx/bdd/static/cluster.yaml \
   --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
   --provider=gke \
   --git-provider=ghe \

--- a/jx/bdd/static/ci.sh
+++ b/jx/bdd/static/ci.sh
@@ -46,8 +46,11 @@ git config --global --add user.email jenkins-x@googlegroups.com
 # Disable checking that the PipelineActivity has been updated by the build controller properly, since we're not using the build controller with static masters.
 export BDD_DISABLE_PIPELINEACTIVITY_CHECK=true
 
+git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
+cd boot-source
+
 # lets trigger the BDD tests in a clusterand git provider
-jx step bdd -b \
+jx step bdd \
   --config jx/bdd/static/cluster.yaml \
   --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
   --provider=gke \

--- a/jx/bdd/static/cluster.yaml
+++ b/jx/bdd/static/cluster.yaml
@@ -11,3 +11,8 @@ clusters:
       - --max-num-nodes=5
       - -z=europe-west1-c
       - --skip-login
+    commands:
+      - command: jx
+        args:
+          - boot
+          - -b

--- a/jx/bdd/static/jx-requirements.yml
+++ b/jx/bdd/static/jx-requirements.yml
@@ -1,0 +1,46 @@
+gitops: true
+cluster:
+  clusterName: bdd-boot-lh-ghe
+  environmentGitOwner: dev1
+  gitKind: github
+  gitName: ghe
+  gitServer: https://github.beescloud.com
+  project: jenkins-x-bdd3
+  provider: gke
+  zone: europe-west1-c
+environments:
+  - key: dev
+    owner: ""
+    repository: ""
+  - key: staging
+    owner: ""
+    repository: ""
+  - key: production
+    owner: ""
+    repository: ""
+ingress:
+  domain: ""
+  externalDNS: false
+  tls:
+    email: ""
+    enabled: false
+    production: false
+kaniko: true
+secretStorage: vault
+storage:
+  logs:
+    enabled: false
+    url: ""
+  reports:
+    enabled: false
+    url: ""
+  repository:
+    enabled: false
+    url: ""
+webhook: lighthouse
+vault:
+  disableURLDiscovery: true
+versionStream:
+  ref: "master"
+  url: https://github.com/jenkins-x/jenkins-x-versions.git
+

--- a/jx/bdd/tekton/ci.sh
+++ b/jx/bdd/tekton/ci.sh
@@ -41,7 +41,7 @@ cd boot-source
 echo "running the BDD tests with JX_HOME = $JX_HOME"
 jx step bdd \
   --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
-  --config jx/bdd/tekton/cluster.yaml \
+  --config ../jx/bdd/tekton/cluster.yaml \
   --gopath /tmp  \
   --git-provider=github \
   --git-username $GH_USERNAME \

--- a/jx/bdd/tekton/ci.sh
+++ b/jx/bdd/tekton/ci.sh
@@ -35,8 +35,12 @@ git config --global --add user.email jenkins-x@googlegroups.com
 # lets avoid the git/credentials causing confusion during the test
 export XDG_CONFIG_HOME=$JX_HOME
 
+git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
+cd boot-source
+
 echo "running the BDD tests with JX_HOME = $JX_HOME"
-jx step bdd --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+jx step bdd \
+  --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
   --config jx/bdd/tekton/cluster.yaml \
   --gopath /tmp  \
   --git-provider=github \

--- a/jx/bdd/tekton/cluster.yaml
+++ b/jx/bdd/tekton/cluster.yaml
@@ -14,6 +14,10 @@ clusters:
     commands:
       - command: jx
         args:
+          - boot
+          - -b
+      - command: jx
+        args:
           - step
           - git
           - credentials

--- a/jx/bdd/tekton/cluster.yaml
+++ b/jx/bdd/tekton/cluster.yaml
@@ -4,7 +4,6 @@ clusters:
       - create
       - cluster
       - gke
-      - --tekton
       - --project-id=jenkins-x-bdd3
       - -m=n1-standard-2
       - --min-num-nodes=3
@@ -14,7 +13,8 @@ clusters:
     commands:
       - command: jx
         args:
-          - boot
+          - install
+          - --tekton
           - -b
       - command: jx
         args:

--- a/jx/bdd/tekton/jx-requirements.yml
+++ b/jx/bdd/tekton/jx-requirements.yml
@@ -1,0 +1,46 @@
+gitops: true
+cluster:
+  clusterName: bdd-boot-lh-ghe
+  environmentGitOwner: dev1
+  gitKind: github
+  gitName: ghe
+  gitServer: https://github.beescloud.com
+  project: jenkins-x-bdd3
+  provider: gke
+  zone: europe-west1-c
+environments:
+  - key: dev
+    owner: ""
+    repository: ""
+  - key: staging
+    owner: ""
+    repository: ""
+  - key: production
+    owner: ""
+    repository: ""
+ingress:
+  domain: ""
+  externalDNS: false
+  tls:
+    email: ""
+    enabled: false
+    production: false
+kaniko: true
+secretStorage: vault
+storage:
+  logs:
+    enabled: false
+    url: ""
+  reports:
+    enabled: false
+    url: ""
+  repository:
+    enabled: false
+    url: ""
+webhook: lighthouse
+vault:
+  disableURLDiscovery: true
+versionStream:
+  ref: "master"
+  url: https://github.com/jenkins-x/jenkins-x-versions.git
+

--- a/pkg/cmd/create/create_cluster.go
+++ b/pkg/cmd/create/create_cluster.go
@@ -6,12 +6,9 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/create/options"
 
 	"github.com/jenkins-x/jx/pkg/cmd/initcmd"
-	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
-
-	"github.com/jenkins-x/jx/pkg/log"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
@@ -23,10 +20,9 @@ type KubernetesProvider string
 // CreateClusterOptions the flags for running create cluster
 type CreateClusterOptions struct {
 	options.CreateOptions
-	InstallOptions   InstallOptions
-	Flags            initcmd.InitFlags
-	Provider         string
-	SkipInstallation bool `mapstructure:"skip-installation"`
+	InstallOptions InstallOptions
+	Flags          initcmd.InitFlags
+	Provider       string
 }
 
 const (
@@ -35,7 +31,6 @@ const (
 	optionCluster           = "cluster"
 	optionClusterName       = "cluster-name"
 	optionCloudProvider     = "cloud-provider"
-	optionSkipInstallation  = "skip-installation"
 )
 
 const (
@@ -138,30 +133,6 @@ func createCreateClusterOptions(commonOpts *opts.CommonOptions, cloudProvider st
 		InstallOptions: CreateInstallOptions(commonOpts),
 	}
 	return options
-}
-
-func (o *CreateClusterOptions) initAndInstall(provider string) error {
-	err := o.GetConfiguration(&o)
-	if err != nil {
-		return errors.Wrap(err, "getting create cluster configuration")
-	}
-
-	if o.SkipInstallation {
-		log.Logger().Infof("%s cluster created. Skipping Jenkins X installation.", o.Provider)
-		return nil
-	}
-
-	o.InstallOptions.BatchMode = o.BatchMode
-	o.InstallOptions.Flags.Provider = provider
-
-	installOpts := &o.InstallOptions
-
-	// call jx install
-	err = installOpts.Run()
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 // Run returns help if function is run without any argument

--- a/pkg/cmd/create/create_cluster.go
+++ b/pkg/cmd/create/create_cluster.go
@@ -6,7 +6,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/create/options"
 
 	"github.com/jenkins-x/jx/pkg/cmd/initcmd"
-	"github.com/spf13/viper"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
@@ -120,8 +119,6 @@ func NewCmdCreateCluster(commonOpts *opts.CommonOptions) *cobra.Command {
 
 func (o *CreateClusterOptions) addCreateClusterFlags(cmd *cobra.Command) {
 	o.InstallOptions.AddInstallFlags(cmd, true)
-	cmd.Flags().BoolVarP(&o.SkipInstallation, optionSkipInstallation, "", false, "Provision cluster only, don't install Jenkins X into it")
-	_ = viper.BindPFlag(optionSkipInstallation, cmd.Flags().Lookup(optionSkipInstallation))
 }
 
 func createCreateClusterOptions(commonOpts *opts.CommonOptions, cloudProvider string) CreateClusterOptions {

--- a/pkg/cmd/create/create_cluster.go
+++ b/pkg/cmd/create/create_cluster.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jenkins-x/jx/pkg/cmd/create/options"
+	"github.com/jenkins-x/jx/pkg/cmd/initcmd"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
@@ -17,7 +18,9 @@ type KubernetesProvider string
 // CreateClusterOptions the flags for running create cluster
 type CreateClusterOptions struct {
 	options.CreateOptions
-	Provider string
+	Provider       string
+	InstallOptions InstallOptions
+	Flags          initcmd.InitFlags
 }
 
 const (

--- a/pkg/cmd/create/create_cluster.go
+++ b/pkg/cmd/create/create_cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type KubernetesProvider string
@@ -18,9 +19,10 @@ type KubernetesProvider string
 // CreateClusterOptions the flags for running create cluster
 type CreateClusterOptions struct {
 	options.CreateOptions
-	Provider       string
-	InstallOptions InstallOptions
-	Flags          initcmd.InitFlags
+	Provider         string
+	InstallOptions   InstallOptions
+	Flags            initcmd.InitFlags
+	SkipInstallation bool `mapstructure:"skip-installation"`
 }
 
 const (
@@ -118,6 +120,8 @@ func NewCmdCreateCluster(commonOpts *opts.CommonOptions) *cobra.Command {
 
 func (o *CreateClusterOptions) addCreateClusterFlags(cmd *cobra.Command) {
 	o.InstallOptions.AddInstallFlags(cmd, true)
+	cmd.Flags().BoolVarP(&o.SkipInstallation, optionSkipInstallation, "", false, "Provision cluster only, don't install Jenkins X into it")
+	_ = viper.BindPFlag(optionSkipInstallation, cmd.Flags().Lookup(optionSkipInstallation))
 }
 
 func createCreateClusterOptions(commonOpts *opts.CommonOptions, cloudProvider string) CreateClusterOptions {

--- a/pkg/cmd/create/create_cluster.go
+++ b/pkg/cmd/create/create_cluster.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/cmd/create/options"
 
-	"github.com/jenkins-x/jx/pkg/cmd/initcmd"
-
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
@@ -19,9 +17,7 @@ type KubernetesProvider string
 // CreateClusterOptions the flags for running create cluster
 type CreateClusterOptions struct {
 	options.CreateOptions
-	InstallOptions InstallOptions
-	Flags          initcmd.InitFlags
-	Provider       string
+	Provider string
 }
 
 const (

--- a/pkg/cmd/create/create_cluster.go
+++ b/pkg/cmd/create/create_cluster.go
@@ -31,6 +31,7 @@ const (
 	optionCluster           = "cluster"
 	optionClusterName       = "cluster-name"
 	optionCloudProvider     = "cloud-provider"
+	optionSkipInstallation  = "skip-installation"
 )
 
 const (
@@ -120,7 +121,7 @@ func NewCmdCreateCluster(commonOpts *opts.CommonOptions) *cobra.Command {
 
 func (o *CreateClusterOptions) addCreateClusterFlags(cmd *cobra.Command) {
 	o.InstallOptions.AddInstallFlags(cmd, true)
-	cmd.Flags().BoolVarP(&o.SkipInstallation, optionSkipInstallation, "", false, "Provision cluster only, don't install Jenkins X into it")
+	cmd.Flags().BoolVarP(&o.SkipInstallation, optionSkipInstallation, "", true, "Provision cluster only, don't install Jenkins X into it")
 	_ = viper.BindPFlag(optionSkipInstallation, cmd.Flags().Lookup(optionSkipInstallation))
 }
 

--- a/pkg/cmd/create/create_cluster_aks.go
+++ b/pkg/cmd/create/create_cluster_aks.go
@@ -378,7 +378,4 @@ func (o *CreateClusterAKSOptions) createClusterAKS() error {
 	if err != nil {
 		return err
 	}
-
-	log.Logger().Info("Initialising cluster ...")
-	return o.initAndInstall(cloud.AKS)
 }

--- a/pkg/cmd/create/create_cluster_aks.go
+++ b/pkg/cmd/create/create_cluster_aks.go
@@ -378,4 +378,5 @@ func (o *CreateClusterAKSOptions) createClusterAKS() error {
 	if err != nil {
 		return err
 	}
+	return nil
 }

--- a/pkg/cmd/create/create_cluster_aws.go
+++ b/pkg/cmd/create/create_cluster_aws.go
@@ -341,6 +341,7 @@ func (o *CreateClusterAWSOptions) Run() error {
 	o.InstallOptions.SetInstallValues(map[string]string{
 		kube.Region: region,
 	})
+	return nil
 }
 
 func (o *CreateClusterAWSOptions) waitForClusterJson(clusterName string) (string, error) {

--- a/pkg/cmd/create/create_cluster_aws.go
+++ b/pkg/cmd/create/create_cluster_aws.go
@@ -341,9 +341,6 @@ func (o *CreateClusterAWSOptions) Run() error {
 	o.InstallOptions.SetInstallValues(map[string]string{
 		kube.Region: region,
 	})
-
-	log.Logger().Info("Initialising cluster ...")
-	return o.initAndInstall(cloud.AWS)
 }
 
 func (o *CreateClusterAWSOptions) waitForClusterJson(clusterName string) (string, error) {

--- a/pkg/cmd/create/create_cluster_aws.go
+++ b/pkg/cmd/create/create_cluster_aws.go
@@ -334,11 +334,6 @@ func (o *CreateClusterAWSOptions) Run() error {
 	log.Logger().Info("State of kops cluster: OK")
 	log.Blank()
 
-	region, err := session.ResolveRegion(o.Flags.Profile, o.Flags.Region)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/cmd/create/create_cluster_aws.go
+++ b/pkg/cmd/create/create_cluster_aws.go
@@ -338,9 +338,7 @@ func (o *CreateClusterAWSOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	o.InstallOptions.SetInstallValues(map[string]string{
-		kube.Region: region,
-	})
+
 	return nil
 }
 

--- a/pkg/cmd/create/create_cluster_eks.go
+++ b/pkg/cmd/create/create_cluster_eks.go
@@ -240,6 +240,7 @@ cluster provisioning. Cleaning up stack %s and recreating it with eksctl.`,
 	o.InstallOptions.SetInstallValues(map[string]string{
 		kube.Region: region,
 	})
+	return nil
 }
 
 func (o *CreateClusterEKSOptions) addTagsToCluster(awsProvider amazon.Provider) error {

--- a/pkg/cmd/create/create_cluster_eks.go
+++ b/pkg/cmd/create/create_cluster_eks.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/cloud"
 	"github.com/jenkins-x/jx/pkg/cloud/amazon"
 	"github.com/jenkins-x/jx/pkg/features"
-	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 
@@ -237,9 +236,6 @@ cluster provisioning. Cleaning up stack %s and recreating it with eksctl.`,
 		return errors.Wrap(err, "there was a problem adding flags to the cluster")
 	}
 
-	o.InstallOptions.SetInstallValues(map[string]string{
-		kube.Region: region,
-	})
 	return nil
 }
 

--- a/pkg/cmd/create/create_cluster_eks.go
+++ b/pkg/cmd/create/create_cluster_eks.go
@@ -240,9 +240,6 @@ cluster provisioning. Cleaning up stack %s and recreating it with eksctl.`,
 	o.InstallOptions.SetInstallValues(map[string]string{
 		kube.Region: region,
 	})
-
-	log.Logger().Info("Initialising cluster ...")
-	return o.initAndInstall(cloud.EKS)
 }
 
 func (o *CreateClusterEKSOptions) addTagsToCluster(awsProvider amazon.Provider) error {

--- a/pkg/cmd/create/create_cluster_gke.go
+++ b/pkg/cmd/create/create_cluster_gke.go
@@ -600,19 +600,12 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 		return err
 	}
 
-	log.Logger().Info("Initialising cluster ...")
-
 	o.InstallOptions.SetInstallValues(map[string]string{
 		kube.Zone:        zone,
 		kube.Region:      region,
 		kube.ProjectID:   projectID,
 		kube.ClusterName: o.Flags.ClusterName,
 	})
-
-	err = o.initAndInstall(cloud.GKE)
-	if err != nil {
-		return err
-	}
 
 	getCredsCommand := []string{"container", "clusters", "get-credentials", o.Flags.ClusterName}
 	if "" != zone {

--- a/pkg/cmd/create/create_cluster_gke.go
+++ b/pkg/cmd/create/create_cluster_gke.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/cloud"
 	"github.com/jenkins-x/jx/pkg/features"
-	"github.com/jenkins-x/jx/pkg/kube"
 
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
@@ -599,13 +598,6 @@ func (o *CreateClusterGKEOptions) createClusterGKE() error {
 	if err != nil {
 		return err
 	}
-
-	o.InstallOptions.SetInstallValues(map[string]string{
-		kube.Zone:        zone,
-		kube.Region:      region,
-		kube.ProjectID:   projectID,
-		kube.ClusterName: o.Flags.ClusterName,
-	})
 
 	getCredsCommand := []string{"container", "clusters", "get-credentials", o.Flags.ClusterName}
 	if "" != zone {

--- a/pkg/cmd/create/create_cluster_iks.go
+++ b/pkg/cmd/create/create_cluster_iks.go
@@ -544,7 +544,4 @@ L:
 	log.Logger().Info("Setting kube config file")
 	log.Logger().Infof("export KUBECONFIG=\"%s\"", kubeconfig)
 	os.Setenv("KUBECONFIG", kubeconfig)
-	log.Logger().Info("Initialising cluster ...")
-
-	return o.initAndInstall(cloud.IKS)
 }

--- a/pkg/cmd/create/create_cluster_iks.go
+++ b/pkg/cmd/create/create_cluster_iks.go
@@ -544,4 +544,6 @@ L:
 	log.Logger().Info("Setting kube config file")
 	log.Logger().Infof("export KUBECONFIG=\"%s\"", kubeconfig)
 	os.Setenv("KUBECONFIG", kubeconfig)
+
+	return nil
 }

--- a/pkg/cmd/create/create_cluster_minikube.go
+++ b/pkg/cmd/create/create_cluster_minikube.go
@@ -279,12 +279,6 @@ func (o *CreateClusterMinikubeOptions) createClusterMinikube() error {
 		o.InstallOptions.Flags.Domain = o.CreateClusterOptions.InstallOptions.InitOptions.Flags.Domain
 	}
 
-	log.Logger().Info("Initialising cluster ...")
-	err = o.initAndInstall(cloud.MINIKUBE)
-	if err != nil {
-		return err
-	}
-
 	context, err := o.GetCommandOutput("", "kubectl", "config", "current-context")
 	if err != nil {
 		return err

--- a/pkg/cmd/create/create_cluster_minishift.go
+++ b/pkg/cmd/create/create_cluster_minishift.go
@@ -254,11 +254,5 @@ func (o *CreateClusterMinishiftOptions) createClusterMinishift() error {
 		}
 	}
 
-	log.Logger().Info("Initialising cluster ...")
-	err = o.initAndInstall(cloud.MINISHIFT)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/pkg/cmd/create/create_cluster_oke.go
+++ b/pkg/cmd/create/create_cluster_oke.go
@@ -464,9 +464,6 @@ func (o *CreateClusterOKEOptions) createClusterOKE() error {
 			if err != nil {
 				return err
 			}
-			log.Logger().Info("Initialising cluster ...")
-
-			return o.initAndInstall(cloud.OKE)
 		}
 	}
 	return nil


### PR DESCRIPTION
…r command

Signed-off-by: Kara de la Marck <MarckK@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

 `jx create cluster` creates a cluster and installs Jenkins X by default. 
It is recommended that installation of Jenkins X be done by `jx boot`, therefore this default functionality should be taken out.


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #5537

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
