### PR TITLE
[wip] feat: add promotion information to PA for automatic promotion only

### DIFF
--- a/pkg/cmd/controller/controller_workflow_integration_test.go
+++ b/pkg/cmd/controller/controller_workflow_integration_test.go
@@ -153,11 +153,11 @@ func TestSequentialWorkflow(t *testing.T) {
 
 	// lets make sure we don't create a PR for production as we have not completed the staging PR yet
 	err = o.Run()
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, "production")
 
 	// still no PR merged so cannot create a PR for production
 	pollGitStatusAndReactToPipelineChanges(t, o, jxClient, ns)
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, "production")
 
 	// test no PR on production until staging completed
 	if !testhelpers.AssertSetPullRequestMerged(t, fakeGitProvider, stagingRepo.Owner, stagingRepo.GitRepo.Name, 1) {
@@ -165,7 +165,7 @@ func TestSequentialWorkflow(t *testing.T) {
 	}
 
 	pollGitStatusAndReactToPipelineChanges(t, o, jxClient, ns)
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, "production")
 
 	if !testhelpers.AssertSetPullRequestComplete(t, fakeGitProvider, stagingRepo, 1) {
 		return
@@ -295,7 +295,7 @@ func TestWorkflowManualPromote(t *testing.T) {
 
 	// lets make sure we don't create a PR for production as its manual
 	pollGitStatusAndReactToPipelineChanges(t, o, jxClient, ns)
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, "production")
 
 	if !testhelpers.AssertSetPullRequestMerged(t, fakeGitProvider, stagingRepo.Owner, stagingRepo.GitRepo.Name, 1) {
 		return
@@ -308,7 +308,7 @@ func TestWorkflowManualPromote(t *testing.T) {
 
 	testhelpers.AssertWorkflowStatus(t, activities, a.Name, v1.ActivityStatusTypeSucceeded)
 
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, "production")
 	testhelpers.AssertHasPromoteStatus(t, activities, a.Name, "staging", v1.ActivityStatusTypeSucceeded)
 	testhelpers.AssertAllPromoteStepsSuccessful(t, activities, a.Name)
 
@@ -524,11 +524,11 @@ func TestParallelWorkflow(t *testing.T) {
 
 	// lets make sure we don't create a PR for production as we have not completed the staging PR yet
 	err = o.Run()
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, envNameC)
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, envNameC)
 
 	// still no PR merged so cannot create a PR for C until A and B complete
 	pollGitStatusAndReactToPipelineChanges(t, o, jxClient, ns)
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, envNameC)
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, envNameC)
 
 	// test no PR on production until staging completed
 	if !testhelpers.AssertSetPullRequestMerged(t, fakeGitProvider, repoA.Owner, repoA.GitRepo.Name, 1) {
@@ -536,7 +536,7 @@ func TestParallelWorkflow(t *testing.T) {
 	}
 
 	pollGitStatusAndReactToPipelineChanges(t, o, jxClient, ns)
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, envNameC)
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, envNameC)
 
 	if !testhelpers.AssertSetPullRequestComplete(t, fakeGitProvider, repoA, 1) {
 		return
@@ -545,7 +545,7 @@ func TestParallelWorkflow(t *testing.T) {
 	// now lets poll again due to change to the activity to detect the staging is complete
 	pollGitStatusAndReactToPipelineChanges(t, o, jxClient, ns)
 
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, envNameC)
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, envNameC)
 	testhelpers.AssertHasPromoteStatus(t, activities, a.Name, envNameA, v1.ActivityStatusTypeSucceeded)
 	testhelpers.AssertHasPromoteStatus(t, activities, a.Name, envNameB, v1.ActivityStatusTypeRunning)
 	testhelpers.AssertHasPipelineStatus(t, activities, a.Name, v1.ActivityStatusTypeRunning)
@@ -715,13 +715,13 @@ func TestNewVersionWhileExistingWorkflow(t *testing.T) {
 
 	// lets make sure we don't create a PR for production as we have not completed the staging PR yet
 	pollGitStatusAndReactToPipelineChanges(t, o, jxClient, ns)
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, "production")
 
 	testhelpers.AssertWorkflowStatus(t, activities, aOld.Name, v1.ActivityStatusTypeAborted)
 
 	// still no PR merged so cannot create a PR for production
 	pollGitStatusAndReactToPipelineChanges(t, o, jxClient, ns)
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, "production")
 
 	// test no PR on production until staging completed
 	if !testhelpers.AssertSetPullRequestMerged(t, fakeGitProvider, stagingRepo.Owner, stagingRepo.GitRepo.Name, 2) {
@@ -729,7 +729,7 @@ func TestNewVersionWhileExistingWorkflow(t *testing.T) {
 	}
 
 	pollGitStatusAndReactToPipelineChanges(t, o, jxClient, ns)
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, "production")
 
 	if !testhelpers.AssertSetPullRequestComplete(t, fakeGitProvider, stagingRepo, 2) {
 		return

--- a/pkg/cmd/promote/promote_test.go
+++ b/pkg/cmd/promote/promote_test.go
@@ -68,12 +68,11 @@ func TestPromoteToProductionRun(t *testing.T) {
 	}
 	commonOpts := *testEnv.CommonOptions
 	promoteOptions.CommonOptions = &commonOpts // Factory and other mocks initialized by cmd.ConfigureTestOptionsWithResources
-	promoteOptions.BatchMode = true            // --batch-mode
 
 	// Check there is no PR for production env yet
 	jxClient, ns, err := promoteOptions.JXClientAndDevNamespace()
 	activities := jxClient.JenkinsV1().PipelineActivities(ns)
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, testEnv.Activity.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, testEnv.Activity.Name, "production")
 
 	// Run the promotion
 	err = promoteOptions.Run()
