### PR TITLE
feat: add the option to run the bdd tests directly without importing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2020-01-08T12:53:48Z",
+  "generated_at": "2020-01-10T15:16:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -479,19 +479,19 @@
       {
         "hashed_secret": "a98ac19f37a5b149dcea35391319b3acedaf777e",
         "is_secret": true,
-        "line_number": 163,
+        "line_number": 207,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "5539b03858eb5852fefd87bbbe81b09f61575703",
         "is_secret": true,
-        "line_number": 165,
+        "line_number": 209,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "5037b735ee3617033703e96afc0c61b016e7e39e",
         "is_secret": true,
-        "line_number": 168,
+        "line_number": 212,
         "type": "Secret Keyword"
       }
     ],

--- a/jx/bdd/boot-vault/ci.sh
+++ b/jx/bdd/boot-vault/ci.sh
@@ -46,11 +46,16 @@ export JX_VALUE_PROW_HMACTOKEN="$GH_ACCESS_TOKEN"
 # TODO temporary hack until the batch mode in jx is fixed...
 export JX_BATCH_MODE="true"
 
+# Use the latest boot config promoted in the version stream instead of master to avoid conflicts during boot, because
+# boot fetches always the latest version available in the version stream.
+git clone  https://github.com/jenkins-x/jenkins-x-versions.git versions
+export BOOT_CONFIG_VERSION=$(jx step get dependency-version --host=github.com --owner=jenkins-x --repo=jenkins-x-boot-config --dir versions | sed 's/.*: \(.*\)/\1/')
 git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
 cd boot-source
+git checkout tags/v${BOOT_CONFIG_VERSION} -b latest-boot-config
+
 cp ../jx/bdd/boot-vault/jx-requirements.yml .
 cp ../jx/bdd/boot-vault/parameters.yaml env
-
 cp env/jenkins-x-platform/values.tmpl.yaml tmp.yaml
 cat tmp.yaml ../boot-vault.platform.yaml > env/jenkins-x-platform/values.tmpl.yaml
 rm tmp.yaml

