### PR TITLE
feat: pass tags and global chart variables when deploying an application

### DIFF
--- a/pkg/cmd/add/add_app_test.go
+++ b/pkg/cmd/add/add_app_test.go
@@ -291,6 +291,7 @@ func TestAddAppWithSecrets(t *testing.T) {
 			pegomock.AnyBool(),
 			pegomock.AnyStringSlice(),
 			pegomock.AnyStringSlice(),
+			pegomock.AnyStringSlice(),
 			pegomock.EqString(kube.DefaultChartMuseumURL),
 			pegomock.AnyString(),
 			pegomock.AnyString())).
@@ -348,6 +349,7 @@ func TestAddAppWithSecrets(t *testing.T) {
 				pegomock.AnyInt(),
 				pegomock.AnyBool(),
 				pegomock.AnyBool(),
+				pegomock.AnyStringSlice(),
 				pegomock.AnyStringSlice(),
 				pegomock.AnyStringSlice(),
 				pegomock.EqString(kube.DefaultChartMuseumURL),
@@ -436,6 +438,7 @@ func TestAddAppWithDefaults(t *testing.T) {
 			pegomock.AnyBool(),
 			pegomock.AnyStringSlice(),
 			pegomock.AnyStringSlice(),
+			pegomock.AnyStringSlice(),
 			pegomock.EqString(kube.DefaultChartMuseumURL),
 			pegomock.AnyString(),
 			pegomock.AnyString())).
