### PR TITLE
fix: Stop lowercasing environmentGitOwner value

### DIFF
--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -647,7 +647,7 @@ func (o *StepVerifyPreInstallOptions) gatherRequirements(requirements *config.Re
 }
 
 func (o *StepVerifyPreInstallOptions) gatherGitRequirements(requirements *config.RequirementsConfig) error {
-	requirements.Cluster.EnvironmentGitOwner = strings.TrimSpace(strings.ToLower(requirements.Cluster.EnvironmentGitOwner))
+	requirements.Cluster.EnvironmentGitOwner = strings.TrimSpace(requirements.Cluster.EnvironmentGitOwner)
 
 	// lets fix up any missing or incorrect git kinds for public git servers
 	if gits.IsGitHubServerURL(requirements.Cluster.GitServer) {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Prow is case-sensitive when it comes to matching events for an org/repo name combo to a configured org/repo name combo in its configuration. So if you're using an org with upper-case letters in its name as things stand before this change (let's say `SomeOrg`), your Prow config will end up having `someorg/environment-whatever-staging`, but the hooks sent from GitHub will be for `SomeOrg/environment-whatever-staging`, and Prow will not find any actions to take based on the `SomeOrg` event.

#### Special notes for the reviewer(s)

Depends on https://github.com/jenkins-x-charts/jxboot-resources/pull/22 being merged to really work right.

#### Which issue this PR fixes

fixes #5914