--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -851,7 +851,7 @@ func (o *CreateDevPodOptions) Run() error {
 			if err != nil {
 				return errors.Wrap(err, "creating git auth config service")
 			}
-			gitCredentials, err := o.GitCredentials.CreateGitCredentials(gitAuthSvc)
+			gitCredentials, err := o.GitCredentials.CreateGitCredentialsFromAuthService(gitAuthSvc)
 			if err != nil {
 				return errors.Wrap(err, "creating git credentials")
 			}

--- a/pkg/cmd/create/create_quickstart.go
+++ b/pkg/cmd/create/create_quickstart.go
@@ -111,6 +111,10 @@ func (o *CreateQuickstartOptions) Run() error {
 	if err != nil {
 		return err
 	}
+	return o.CreateQuickStart(q)
+}
+
+func (o *CreateQuickstartOptions) CreateQuickStart(q *quickstarts.QuickstartForm) error {
 	if q == nil {
 		return fmt.Errorf("no quickstart chosen")
 	}
@@ -120,6 +124,7 @@ func (o *CreateQuickstartOptions) Run() error {
 	o.GitRepositoryOptions.RepoName = o.ImportOptions.Repository
 	repoName := o.GitRepositoryOptions.RepoName
 	if !o.BatchMode {
+		var err error
 		details, err = o.GetGitRepositoryDetails()
 		if err != nil {
 			return err
@@ -140,6 +145,7 @@ func (o *CreateQuickstartOptions) Run() error {
 		if q.Name == "" {
 			return util.MissingOption("project-name")
 		}
+
 	}
 
 	githubAppMode, err := o.IsGitHubAppMode()
@@ -152,7 +158,13 @@ func (o *CreateQuickstartOptions) Run() error {
 			Factory: o.GetFactory(),
 		}
 
-		installed, err := githubApp.Install(details.Organisation, details.RepoName, o.GetIOFileHandles(), true)
+		owner := o.GitRepositoryOptions.Owner
+		repoName := o.GitRepositoryOptions.RepoName
+		if details != nil {
+			owner = details.Organisation
+			repoName = details.RepoName
+		}
+		installed, err := githubApp.Install(owner, repoName, o.GetIOFileHandles(), true)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/create/create_quickstart.go
+++ b/pkg/cmd/create/create_quickstart.go
@@ -206,8 +206,6 @@ func (o *CreateQuickstartOptions) CreateQuickStart(q *quickstarts.QuickstartForm
 			o.PostDraftPackCallback = func() error {
 				_, appName := filepath.Split(genDir)
 				appChartDir := filepath.Join(genDir, "charts", appName)
-
-				log.Logger().Infof("### PostDraftPack callback copying from %s to %s!!!s", chartsDir, appChartDir)
 				err := util.CopyDirOverwrite(chartsDir, appChartDir)
 				if err != nil {
 					return err
@@ -218,11 +216,9 @@ func (o *CreateQuickstartOptions) CreateQuickStart(q *quickstarts.QuickstartForm
 				}
 				return o.Git().Remove(genDir, filepath.Join("charts", folder))
 			}
-		} else {
-			log.Logger().Infof("### NO charts folder %s", chartsDir)
 		}
 	}
-	log.Logger().Infof("Created project at %s\n", util.ColorInfo(genDir))
+	o.GetReporter().CreatedProject(genDir)
 
 	o.CreateProjectOptions.ImportOptions.GitProvider = o.GitProvider
 
@@ -290,7 +286,7 @@ func (o *CreateQuickstartOptions) createQuickstart(f *quickstarts.QuickstartForm
 	if err != nil {
 		return answer, fmt.Errorf("failed to rename temp dir %s to %s: %s", tmpDir, answer, err)
 	}
-	log.Logger().Infof("Generated quickstart at %s", answer)
+	o.GetReporter().GeneratedQuickStartAt(answer)
 	return answer, nil
 }
 

--- a/pkg/cmd/create/create_quickstart.go
+++ b/pkg/cmd/create/create_quickstart.go
@@ -114,6 +114,7 @@ func (o *CreateQuickstartOptions) Run() error {
 	return o.CreateQuickStart(q)
 }
 
+// CreateQuickStart helper method to create a quickstart from a quickstart resource
 func (o *CreateQuickstartOptions) CreateQuickStart(q *quickstarts.QuickstartForm) error {
 	if q == nil {
 		return fmt.Errorf("no quickstart chosen")

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -1553,6 +1553,7 @@ func (options *ImportOptions) DefaultsFromTeamSettings() error {
 	return options.DefaultValuesFromTeamSettings(settings)
 }
 
+// DefaultValuesFromTeamSettings defaults the repository options from the given team settings
 func (options *ImportOptions) DefaultValuesFromTeamSettings(settings *v1.TeamSettings) error {
 	if options.DeployKind == "" {
 		options.DeployKind = settings.DeployKind

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -1535,6 +1535,10 @@ func (options *ImportOptions) DefaultsFromTeamSettings() error {
 	if err != nil {
 		return err
 	}
+	return options.DefaultValuesFromTeamSettings(settings)
+}
+
+func (options *ImportOptions) DefaultValuesFromTeamSettings(settings *v1.TeamSettings) error {
 	if options.DeployKind == "" {
 		options.DeployKind = settings.DeployKind
 	}

--- a/pkg/cmd/importcmd/import_reporter.go
+++ b/pkg/cmd/importcmd/import_reporter.go
@@ -1,0 +1,68 @@
+package importcmd
+
+import (
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+)
+
+var info = util.ColorInfo
+
+// ImportReporter an interface for reporting updates from the process
+type ImportReporter interface {
+	// UsingGitUserName report progress
+	UsingGitUserName(username string)
+	// PushedGitRepository report progress
+	PushedGitRepository(url string)
+	// GitRepositoryCreated report progress
+	GitRepositoryCreated()
+	// CreatedDevRepoPullRequest report progress
+	CreatedDevRepoPullRequest(prURL string, devGitURL string)
+	// CreatedProject report progress
+	CreatedProject(genDir string)
+	// GeneratedQuickStartAt report progress
+	GeneratedQuickStartAt(genDir string)
+
+	// Trace report generic trace message
+	Trace(message string, options ...interface{})
+}
+
+var _ ImportReporter = &LogImportReporter{}
+
+// LogImportReporter default implementation to log to the console
+type LogImportReporter struct {
+}
+
+// Trace report generic trace message
+func (r *LogImportReporter) Trace(message string, args ...interface{}) {
+	log.Logger().Infof(message, args...)
+}
+
+// CreatedDevRepoPullRequest report progress
+func (r *LogImportReporter) CreatedDevRepoPullRequest(prURL string, devGitURL string) {
+	log.Logger().Infof("created pull request %s on the development git repository %s", info(prURL), info(devGitURL))
+}
+
+// GitRepositoryCreated report progress
+func (r *LogImportReporter) GitRepositoryCreated() {
+	log.Logger().Infof("\nGit repository created")
+}
+
+// UsingGitUserName report progress
+func (r *LogImportReporter) UsingGitUserName(username string) {
+	log.Logger().Infof("Using Git user name: %s", username)
+}
+
+// PushedGitRepository report progress
+func (r *LogImportReporter) PushedGitRepository(repoURL string) {
+	log.Logger().Infof("Pushed Git repository to %s\n", info(repoURL))
+}
+
+// CreatedProject report progress
+func (r *LogImportReporter) CreatedProject(genDir string) {
+	log.Logger().Infof("Created project at %s\n", util.ColorInfo(genDir))
+}
+
+// GeneratedQuickStartAt report progress
+func (r *LogImportReporter) GeneratedQuickStartAt(genDir string) {
+	log.Logger().Infof("Generated quickstart at %s", genDir)
+}

--- a/pkg/cmd/step/git/step_git_credentials.go
+++ b/pkg/cmd/step/git/step_git_credentials.go
@@ -167,7 +167,7 @@ func (o *StepGitCredentialsOptions) CreateGitCredentialsFile(fileName string, co
 	return nil
 }
 
-// CreateGitCredentialsFile creates the git credentials into file using the provided username, token & url
+// CreateGitCredentialsFileFromUsernameAndToken creates the git credentials into file using the provided username, token & url
 func (o *StepGitCredentialsOptions) CreateGitCredentialsFileFromUsernameAndToken(fileName string, username string, token string, url string) error {
 	data, err := o.CreateGitCredentialsFromUsernameAndToken(username, token, url)
 	if err != nil {
@@ -180,7 +180,7 @@ func (o *StepGitCredentialsOptions) CreateGitCredentialsFileFromUsernameAndToken
 	return nil
 }
 
-// CreateGitCredentials creates the git credentials using the auth config service
+// CreateGitCredentialsFromAuthService creates the git credentials using the auth config service
 func (o *StepGitCredentialsOptions) CreateGitCredentialsFromAuthService(authConfigSvc auth.ConfigService) ([]byte, error) {
 	cfg := authConfigSvc.Config()
 	if cfg == nil {
@@ -233,7 +233,7 @@ func (o *StepGitCredentialsOptions) CreateGitCredentialsFromAuthService(authConf
 	return buffer.Bytes(), nil
 }
 
-// CreateGitCredentials creates the git credentials using the auth config service
+// CreateGitCredentialsFromUsernameAndToken creates the git credentials using the auth config service
 func (o *StepGitCredentialsOptions) CreateGitCredentialsFromUsernameAndToken(username string, token string, serverURL string) ([]byte, error) {
 	var buffer bytes.Buffer
 

--- a/pkg/cmd/step/git/step_git_credentials.go
+++ b/pkg/cmd/step/git/step_git_credentials.go
@@ -125,7 +125,6 @@ func (o *StepGitCredentialsOptions) Run() error {
 		url := string(secret.Data["url"])
 
 		return o.CreateGitCredentialsFileFromUsernameAndToken(outFile, username, token, url)
-
 	}
 
 	gha, err := o.IsGitHubAppMode()

--- a/pkg/cmd/step/git/step_git_credentials.go
+++ b/pkg/cmd/step/git/step_git_credentials.go
@@ -19,6 +19,9 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -30,9 +33,10 @@ const (
 type StepGitCredentialsOptions struct {
 	step.StepOptions
 
-	OutputFile     string
-	GitHubAppOwner string
-	GitKind        string
+	OutputFile        string
+	GitHubAppOwner    string
+	GitKind           string
+	CredentialsSecret string
 }
 
 var (
@@ -71,19 +75,17 @@ func NewCmdStepGitCredentials(commonOpts *opts.CommonOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&options.OutputFile, optionOutputFile, "o", "", "The output file name")
 	cmd.Flags().StringVarP(&options.GitHubAppOwner, optionGitHubAppOwner, "g", "", "The owner (organisation or user name) if using GitHub App based tokens")
+	cmd.Flags().StringVarP(&options.CredentialsSecret, "credentials-secret", "s", "", "The secret name to read the credentials from")
 	cmd.Flags().StringVarP(&options.GitKind, "git-kind", "", "", "The git kind. e.g. github, bitbucketserver etc")
 	return cmd
 }
 
 func (o *StepGitCredentialsOptions) Run() error {
-	gha, err := o.IsGitHubAppMode()
-	if err != nil {
-		return err
+	if os.Getenv("JX_CREDENTIALS_FROM_SECRET") != "" {
+		log.Logger().Infof("Overriding CredentialsSecret from env var JX_CREDENTIALS_FROM_SECRET")
+		o.CredentialsSecret = os.Getenv("JX_CREDENTIALS_FROM_SECRET")
 	}
-	if gha && o.GitHubAppOwner == "" {
-		log.Logger().Infof("this command does nothing if using github app mode and no %s option specified", optionGitHubAppOwner)
-		return nil
-	}
+
 	outFile := o.OutputFile
 	if outFile == "" {
 		// lets figure out the default output file
@@ -106,6 +108,36 @@ func (o *StepGitCredentialsOptions) Run() error {
 		}
 	}
 
+	if o.CredentialsSecret != "" {
+		// get secret
+		kubeClient, ns, err := o.KubeClientAndDevNamespace()
+		if err != nil {
+			return err
+		}
+
+		secret, err := kubeClient.CoreV1().Secrets(ns).Get(o.CredentialsSecret, metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to find secret '%s' in namespace '%s'", o.CredentialsSecret, ns)
+		}
+
+		username := string(secret.Data["user"])
+		token := string(secret.Data["token"])
+		url := string(secret.Data["url"])
+
+		return o.CreateGitCredentialsFileFromUsernameAndToken(outFile, username, token, url)
+
+	}
+
+	gha, err := o.IsGitHubAppMode()
+	if err != nil {
+		return err
+	}
+
+	if gha && o.GitHubAppOwner == "" {
+		log.Logger().Infof("this command does nothing if using github app mode and no %s option specified", optionGitHubAppOwner)
+		return nil
+	}
+
 	var authConfigSvc auth.ConfigService
 	if gha {
 		authConfigSvc, err = o.GitAuthConfigServiceGitHubMode(o.GitKind)
@@ -124,7 +156,20 @@ func (o *StepGitCredentialsOptions) Run() error {
 
 // CreateGitCredentialsFile creates the git credentials into file using the provided auth config service
 func (o *StepGitCredentialsOptions) CreateGitCredentialsFile(fileName string, configSvc auth.ConfigService) error {
-	data, err := o.CreateGitCredentials(configSvc)
+	data, err := o.CreateGitCredentialsFromAuthService(configSvc)
+	if err != nil {
+		return errors.Wrap(err, "creating git credentials")
+	}
+	if err := ioutil.WriteFile(fileName, data, util.DefaultWritePermissions); err != nil {
+		return fmt.Errorf("Failed to write to %s: %s", fileName, err)
+	}
+	log.Logger().Infof("Generated Git credentials file %s", util.ColorInfo(fileName))
+	return nil
+}
+
+// CreateGitCredentialsFile creates the git credentials into file using the provided username, token & url
+func (o *StepGitCredentialsOptions) CreateGitCredentialsFileFromUsernameAndToken(fileName string, username string, token string, url string) error {
+	data, err := o.CreateGitCredentialsFromUsernameAndToken(username, token, url)
 	if err != nil {
 		return errors.Wrap(err, "creating git credentials")
 	}
@@ -136,7 +181,7 @@ func (o *StepGitCredentialsOptions) CreateGitCredentialsFile(fileName string, co
 }
 
 // CreateGitCredentials creates the git credentials using the auth config service
-func (o *StepGitCredentialsOptions) CreateGitCredentials(authConfigSvc auth.ConfigService) ([]byte, error) {
+func (o *StepGitCredentialsOptions) CreateGitCredentialsFromAuthService(authConfigSvc auth.ConfigService) ([]byte, error) {
 	cfg := authConfigSvc.Config()
 	if cfg == nil {
 		return nil, errors.New("no git auth config found")
@@ -185,5 +230,26 @@ func (o *StepGitCredentialsOptions) CreateGitCredentials(authConfigSvc auth.Conf
 			buffer.WriteString(u.String() + "\n")
 		}
 	}
+	return buffer.Bytes(), nil
+}
+
+// CreateGitCredentials creates the git credentials using the auth config service
+func (o *StepGitCredentialsOptions) CreateGitCredentialsFromUsernameAndToken(username string, token string, serverURL string) ([]byte, error) {
+	var buffer bytes.Buffer
+
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		log.Logger().Warnf("Ignoring invalid git service URL %q", serverURL)
+		return nil, err
+	}
+
+	u.User = url.UserPassword(username, token)
+	buffer.WriteString(u.String() + "\n")
+	// Write the https protocol in case only https is set for completeness
+	if u.Scheme == "http" {
+		u.Scheme = "https"
+	}
+
+	buffer.WriteString(u.String() + "\n")
 	return buffer.Bytes(), nil
 }

--- a/pkg/cmd/step/verify/step_verify_behavior.go
+++ b/pkg/cmd/step/verify/step_verify_behavior.go
@@ -31,9 +31,10 @@ import (
 type BehaviorOptions struct {
 	*opts.CommonOptions
 
-	SourceGitURL string
-	Branch       string
-	NoImport     bool
+	SourceGitURL      string
+	Branch            string
+	NoImport          bool
+	CredentialsSecret string
 }
 
 var (
@@ -70,6 +71,7 @@ func NewCmdStepVerifyBehavior(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.SourceGitURL, "git-url", "u", "https://github.com/jenkins-x/bdd-jx.git", "The git URL of the BDD tests pipeline")
 	cmd.Flags().StringVarP(&options.Branch, "branch", "", "master", "The git branch to use to run the BDD tests")
 	cmd.Flags().BoolVarP(&options.NoImport, "no-import", "", false, "Create the pipeline directly, don't import the repository")
+	cmd.Flags().StringVarP(&options.CredentialsSecret, "credentials-secret", "", "", "The name of the secret to generate the bdd credentials from, if not specified, the default git auth will be used")
 	return cmd
 }
 
@@ -216,6 +218,10 @@ func (o *BehaviorOptions) runPipelineDirectly(owner string, repo string, sourceU
 
 	pullRefData := metapipeline.NewPullRef(sourceURL, branch, "")
 	envVars := map[string]string{}
+	if o.CredentialsSecret != "" {
+		envVars["JX_CREDENTIALS_FROM_SECRET"] = o.CredentialsSecret
+	}
+
 	pipelineCreateParam := metapipeline.PipelineCreateParam{
 		PullRef:      pullRefData,
 		PipelineKind: kind,

--- a/pkg/cmd/step/verify/step_verify_behavior.go
+++ b/pkg/cmd/step/verify/step_verify_behavior.go
@@ -228,6 +228,7 @@ func (o *BehaviorOptions) runPipelineDirectly(owner string, repo string, sourceU
 		DefaultImage:        "",
 		EnvVariables:        envVars,
 		UseBranchAsRevision: true,
+		NoReleasePrepare:    true,
 	}
 
 	c, err := metapipeline.NewMetaPipelineClient()

--- a/pkg/cmd/step/verify/step_verify_preinstall_test.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall_test.go
@@ -13,9 +13,12 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/prow"
 	"github.com/jenkins-x/jx/pkg/tests"
+	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 var timeout = 1 * time.Second
@@ -98,6 +101,7 @@ func Test_doesnt_ask_for_confirmation_when_in_gke(t *testing.T) {
 	testConfig.Cluster.ProjectID = "test"
 	testConfig.Cluster.Zone = "exzone"
 	testConfig.Cluster.ClusterName = "acme"
+	testConfig.Cluster.DevEnvApprovers = []string{"bob"}
 
 	testOptions.gatherRequirements(testConfig, "")
 	fakeStdout.Close()
@@ -129,6 +133,7 @@ func Test_doesnt_ask_for_confirmation_when_in_batch_mode_and_with_different_prov
 	testConfig.Cluster.ProjectID = "test"
 	testConfig.Cluster.Zone = "exzone"
 	testConfig.Cluster.ClusterName = "acme"
+	testConfig.Cluster.DevEnvApprovers = []string{"bob"}
 
 	testOptions.gatherRequirements(testConfig, "")
 	fakeStdout.Close()
@@ -165,6 +170,7 @@ func Test_asks_for_confirmation_when_not_in_batch_mode_and_with_different_provid
 	testConfig.Cluster.ProjectID = "test"
 	testConfig.Cluster.Zone = "exzone"
 	testConfig.Cluster.ClusterName = "acme"
+	testConfig.Cluster.DevEnvApprovers = []string{"bob"}
 
 	done := make(chan struct{})
 	go func() {
@@ -255,7 +261,7 @@ func TestGatherRequirements_PreserveEnvironmentGitOwnerCase(t *testing.T) {
 	assert.Equal(t, "ACME", requirementsWithDefaults.Cluster.EnvironmentGitOwner)
 }
 
-func TestGatherRequirements_SetsDefaults(t *testing.T) {
+func TestGatherRequirements_DevEnvApprovers(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "test-step-verify-preinstall-")
 	require.NoError(t, err)
 
@@ -267,9 +273,14 @@ func TestGatherRequirements_SetsDefaults(t *testing.T) {
 	testConfig.Cluster.ProjectID = "test"
 	testConfig.Cluster.Zone = "exzone"
 	testConfig.Cluster.ClusterName = "acme"
+	testConfig.Cluster.DevEnvApprovers = []string{
+		"bob",
+		"steve",
+	}
 
 	testOptions := &StepVerifyPreInstallOptions{
 		WorkloadIdentity: true,
+		Dir:              tempDir,
 		StepVerifyOptions: StepVerifyOptions{
 			StepOptions: step.StepOptions{
 				CommonOptions: &opts.CommonOptions{
@@ -291,4 +302,69 @@ func TestGatherRequirements_SetsDefaults(t *testing.T) {
 	assert.Equal(t, "github", requirementsWithDefaults.Cluster.GitName)
 	assert.Equal(t, "-jx.", requirementsWithDefaults.Ingress.NamespaceSubDomain)
 	assert.Equal(t, config.RepositoryTypeNexus, requirementsWithDefaults.Repository)
+	assert.Len(t, requirementsWithDefaults.Cluster.DevEnvApprovers, 2)
+	assert.Equal(t, []string{"bob", "steve"}, requirementsWithDefaults.Cluster.DevEnvApprovers)
+
+	ownersFileName := filepath.Join(tempDir, "OWNERS")
+	ownersExists, err := util.FileExists(ownersFileName)
+	assert.NoError(t, err)
+	assert.True(t, ownersExists)
+
+	expectedOwners := &prow.Owners{
+		Approvers: []string{"bob", "steve"},
+		Reviewers: []string{"bob", "steve"},
+	}
+	loadedOwners := &prow.Owners{}
+
+	ownersContent, err := ioutil.ReadFile(ownersFileName)
+	assert.NoError(t, err)
+
+	err = yaml.Unmarshal(ownersContent, loadedOwners)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOwners, loadedOwners)
+}
+
+func TestGatherRequirements_SetsDefaults(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "test-step-verify-preinstall-")
+	require.NoError(t, err)
+
+	requirementsFileName := filepath.Join(tempDir, "jx-requirements.yml")
+
+	testConfig := &config.RequirementsConfig{}
+	testConfig.Cluster.Provider = "gke"
+	testConfig.Cluster.EnvironmentGitOwner = "acme"
+	testConfig.Cluster.ProjectID = "test"
+	testConfig.Cluster.Zone = "exzone"
+	testConfig.Cluster.ClusterName = "acme"
+
+	testOptions := &StepVerifyPreInstallOptions{
+		WorkloadIdentity: true,
+		Dir:              tempDir,
+		StepVerifyOptions: StepVerifyOptions{
+			StepOptions: step.StepOptions{
+				CommonOptions: &opts.CommonOptions{
+					BatchMode: true,
+				},
+			},
+		},
+	}
+
+	_, err = testOptions.gatherRequirements(testConfig, requirementsFileName)
+	assert.NoError(t, err)
+
+	requirementsWithDefaults, err := config.LoadRequirementsConfigFile(requirementsFileName)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "jx", requirementsWithDefaults.Cluster.Namespace)
+	assert.Equal(t, "https://github.com", requirementsWithDefaults.Cluster.GitServer)
+	assert.Equal(t, "github", requirementsWithDefaults.Cluster.GitKind)
+	assert.Equal(t, "github", requirementsWithDefaults.Cluster.GitName)
+	assert.Equal(t, "-jx.", requirementsWithDefaults.Ingress.NamespaceSubDomain)
+	assert.Equal(t, config.RepositoryTypeNexus, requirementsWithDefaults.Repository)
+	assert.Len(t, requirementsWithDefaults.Cluster.DevEnvApprovers, 0)
+
+	ownersFileName := filepath.Join(tempDir, "OWNERS")
+	ownersExists, err := util.FileExists(ownersFileName)
+	assert.NoError(t, err)
+	assert.False(t, ownersExists)
 }

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -110,6 +110,8 @@ const (
 	RequirementGitAppEnabled = "JX_REQUIREMENT_GITHUB_APP_ENABLED"
 	// RequirementGitAppURL contains the URL to the github app
 	RequirementGitAppURL = "JX_REQUIREMENT_GITHUB_APP_URL"
+	// RequirementDevEnvApprovers contains the optional list of users to populate the dev env's OWNERS with
+	RequirementDevEnvApprovers = "JX_REQUIREMENT_DEV_ENV_APPROVERS"
 )
 
 const (
@@ -333,6 +335,8 @@ type ClusterConfig struct {
 	KanikoSAName string `json:"kanikoSAName,omitempty"`
 	// HelmMajorVersion contains the major helm version number. Assumes helm 2.x with no tiller if no value specified
 	HelmMajorVersion string `json:"helmMajorVersion,omitempty"`
+	// DevEnvApprovers contains an optional list of approvers to populate the initial OWNERS file in the dev env repo
+	DevEnvApprovers []string `json:"devEnvApprovers,omitempty"`
 }
 
 // VaultConfig contains Vault configuration for boot
@@ -981,6 +985,12 @@ func (c *RequirementsConfig) OverrideRequirementsFromEnvironment(gcloudFn func()
 			c.GithubApp = &GithubAppConfig{}
 		}
 		c.GithubApp.URL = os.Getenv(RequirementGitAppURL)
+	}
+	if "" != os.Getenv(RequirementDevEnvApprovers) {
+		rawApprovers := os.Getenv(RequirementDevEnvApprovers)
+		for _, approver := range strings.Split(rawApprovers, ",") {
+			c.Cluster.DevEnvApprovers = append(c.Cluster.DevEnvApprovers, strings.TrimSpace(approver))
+		}
 	}
 	// set this if its not currently configured
 	if c.Cluster.Provider == "gke" {

--- a/pkg/config/zz_generated.deepcopy.go
+++ b/pkg/config/zz_generated.deepcopy.go
@@ -233,6 +233,11 @@ func (in *ClusterConfig) DeepCopyInto(out *ClusterConfig) {
 		*out = new(GKEConfig)
 		**out = **in
 	}
+	if in.DevEnvApprovers != nil {
+		in, out := &in.DevEnvApprovers, &out.DevEnvApprovers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/tekton/metapipeline/client.go
+++ b/pkg/tekton/metapipeline/client.go
@@ -38,6 +38,9 @@ type PipelineCreateParam struct {
 	// UseBranchAsRevision forces step_create_task to use the branch it's passed as the revision to checkout for release
 	// pipelines, rather than use the version tag
 	UseBranchAsRevision bool
+
+	// NoReleasePrepare do not prepare the release, this passes the --no-release-prepare flag to `jx step create task`
+	NoReleasePrepare bool
 }
 
 // Client defines the interface for meta pipeline creation and application.

--- a/pkg/tekton/metapipeline/clientfactory.go
+++ b/pkg/tekton/metapipeline/clientfactory.go
@@ -139,6 +139,7 @@ func (c *clientFactory) Create(param PipelineCreateParam) (kube.PromoteStepActiv
 		VersionsDir:         c.versionDir,
 		GitInfo:             *gitInfo,
 		UseBranchAsRevision: param.UseBranchAsRevision,
+		NoReleasePrepare:    param.NoReleasePrepare,
 	}
 
 	return c.createActualCRDs(buildNumber, branchIdentifier, param.Context, param.PullRef, crdCreationParams)

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -57,6 +57,7 @@ type CRDCreationParameters struct {
 	Apps                []jenkinsv1.App
 	VersionsDir         string
 	UseBranchAsRevision bool
+	NoReleasePrepare    bool
 }
 
 // createMetaPipelineCRDs creates the Tekton CRDs needed to execute the meta pipeline.
@@ -261,6 +262,9 @@ func stepCreateTektonCRDs(params CRDCreationParameters) syntax.Step {
 	}
 	if params.UseBranchAsRevision {
 		args = append(args, "--branch-as-revision")
+	}
+	if params.NoReleasePrepare {
+		args = append(args, "--no-release-prepare")
 	}
 	for k, v := range params.Labels {
 		args = append(args, "--label", fmt.Sprintf("%s=%s", k, v))


### PR DESCRIPTION
this change gives us the option to run the bdd tests directly via the meta
pipeline client, rather than having to import the repository as a source repo
with an assosicated scheduler.

fixes cloudbees/arcalos#567

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->