### PR TITLE
fix: use common options github app mode check as well as the github owner for gitprovider

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2019-12-17T16:09:38Z",
+  "generated_at": "2020-01-08T12:53:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -479,19 +479,19 @@
       {
         "hashed_secret": "a98ac19f37a5b149dcea35391319b3acedaf777e",
         "is_secret": true,
-        "line_number": 154,
+        "line_number": 163,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "5539b03858eb5852fefd87bbbe81b09f61575703",
         "is_secret": true,
-        "line_number": 156,
+        "line_number": 165,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "5037b735ee3617033703e96afc0c61b016e7e39e",
         "is_secret": true,
-        "line_number": 159,
+        "line_number": 168,
         "type": "Secret Keyword"
       }
     ],

--- a/pkg/cmd/opts/auth.go
+++ b/pkg/cmd/opts/auth.go
@@ -158,10 +158,7 @@ func (o *CommonOptions) GitAuthConfigService() (auth.ConfigService, error) {
 }
 
 // GitAuthConfigServiceGitHubMode create the git auth config service optionally handling github app mode
-func (o *CommonOptions) GitAuthConfigServiceGitHubMode(gha bool, serviceKind string) (auth.ConfigService, error) {
-	if !gha {
-		return o.GitAuthConfigService()
-	}
+func (o *CommonOptions) GitAuthConfigServiceGitHubMode(serviceKind string) (auth.ConfigService, error) {
 	client, ns, err := o.KubeClientAndDevNamespace()
 	if err != nil {
 		return nil, errors.Wrap(err, "creating the kube client")

--- a/pkg/cmd/opts/git.go
+++ b/pkg/cmd/opts/git.go
@@ -220,7 +220,20 @@ func (o *CommonOptions) GitProviderForGitServerURL(gitServiceURL string, gitKind
 	if o.fakeGitProvider != nil {
 		return o.fakeGitProvider, nil
 	}
-	authConfigSvc, err := o.GitAuthConfigServiceGitHubMode(ghOwner != "", gitKind)
+
+	gha := ghOwner != ""
+	// if the github owner is empty then check if github app mode is enabled
+	if !gha {
+		ghaMode, err := o.IsGitHubAppMode()
+		if err != nil {
+			return nil, errors.Wrap(err, "when trying to check if in GitHub App mode")
+		}
+		if ghaMode {
+			gha = ghaMode
+		}
+	}
+
+	authConfigSvc, err := o.GitAuthConfigServiceGitHubMode(gha, gitKind)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/step/git/step_git_credentials.go
+++ b/pkg/cmd/step/git/step_git_credentials.go
@@ -106,11 +106,20 @@ func (o *StepGitCredentialsOptions) Run() error {
 		}
 	}
 
-	gitAuthSvc, err := o.GitAuthConfigServiceGitHubMode(gha, o.GitKind)
-	if err != nil {
-		return errors.Wrap(err, "creating git auth service")
+	var authConfigSvc auth.ConfigService
+	if gha {
+		authConfigSvc, err = o.GitAuthConfigServiceGitHubMode(o.GitKind)
+		if err != nil {
+			return errors.Wrap(err, "when creating auth config service using GitAuthConfigServiceGitHubMode")
+		}
+	} else {
+		authConfigSvc, err = o.GitAuthConfigService()
+		if err != nil {
+			return errors.Wrap(err, "when creating auth config service using GitAuthConfigService")
+		}
 	}
-	return o.CreateGitCredentialsFile(outFile, gitAuthSvc)
+
+	return o.CreateGitCredentialsFile(outFile, authConfigSvc)
 }
 
 // CreateGitCredentialsFile creates the git credentials into file using the provided auth config service


### PR DESCRIPTION
When creating the git provider for git server url (in this case: github) it seems that it was only using the github owner to determine if in github app mode or not. We should ideally use the common options `isGitHubAppMode` function to correctly determine whether GitHubApps mode is enabled or not.
Signed-off-by: Cai Cooper <caicooper82@gmail.com>

