### PR TITLE
fix: Validate that container option volume mounts use defined, existing volumes

### DIFF
--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -595,6 +595,7 @@ func (o *StepCreateTaskOptions) createEffectiveProjectConfig(packsDir string, pr
 		GitInfo:           o.GitInfo,
 		PodTemplates:      o.PodTemplates,
 		VersionResolver:   o.VersionResolver,
+		ValidateInCluster: !o.InterpretMode,
 	}
 	commonCopy := *o.CommonOptions
 	createEffective.CommonOptions = &commonCopy

--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -381,6 +381,38 @@ func TestGenerateTektonCRDs(t *testing.T) {
 				"docker.registry": "gcr.io",
 			},
 		},
+		// Dummy secrets created for validation purposes
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "jenkins-docker-cfg",
+				Namespace: "jx",
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "jenkins-maven-settings",
+				Namespace: "jx",
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "jenkins-release-gpg",
+				Namespace: "jx",
+			},
+		},
+		// Dummy PVCs created for validation purposes
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "top-level-volume",
+				Namespace: "jx",
+			},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stage-level-volume",
+				Namespace: "jx",
+			},
+		},
 	}
 	repoOwnerUUID, err := uuid.NewV4()
 	assert.NoError(t, err)

--- a/pkg/cmd/step/syntax/step_syntax_effective.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/jenkins-x/jx/pkg/versionstream"
 
@@ -48,6 +49,8 @@ type StepSyntaxEffectiveOptions struct {
 	CustomEnvs        []string
 	OutputFile        string
 	ShortView         bool
+
+	ValidateInCluster bool
 
 	PodTemplates map[string]*corev1.Pod
 
@@ -114,6 +117,7 @@ func (o *StepSyntaxEffectiveOptions) addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.ProjectID, "project-id", "", "", "The cloud project ID. If not specified we default to the install project")
 	cmd.Flags().StringVarP(&o.DockerRegistry, "docker-registry", "", "", "The Docker Registry host name to use which is added as a prefix to docker images")
 	cmd.Flags().StringVarP(&o.DockerRegistryOrg, "docker-registry-org", "", "", "The Docker registry organisation. If blank the git repository owner is used")
+	cmd.Flags().BoolVarP(&o.ValidateInCluster, "validate-in-cluster", "", false, "Validate that resources referenced in the effective pipeline, such as volumes, exist in the current context cluster")
 }
 
 // Run implements this command
@@ -441,10 +445,21 @@ func (o *StepSyntaxEffectiveOptions) createPipelineForKind(kind string, lifecycl
 		}
 	}
 
+	var kubeClient kubernetes.Interface
+	var ns string
+
+	// If we're validating in the cluster, get the kubeClient. Otherwise it'll be nil and ignored.
+	if o.ValidateInCluster {
+		kubeClient, ns, err = o.KubeClientAndDevNamespace()
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create Kube client")
+		}
+	}
+
 	// TODO: Seeing weird behavior seemingly related to https://golang.org/doc/faq#nil_error
 	// if err is reused, maybe we need to switch return types (perhaps upstream in build-pipeline)?
 	ctx := context.Background()
-	if validateErr := parsed.Validate(ctx); validateErr != nil {
+	if validateErr := parsed.ValidateInCluster(ctx, kubeClient, ns); validateErr != nil {
 		return nil, errors.Wrapf(validateErr, "validation failed for Pipeline")
 	}
 

--- a/pkg/cmd/step/syntax/step_syntax_effective_test.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective_test.go
@@ -120,6 +120,28 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 									tb.VolumeMount("docker-daemon", "/var/run/docker.sock"),
 									tb.VolumeMount("volume-0", "/home/jenkins/.docker"),
 								),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "workspace-volume",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "docker-daemon",
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/var/run/docker.sock",
+										},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "volume-0",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "jenkins-docker-cfg",
+										},
+									},
+								}),
 							),
 							sht.PipelineStage("from-build-pack",
 								sht.StageAgent("nodejs"),
@@ -162,6 +184,28 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 									tb.VolumeMount("docker-daemon", "/var/run/docker.sock"),
 									tb.VolumeMount("volume-0", "/home/jenkins/.docker"),
 								),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "workspace-volume",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "docker-daemon",
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/var/run/docker.sock",
+										},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "volume-0",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "jenkins-docker-cfg",
+										},
+									},
+								}),
 							),
 							sht.PipelineStage("from-build-pack",
 								sht.StageAgent("nodejs"),
@@ -255,6 +299,28 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 									tb.VolumeMount("docker-daemon", "/var/run/docker.sock"),
 									tb.VolumeMount("volume-0", "/home/jenkins/.docker"),
 								),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "workspace-volume",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "docker-daemon",
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/var/run/docker.sock",
+										},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "volume-0",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "jenkins-docker-cfg",
+										},
+									},
+								}),
 							),
 							sht.PipelineStage("from-build-pack",
 								sht.StageAgent("nodejs"),
@@ -301,6 +367,28 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 									tb.VolumeMount("docker-daemon", "/var/run/docker.sock"),
 									tb.VolumeMount("volume-0", "/home/jenkins/.docker"),
 								),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "workspace-volume",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "docker-daemon",
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/var/run/docker.sock",
+										},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "volume-0",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "jenkins-docker-cfg",
+										},
+									},
+								}),
 							),
 							sht.PipelineStage("from-build-pack",
 								sht.StageAgent("nodejs"),
@@ -525,6 +613,44 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 									tb.VolumeMount("volume-1", "/home/jenkins/.docker"),
 									tb.VolumeMount("volume-2", "/home/jenkins/.gnupg"),
 								),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "workspace-volume",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "docker-daemon",
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/var/run/docker.sock",
+										},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "volume-0",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "jenkins-maven-settings",
+										},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "volume-1",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "jenkins-docker-cfg",
+										},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "volume-2",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "jenkins-release-gpg",
+										},
+									},
+								}),
 							),
 							sht.PipelineStage("from-build-pack",
 								sht.StageAgent("maven"),
@@ -578,6 +704,44 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 									tb.VolumeMount("volume-1", "/home/jenkins/.docker"),
 									tb.VolumeMount("volume-2", "/home/jenkins/.gnupg"),
 								),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "workspace-volume",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "docker-daemon",
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/var/run/docker.sock",
+										},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "volume-0",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "jenkins-maven-settings",
+										},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "volume-1",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "jenkins-docker-cfg",
+										},
+									},
+								}),
+								sht.PipelineVolume(&corev1.Volume{
+									Name: "volume-2",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "jenkins-release-gpg",
+										},
+									},
+								}),
 							),
 							sht.PipelineStage("from-build-pack",
 								sht.StageAgent("maven"),
@@ -694,6 +858,25 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 				"docker.registry": "gcr.io",
 			},
 		},
