### PR TITLE
fix: Cloning for environments shouldn't leave strange state in JX_HOME

### DIFF
--- a/pkg/apps/gitops.go
+++ b/pkg/apps/gitops.go
@@ -167,15 +167,14 @@ func (o *GitOpsOptions) DeleteApp(app string, alias string, autoMerge bool) erro
 
 // GetApps retrieves all the apps information for the given appNames from the repository and / or the CRD API
 func (o *GitOpsOptions) GetApps(appNames map[string]bool, expandFn func([]string) (*v1.AppList, error)) (*v1.AppList, error) {
-	dir := o.EnvironmentCloneDir
-	if dir == "" {
-		tmpDir, err := ioutil.TempDir("", "get-apps-")
-		if err != nil {
-			return nil, err
-		}
-		defer os.RemoveAll(tmpDir)
-		dir = tmpDir
+	// AddApp, DeleteApp, and UpgradeApps delegate selecting/creating the directory to clone in to environments/gitops.go's
+	// Create function, but here we need to create the directory explicitly. since we aren't calling Create, because we're
+	// not creating a pull request.
+	dir, err := ioutil.TempDir("", "get-apps-")
+	if err != nil {
+		return nil, err
 	}
+	defer os.RemoveAll(dir)
 
 	gitInfo, err := gits.ParseGitURL(o.DevEnv.Spec.Source.URL)
 	if err != nil {

--- a/pkg/apps/install.go
+++ b/pkg/apps/install.go
@@ -36,24 +36,24 @@ import (
 
 // InstallOptions are shared options for installing, removing or upgrading apps for either GitOps or HelmOps
 type InstallOptions struct {
-	Helmer          helm.Helmer
-	KubeClient      kubernetes.Interface
-	InstallTimeout  string
-	JxClient        versioned.Interface
-	Namespace       string
-	EnvironmentsDir string
-	GitProvider     gits.GitProvider
-	Gitter          gits.Gitter
-	Verbose         bool
-	DevEnv          *jenkinsv1.Environment
-	BatchMode       bool
-	IOFileHandles   util.IOFileHandles
-	GitOps          bool
-	TeamName        string
-	BasePath        string
-	VaultClient     vault.Client
-	AutoMerge       bool
-	SecretsScheme   string
+	Helmer              helm.Helmer
+	KubeClient          kubernetes.Interface
+	InstallTimeout      string
+	JxClient            versioned.Interface
+	Namespace           string
+	EnvironmentCloneDir string
+	GitProvider         gits.GitProvider
+	Gitter              gits.Gitter
+	Verbose             bool
+	DevEnv              *jenkinsv1.Environment
+	BatchMode           bool
+	IOFileHandles       util.IOFileHandles
+	GitOps              bool
+	TeamName            string
+	BasePath            string
+	VaultClient         vault.Client
+	AutoMerge           bool
+	SecretsScheme       string
 
 	valuesFiles *environments.ValuesFiles // internal variable used to track, most be passed in
 }
@@ -104,7 +104,7 @@ func (o *InstallOptions) AddApp(app string, version string, repository string, u
 			opts := GitOpsOptions{
 				InstallOptions: o,
 			}
-			err := opts.AddApp(chartDetails.Name, dir, chartDetails.Version, repository, alias, o.AutoMerge)
+			err = opts.AddApp(chartDetails.Name, dir, chartDetails.Version, repository, alias, o.AutoMerge)
 			if err != nil {
 				return errors.Wrapf(err, "adding app %s version %s with alias %s using gitops", chartName, version, alias)
 			}

--- a/pkg/cmd/add/add_app.go
+++ b/pkg/cmd/add/add_app.go
@@ -40,6 +40,9 @@ type AddAppOptions struct {
 	ValuesFiles []string
 	HelmUpdate  bool
 	AutoMerge   bool
+
+	// Used for testing
+	CloneDir string
 }
 
 const (
@@ -141,11 +144,12 @@ func (o *AddAppOptions) Run() error {
 		AutoMerge:     o.AutoMerge,
 		SecretsScheme: "vault",
 
-		Helmer:         o.Helm(),
-		Namespace:      o.Namespace,
-		KubeClient:     kubeClient,
-		JxClient:       jxClient,
-		InstallTimeout: opts.DefaultInstallTimeout,
+		Helmer:              o.Helm(),
+		Namespace:           o.Namespace,
+		KubeClient:          kubeClient,
+		JxClient:            jxClient,
+		InstallTimeout:      opts.DefaultInstallTimeout,
+		EnvironmentCloneDir: o.CloneDir,
 	}
 
 	if o.GitOps {
@@ -163,11 +167,6 @@ func (o *AddAppOptions) Run() error {
 			return util.InvalidOptionf(optionValues, o.SetValues,
 				"no more than one --%s can be specified when using GitOps for your dev environment", optionValues)
 		}
-		environmentsDir, err := o.EnvironmentsDir()
-		if err != nil {
-			return errors.Wrapf(err, "getting environments dir")
-		}
-		installOpts.EnvironmentsDir = environmentsDir
 
 		gitProvider, _, err := o.CreateGitProviderForURLWithoutKind(o.DevEnv.Spec.Source.URL)
 		if err != nil {

--- a/pkg/cmd/add/add_app_test.go
+++ b/pkg/cmd/add/add_app_test.go
@@ -80,6 +80,11 @@ func TestAddAppForGitOps(t *testing.T) {
 			DevEnv:     testOptions.DevEnv,
 			HelmUpdate: true, // Flag default when run on CLI
 		}
+		envDir, err := o.CommonOptions.EnvironmentsDir()
+		assert.NoError(r, err)
+		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+		o.CloneDir = devEnvDir
+
 		helm_test.StubFetchChart(name, "", kube.DefaultChartMuseumURL, &chart.Chart{
 			Metadata: &chart.Metadata{
 				Name:        name,
@@ -96,9 +101,6 @@ func TestAddAppForGitOps(t *testing.T) {
 		assert.Equal(r, fmt.Sprintf("Add %s %s", name, version), pr.Title)
 		assert.Equal(r, fmt.Sprintf("Add app %s %s", name, version), pr.Body)
 		// Validate the branch name
-		envDir, err := o.CommonOptions.EnvironmentsDir()
-		assert.NoError(r, err)
-		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 		branchName, err := o.Git().Branch(devEnvDir)
 		assert.NoError(r, err)
 		assert.Equal(r, fmt.Sprintf("add-app-%s-%s", name, version), branchName)
@@ -153,6 +155,11 @@ func TestAddAppForGitOpsWithShortName(t *testing.T) {
 			DevEnv:     testOptions.DevEnv,
 			HelmUpdate: true, // Flag default when run on CLI
 		}
+		envDir, err := o.CommonOptions.EnvironmentsDir()
+		assert.NoError(r, err)
+		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+		o.CloneDir = devEnvDir
+
 		pegomock.When(testOptions.MockHelmer.ListRepos()).ThenReturn(
 			map[string]string{
 				"repo1": kube.DefaultChartMuseumURL,
@@ -181,9 +188,6 @@ func TestAddAppForGitOpsWithShortName(t *testing.T) {
 		assert.Equal(r, fmt.Sprintf("Add %s %s", name, version), pr.Title)
 		assert.Equal(r, fmt.Sprintf("Add app %s %s", name, version), pr.Body)
 		// Validate the branch name
-		envDir, err := o.CommonOptions.EnvironmentsDir()
-		assert.NoError(r, err)
-		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 		branchName, err := o.Git().Branch(devEnvDir)
 		assert.NoError(r, err)
 		assert.Equal(r, fmt.Sprintf("add-app-%s-%s", name, version), branchName)
@@ -608,6 +612,10 @@ func TestAddAppForGitOpsWithSecrets(t *testing.T) {
 		}
 		o.Args = []string{name}
 		o.BatchMode = false
+		envDir, err := o.CommonOptions.EnvironmentsDir()
+		assert.NoError(r, err)
+		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+		o.CloneDir = devEnvDir
 
 		helm_test.StubFetchChart(name, "", kube.DefaultChartMuseumURL, &chart.Chart{
 			Metadata: &chart.Metadata{
@@ -651,9 +659,7 @@ func TestAddAppForGitOpsWithSecrets(t *testing.T) {
 		r.Logf(expect.StripTrailingEmptyLines(console.CurrentState()))
 
 		// Validate that the secret reference is generated
-		envDir, err := o.CommonOptions.EnvironmentsDir()
-		assert.NoError(r, err)
-		valuesFromPrPath := filepath.Join(testOptions.GetFullDevEnvDir(envDir), name, helm.ValuesFileName)
+		valuesFromPrPath := filepath.Join(devEnvDir, name, helm.ValuesFileName)
 		_, err = os.Stat(valuesFromPrPath)
 		assert.NoError(r, err)
 		data, err := ioutil.ReadFile(valuesFromPrPath)
@@ -961,12 +967,13 @@ func TestAddAppWithValuesFileForGitOps(t *testing.T) {
 		ValuesFiles: []string{file.Name()},
 	}
 	o.Args = []string{name}
-	err = o.Run()
-	assert.NoError(t, err)
-	// Validate that the values.yaml file is in the right place
 	envDir, err := o.CommonOptions.EnvironmentsDir()
 	assert.NoError(t, err)
 	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+	o.CloneDir = devEnvDir
+	err = o.Run()
+	assert.NoError(t, err)
+	// Validate that the values.yaml file is in the right place
 	valuesFromPrPath := filepath.Join(devEnvDir, name, helm.ValuesFileName)
 	_, err = os.Stat(valuesFromPrPath)
 	assert.NoError(t, err)
@@ -1017,6 +1024,10 @@ func TestAddAppWithReadmeForGitOps(t *testing.T) {
 		HelmUpdate: true, // Flag default when run on CLI
 	}
 	o.Args = []string{name}
+	envDir, err := o.CommonOptions.EnvironmentsDir()
+	assert.NoError(t, err)
+	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+	o.CloneDir = devEnvDir
 	helm_test.StubFetchChart(name, "", kube.DefaultChartMuseumURL, &chart.Chart{
 		Metadata: &chart.Metadata{
 			Name:        name,
@@ -1033,9 +1044,6 @@ func TestAddAppWithReadmeForGitOps(t *testing.T) {
 	err = o.Run()
 	assert.NoError(t, err)
 	// Validate that the README.md file is in the right place
-	envDir, err := o.CommonOptions.EnvironmentsDir()
-	assert.NoError(t, err)
-	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 	readmeFromPrPath := filepath.Join(devEnvDir, name, "README.MD")
 	_, err = os.Stat(readmeFromPrPath)
 	assert.NoError(t, err)
@@ -1090,6 +1098,10 @@ func TestAddAppWithCustomReadmeForGitOps(t *testing.T) {
 	}
 	o.Verbose = true
 	o.Args = []string{name}
+	envDir, err := o.CommonOptions.EnvironmentsDir()
+	assert.NoError(t, err)
+	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+	o.CloneDir = devEnvDir
 	readmeFileName := "README.MD"
 	readme := "Tasty Cheese!\n"
 	helm_test.StubFetchChart(name, "", kube.DefaultChartMuseumURL, &chart.Chart{
@@ -1107,9 +1119,6 @@ func TestAddAppWithCustomReadmeForGitOps(t *testing.T) {
 	err = o.Run()
 	assert.NoError(t, err)
 	// Validate that the README.md file is in the right place
-	envDir, err := o.CommonOptions.EnvironmentsDir()
-	assert.NoError(t, err)
-	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 	readmeFromPrPath := filepath.Join(devEnvDir, name, readmeFileName)
 	_, err = os.Stat(readmeFromPrPath)
 	assert.NoError(t, err)
@@ -1154,6 +1163,10 @@ func TestAddLatestAppForGitOps(t *testing.T) {
 	}
 	o.Args = []string{name}
 	o.Verbose = true
+	envDir, err := o.CommonOptions.EnvironmentsDir()
+	assert.NoError(t, err)
+	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+	o.CloneDir = devEnvDir
 
 	helm_test.StubFetchChart(name, "", kube.DefaultChartMuseumURL, &chart.Chart{
 		Metadata: &chart.Metadata{
@@ -1170,9 +1183,6 @@ func TestAddLatestAppForGitOps(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("Add %s %s", name, version), pr.Title)
 	assert.Equal(t, fmt.Sprintf("Add app %s %s", name, version), pr.Body)
 	// Validate the branch name
-	envDir, err := o.CommonOptions.EnvironmentsDir()
-	assert.NoError(t, err)
-	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 	branchName, err := o.Git().Branch(devEnvDir)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("add-app-%s-%s", name, version), branchName)
@@ -1224,6 +1234,10 @@ func TestAddAppIncludingConditionalQuestionsForGitOps(t *testing.T) {
 		}
 		o.Args = []string{name}
 		o.BatchMode = false
+		envDir, err := o.CommonOptions.EnvironmentsDir()
+		assert.NoError(t, err)
+		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+		o.CloneDir = devEnvDir
 
 		helm_test.StubFetchChart(name, "", kube.DefaultChartMuseumURL, &chart.Chart{
 			Metadata: &chart.Metadata{
@@ -1275,9 +1289,7 @@ func TestAddAppIncludingConditionalQuestionsForGitOps(t *testing.T) {
 		<-donec
 		r.Logf(expect.StripTrailingEmptyLines(console.CurrentState()))
 
-		envDir, err := o.CommonOptions.EnvironmentsDir()
-		assert.NoError(r, err)
-		valuesFromPrPath := filepath.Join(testOptions.GetFullDevEnvDir(envDir), name, helm.ValuesFileName)
+		valuesFromPrPath := filepath.Join(devEnvDir, name, helm.ValuesFileName)
 		_, err = os.Stat(valuesFromPrPath)
 		assert.NoError(r, err)
 		data, err := ioutil.ReadFile(valuesFromPrPath)
@@ -1333,6 +1345,10 @@ func TestAddAppExcludingConditionalQuestionsForGitOps(t *testing.T) {
 		}
 		o.Args = []string{name}
 		o.BatchMode = false
+		envDir, err := o.CommonOptions.EnvironmentsDir()
+		assert.NoError(t, err)
+		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+		o.CloneDir = devEnvDir
 
 		helm_test.StubFetchChart(name, "", kube.DefaultChartMuseumURL, &chart.Chart{
 			Metadata: &chart.Metadata{
@@ -1375,9 +1391,7 @@ func TestAddAppExcludingConditionalQuestionsForGitOps(t *testing.T) {
 		<-donec
 		r.Logf(expect.StripTrailingEmptyLines(console.CurrentState()))
 
-		envDir, err := o.CommonOptions.EnvironmentsDir()
-		assert.NoError(r, err)
-		valuesFromPrPath := filepath.Join(testOptions.GetFullDevEnvDir(envDir), name, helm.ValuesFileName)
+		valuesFromPrPath := filepath.Join(devEnvDir, name, helm.ValuesFileName)
 		_, err = os.Stat(valuesFromPrPath)
 		assert.NoError(r, err)
 		data, err := ioutil.ReadFile(valuesFromPrPath)
@@ -1415,6 +1429,10 @@ func TestAddAppForGitOpsWithSNAPSHOTVersion(t *testing.T) {
 			DevEnv:     testOptions.DevEnv,
 			HelmUpdate: true, // Flag default when run on CLI
 		}
+		envDir, err := o.CommonOptions.EnvironmentsDir()
+		assert.NoError(r, err)
+		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+		o.CloneDir = devEnvDir
 		pegomock.When(testOptions.MockHelmer.ListRepos()).ThenReturn(
 			map[string]string{
 				"repo1": kube.DefaultChartMuseumURL,
@@ -1443,9 +1461,6 @@ func TestAddAppForGitOpsWithSNAPSHOTVersion(t *testing.T) {
 		assert.Equal(r, fmt.Sprintf("Add %s %s", name, version), pr.Title)
 		assert.Equal(r, fmt.Sprintf("Add app %s %s", name, version), pr.Body)
 		// Validate the branch name
-		envDir, err := o.CommonOptions.EnvironmentsDir()
-		assert.NoError(r, err)
-		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 		branchName, err := o.Git().Branch(devEnvDir)
 		assert.NoError(r, err)
 		assert.Equal(r, fmt.Sprintf("add-app-%s-%s", name, version), branchName)

--- a/pkg/cmd/deletecmd/delete_app_test.go
+++ b/pkg/cmd/deletecmd/delete_app_test.go
@@ -44,6 +44,11 @@ func TestDeleteAppForGitOps(t *testing.T) {
 		Alias:         alias,
 	}
 	o.Args = []string{name}
+	// Validate the branch name
+	envDir, err := o.CommonOptions.EnvironmentsDir()
+	assert.NoError(t, err)
+	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+	o.CloneDir = devEnvDir
 
 	err = o.Run()
 	assert.NoError(t, err)
@@ -53,10 +58,6 @@ func TestDeleteAppForGitOps(t *testing.T) {
 	// Validate the PR has the right title, message
 	assert.Equal(t, fmt.Sprintf("Delete %s", name), pr.Title)
 	assert.Equal(t, fmt.Sprintf("Delete app %s", name), pr.Body)
-	// Validate the branch name
-	envDir, err := o.CommonOptions.EnvironmentsDir()
-	assert.NoError(t, err)
-	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 	branchName, err := o.Git().Branch(devEnvDir)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("delete-app-%s", name), branchName)
@@ -89,6 +90,11 @@ func TestDeleteAppWithShortNameForGitOps(t *testing.T) {
 		Alias:         alias,
 	}
 	o.Args = []string{shortName}
+	// Validate the branch name
+	envDir, err := o.CommonOptions.EnvironmentsDir()
+	assert.NoError(t, err)
+	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+	o.CloneDir = devEnvDir
 
 	err = o.Run()
 	assert.NoError(t, err)
@@ -98,10 +104,6 @@ func TestDeleteAppWithShortNameForGitOps(t *testing.T) {
 	// Validate the PR has the right title, message
 	assert.Equal(t, fmt.Sprintf("Delete %s", name), pr.Title)
 	assert.Equal(t, fmt.Sprintf("Delete app %s", name), pr.Body)
-	// Validate the branch name
-	envDir, err := o.CommonOptions.EnvironmentsDir()
-	assert.NoError(t, err)
-	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 	branchName, err := o.Git().Branch(devEnvDir)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("delete-app-%s", name), branchName)

--- a/pkg/cmd/deletecmd/delete_application.go
+++ b/pkg/cmd/deletecmd/delete_application.go
@@ -75,6 +75,9 @@ type DeleteApplicationOptions struct {
 	// calculated fields
 	TimeoutDuration         *time.Duration
 	PullRequestPollDuration *time.Duration
+
+	// Used for testing
+	CloneDir string
 }
 
 // NewCmdDeleteApplication creates a command object for this command
@@ -406,11 +409,11 @@ func (o *DeleteApplicationOptions) deleteApplicationFromEnvironment(env *v1.Envi
 	if err != nil {
 		return errors.Wrapf(err, "creating git provider for %s", env.Spec.Source.URL)
 	}
-	environmentsDir, err := o.EnvironmentsDir()
-	if err != nil {
-		return errors.Wrapf(err, "getting environments dir")
-	}
 
+	envDir := ""
+	if o.CloneDir != "" {
+		envDir = o.CloneDir
+	}
 	details := gits.PullRequestDetails{
 		BranchName: "delete-" + applicationName,
 		Title:      "Delete application " + applicationName + " from this environment",
@@ -421,7 +424,7 @@ func (o *DeleteApplicationOptions) deleteApplicationFromEnvironment(env *v1.Envi
 		ModifyChartFn: modifyChartFn,
 		GitProvider:   gitProvider,
 	}
-	info, err := options.Create(env, environmentsDir, &details, nil, "", o.AutoMerge)
+	info, err := options.Create(env, envDir, &details, nil, "", o.AutoMerge)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/get/get_apps.go
+++ b/pkg/cmd/get/get_apps.go
@@ -26,6 +26,9 @@ type GetAppsOptions struct {
 	ShowStatus bool
 	GitOps     bool
 	DevEnv     *v1.Environment
+
+	// Used for testing
+	CloneDir string
 }
 
 type appsResult struct {
@@ -118,14 +121,14 @@ func (o *GetAppsOptions) Run() error {
 		return errors.Wrap(err, "getting the the GitOps environments dir")
 	}
 	installOptions := apps.InstallOptions{
-		IOFileHandles:   o.GetIOFileHandles(),
-		DevEnv:          o.DevEnv,
-		Verbose:         o.Verbose,
-		GitOps:          o.GitOps,
-		BatchMode:       o.BatchMode,
-		Helmer:          o.Helm(),
-		JxClient:        jxClient,
-		EnvironmentsDir: envsDir,
+		IOFileHandles:       o.GetIOFileHandles(),
+		DevEnv:              o.DevEnv,
+		Verbose:             o.Verbose,
+		GitOps:              o.GitOps,
+		BatchMode:           o.BatchMode,
+		Helmer:              o.Helm(),
+		JxClient:            jxClient,
+		EnvironmentCloneDir: envsDir,
 	}
 
 	if o.GetSecretsLocation() == secrets.VaultLocationKind {
@@ -150,10 +153,9 @@ func (o *GetAppsOptions) Run() error {
 		if err != nil {
 			return errors.Wrapf(err, "creating git provider for %s", o.DevEnv.Spec.Source.URL)
 		}
-		environmentsDir := envsDir
 		installOptions.GitProvider = gitProvider
 		installOptions.Gitter = o.Git()
-		installOptions.EnvironmentsDir = environmentsDir
+		installOptions.EnvironmentCloneDir = o.CloneDir
 	}
 
 	apps, err := installOptions.GetApps(o.Args)

--- a/pkg/cmd/get/get_apps.go
+++ b/pkg/cmd/get/get_apps.go
@@ -26,9 +26,6 @@ type GetAppsOptions struct {
 	ShowStatus bool
 	GitOps     bool
 	DevEnv     *v1.Environment
-
-	// Used for testing
-	CloneDir string
 }
 
 type appsResult struct {
@@ -155,7 +152,6 @@ func (o *GetAppsOptions) Run() error {
 		}
 		installOptions.GitProvider = gitProvider
 		installOptions.Gitter = o.Git()
-		installOptions.EnvironmentCloneDir = o.CloneDir
 	}
 
 	apps, err := installOptions.GetApps(o.Args)

--- a/pkg/cmd/promote/promote.go
+++ b/pkg/cmd/promote/promote.go
@@ -80,6 +80,9 @@ type PromoteOptions struct {
 	releaseResource         *v1.Release
 	ReleaseInfo             *ReleaseInfo
 	prow                    bool
+
+	// Used for testing
+	CloneDir string
 }
 
 type ReleaseInfo struct {
@@ -560,9 +563,10 @@ func (o *PromoteOptions) PromoteViaPullRequest(env *v1.Environment, releaseInfo 
 	if err != nil {
 		return errors.Wrapf(err, "creating git provider for %s", env.Spec.Source.URL)
 	}
-	environmentsDir, err := o.EnvironmentsDir()
-	if err != nil {
-		return errors.Wrapf(err, "getting environments dir")
+
+	envDir := ""
+	if o.CloneDir != "" {
+		envDir = o.CloneDir
 	}
 
 	options := environments.EnvironmentPullRequestOptions{
@@ -574,7 +578,7 @@ func (o *PromoteOptions) PromoteViaPullRequest(env *v1.Environment, releaseInfo 
 	if releaseInfo.PullRequestInfo != nil && releaseInfo.PullRequestInfo.PullRequest != nil {
 		filter.Number = releaseInfo.PullRequestInfo.PullRequest.Number
 	}
-	info, err := options.Create(env, environmentsDir, &details, filter, "", true)
+	info, err := options.Create(env, envDir, &details, filter, "", true)
 	releaseInfo.PullRequestInfo = info
 	return err
 }

--- a/pkg/cmd/step/scheduler/step_scheduler_config_apply.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_apply.go
@@ -15,6 +15,9 @@ type StepSchedulerConfigApplyOptions struct {
 	step.StepOptions
 	Agent         string
 	ApplyDirectly bool
+
+	// Used for testing
+	CloneDir string
 }
 
 var (
@@ -81,11 +84,10 @@ func (o *StepSchedulerConfigApplyOptions) Run() error {
 				Verbose: o.Verbose,
 				DevEnv:  devEnv,
 			}
-			environmentsDir, err := o.EnvironmentsDir()
-			if err != nil {
-				return errors.Wrapf(err, "getting environments dir")
+			opts.PullRequestCloneDir = ""
+			if o.CloneDir != "" {
+				opts.PullRequestCloneDir = o.CloneDir
 			}
-			opts.EnvironmentsDir = environmentsDir
 
 			gitProvider, _, err := o.CreateGitProviderForURLWithoutKind(devEnv.Spec.Source.URL)
 			if err != nil {

--- a/pkg/cmd/step/scheduler/step_scheduler_config_apply_test.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_apply_test.go
@@ -98,11 +98,12 @@ func TestStepSchedulerConfigApplyGitopsAll(t *testing.T) {
 		err := testhelpers.CleanupTestKubeConfigDir(originalKubeCfg, tempKubeCfg)
 		assert.NoError(t, err)
 	}()
-	err = testOptions.StepSchedulerConfigApplyOptions.Run()
-	assert.NoError(t, err)
 	envDir, err := testOptions.StepSchedulerConfigApplyOptions.CommonOptions.EnvironmentsDir()
 	assert.NoError(t, err)
 	devEnvDir := filepath.Join(envDir, testOptions.DevEnvName)
+	testOptions.StepSchedulerConfigApplyOptions.CloneDir = devEnvDir
+	err = testOptions.StepSchedulerConfigApplyOptions.Run()
+	assert.NoError(t, err)
 	verifyProwGitopsConfig(err, testOptions, devEnvDir, t)
 }
 
@@ -123,11 +124,12 @@ func TestStepSchedulerConfigApplyGitopsDefaultScheduler(t *testing.T) {
 		err := testhelpers.CleanupTestKubeConfigDir(originalKubeCfg, tempKubeCfg)
 		assert.NoError(t, err)
 	}()
-	err = testOptions.StepSchedulerConfigApplyOptions.Run()
-	assert.NoError(t, err)
 	envDir, err := testOptions.StepSchedulerConfigApplyOptions.CommonOptions.EnvironmentsDir()
 	assert.NoError(t, err)
 	devEnvDir := filepath.Join(envDir, testOptions.DevEnvName)
+	testOptions.StepSchedulerConfigApplyOptions.CloneDir = devEnvDir
+	err = testOptions.StepSchedulerConfigApplyOptions.Run()
+	assert.NoError(t, err)
 	verifyProwGitopsConfig(err, testOptions, devEnvDir, t)
 }
 
@@ -148,11 +150,12 @@ func TestStepSchedulerConfigApplyGitopsRepoScheduler(t *testing.T) {
 		err := testhelpers.CleanupTestKubeConfigDir(originalKubeCfg, tempKubeCfg)
 		assert.NoError(t, err)
 	}()
-	err = testOptions.StepSchedulerConfigApplyOptions.Run()
-	assert.NoError(t, err)
 	envDir, err := testOptions.StepSchedulerConfigApplyOptions.CommonOptions.EnvironmentsDir()
 	assert.NoError(t, err)
 	devEnvDir := filepath.Join(envDir, testOptions.DevEnvName)
+	testOptions.StepSchedulerConfigApplyOptions.CloneDir = devEnvDir
+	err = testOptions.StepSchedulerConfigApplyOptions.Run()
+	assert.NoError(t, err)
 	verifyProwGitopsConfig(err, testOptions, devEnvDir, t)
 }
 
@@ -173,11 +176,12 @@ func TestStepSchedulerConfigApplyGitopsRepoGroupScheduler(t *testing.T) {
 		err := testhelpers.CleanupTestKubeConfigDir(originalKubeCfg, tempKubeCfg)
 		assert.NoError(t, err)
 	}()
-	err = testOptions.StepSchedulerConfigApplyOptions.Run()
-	assert.NoError(t, err)
 	envDir, err := testOptions.StepSchedulerConfigApplyOptions.CommonOptions.EnvironmentsDir()
 	assert.NoError(t, err)
 	devEnvDir := filepath.Join(envDir, testOptions.DevEnvName)
+	testOptions.StepSchedulerConfigApplyOptions.CloneDir = devEnvDir
+	err = testOptions.StepSchedulerConfigApplyOptions.Run()
+	assert.NoError(t, err)
 	verifyProwGitopsConfig(err, testOptions, devEnvDir, t)
 }
 

--- a/pkg/cmd/step/scheduler/step_scheduler_config_migrate.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_migrate.go
@@ -19,6 +19,9 @@ type StepSchedulerConfigMigrateOptions struct {
 	ProwPluginsFileLocation string
 	SkipVerification        bool
 	DryRun                  bool
+
+	// Used for testing
+	CloneDir string
 }
 
 var (
@@ -98,11 +101,10 @@ func (o *StepSchedulerConfigMigrateOptions) Run() error {
 					Verbose: o.Verbose,
 					DevEnv:  devEnv,
 				}
-				environmentsDir, err := o.EnvironmentsDir()
-				if err != nil {
-					return errors.Wrapf(err, "getting environments dir")
+				opts.PullRequestCloneDir = ""
+				if o.CloneDir != "" {
+					opts.PullRequestCloneDir = o.CloneDir
 				}
-				opts.EnvironmentsDir = environmentsDir
 
 				gitProvider, _, err := o.CreateGitProviderForURLWithoutKind(devEnv.Spec.Source.URL)
 				if err != nil {

--- a/pkg/cmd/step/scheduler/step_scheduler_config_migrate_test.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_migrate_test.go
@@ -67,10 +67,12 @@ func TestStepSchedulerConfigMigrateGitopsBasic(t *testing.T) {
 	testOptions.createSchedulerMigrateTestOptions("gitops_basic", true, t)
 	testOptions.StepSchedulerConfigMigrateOptions.ProwConfigFileLocation = "test_data/step_scheduler_config_migrate/" + testOptions.TestType + "/config.yaml"
 	testOptions.StepSchedulerConfigMigrateOptions.ProwPluginsFileLocation = "test_data/step_scheduler_config_migrate/" + testOptions.TestType + "/plugins.yaml"
-	err := testOptions.StepSchedulerConfigMigrateOptions.Run()
-	assert.NoError(t, err)
 	envDir, err := testOptions.StepSchedulerConfigMigrateOptions.CommonOptions.EnvironmentsDir()
+	assert.NoError(t, err)
 	devEnvDir := filepath.Join(envDir, testOptions.DevEnvName)
+	testOptions.StepSchedulerConfigMigrateOptions.CloneDir = devEnvDir
+	err = testOptions.StepSchedulerConfigMigrateOptions.Run()
+	assert.NoError(t, err)
 	verifySchedulerGitOps(err, t, testOptions, devEnvDir, "cb-kubecd-jx-scheduler-test-group-repo-scheduler")
 	verifySchedulerGitOps(err, t, testOptions, devEnvDir, "cb-kubecd-jx-scheduler-test-repo-scheduler")
 	verifySchedulerGitOps(err, t, testOptions, devEnvDir, "default-scheduler")

--- a/pkg/cmd/testhelpers/app_test_helpers.go
+++ b/pkg/cmd/testhelpers/app_test_helpers.go
@@ -87,6 +87,12 @@ func (o *AppTestOptions) AddApp(values map[string]interface{}, prefix string) (s
 		},
 	}, o.MockHelmer)
 	installOpts.Args = []string{name}
+	envDir, err := o.CommonOptions.EnvironmentsDir()
+	if err != nil {
+		return "", "", "", errors.WithStack(err)
+	}
+	devEnvDir := o.GetFullDevEnvDir(envDir)
+	installOpts.CloneDir = devEnvDir
 	err = installOpts.Run()
 	if err != nil {
 		return "", "", "", errors.WithStack(err)

--- a/pkg/cmd/upgrade/upgrade_apps.go
+++ b/pkg/cmd/upgrade/upgrade_apps.go
@@ -60,6 +60,9 @@ type UpgradeAppsOptions struct {
 
 	Namespace string
 	Set       []string
+
+	// Used for testing
+	CloneDir string
 }
 
 // NewCmdUpgradeApps defines the command
@@ -132,11 +135,12 @@ func (o *UpgradeAppsOptions) Run() error {
 		AutoMerge:     o.AutoMerge,
 		SecretsScheme: "vault",
 
-		Helmer:         o.Helm(),
-		Namespace:      o.Namespace,
-		KubeClient:     kubeClient,
-		JxClient:       jxClient,
-		InstallTimeout: opts.DefaultInstallTimeout,
+		Helmer:              o.Helm(),
+		Namespace:           o.Namespace,
+		KubeClient:          kubeClient,
+		JxClient:            jxClient,
+		InstallTimeout:      opts.DefaultInstallTimeout,
+		EnvironmentCloneDir: o.CloneDir,
 	}
 	if o.Namespace != "" {
 		installOpts.Namespace = o.Namespace
@@ -158,11 +162,6 @@ func (o *UpgradeAppsOptions) Run() error {
 		if !o.HelmUpdate {
 			return util.InvalidOptionf(optionHelmUpdate, o.HelmUpdate, msg, optionHelmUpdate)
 		}
-		environmentsDir, err := o.EnvironmentsDir()
-		if err != nil {
-			return errors.Wrapf(err, "getting environments dir")
-		}
-		installOpts.EnvironmentsDir = environmentsDir
 
 		gitProvider, _, err := o.CreateGitProviderForURLWithoutKind(o.DevEnv.Spec.Source.URL)
 		if err != nil {

--- a/pkg/cmd/upgrade/upgrade_apps_test.go
+++ b/pkg/cmd/upgrade/upgrade_apps_test.go
@@ -58,6 +58,10 @@ func TestUpgradeAppForGitOps(t *testing.T) {
 		DevEnv:     testOptions.DevEnv,
 	}
 	o.Args = []string{name}
+	envDir, err := o.CommonOptions.EnvironmentsDir()
+	assert.NoError(t, err)
+	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+	o.CloneDir = devEnvDir
 
 	helm_test.StubFetchChart(name, newVersion.String(), helm.FakeChartmusuem, &chart.Chart{
 		Metadata: &chart.Metadata{
@@ -75,9 +79,6 @@ func TestUpgradeAppForGitOps(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("Upgrade %s to %s", name, newVersion.String()), pr.Title)
 	assert.Equal(t, fmt.Sprintf("Upgrade %s from %s to %s", name, version, newVersion.String()), pr.Body)
 	// Validate the branch name
-	envDir, err := o.CommonOptions.EnvironmentsDir()
-	assert.NoError(t, err)
-	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 	branchName, err := o.Git().Branch(devEnvDir)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("upgrade-app-%s-%s", name, newVersion.String()), branchName[:len(branchName)-6])
@@ -121,6 +122,11 @@ func TestUpgradeAppWithShortNameForGitOps(t *testing.T) {
 		HelmUpdate: true,
 		DevEnv:     testOptions.DevEnv,
 	}
+	envDir, err := o.CommonOptions.EnvironmentsDir()
+	assert.NoError(t, err)
+	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+	o.CloneDir = devEnvDir
+
 	pegomock.When(testOptions.MockHelmer.ListRepos()).ThenReturn(
 		map[string]string{
 			"repo1": kube.DefaultChartMuseumURL,
@@ -153,9 +159,6 @@ func TestUpgradeAppWithShortNameForGitOps(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("Upgrade %s to %s", name, newVersion.String()), pr.Title)
 	assert.Equal(t, fmt.Sprintf("Upgrade %s from %s to %s", name, version, newVersion.String()), pr.Body)
 	// Validate the branch name
-	envDir, err := o.CommonOptions.EnvironmentsDir()
-	assert.NoError(t, err)
-	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 	branchName, err := o.Git().Branch(devEnvDir)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("upgrade-app-%s-%s", name, newVersion.String()), branchName[:len(branchName)-6])
@@ -196,7 +199,8 @@ func TestUpgradeAppWithExistingAndDefaultAnswersForGitOpsInBatchMode(t *testing.
 
 		envDir, err := testOptions.CommonOptions.EnvironmentsDir()
 		assert.NoError(r, err)
-		appDir := filepath.Join(testOptions.GetFullDevEnvDir(envDir), name)
+		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+		appDir := filepath.Join(devEnvDir, name)
 
 		// Now let's upgrade
 
@@ -214,6 +218,7 @@ func TestUpgradeAppWithExistingAndDefaultAnswersForGitOpsInBatchMode(t *testing.
 			HelmUpdate: true,
 			DevEnv:     testOptions.DevEnv,
 		}
+		o.CloneDir = devEnvDir
 		o.Args = []string{name}
 
 		helm_test.StubFetchChart(name, newVersion.String(),
@@ -282,7 +287,8 @@ func TestUpgradeAppWithExistingAndDefaultAnswersForGitOps(t *testing.T) {
 
 		envDir, err := testOptions.CommonOptions.EnvironmentsDir()
 		assert.NoError(r, err)
-		appDir := filepath.Join(testOptions.GetFullDevEnvDir(envDir), name)
+		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+		appDir := filepath.Join(devEnvDir, name)
 		// Now let's upgrade
 
 		newVersion, err := semver.Parse(version)
@@ -299,6 +305,7 @@ func TestUpgradeAppWithExistingAndDefaultAnswersForGitOps(t *testing.T) {
 			HelmUpdate: true,
 			DevEnv:     testOptions.DevEnv,
 		}
+		o.CloneDir = devEnvDir
 		o.Args = []string{name}
 		o.BatchMode = false
 
@@ -380,7 +387,8 @@ func TestUpgradeAppWithExistingAndDefaultAnswersAndAskAllForGitOps(t *testing.T)
 
 		envDir, err := testOptions.CommonOptions.EnvironmentsDir()
 		assert.NoError(r, err)
-		appDir := filepath.Join(testOptions.GetFullDevEnvDir(envDir), name)
+		devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+		appDir := filepath.Join(devEnvDir, name)
 
 		// Now let's upgrade
 
@@ -399,6 +407,7 @@ func TestUpgradeAppWithExistingAndDefaultAnswersAndAskAllForGitOps(t *testing.T)
 			DevEnv:     testOptions.DevEnv,
 			AskAll:     true,
 		}
+		o.CloneDir = devEnvDir
 		o.Args = []string{name}
 		o.BatchMode = false
 
@@ -562,6 +571,10 @@ func TestUpgradeAppToLatestForGitOps(t *testing.T) {
 		DevEnv:     testOptions.DevEnv,
 	}
 	o.Args = []string{name}
+	envDir, err := o.CommonOptions.EnvironmentsDir()
+	assert.NoError(t, err)
+	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+	o.CloneDir = devEnvDir
 
 	helm_test.StubFetchChart(name, "", helm.FakeChartmusuem, &chart.Chart{
 		Metadata: &chart.Metadata{
@@ -579,9 +592,6 @@ func TestUpgradeAppToLatestForGitOps(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("Upgrade %s to %s", name, newVersion.String()), pr.Title)
 	assert.Equal(t, fmt.Sprintf("Upgrade %s from %s to %s", name, version, newVersion.String()), pr.Body)
 	// Validate the branch name
-	envDir, err := o.CommonOptions.EnvironmentsDir()
-	assert.NoError(t, err)
-	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 	branchName, err := o.Git().Branch(devEnvDir)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("upgrade-app-%s-%s", name, newVersion.String()), branchName[:len(branchName)-6])
@@ -628,6 +638,10 @@ func TestUpgradeAllAppsForGitOps(t *testing.T) {
 		HelmUpdate: true,
 		DevEnv:     testOptions.DevEnv,
 	}
+	envDir, err := o.CommonOptions.EnvironmentsDir()
+	assert.NoError(t, err)
+	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
+	o.CloneDir = devEnvDir
 
 	helm_test.StubFetchChart(name1, "", helm.FakeChartmusuem, &chart.Chart{
 		Metadata: &chart.Metadata{
@@ -656,9 +670,6 @@ func TestUpgradeAllAppsForGitOps(t *testing.T) {
 		version1,
 		newVersion1.String(), name2, version2, newVersion2.String()), pr.Body)
 	// Validate the branch name1
-	envDir, err := o.CommonOptions.EnvironmentsDir()
-	assert.NoError(t, err)
-	devEnvDir := testOptions.GetFullDevEnvDir(envDir)
 	branchName, err := o.Git().Branch(devEnvDir)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("upgrade-all-apps"), branchName[:len(branchName)-6])

--- a/pkg/pipelinescheduler/generator.go
+++ b/pkg/pipelinescheduler/generator.go
@@ -517,12 +517,12 @@ func ApplySchedulersDirectly(jxClient versioned.Interface, namespace string, sou
 
 //GitOpsOptions are options for running AddToEnvironmentRepo
 type GitOpsOptions struct {
-	Gitter          gits.Gitter
-	Verbose         bool
-	Helmer          helm.Helmer
-	GitProvider     gits.GitProvider
-	DevEnv          *jenkinsv1.Environment
-	EnvironmentsDir string
+	Gitter              gits.Gitter
+	Verbose             bool
+	Helmer              helm.Helmer
+	GitProvider         gits.GitProvider
+	DevEnv              *jenkinsv1.Environment
+	PullRequestCloneDir string
 }
 
 // AddToEnvironmentRepo adds the prow config to the gitops environment repo
@@ -574,7 +574,7 @@ func (o *GitOpsOptions) AddToEnvironmentRepo(cfg *config.Config, plugs *plugins.
 		GitProvider:   o.GitProvider,
 	}
 
-	info, err := options.Create(o.DevEnv, o.EnvironmentsDir, &details, nil, "", false)
+	info, err := options.Create(o.DevEnv, o.PullRequestCloneDir, &details, nil, "", false)
 
 	if err != nil {
 		return errors.Wrapf(err, "creating pr for prow config")
@@ -709,7 +709,7 @@ func (o *GitOpsOptions) AddSchedulersToEnvironmentRepo(sourceRepositoryGroups []
 		GitProvider:   o.GitProvider,
 	}
 
-	info, err := options.Create(o.DevEnv, o.EnvironmentsDir, &details, nil, "", false)
+	info, err := options.Create(o.DevEnv, o.PullRequestCloneDir, &details, nil, "", false)
 
 	if err != nil {
 		return errors.Wrapf(err, "creating pr for scheduler config")


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Until this, `jx delete app`, `jx add app`, and `jx get apps` all did weird things with/under `~/.jx/environments`. All of them used `ForkAndPullRepo` to clone under there - `jx get apps` directly into `~/.jx/environments`, and `jx add app` and `jx delete app` into `~/.jx/environments/dev`. Literally none of this made sense. =)

This reworks not just the app commands, but all commands that create PRs (i.e., gitops) against the dev/prod/staging environments to use temporary directories for the fork/clone/push, with the option, just used in tests, of specifying an existing directory to use instead, while `jx get apps` just clones to a temporary directory as well.

Switching all this to temporary directories also really helps users who manage/work with multiple JX clusters from a single laptop/desktop/host, since namespacing `~/.jx/environments` by cluster is basically impossible so far as I can tell.

Also adds `--auto-merge` to `jx delete app` because I was here.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6350

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
