### PR TITLE
chore: remove velero config omitempty tags

### DIFF
--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -425,9 +425,9 @@ type VeleroConfig struct {
 	// ServiceAccount the cloud service account used to run velero
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 	// Schedule of backups
-	Schedule string `json:"schedule,omitempty" envconfig:"JX_REQUIREMENT_VELERO_SCHEDULE"`
+	Schedule string `json:"schedule" envconfig:"JX_REQUIREMENT_VELERO_SCHEDULE"`
 	// TimeToLive period for backups to be retained
-	TimeToLive string `json:"ttl,omitempty" envconfig:"JX_REQUIREMENT_VELERO_TTL"`
+	TimeToLive string `json:"ttl" envconfig:"JX_REQUIREMENT_VELERO_TTL"`
 }
 
 // AutoUpdateConfig contains auto update config


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Removing omitempty from the tags of these velero config items so that a default can be specified in the template without occurring an error.