### PR TITLE
fix: Use anonymous github.com creds for API calls on certain repos when there are no github.com credentials available

### DIFF
--- a/boot-vault.platform.yaml.template
+++ b/boot-vault.platform.yaml.template
@@ -21,7 +21,28 @@ jenkins:
         EnvVars:
           CODECOV_TOKEN: $CODECOV_TOKEN
 
+{{- if eq .Requirements.webhook "lighthouse" }}
 controllerbuild:
+  enabled: true
+  args:
+  - "controller"
+  - "build"
+  - "--git-reporting"
+  - "--batch-mode"
+  - "--git-credentials"
+  - "--verbose"
   image:
     repository: gcr.io/jenkinsxio/builder-go
     tag: $VERSION
+{{- else }}
+controllerbuild:
+  enabled: true
+  args:
+  - "controller"
+  - "build"
+  - "--batch-mode"
+  - "--verbose"
+  image:
+    repository: gcr.io/jenkinsxio/builder-go
+    tag: $VERSION
+{{- end }}

--- a/jenkins-x-boot-lh-ghe.yml
+++ b/jenkins-x-boot-lh-ghe.yml
@@ -1,0 +1,159 @@
+buildPack: none
+pipelineConfig:
+  pipelines:
+    pullRequest:
+      pipeline:
+        agent:
+          image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        stages:
+          - name: build
+            environment:
+              - name: GIT_COMMITTER_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_NAME
+                value: jenkins-x-bot
+              - name: GIT_COMMITTER_NAME
+                value: jenkins-x-bot
+              - name: BASE_WORKSPACE
+                value: /workspace/source
+              - name: GOPROXY
+                value: http://jenkins-x-athens-proxy:80
+              - name: PARALLEL_BUILDS
+                value: "2"
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /secrets/kaniko/kaniko-secret.json
+              - name: DISABLE_TEST_CACHING
+                value: "true"
+            options:
+              volumes:
+                - name: kaniko-secret
+                  secret:
+                    secretName: kaniko-secret
+                    items:
+                      - key: kaniko-secret
+                        path: kaniko/kaniko-secret.json
+              containerOptions:
+                volumeMounts:
+                  - name: kaniko-secret
+                    mountPath: /secrets
+
+            steps:
+              - name: build-binary
+                image: docker.io/golang:1.12.4
+                command: make
+                args: ['linux']
+
+              - name: validate-binary
+                image: docker.io/golang:1.12.4
+                command: "./build/linux/jx"
+                args: ['help']
+
+              - name: build-and-push-image
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-nodejs
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-maven
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-go
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+              - name: build-and-push-go-nodejs
+                command: /kaniko/executor
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go-nodejs','--destination=gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+
+          - name: e2e-tests
+            options:
+              volumes:
+                - name: sa
+                  secret:
+                    secretName: bdd-secret
+                    items:
+                      - key: bdd-credentials.json
+                        path: bdd/sa.json
+              containerOptions:
+                volumeMounts:
+                  - mountPath: /secrets
+                    name: sa
+            environment:
+              - name: GKE_SA
+                value: /secrets/bdd/sa.json
+              - name: GIT_COMMITTER_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_EMAIL
+                value: jenkins-x@googlegroups.com
+              - name: GIT_AUTHOR_NAME
+                value: jenkins-x-bot
+              - name: GIT_COMMITTER_NAME
+                value: jenkins-x-bot
+              - name: BASE_WORKSPACE
+                value: /workspace/source
+              - name: GOPROXY
+                value: http://jenkins-x-athens-proxy:80
+              - name: PARALLEL_BUILDS
+                value: "2"
+              - name: GHE_ACCESS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: jx-pipeline-git-github-ghe
+                    key: password
+              - name: JENKINS_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: test-jenkins-user 
+                    key: password
+            steps:
+              - name: boot-lh-ghe-e2e-tests
+                image: gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}
+                command: ./jx/bdd/boot-lh-ghe/ci.sh
+
+              - name: generate-report
+                image: gcr.io/jenkinsxio/builder-nodejs10x:0.1.607
+                command: jx
+                args:
+                  - step
+                  - report
+                  - --in-dir
+                  - /workspace/source/build/reports
+                  - --target-report
+                  - create_spring_application.junit.xml
+                  - --merge
+                  - --out-dir
+                  - /workspace/source/build/reports
+                  - --output-name
+                  - junit.html
+                  - --suite-name
+                  - "BDD_Boot_LH_GHE_Tests"
+
+              - name: clear-kubeconfig
+                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                command: rm ~/.kube/config
+
+              - name: stash_html_report
+                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                command: jx
+                args:
+                  - step
+                  - stash
+                  - -c
+                  - e2e-tests
+                  - -p
+                  - "/workspace/source/build/reports/junit.html"
+                  - --bucket-url gs://jx-prod-logs

