### PR TITLE
feat: extend the create docs command to generate a docs page for all deprecated commands

### DIFF
--- a/pkg/cmd/create/create_docs.go
+++ b/pkg/cmd/create/create_docs.go
@@ -140,7 +140,7 @@ func (o *CreateDocsOptions) genMarkdownDeprecation(cmd *cobra.Command, dir strin
 	return nil
 }
 
-func (o *CreateDocsOptions) genMarkdownTableRows(cmd *cobra.Command, buf *bytes.Buffer) {
+func (o *CreateDocsOptions) genMarkdownTableRows(cmd *cobra.Command, buf io.StringWriter) {
 	if cmd.Deprecated != "" {
 		buf.WriteString(fmt.Sprintf("| %s | %s | %s |\n",
 			cmd.CommandPath(),

--- a/pkg/cmd/deprecation/deprecated.go
+++ b/pkg/cmd/deprecation/deprecated.go
@@ -11,19 +11,19 @@ import (
 // deprecatedCommands list of deprecated commands along with some more deprecation details
 var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
 	"install": {
-		replacement: "boot",
+		replacement: "jx boot",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/")),
 	},
 	"init": {
-		replacement: "boot",
+		replacement: "jx boot",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/")),
 	},
 	"create terraform": {
-		replacement: "boot",
+		replacement: "jx boot",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/")),
@@ -58,37 +58,37 @@ var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
 		info: fmt.Sprintf("This will be renamed to %s command.", util.ColorStatus("edit pipeline")),
 	},
 	"create archetype": {
-		replacement: "create quickstart",
+		replacement: "jx create quickstart",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/first-project/create-quickstart/")),
 	},
 	"create micro": {
-		replacement: "create quickstart",
+		replacement: "jx create quickstart",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/first-project/create-quickstart/")),
 	},
 	"create lile": {
-		replacement: "create quickstart",
+		replacement: "jx create quickstart",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/first-project/create-quickstart/")),
 	},
 	"create camel": {
-		replacement: "create quickstart",
+		replacement: "jx create quickstart",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/first-project/create-quickstart/")),
 	},
 	"create jhipster": {
-		replacement: "create quickstart",
+		replacement: "jx create quickstart",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/first-project/create-quickstart/")),
 	},
 	"create spring": {
-		replacement: "create quickstart",
+		replacement: "jx create quickstart",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/first-project/create-quickstart/")),
@@ -105,13 +105,13 @@ var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
 		info: "No longer needed",
 	},
 	"upgrade platform": {
-		replacement: "upgrade boot",
+		replacement: "jx upgrade boot",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/")),
 	},
 	"upgrade cluster": {
-		replacement: "boot",
+		replacement: "jx boot",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/")),
@@ -123,13 +123,13 @@ var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
 			util.ColorStatus("https://cloud.google.com/sdk/gcloud/")),
 	},
 	"upgrade ingress": {
-		replacement: "boot",
+		replacement: "jx boot",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/")),
 	},
 	"upgrade extensions": {
-		replacement: "upgrade apps",
+		replacement: "jx upgrade apps",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/managing-jx/common-tasks/upgrade-jx/#upgrading-apps")),
@@ -189,11 +189,11 @@ var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
 	},
 	"step credential": {
 		date: "Feb 1 2020",
-		info: "This replaced by Tekton's mounted secrets",
+		info: "This is replaced by Tekton's mounted secrets",
 	},
 	"step git credential": {
 		date: "Apr 1 2020",
-		info: "This replaced by Tekton's mounted secrets",
+		info: "This is replaced by Tekton's mounted secrets",
 	},
 	"step split monorepo": {
 		date: "Feb 1 2020",
@@ -205,7 +205,7 @@ var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
 		date: "Feb 1 2020",
 	},
 	"console": {
-		replacement: "ui",
+		replacement: "jx ui",
 		date:        "Mar 1 2020",
 		info:        "Classic Jenkins console will be replaced by Jenkins X UI app",
 	},
@@ -234,6 +234,24 @@ func DeprecateCommands(cmd *cobra.Command) {
 	for _, c := range cmd.Commands() {
 		DeprecateCommands(c)
 	}
+}
+
+// GetRemovalDate returns the date when the command is planned to be removed
+func GetRemovalDate(cmd *cobra.Command) string {
+	path := commandPath(cmd)
+	if deprecation, ok := deprecatedCommands[path]; ok {
+		return deprecation.date
+	}
+	return ""
+}
+
+// GetReplacement returns the command replacement if any available
+func GetReplacement(cmd *cobra.Command) string {
+	path := commandPath(cmd)
+	if deprecation, ok := deprecatedCommands[path]; ok {
+		return deprecation.replacement
+	}
+	return ""
 }
 
 func deprecationMessage(dep deprecationInfo) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The `create docs` command will generate a file with all the deprecated commands in the `commands folder`. The file content looks like this:

```
---
date: 2020-01-02T15:22:41+01:00
title: "deprecated commands"
slug: deprecation
url: /commands/deprecation/
---


## Deprecated Commands



| Command        | Removal Date   | Replacement  |
|----------------|----------------|--------------|
| jx console | Mar 1 2020 | jx ui |
| jx controller workflow | Feb 1 2020 |  |
| jx create addon knative-build | Feb 1 2020 |  |
| jx create archetype | Feb 1 2020 | jx create quickstart |
| jx create camel | Feb 1 2020 | jx create quickstart |
| jx create cluster aws | Feb 1 2020 |  |
| jx create cluster minikube | Feb 1 2020 | minikube start |
| jx create cluster minishift | Feb 1 2020 |  |
| jx create cluster oke | Feb 1 2020 |  |
| jx create codeship | Feb 1 2020 |  |
| jx create jhipster | Feb 1 2020 | jx create quickstart |
| jx create lile | Feb 1 2020 | jx create quickstart |
| jx create micro | Feb 1 2020 | jx create quickstart |
| jx create post | Feb 1 2020 |  |
| jx create spring | Feb 1 2020 | jx create quickstart |
| jx create step | Feb 1 2020 |  |
| jx create terraform | Feb 1 2020 | jx boot |
| jx delete addon knative-build | Feb 1 2020 |  |
| jx delete aws | Feb 1 2020 |  |
| jx delete eks | Feb 1 2020 | eksctl delete cluster |
| jx delete extension | Feb 1 2020 |  |
| jx delete post | Feb 1 2020 |  |
| jx edit deploy | Feb 1 2020 |  |
| jx edit extensionsrepository | Feb 1 2020 |  |
| jx get aws | Feb 1 2020 |  |
| jx get clusters | Feb 1 2020 | gcloud container clusters list |
| jx get eks | Feb 1 2020 | eksctl get clusters |
| jx get post | Feb 1 2020 |  |
| jx get workflows | Feb 1 2020 |  |
| jx init | Feb 1 2020 | jx boot |
| jx install | Feb 1 2020 | jx boot |
| jx step create jenkins | Feb 1 2020 |  |
| jx step credential | Feb 1 2020 |  |
| jx step nexus drop | Feb 1 2020 |  |
| jx step nexus release | Feb 1 2020 |  |
| jx step post | Feb 1 2020 |  |
| jx step pre | Feb 1 2020 |  |
| jx update cluster | Feb 1 2020 | gcloud container cluster upgrade |
| jx upgrade cluster | Feb 1 2020 | jx boot |
| jx upgrade extensions | Feb 1 2020 | jx upgrade apps |
| jx upgrade ingress | Feb 1 2020 | jx boot |
| jx upgrade platform | Feb 1 2020 | jx upgrade boot |
```

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->