@@ -478,6 +481,7 @@ func TestAddAppWithDefaults(t *testing.T) {
 				pegomock.AnyInt(),
 				pegomock.AnyBool(),
 				pegomock.AnyBool(),
+				pegomock.AnyStringSlice(),
 				pegomock.AnyStringSlice(),
 				pegomock.AnyStringSlice(),
 				pegomock.EqString(kube.DefaultChartMuseumURL),
@@ -715,6 +719,7 @@ func TestAddApp(t *testing.T) {
 			pegomock.AnyBool(),
 			pegomock.AnyStringSlice(),
 			pegomock.AnyStringSlice(),
+			pegomock.AnyStringSlice(),
 			pegomock.EqString(kube.DefaultChartMuseumURL),
 			pegomock.AnyString(),
 			pegomock.AnyString())
@@ -786,6 +791,7 @@ func TestAddAppWithShortName(t *testing.T) {
 			pegomock.AnyBool(),
 			pegomock.AnyStringSlice(),
 			pegomock.AnyStringSlice(),
+			pegomock.AnyStringSlice(),
 			pegomock.EqString(kube.DefaultChartMuseumURL),
 			pegomock.AnyString(),
 			pegomock.AnyString())
@@ -843,6 +849,7 @@ func TestAddAppFromPath(t *testing.T) {
 			pegomock.AnyInt(),
 			pegomock.AnyBool(),
 			pegomock.AnyBool(),
+			pegomock.AnyStringSlice(),
 			pegomock.AnyStringSlice(),
 			pegomock.AnyStringSlice(),
 			pegomock.AnyString(),
@@ -904,6 +911,7 @@ func TestAddLatestApp(t *testing.T) {
 			pegomock.AnyInt(),
 			pegomock.AnyBool(),
 			pegomock.AnyBool(),
+			pegomock.AnyStringSlice(),
 			pegomock.AnyStringSlice(),
 			pegomock.AnyStringSlice(),
 			pegomock.EqString(kube.DefaultChartMuseumURL),
@@ -1231,7 +1239,7 @@ func TestAddAppIncludingConditionalQuestionsForGitOps(t *testing.T) {
   "description": "test values.yaml",
   "type": "object",
   "properties": {
-    "enablePersistentStorage": { 
+    "enablePersistentStorage": {
       "type": "boolean"
     }
     },
@@ -1239,8 +1247,8 @@ func TestAddAppIncludingConditionalQuestionsForGitOps(t *testing.T) {
       "properties": { "enablePersistentStorage": { "const": "true", "type": "boolean" } }
     },
     "then": {
-      "properties": { "databaseConnectionUrl": { "type": "string" }, 
-                      "databaseUsername": { "type": "string"}, 
+      "properties": { "databaseConnectionUrl": { "type": "string" },
+                      "databaseUsername": { "type": "string"},
                       "databasePassword": { "type": "string", "format" : "password"} }
     }}`),
 				},

--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -502,10 +502,14 @@ func (o *PreviewOptions) Run() error {
 		return err
 	}
 
+	setValues, setStrings := o.GetEnvChartValues(o.Namespace, env)
+
 	helmOptions := helm.InstallChartOptions{
 		Chart:       ".",
 		ReleaseName: o.ReleaseName,
 		Ns:          o.Namespace,
+		SetValues:   setValues,
+		SetStrings:  setStrings,
 		ValueFiles:  []string{configFileName},
 		Wait:        true,
 	}

--- a/pkg/cmd/promote/promote_test.go
+++ b/pkg/cmd/promote/promote_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/jenkins-x/jx/pkg/cmd/clients/fake"
@@ -30,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	resources_mock "github.com/jenkins-x/jx/pkg/kube/resources/mocks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -347,6 +349,135 @@ func TestEnsureApplicationNameIsDefinedWithoutApplicationFlagUserSaysNo(t *testi
 
 	assert.Error(t, err)
 	assert.Equal(t, "", promoteOptions.Application)
+}
+
+func TestGetEnvChartValues(t *testing.T) {
+	tests := []struct {
+		ns           string
+		env          v1.Environment
+		values       []string
+		valueStrings []string
+	}{{
+		"jx-test-preview-pr-6",
+		v1.Environment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-preview",
+			},
+			Spec: v1.EnvironmentSpec{
+				Namespace:         "jx-test-preview-pr-6",
+				Label:             "Test preview",
+				Kind:              v1.EnvironmentKindTypePreview,
+				PromotionStrategy: v1.PromotionStrategyTypeAutomatic,
+				PullRequestURL:    "https://github.com/my-project/my-app/pull/6",
+				Order:             999,
+				Source: v1.EnvironmentRepository{
+					Kind: v1.EnvironmentRepositoryTypeGit,
+					URL:  "https://github.com/my-project/my-app",
+					Ref:  "my-branch",
+				},
+				PreviewGitSpec: v1.PreviewGitSpec{
+					ApplicationName: "my-app",
+					Name:            "6",
+					URL:             "https://github.com/my-project/my-app/pull/6",
+				},
+			},
+		},
+		[]string{
+			"tags.jx-preview=true",
+			"tags.jx-env-test-preview=true",
+			"tags.jx-ns-jx-test-preview-pr-6=true",
+			"global.jx-preview=true",
+			"global.jx-env-test-preview=true",
+			"global.jx-ns-jx-test-preview-pr-6=true",
+		},
+		[]string{
+			"global.jx-type-env=preview",
+			"global.jx-env=test-preview",
+			"global.jx-ns=jx-test-preview-pr-6",
+			"global.jx-preview-app=my-app",
+			"global.jx-preview-pr=6",
+		},
+	}, {
+		"jx-custom-env",
+		v1.Environment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "custom-env",
+			},
+			Spec: v1.EnvironmentSpec{
+				Namespace:         "jx-custom-env",
+				Label:             "Custom environment",
+				Kind:              v1.EnvironmentKindTypePermanent,
+				PromotionStrategy: v1.PromotionStrategyTypeManual,
+				Order:             5,
+				Source: v1.EnvironmentRepository{
+					Kind: v1.EnvironmentRepositoryTypeGit,
+					URL:  "https://github.com/my-project/jx-environment-custom-env",
+					Ref:  "master",
+				},
+			},
+		},
+		[]string{
+			"tags.jx-permanent=true",
+			"tags.jx-env-custom-env=true",
+			"tags.jx-ns-jx-custom-env=true",
+			"global.jx-permanent=true",
+			"global.jx-env-custom-env=true",
+			"global.jx-ns-jx-custom-env=true",
+		},
+		[]string{
+			"global.jx-type-env=permanent",
+			"global.jx-env=custom-env",
+			"global.jx-ns=jx-custom-env",
+		},
+	}, {
+		"ns-rand",
+		v1.Environment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "random-env",
+			},
+			Spec: v1.EnvironmentSpec{
+				Namespace:         "ns-other",
+				Label:             "Random environment",
+				Kind:              v1.EnvironmentKindTypeEdit,
+				PromotionStrategy: v1.PromotionStrategyTypeNever,
+				Order:             666,
+				Source: v1.EnvironmentRepository{
+					Kind: v1.EnvironmentRepositoryTypeGit,
+					URL:  "https://github.com/my-project/random",
+					Ref:  "master",
+				},
+				PreviewGitSpec: v1.PreviewGitSpec{
+					ApplicationName: "random",
+					Name:            "2",
+					URL:             "https://github.com/my-project/random/pull/6",
+				},
+			},
+		},
+		[]string{
+			"tags.jx-edit=true",
+			"tags.jx-env-random-env=true",
+			"tags.jx-ns-ns-rand=true",
+			"global.jx-edit=true",
+			"global.jx-env-random-env=true",
+			"global.jx-ns-ns-rand=true",
+		},
+		[]string{
+			"global.jx-type-env=edit",
+			"global.jx-env=random-env",
+			"global.jx-ns=ns-rand",
+		},
+	}}
+
+	for _, test := range tests {
+		promoteOptions := &promote.PromoteOptions{}
+		values, valueStrings := promoteOptions.GetEnvChartValues(test.ns, &test.env)
+		sort.Strings(values)
+		sort.Strings(test.values)
+		assert.Equal(t, values, test.values)
+		sort.Strings(valueStrings)
+		sort.Strings(test.valueStrings)
+		assert.Equal(t, valueStrings, test.valueStrings)
+	}
 }
 
 // Contains all useful data from the test environment initialized by `prepareInitialPromotionEnv`

--- a/pkg/cmd/step/helm/step_helm.go
+++ b/pkg/cmd/step/helm/step_helm.go
@@ -387,3 +387,12 @@ func (o *StepHelmOptions) overwriteProviderValues(requirements *config.Requireme
 	data, err := yaml.Marshal(values)
 	return data, err
 }
+
+func (o *StepHelmOptions) getChartValues(targetNS string) ([]string, []string) {
+	return []string{
+			fmt.Sprintf("tags.jx-ns-%s=true", targetNS),
+			fmt.Sprintf("global.jx-ns-%s=true", targetNS),
+		}, []string{
+			fmt.Sprintf("global.jx-ns=%s", targetNS),
+		}
+}

--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -54,7 +54,7 @@ var (
 `)
 
 	StepHelmApplyExample = templates.Examples(`
-		# apply the chart in the env folder to namespace jx-staging 
+		# apply the chart in the env folder to namespace jx-staging
 		jx step helm apply --dir env --namespace jx-staging
 
 `)
@@ -356,11 +356,15 @@ func (o *StepHelmApplyOptions) Run() error {
 		return errors.Wrap(err, "applying chart overrides")
 	}
 
+	setValues, setStrings := o.getChartValues(ns)
+
 	helmOptions := helm.InstallChartOptions{
 		Chart:       chartName,
 		ReleaseName: releaseName,
 		Ns:          ns,
 		NoForce:     !o.Force,
+		SetValues:   setValues,
+		SetStrings:  setStrings,
 		ValueFiles:  valueFiles,
 		Dir:         dir,
 	}

--- a/pkg/cmd/step/helm/step_helm_install.go
+++ b/pkg/cmd/step/helm/step_helm_install.go
@@ -20,11 +20,12 @@ import (
 type StepHelmInstallOptions struct {
 	StepHelmOptions
 
-	Name        string
-	Namespace   string
-	Version     string
-	Values      []string
-	ValuesFiles []string
+	Name         string
+	Namespace    string
+	Version      string
+	Values       []string
+	ValueStrings []string
+	ValuesFiles  []string
 }
 
 var (
@@ -66,6 +67,7 @@ func NewCmdStepHelmInstall(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Version, "version", "v", "", "The version to install. Defaults to the latest")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "", "", "The namespace to install into. Defaults to the current namespace")
 	cmd.Flags().StringArrayVarP(&options.Values, "set", "", []string{}, "The values to override in the helm chart")
+	cmd.Flags().StringArrayVarP(&options.ValueStrings, "set-string", "", []string{}, "The STRING values to override in the helm chart")
 	cmd.Flags().StringArrayVarP(&options.ValuesFiles, "set-file", "", []string{}, "The values files to override values in the helm chart")
 
 	return cmd
@@ -94,12 +96,16 @@ func (o *StepHelmInstallOptions) Run() error {
 	if o.Version == "" {
 		version = ""
 	}
+
+	SetValues, setStrings := o.getChartValues(ns)
+
 	helmOptions := helm.InstallChartOptions{
 		Chart:       chart,
 		ReleaseName: releaseName,
 		Version:     version,
 		Ns:          ns,
-		SetValues:   o.Values,
+		SetValues:   append(SetValues, o.Values...),
+		SetStrings:  append(setStrings, o.ValueStrings...),
 		ValueFiles:  o.ValuesFiles,
 	}
 	err = o.InstallChartWithOptions(helmOptions)

--- a/pkg/environments/gitops.go
+++ b/pkg/environments/gitops.go
@@ -554,7 +554,7 @@ func LocateAppResource(helmer helm.Helmer, chartDir string, appName string) (*je
 		},
 		Spec: jenkinsv1.AppSpec{},
 	}
-	err = helmer.Template(chartDir, appName, "", templateWorkDir, false, make([]string, 0), make([]string, 0))
+	err = helmer.Template(chartDir, appName, "", templateWorkDir, false, make([]string, 0), make([]string, 0), make([]string, 0))
 	if err != nil {
 		templateWorkDir = chartDir
 	}

--- a/pkg/helm/helm_cli.go
+++ b/pkg/helm/helm_cli.go
@@ -294,7 +294,7 @@ func (h *HelmCLI) BuildDependency() error {
 
 // InstallChart installs a helm chart according with the given flags
 func (h *HelmCLI) InstallChart(chart string, releaseName string, ns string, version string, timeout int,
-	values []string, valueFiles []string, repo string, username string, password string) error {
+	values []string, valueStrings []string, valueFiles []string, repo string, username string, password string) error {
 	var err error
 	currentNamespace := ""
 	if h.Binary == "helm3" {
@@ -329,6 +329,9 @@ func (h *HelmCLI) InstallChart(chart string, releaseName string, ns string, vers
 	}
 	for _, value := range values {
 		args = append(args, "--set", value)
+	}
+	for _, value := range valueStrings {
+		args = append(args, "--set-string", value)
 	}
 	for _, valueFile := range valueFiles {
 		args = append(args, "--values", valueFile)
@@ -406,13 +409,16 @@ func (h *HelmCLI) FetchChart(chart string, version string, untar bool, untardir 
 
 // Template generates the YAML from the chart template to the given directory
 func (h *HelmCLI) Template(chart string, releaseName string, ns string, outDir string, upgrade bool,
-	values []string, valueFiles []string) error {
+	values []string, valueStrings []string, valueFiles []string) error {
 	args := []string{"template", "--name", releaseName, "--namespace", ns, chart, "--output-dir", outDir, "--debug"}
 	if upgrade {
 		args = append(args, "--is-upgrade")
 	}
 	for _, value := range values {
 		args = append(args, "--set", value)
+	}
+	for _, value := range valueStrings {
+		args = append(args, "--set-string", value)
 	}
 	for _, valueFile := range valueFiles {
 		args = append(args, "--values", valueFile)
@@ -429,7 +435,7 @@ func (h *HelmCLI) Template(chart string, releaseName string, ns string, outDir s
 }
 
 // UpgradeChart upgrades a helm chart according with given helm flags
-func (h *HelmCLI) UpgradeChart(chart string, releaseName string, ns string, version string, install bool, timeout int, force bool, wait bool, values []string, valueFiles []string, repo string, username string, password string) error {
+func (h *HelmCLI) UpgradeChart(chart string, releaseName string, ns string, version string, install bool, timeout int, force bool, wait bool, values []string, valueStrings []string, valueFiles []string, repo string, username string, password string) error {
 	var err error
 	currentNamespace := ""
 	if h.Binary == "helm3" {
@@ -473,6 +479,9 @@ func (h *HelmCLI) UpgradeChart(chart string, releaseName string, ns string, vers
 	}
 	for _, value := range values {
 		args = append(args, "--set", value)
+	}
+	for _, value := range valueStrings {
+		args = append(args, "--set-string", value)
 	}
 	for _, valueFile := range valueFiles {
 		args = append(args, "--values", valueFile)

--- a/pkg/helm/helm_cli_test.go
+++ b/pkg/helm/helm_cli_test.go
@@ -193,27 +193,29 @@ func TestBuildDependency(t *testing.T) {
 }
 
 func TestInstallChart(t *testing.T) {
-	value := []string{"test"}
+	value := []string{"test=true"}
+	valueString := []string{"context=test"}
 	valueFile := []string{"./myvalues.yaml"}
 	expectedArgs := []string{"install", "--wait", "--name", releaseName, "--namespace", namespace,
-		chart, "--set", value[0], "--values", valueFile[0]}
+		chart, "--set", value[0], "--set-string", valueString[0], "--values", valueFile[0]}
 	helm, runner := createHelm(t, nil, "")
 
-	err := helm.InstallChart(chart, releaseName, namespace, "", -1, value, valueFile, "", "", "")
+	err := helm.InstallChart(chart, releaseName, namespace, "", -1, value, valueString, valueFile, "", "", "")
 	assert.NoError(t, err, "should install the chart without any error")
 	verifyArgs(t, helm, runner, expectedArgs...)
 }
 
 func TestUpgradeChart(t *testing.T) {
-	value := []string{"test"}
+	value := []string{"test=true"}
+	valueString := []string{"context=test"}
 	valueFile := []string{"./myvalues.yaml"}
 	version := "0.0.1"
 	timeout := 600
 	expectedArgs := []string{"upgrade", "--namespace", namespace, "--install", "--wait", "--force",
-		"--timeout", fmt.Sprintf("%d", timeout), "--version", version, "--set", value[0], "--values", valueFile[0], releaseName, chart}
+		"--timeout", fmt.Sprintf("%d", timeout), "--version", version, "--set", value[0], "--set-string", valueString[0], "--values", valueFile[0], releaseName, chart}
 	helm, runner := createHelm(t, nil, "")
 
-	err := helm.UpgradeChart(chart, releaseName, namespace, version, true, timeout, true, true, value, valueFile, "", "", "")
+	err := helm.UpgradeChart(chart, releaseName, namespace, version, true, timeout, true, true, value, valueString, valueFile, "", "", "")
 
 	assert.NoError(t, err, "should upgrade the chart without any error")
 	verifyArgs(t, helm, runner, expectedArgs...)

--- a/pkg/helm/helm_helpers.go
+++ b/pkg/helm/helm_helpers.go
@@ -518,6 +518,7 @@ type InstallChartOptions struct {
 	Ns             string
 	HelmUpdate     bool
 	SetValues      []string
+	SetStrings     []string
 	ValueFiles     []string
 	Repository     string
 	Username       string
@@ -572,10 +573,10 @@ func InstallFromChartOptions(options InstallChartOptions, helmer Helmer, kubeCli
 	helmer.SetCWD(options.Dir)
 	if options.InstallOnly {
 		return helmer.InstallChart(chart, options.ReleaseName, options.Ns, options.Version, timeout,
-			options.SetValues, options.ValueFiles, options.Repository, options.Username, options.Password)
+			options.SetValues, options.SetStrings, options.ValueFiles, options.Repository, options.Username, options.Password)
 	}
 	return helmer.UpgradeChart(chart, options.ReleaseName, options.Ns, options.Version, !options.UpgradeOnly, timeout,
-		!options.NoForce, options.Wait, options.SetValues, options.ValueFiles, options.Repository,
+		!options.NoForce, options.Wait, options.SetValues, options.SetStrings, options.ValueFiles, options.Repository,
 		options.Username, options.Password)
 }
 

--- a/pkg/helm/helm_template.go
+++ b/pkg/helm/helm_template.go
@@ -225,17 +225,17 @@ func (h *HelmTemplate) Version(tls bool) (string, error) {
 }
 
 // Template generates the YAML from the chart template to the given directory
-func (h *HelmTemplate) Template(chart string, releaseName string, ns string, outDir string, upgrade bool, values []string,
+func (h *HelmTemplate) Template(chart string, releaseName string, ns string, outDir string, upgrade bool, values []string, valueStrings []string,
 	valueFiles []string) error {
 
-	return h.Client.Template(chart, releaseName, ns, outDir, upgrade, values, valueFiles)
+	return h.Client.Template(chart, releaseName, ns, outDir, upgrade, values, valueStrings, valueFiles)
 }
 
 // Mutation API
 
 // InstallChart installs a helm chart according with the given flags
 func (h *HelmTemplate) InstallChart(chart string, releaseName string, ns string, version string, timeout int,
-	values []string, valueFiles []string, repo string, username string, password string) error {
+	values []string, valueStrings []string, valueFiles []string, repo string, username string, password string) error {
 
 	err := h.clearOutputDir(releaseName)
 	if err != nil {
@@ -247,7 +247,7 @@ func (h *HelmTemplate) InstallChart(chart string, releaseName string, ns string,
 	if err != nil {
 		return err
 	}
-	err = h.Client.Template(chartDir, releaseName, ns, outputDir, false, values, valueFiles)
+	err = h.Client.Template(chartDir, releaseName, ns, outputDir, false, values, valueStrings, valueFiles)
 	if err != nil {
 		return err
 	}
@@ -312,7 +312,7 @@ func (h *HelmTemplate) FetchChart(chart string, version string, untar bool, unta
 }
 
 // UpgradeChart upgrades a helm chart according with given helm flags
-func (h *HelmTemplate) UpgradeChart(chart string, releaseName string, ns string, version string, install bool, timeout int, force bool, wait bool, values []string, valueFiles []string, repo string, username string, password string) error {
+func (h *HelmTemplate) UpgradeChart(chart string, releaseName string, ns string, version string, install bool, timeout int, force bool, wait bool, values []string, valueStrings []string, valueFiles []string, repo string, username string, password string) error {
 
 	err := h.clearOutputDir(releaseName)
 	if err != nil {
@@ -333,7 +333,7 @@ func (h *HelmTemplate) UpgradeChart(chart string, releaseName string, ns string,
 			return err
 		}
 	}
-	err = h.Client.Template(chartDir, releaseName, ns, outputDir, false, values, valueFiles)
+	err = h.Client.Template(chartDir, releaseName, ns, outputDir, false, values, valueStrings, valueFiles)
 	if err != nil {
 		return err
 	}

--- a/pkg/helm/interface.go
+++ b/pkg/helm/interface.go
@@ -15,9 +15,9 @@ type Helmer interface {
 	RemoveRequirementsLock() error
 	BuildDependency() error
 	InstallChart(chart string, releaseName string, ns string, version string, timeout int,
-		values []string, valueFiles []string, repo string, username string, password string) error
+		values []string, valueStrings []string, valueFiles []string, repo string, username string, password string) error
 	UpgradeChart(chart string, releaseName string, ns string, version string, install bool, timeout int, force bool, wait bool,
-		values []string, valueFiles []string, repo string, username string, password string) error
+		values []string, valueStrings []string, valueFiles []string, repo string, username string, password string) error
 	FetchChart(chart string, version string, untar bool, untardir string, repo string, username string,
 		password string) error
 	DeleteRelease(ns string, releaseName string, purge bool) error
@@ -32,5 +32,5 @@ type Helmer interface {
 	SetHost(host string)
 	Env() map[string]string
 	DecryptSecrets(location string) error
-	Template(chartDir string, releaseName string, ns string, outputDir string, upgrade bool, values []string, valueFiles []string) error
+	Template(chartDir string, releaseName string, ns string, outputDir string, upgrade bool, values []string, valueStrings []string, valueFiles []string) error
 }

--- a/pkg/helm/mocks/helmer.go
+++ b/pkg/helm/mocks/helmer.go
@@ -165,11 +165,11 @@ func (mock *MockHelmer) Init(_param0 bool, _param1 string, _param2 string, _para
 	return ret0
 }
 
-func (mock *MockHelmer) InstallChart(_param0 string, _param1 string, _param2 string, _param3 string, _param4 int, _param5 []string, _param6 []string, _param7 string, _param8 string, _param9 string) error {
+func (mock *MockHelmer) InstallChart(_param0 string, _param1 string, _param2 string, _param3 string, _param4 int, _param5 []string, _param6 []string, _param7 []string, _param8 string, _param9 string, _param10 string) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockHelmer().")
 	}
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9, _param10}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("InstallChart", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
@@ -386,11 +386,11 @@ func (mock *MockHelmer) StatusReleaseWithOutput(_param0 string, _param1 string, 
 	return ret0, ret1
 }
 
-func (mock *MockHelmer) Template(_param0 string, _param1 string, _param2 string, _param3 string, _param4 bool, _param5 []string, _param6 []string) error {
+func (mock *MockHelmer) Template(_param0 string, _param1 string, _param2 string, _param3 string, _param4 bool, _param5 []string, _param6 []string, _param7 []string) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockHelmer().")
 	}
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("Template", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
@@ -416,11 +416,11 @@ func (mock *MockHelmer) UpdateRepo() error {
 	return ret0
 }
 
-func (mock *MockHelmer) UpgradeChart(_param0 string, _param1 string, _param2 string, _param3 string, _param4 bool, _param5 int, _param6 bool, _param7 bool, _param8 []string, _param9 []string, _param10 string, _param11 string, _param12 string) error {
+func (mock *MockHelmer) UpgradeChart(_param0 string, _param1 string, _param2 string, _param3 string, _param4 bool, _param5 int, _param6 bool, _param7 bool, _param8 []string, _param9 []string, _param10 []string, _param11 string, _param12 string, _param13 string) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockHelmer().")
 	}
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9, _param10, _param11, _param12}
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9, _param10, _param11, _param12, _param13}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("UpgradeChart", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
@@ -746,8 +746,8 @@ func (c *MockHelmer_Init_OngoingVerification) GetAllCapturedArguments() (_param0
 	return
 }
 
-func (verifier *VerifierMockHelmer) InstallChart(_param0 string, _param1 string, _param2 string, _param3 string, _param4 int, _param5 []string, _param6 []string, _param7 string, _param8 string, _param9 string) *MockHelmer_InstallChart_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9}
+func (verifier *VerifierMockHelmer) InstallChart(_param0 string, _param1 string, _param2 string, _param3 string, _param4 int, _param5 []string, _param6 []string, _param7 []string, _param8 string, _param9 string, _param10 string) *MockHelmer_InstallChart_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9, _param10}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "InstallChart", params, verifier.timeout)
 	return &MockHelmer_InstallChart_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -757,12 +757,12 @@ type MockHelmer_InstallChart_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockHelmer_InstallChart_OngoingVerification) GetCapturedArguments() (string, string, string, string, int, []string, []string, string, string, string) {
-	_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1], _param6[len(_param6)-1], _param7[len(_param7)-1], _param8[len(_param8)-1], _param9[len(_param9)-1]
+func (c *MockHelmer_InstallChart_OngoingVerification) GetCapturedArguments() (string, string, string, string, int, []string, []string, []string, string, string, string) {
+	_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9, _param10 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1], _param6[len(_param6)-1], _param7[len(_param7)-1], _param8[len(_param8)-1], _param9[len(_param9)-1], _param10[len(_param10)-1]
 }
 
-func (c *MockHelmer_InstallChart_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string, _param3 []string, _param4 []int, _param5 [][]string, _param6 [][]string, _param7 []string, _param8 []string, _param9 []string) {
+func (c *MockHelmer_InstallChart_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string, _param3 []string, _param4 []int, _param5 [][]string, _param6 [][]string, _param7 [][]string, _param8 []string, _param9 []string, _param10 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(c.methodInvocations))
@@ -793,9 +793,9 @@ func (c *MockHelmer_InstallChart_OngoingVerification) GetAllCapturedArguments() 
 		for u, param := range params[6] {
 			_param6[u] = param.([]string)
 		}
-		_param7 = make([]string, len(c.methodInvocations))
+		_param7 = make([][]string, len(c.methodInvocations))
 		for u, param := range params[7] {
-			_param7[u] = param.(string)
+			_param7[u] = param.([]string)
 		}
 		_param8 = make([]string, len(c.methodInvocations))
 		for u, param := range params[8] {
@@ -804,6 +804,10 @@ func (c *MockHelmer_InstallChart_OngoingVerification) GetAllCapturedArguments() 
 		_param9 = make([]string, len(c.methodInvocations))
 		for u, param := range params[9] {
 			_param9[u] = param.(string)
+		}
+		_param10 = make([]string, len(c.methodInvocations))
+		for u, param := range params[10] {
+			_param10[u] = param.(string)
 		}
 	}
 	return
@@ -1146,8 +1150,8 @@ func (c *MockHelmer_StatusReleaseWithOutput_OngoingVerification) GetAllCapturedA
 	return
 }
 
-func (verifier *VerifierMockHelmer) Template(_param0 string, _param1 string, _param2 string, _param3 string, _param4 bool, _param5 []string, _param6 []string) *MockHelmer_Template_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6}
+func (verifier *VerifierMockHelmer) Template(_param0 string, _param1 string, _param2 string, _param3 string, _param4 bool, _param5 []string, _param6 []string, _param7 []string) *MockHelmer_Template_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Template", params, verifier.timeout)
 	return &MockHelmer_Template_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -1157,12 +1161,12 @@ type MockHelmer_Template_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockHelmer_Template_OngoingVerification) GetCapturedArguments() (string, string, string, string, bool, []string, []string) {
-	_param0, _param1, _param2, _param3, _param4, _param5, _param6 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1], _param6[len(_param6)-1]
+func (c *MockHelmer_Template_OngoingVerification) GetCapturedArguments() (string, string, string, string, bool, []string, []string, []string) {
+	_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1], _param6[len(_param6)-1], _param7[len(_param7)-1]
 }
 
-func (c *MockHelmer_Template_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string, _param3 []string, _param4 []bool, _param5 [][]string, _param6 [][]string) {
+func (c *MockHelmer_Template_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string, _param3 []string, _param4 []bool, _param5 [][]string, _param6 [][]string, _param7 [][]string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(c.methodInvocations))
@@ -1193,6 +1197,10 @@ func (c *MockHelmer_Template_OngoingVerification) GetAllCapturedArguments() (_pa
 		for u, param := range params[6] {
 			_param6[u] = param.([]string)
 		}
+		_param7 = make([][]string, len(c.methodInvocations))
+		for u, param := range params[7] {
+			_param7[u] = param.([]string)
+		}
 	}
 	return
 }
@@ -1214,8 +1222,8 @@ func (c *MockHelmer_UpdateRepo_OngoingVerification) GetCapturedArguments() {
 func (c *MockHelmer_UpdateRepo_OngoingVerification) GetAllCapturedArguments() {
 }
 
-func (verifier *VerifierMockHelmer) UpgradeChart(_param0 string, _param1 string, _param2 string, _param3 string, _param4 bool, _param5 int, _param6 bool, _param7 bool, _param8 []string, _param9 []string, _param10 string, _param11 string, _param12 string) *MockHelmer_UpgradeChart_OngoingVerification {
-	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9, _param10, _param11, _param12}
+func (verifier *VerifierMockHelmer) UpgradeChart(_param0 string, _param1 string, _param2 string, _param3 string, _param4 bool, _param5 int, _param6 bool, _param7 bool, _param8 []string, _param9 []string, _param10 []string, _param11 string, _param12 string, _param13 string) *MockHelmer_UpgradeChart_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9, _param10, _param11, _param12, _param13}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpgradeChart", params, verifier.timeout)
 	return &MockHelmer_UpgradeChart_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -1225,12 +1233,12 @@ type MockHelmer_UpgradeChart_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockHelmer_UpgradeChart_OngoingVerification) GetCapturedArguments() (string, string, string, string, bool, int, bool, bool, []string, []string, string, string, string) {
-	_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9, _param10, _param11, _param12 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1], _param6[len(_param6)-1], _param7[len(_param7)-1], _param8[len(_param8)-1], _param9[len(_param9)-1], _param10[len(_param10)-1], _param11[len(_param11)-1], _param12[len(_param12)-1]
+func (c *MockHelmer_UpgradeChart_OngoingVerification) GetCapturedArguments() (string, string, string, string, bool, int, bool, bool, []string, []string, []string, string, string, string) {
+	_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8, _param9, _param10, _param11, _param12, _param13 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1], _param6[len(_param6)-1], _param7[len(_param7)-1], _param8[len(_param8)-1], _param9[len(_param9)-1], _param10[len(_param10)-1], _param11[len(_param11)-1], _param12[len(_param12)-1], _param13[len(_param13)-1]
 }
 
-func (c *MockHelmer_UpgradeChart_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string, _param3 []string, _param4 []bool, _param5 []int, _param6 []bool, _param7 []bool, _param8 [][]string, _param9 [][]string, _param10 []string, _param11 []string, _param12 []string) {
+func (c *MockHelmer_UpgradeChart_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string, _param3 []string, _param4 []bool, _param5 []int, _param6 []bool, _param7 []bool, _param8 [][]string, _param9 [][]string, _param10 [][]string, _param11 []string, _param12 []string, _param13 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(c.methodInvocations))
@@ -1273,9 +1281,9 @@ func (c *MockHelmer_UpgradeChart_OngoingVerification) GetAllCapturedArguments() 
 		for u, param := range params[9] {
 			_param9[u] = param.([]string)
 		}
-		_param10 = make([]string, len(c.methodInvocations))
+		_param10 = make([][]string, len(c.methodInvocations))
 		for u, param := range params[10] {
-			_param10[u] = param.(string)
+			_param10[u] = param.([]string)
 		}
 		_param11 = make([]string, len(c.methodInvocations))
 		for u, param := range params[11] {
@@ -1284,6 +1292,10 @@ func (c *MockHelmer_UpgradeChart_OngoingVerification) GetAllCapturedArguments() 
 		_param12 = make([]string, len(c.methodInvocations))
 		for u, param := range params[12] {
 			_param12[u] = param.(string)
+		}
+		_param13 = make([]string, len(c.methodInvocations))
+		for u, param := range params[13] {
+			_param13[u] = param.(string)
 		}
 	}
 	return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This PR passes useful tags and global chart variables to helm when deploying an application.

Prior to this PR, the only way to check in which environment a chart was deployed was to read `.Release.Namespace`. It was impossible to use such conditions in chart requirements, and preview environment were hard to detect.

Tags can be used to condition chart requirements.
Global variables can be used in chart templates.

`jx promote` and `jx preview` now pass the following variables to helm:
- `tags.jx-ns-<namespace>=true` (ex: `tags.jx-ns-jx-production=true`)
- `tags.jx-<env-type>=true` (ex: `tags.jx-preview=true`)
- `tags.jx-env-<env>=true` (ex: `tags.jx-env-production=true`)
- `global.jx-ns-<namespace>=true` (ex: `tags.jx-ns-jx-production=true`)
- `global.jx-<env-type>=true` (ex: `tags.jx-preview=true`)
- `global.jx-env-<env>=true` (ex: `tags.jx-env-production=true`)
- `global.jx-ns=<namespace>` (ex: `tags.jx-ns=jx-production`)
- `global.jx-type-env=<env-type>` (ex: `tags.jx-type-env=preview`)
- `global.jx-env=<env>` (ex: `tags.jx-env=production`)
- `global.jx-preview-app=<preview-app>` preview only (ex: `global.jx-preview-app=my-app`)
- `global.jx-preview-pr=<preview-pr>` preview only (ex: `global.jx-preview-pr=6`)

`jx step helm install` and `jx step helm apply` now pass the following variables to helm:
- `tags.jx-ns-<namespace>=true` (ex: `tags.jx-ns-jx-production=true`)
- `global.jx-ns-<namespace>=true` (ex: `tags.jx-ns-jx-production=true`)
- `global.jx-ns=<namespace>` (ex: `tags.jx-ns=jx-production`)

Additionally, `jx step helm install` now accepts the `--set-string` parameter, similarly to `helm install`.

#### Special notes for the reviewer(s)

I don't know where such feature can be documented.

Regular environments are currently deployed using `jx step helm apply --namespace <namespace>`, without any mention of which environment is actually being deployed. This unfortunately limits the variables I can pass when deploying a regular environment. Maybe another command or option would be useful.

#### Which issue this PR fixes

fixes #6312

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