--- a/jx/bdd/boot-lh-ghe/README.md
+++ b/jx/bdd/boot-lh-ghe/README.md
@@ -1,0 +1,1 @@
+## BDD test using JX Boot with Local secrets

--- a/jx/bdd/boot-lh-ghe/ci.sh
+++ b/jx/bdd/boot-lh-ghe/ci.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+export GHE_USERNAME="dev1"
+export GHE_EMAIL="jenkins-x@googlegroups.com"
+
+# fix broken `BUILD_NUMBER` env var
+export BUILD_NUMBER="$BUILD_ID"
+
+JX_HOME="/tmp/jxhome"
+KUBECONFIG="/tmp/jxhome/config"
+
+# lets avoid the git/credentials causing confusion during the test
+export XDG_CONFIG_HOME=$JX_HOME
+
+mkdir -p $JX_HOME/git
+
+jx --version
+
+# replace the credentials file with a single user entry
+echo "https://$GHE_USERNAME:$GHE_ACCESS_TOKEN@github.beescloud.com" > $JX_HOME/git/credentials
+
+gcloud auth activate-service-account --key-file $GKE_SA
+
+# lets setup git
+git config --global --add user.name JenkinsXBot
+git config --global --add user.email jenkins-x@googlegroups.com
+
+echo "running the BDD tests with JX_HOME = $JX_HOME"
+
+sed -e s/\$VERSION/${VERSION_PREFIX}${VERSION}/g -e s/\$CODECOV_TOKEN/${CODECOV_TOKEN}/g boot-vault.platform.yaml.template > boot-vault.platform.yaml
+
+# setup jx boot parameters
+export JX_VALUE_ADMINUSER_PASSWORD="$JENKINS_PASSWORD"
+export JX_VALUE_PIPELINEUSER_USERNAME="$GHE_USERNAME"
+export JX_VALUE_PIPELINEUSER_EMAIL="$GHE_EMAIL"
+export JX_VALUE_PIPELINEUSER_TOKEN="$GHE_ACCESS_TOKEN"
+export JX_VALUE_PROW_HMACTOKEN="$GHE_ACCESS_TOKEN"
+
+# TODO temporary hack until the batch mode in jx is fixed...
+export JX_BATCH_MODE="true"
+
+# Use the latest boot config promoted in the version stream instead of master to avoid conflicts during boot, because
+# boot fetches always the latest version available in the version stream.
+git clone  https://github.com/jenkins-x/jenkins-x-versions.git versions
+export BOOT_CONFIG_VERSION=$(jx step get dependency-version --host=github.com --owner=jenkins-x --repo=jenkins-x-boot-config --dir versions | sed 's/.*: \(.*\)/\1/')
+git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
+cd boot-source
+git checkout tags/v${BOOT_CONFIG_VERSION} -b latest-boot-config
+
+cp ../jx/bdd/boot-lh-ghe/jx-requirements.yml .
+cp ../jx/bdd/boot-lh-ghe/parameters.yaml env
+
+cp env/jenkins-x-platform/values.tmpl.yaml tmp.yaml
+cat tmp.yaml ../boot-vault.platform.yaml > env/jenkins-x-platform/values.tmpl.yaml
+rm tmp.yaml
+
+# TODO hack until we fix boot to do this too!
+helm init --client-only
+helm repo add jenkins-x https://storage.googleapis.com/chartmuseum.jenkins-x.io
+
+
+jx step bdd \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config ../jx/bdd/boot-lh-ghe/cluster.yaml \
+    --gopath /tmp \
+    --git-provider=github \
+    --git-provider-url https://github.beescloud.com \
+    --git-username $GHE_USERNAME \
+    --git-api-token $GHE_ACCESS_TOKEN \
+    --default-admin-password $JENKINS_PASSWORD \
+    --no-delete-app \
+    --no-delete-repo \
+    --tests install \
+    --tests test-quickstart-golang-http \
+    --tests test-app-lifecycle

--- a/jx/bdd/boot-lh-ghe/cluster.yaml
+++ b/jx/bdd/boot-lh-ghe/cluster.yaml
@@ -1,0 +1,18 @@
+clusters:
+  - name: boot-lh-ghe
+    args:
+      - create
+      - cluster
+      - gke
+      - --project-id=jenkins-x-bdd3
+      - -m=n1-standard-2
+      - --min-num-nodes=3
+      - --max-num-nodes=5
+      - -z=europe-west1-c
+      - --skip-login
+      - --skip-installation
+    commands:
+      - command: jx
+        args:
+          - boot
+          - -b

