### PR TITLE
fix: removed edit deploy from the list of deprecated commands

### DIFF
--- a/pkg/cmd/deprecation/deprecated.go
+++ b/pkg/cmd/deprecation/deprecated.go
@@ -171,9 +171,6 @@ var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
 		date: "Feb 1 2020",
 		info: "This is now replaced by apps",
 	},
-	"edit deploy": {
-		date: "Feb 1 2020",
-	},
 	"edit extensionsrepository": {
 		date: "Feb 1 2020",
 		info: "This is now replaced by apps",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The `jx edit deploy` command does not seem to be a maintenance burden while, at the same time, it is a useful way to define the deployment model (e.g., default, knative). Also, that command could be useful as we add more deployment processes (e.g., canary), even though it might need to be extended with a few additional arguments.

This PR proposes the removal of `jx edit deploy` from the list of deprecated commands.

#### Special notes for the reviewer(s)

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