@@ -130,7 +129,7 @@ func TestPromoteToProductionNoMergeRun(t *testing.T) {
 	jxClient, ns, err := promoteOptions.JXClientAndDevNamespace()
 	activities := jxClient.JenkinsV1().PipelineActivities(ns)
 
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, testEnv.Activity.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, testEnv.Activity.Name, "production")
 
 	ch := make(chan int)
 
@@ -142,7 +141,7 @@ func TestPromoteToProductionNoMergeRun(t *testing.T) {
 	}()
 
 	// wait for the PR the be created by the promote command
-	testhelpers.WaitForPullRequestForEnv(t, activities, testEnv.Activity.Name, "production")
+	testhelpers.WaitForPullRequestForEnvInPipelineActivity(t, activities, testEnv.Activity.Name, "production")
 	testhelpers.AssertHasPipelineStatus(t, activities, testEnv.Activity.Name, v1.ActivityStatusTypeRunning)
 
 	// merge the PR created by promote command...
@@ -200,7 +199,7 @@ func TestPromoteToProductionPRPollingRun(t *testing.T) {
 	jxClient, ns, err := promoteOptions.JXClientAndDevNamespace()
 	activities := jxClient.JenkinsV1().PipelineActivities(ns)
 
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, testEnv.Activity.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, testEnv.Activity.Name, "production")
 
 	ch := make(chan int)
 
@@ -212,7 +211,7 @@ func TestPromoteToProductionPRPollingRun(t *testing.T) {
 	}()
 
 	// wait for the PR the be created by the promote command
-	testhelpers.WaitForPullRequestForEnv(t, activities, testEnv.Activity.Name, "production")
+	testhelpers.WaitForPullRequestForEnvInPipelineActivity(t, activities, testEnv.Activity.Name, "production")
 	testhelpers.AssertHasPipelineStatus(t, activities, testEnv.Activity.Name, v1.ActivityStatusTypeRunning)
 
 	// mark latest commit as success tu unblock the promotion (PR will be automatically merged)
@@ -610,7 +609,7 @@ func prepareInitialPromotionEnv(t *testing.T, productionManualPromotion bool) (*
 	pollGitStatusAndReactToPipelineChanges(t, o, jxClient, ns)
 
 	// lets make sure we don't create a PR for production as its manual
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, "production")
 
 	// merge PR in staging repo
 	if !testhelpers.AssertSetPullRequestMerged(t, fakeGitProvider, stagingRepo.Owner, stagingRepo.Name(), 1) {
@@ -627,7 +626,7 @@ func prepareInitialPromotionEnv(t *testing.T, productionManualPromotion bool) (*
 	testhelpers.AssertWorkflowStatus(t, activities, a.Name, v1.ActivityStatusTypeSucceeded)
 
 	// There is no PR for production, as it is manual
-	testhelpers.AssertHasNoPullRequestForEnv(t, activities, a.Name, "production")
+	testhelpers.AssertHasNoPullRequestForEnvInPipelineActivity(t, activities, a.Name, "production")
 
 	// Promote to staging succeeded...
 	testhelpers.AssertHasPromoteStatus(t, activities, a.Name, "staging", v1.ActivityStatusTypeSucceeded)

--- a/pkg/cmd/testhelpers/cmd_test_helpers.go
+++ b/pkg/cmd/testhelpers/cmd_test_helpers.go
@@ -83,6 +83,7 @@ func ConfigureTestOptionsWithResources(o *opts.CommonOptions, k8sObjects []runti
 		devEnv := kube.NewPermanentEnvironment("dev")
 		devEnv.Spec.Namespace = currentNamespace
 		devEnv.Spec.Kind = v1.EnvironmentKindTypeDevelopment
+		devEnv.Spec.PromotionStrategy = v1.PromotionStrategyTypeNever
 
 		jxObjects = append(jxObjects, devEnv)
 	}
@@ -349,7 +350,7 @@ func AssertHasPullRequestForEnv(t *testing.T, activities typev1.PipelineActivity
 	dumpFailedActivity(activity)
 }
 
-func WaitForPullRequestForEnv(t *testing.T, activities typev1.PipelineActivityInterface, name string, envName string) {
+func WaitForPullRequestForEnvInPipelineActivity(t *testing.T, activities typev1.PipelineActivityInterface, name string, envName string) {
 	activity, err := activities.Get(name, metav1.GetOptions{})
 	if err != nil {
 		assert.NoError(t, err, "Could not find PipelineActivity %s", name)
@@ -508,7 +509,7 @@ func AssertAllPromoteStepsSuccessful(t *testing.T, activities typev1.PipelineAct
 	}
 }
 
-func AssertHasNoPullRequestForEnv(t *testing.T, activities typev1.PipelineActivityInterface, name string, envName string) {
+func AssertHasNoPullRequestForEnvInPipelineActivity(t *testing.T, activities typev1.PipelineActivityInterface, name string, envName string) {
 	activity, err := activities.Get(name, metav1.GetOptions{})
 	if err != nil {
 		assert.NoError(t, err, "Could not find PipelineActivity %s", name)


### PR DESCRIPTION
fixes https://github.com/jenkins-x/jx/issues/6459

Current behaviour:
- no change for classic jenkins relying on controller_workflow
- if tekton && jx promote batch mode in an environment configure with promotion strategy auto: keeping the same behaviour (updating the project master PA with promotion information)
- if tekton && jx promote in an environment configured with promotion strategy manual: not updating the PA anymore but still creates the PR in the environment repo

Drawback:
- with the current implementation we lose the the ability to follow the promotion PR until it's merged, this code being tightly coupled with the one updating the PA

Is that an acceptable short term change, knowing that if we want to make it perfect, there is probably a lot of refactoring / redesign involved.