--- a/jx/bdd/boot-lh-ghe/jx-requirements.yml
+++ b/jx/bdd/boot-lh-ghe/jx-requirements.yml
@@ -1,0 +1,46 @@
+gitops: true
+cluster:
+  clusterName: bdd-boot-lh-ghe
+  environmentGitOwner: dev1
+  gitKind: github
+  gitName: ghe
+  gitServer: https://github.beescloud.com
+  project: jenkins-x-bdd3
+  provider: gke
+  zone: europe-west1-c
+environments:
+  - key: dev
+    owner: ""
+    repository: ""
+  - key: staging
+    owner: ""
+    repository: ""
+  - key: production
+    owner: ""
+    repository: ""
+ingress:
+  domain: ""
+  externalDNS: false
+  tls:
+    email: ""
+    enabled: false
+    production: false
+kaniko: true
+secretStorage: vault
+storage:
+  logs:
+    enabled: false
+    url: ""
+  reports:
+    enabled: false
+    url: ""
+  repository:
+    enabled: false
+    url: ""
+webhook: lighthouse
+vault:
+  disableURLDiscovery: true
+versionStream:
+  ref: "master"
+  url: https://github.com/jenkins-x/jenkins-x-versions.git
+

--- a/jx/bdd/boot-lh-ghe/parameters.yaml
+++ b/jx/bdd/boot-lh-ghe/parameters.yaml
@@ -1,0 +1,8 @@
+adminUser:
+  username: admin
+enableDocker: false
+gpg: {}
+pipelineUser:
+  username: dev1
+  email: jenkins-x@googlegroups.com
+

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -3,7 +3,10 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/vrischmann/envconfig"
@@ -16,10 +19,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/cloud"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/pkg/errors"
-
-	"io/ioutil"
-	"path/filepath"
-	"reflect"
 
 	"github.com/jenkins-x/jx/pkg/util"
 )

--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -48,8 +49,26 @@ func NewGitHubProvider(server *auth.AuthServer, user *auth.UserAuth, git Gitter)
 	)
 	tc := oauth2.NewClient(ctx, ts)
 
+	return newGitHubProviderFromOauthClient(tc, provider)
+}
+
+// NewAnonymousGitHubProvider returns a new GitHubProvider without any authentication
+func NewAnonymousGitHubProvider(server *auth.AuthServer, git Gitter) (GitProvider, error) {
+	ctx := context.Background()
+
+	provider := GitHubProvider{
+		Server:  *server,
+		User:    auth.UserAuth{},
+		Context: ctx,
+		Git:     git,
+	}
+
+	return newGitHubProviderFromOauthClient(nil, provider)
+}
+
+func newGitHubProviderFromOauthClient(tc *http.Client, provider GitHubProvider) (GitProvider, error) {
 	var err error
-	u := server.URL
+	u := provider.Server.URL
 	if IsGitHubServerURL(u) {
 		provider.Client = github.NewClient(tc)
 	} else {

--- a/pkg/kube/quickstarts.go
+++ b/pkg/kube/quickstarts.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"fmt"
+	"reflect"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -33,4 +34,14 @@ func GetQuickstartLocations(jxClient versioned.Interface, ns string) ([]v1.Quick
 	}
 	answer = env.Spec.TeamSettings.QuickstartLocations
 	return answer, nil
+}
+
+// IsDefaultQuickstartLocation checks whether the given quickstart location is a default one, and if so returns true
+func IsDefaultQuickstartLocation(location v1.QuickStartLocation) bool {
+	for _, l := range DefaultQuickstartLocations {
+		if reflect.DeepEqual(l, location) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

There are a few places where we use an authenticated `GitProvider` to perform API calls against github.com repos or orgs we know are public - `DuplicateGitRepoFromCommitish` for cloning/squashing `jenkins-x-boot-config`, and `jx get quickstarts` getting the default quickstarts from the `jenkins-x-quickstarts` org currently. If a boot cluster with gitops enabled is not using github.com and is instead using GitHub Enterprise, Gitlab, etc, these calls end up failing due to trying to use an authenticated provider when there are no credentials available. In these cases, we should fall back to anonymous authentication for the API calls.

#### Special notes for the reviewer(s)

As a followup, once this has merged, released, and gotten into the version stream, I'm going to be updating the Lighthouse and `jenkins-x-versions` BDD tests for GHE/Gitlab/Bitbucket Server to do gitops, so that we don't miss this regressing.

#### Which issue this PR fixes

fixes #6315 
fixes #6471