+		// Dummy secrets created for validation purposes
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "jenkins-docker-cfg",
+				Namespace: "jx",
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "jenkins-maven-settings",
+				Namespace: "jx",
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "jenkins-release-gpg",
+				Namespace: "jx",
+			},
+		},
 	}
 	jxObjects := []runtime.Object{}
 	repoOwnerUUID, err := uuid.NewV4()
@@ -738,6 +921,7 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 						ServiceAccount: "tekton-bot",
 					},
 				},
+				ValidateInCluster: true,
 			}
 			testhelpers.ConfigureTestOptionsWithResources(createCanonical.CommonOptions, k8sObjects, jxObjects, gits_test.NewMockGitter(), fakeGitProvider, helm_test.NewMockHelmer(), nil)
 

--- a/pkg/jenkinsfile/pipeline.go
+++ b/pkg/jenkinsfile/pipeline.go
@@ -1003,6 +1003,12 @@ func (c *PipelineConfig) CreatePipelineForBuildPack(args CreatePipelineArguments
 					parsed.Options = &syntax.RootOptions{}
 				}
 				parsed.Options.ContainerOptions = &container
+				for _, v := range podTemplate.Spec.Volumes {
+					parsed.Options.Volumes = append(parsed.Options.Volumes, &corev1.Volume{
+						Name:         v.Name,
+						VolumeSource: v.VolumeSource,
+					})
+				}
 			}
 		}
 	}

--- a/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
+++ b/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
@@ -269,6 +269,16 @@ func ContainerSecurityContext(privileged bool) builder.ContainerOp {
 	}
 }
 
+// VolumeMount adds a VolumeMount to the container options
+func VolumeMount(name string, mountPath string) builder.ContainerOp {
+	return func(container *corev1.Container) {
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      name,
+			MountPath: mountPath,
+		})
+	}
+}
+
 // EnvVarFrom adds an environment variable using EnvVarSource to the container options
 func EnvVarFrom(name string, source *corev1.EnvVarSource) builder.ContainerOp {
 	return func(container *corev1.Container) {

--- a/pkg/tekton/syntax/test_data/validation_failures/top_level_missing_volume/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/top_level_missing_volume/jenkins-x.yml
@@ -1,0 +1,18 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        options:
+          containerOptions:
+            volumeMounts:
+              - name: not-present
+                mountPath: /somewhere
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world

--- a/pkg/tekton/syntax/test_data/validation_failures/volume_does_not_exist/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/validation_failures/volume_does_not_exist/jenkins-x.yml
@@ -1,0 +1,23 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        options:
+          containerOptions:
+            volumeMounts:
+              - name: does-not-exist
+                mountPath: /somewhere
+          volumes:
+            - name: does-not-exist
+              persistentVolumeClaim:
+                claimName: does-not-exist
+                readOnly: true
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world

--- a/pkg/tekton/syntax/test_data/volumes/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/volumes/jenkins-x.yml
@@ -17,6 +17,12 @@ pipelineConfig:
                 - name: stage-level-volume
                   gcePersistentDisk:
                     pdName: stage-level-volume
+              containerOptions:
+                volumeMounts:
+                  - name: top-level-volume
+                    mountPath: /mnt/top-level-volume
+                  - name: stage-level-volume
+                    mountPath: /mnt/stage-level-volume
             steps:
               - command: echo
                 args:


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Validate that each `volumeMount` in a `containerOptions` has a corresponding `volume` in the `containerOptions` context (or in a parent context).

Validate that each `secret` or `persistentVolumeClaim` `volume` in the `options` for a pipeline or a stage actually exists, when actually generating the effective pipeline during `jx step create task`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6424
fixes #6426 