### PR TITLE
feat: add the option to run the bdd tests directly without importing

### DIFF
--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -851,7 +851,7 @@ func (o *CreateDevPodOptions) Run() error {
 			if err != nil {
 				return errors.Wrap(err, "creating git auth config service")
 			}
-			gitCredentials, err := o.GitCredentials.CreateGitCredentials(gitAuthSvc)
+			gitCredentials, err := o.GitCredentials.CreateGitCredentialsFromAuthService(gitAuthSvc)
 			if err != nil {
 				return errors.Wrap(err, "creating git credentials")
 			}

--- a/pkg/cmd/step/git/step_git_credentials.go
+++ b/pkg/cmd/step/git/step_git_credentials.go
@@ -167,7 +167,7 @@ func (o *StepGitCredentialsOptions) CreateGitCredentialsFile(fileName string, co
 	return nil
 }
 
-// CreateGitCredentialsFile creates the git credentials into file using the provided username, token & url
+// CreateGitCredentialsFileFromUsernameAndToken creates the git credentials into file using the provided username, token & url
 func (o *StepGitCredentialsOptions) CreateGitCredentialsFileFromUsernameAndToken(fileName string, username string, token string, url string) error {
 	data, err := o.CreateGitCredentialsFromUsernameAndToken(username, token, url)
 	if err != nil {
@@ -180,7 +180,7 @@ func (o *StepGitCredentialsOptions) CreateGitCredentialsFileFromUsernameAndToken
 	return nil
 }
 
-// CreateGitCredentials creates the git credentials using the auth config service
+// CreateGitCredentialsFromAuthService creates the git credentials using the auth config service
 func (o *StepGitCredentialsOptions) CreateGitCredentialsFromAuthService(authConfigSvc auth.ConfigService) ([]byte, error) {
 	cfg := authConfigSvc.Config()
 	if cfg == nil {
@@ -233,7 +233,7 @@ func (o *StepGitCredentialsOptions) CreateGitCredentialsFromAuthService(authConf
 	return buffer.Bytes(), nil
 }
 
-// CreateGitCredentials creates the git credentials using the auth config service
+// CreateGitCredentialsFromUsernameAndToken creates the git credentials using the auth config service
 func (o *StepGitCredentialsOptions) CreateGitCredentialsFromUsernameAndToken(username string, token string, serverURL string) ([]byte, error) {
 	var buffer bytes.Buffer
 

--- a/pkg/cmd/step/git/step_git_credentials.go
+++ b/pkg/cmd/step/git/step_git_credentials.go
@@ -19,6 +19,9 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/spf13/cobra"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -30,9 +33,10 @@ const (
 type StepGitCredentialsOptions struct {
 	step.StepOptions
 
-	OutputFile     string
-	GitHubAppOwner string
-	GitKind        string
+	OutputFile        string
+	GitHubAppOwner    string
+	GitKind           string
+	CredentialsSecret string
 }
 
 var (
@@ -71,19 +75,17 @@ func NewCmdStepGitCredentials(commonOpts *opts.CommonOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&options.OutputFile, optionOutputFile, "o", "", "The output file name")
 	cmd.Flags().StringVarP(&options.GitHubAppOwner, optionGitHubAppOwner, "g", "", "The owner (organisation or user name) if using GitHub App based tokens")
+	cmd.Flags().StringVarP(&options.CredentialsSecret, "credentials-secret", "s", "", "The secret name to read the credentials from")
 	cmd.Flags().StringVarP(&options.GitKind, "git-kind", "", "", "The git kind. e.g. github, bitbucketserver etc")
 	return cmd
 }
 
 func (o *StepGitCredentialsOptions) Run() error {
-	gha, err := o.IsGitHubAppMode()
-	if err != nil {
-		return err
+	if os.Getenv("JX_CREDENTIALS_FROM_SECRET") != "" {
+		log.Logger().Infof("Overriding CredentialsSecret from env var JX_CREDENTIALS_FROM_SECRET")
+		o.CredentialsSecret = os.Getenv("JX_CREDENTIALS_FROM_SECRET")
 	}
-	if gha && o.GitHubAppOwner == "" {
-		log.Logger().Infof("this command does nothing if using github app mode and no %s option specified", optionGitHubAppOwner)
-		return nil
-	}
+
 	outFile := o.OutputFile
 	if outFile == "" {
 		// lets figure out the default output file
@@ -106,6 +108,36 @@ func (o *StepGitCredentialsOptions) Run() error {
 		}
 	}
 
+	if o.CredentialsSecret != "" {
+		// get secret
+		kubeClient, ns, err := o.KubeClientAndDevNamespace()
+		if err != nil {
+			return err
+		}
+
+		secret, err := kubeClient.CoreV1().Secrets(ns).Get(o.CredentialsSecret, metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to find secret '%s' in namespace '%s'", o.CredentialsSecret, ns)
+		}
+
+		username := string(secret.Data["user"])
+		token := string(secret.Data["token"])
+		url := string(secret.Data["url"])
+
+		return o.CreateGitCredentialsFileFromUsernameAndToken(outFile, username, token, url)
+
+	}
+
+	gha, err := o.IsGitHubAppMode()
+	if err != nil {
+		return err
+	}
+
+	if gha && o.GitHubAppOwner == "" {
+		log.Logger().Infof("this command does nothing if using github app mode and no %s option specified", optionGitHubAppOwner)
+		return nil
+	}
+
 	var authConfigSvc auth.ConfigService
 	if gha {
 		authConfigSvc, err = o.GitAuthConfigServiceGitHubMode(o.GitKind)
@@ -124,7 +156,20 @@ func (o *StepGitCredentialsOptions) Run() error {
 
 // CreateGitCredentialsFile creates the git credentials into file using the provided auth config service
 func (o *StepGitCredentialsOptions) CreateGitCredentialsFile(fileName string, configSvc auth.ConfigService) error {
-	data, err := o.CreateGitCredentials(configSvc)
+	data, err := o.CreateGitCredentialsFromAuthService(configSvc)
+	if err != nil {
+		return errors.Wrap(err, "creating git credentials")
+	}
+	if err := ioutil.WriteFile(fileName, data, util.DefaultWritePermissions); err != nil {
+		return fmt.Errorf("Failed to write to %s: %s", fileName, err)
+	}
+	log.Logger().Infof("Generated Git credentials file %s", util.ColorInfo(fileName))
+	return nil
+}
+
+// CreateGitCredentialsFile creates the git credentials into file using the provided username, token & url
+func (o *StepGitCredentialsOptions) CreateGitCredentialsFileFromUsernameAndToken(fileName string, username string, token string, url string) error {
+	data, err := o.CreateGitCredentialsFromUsernameAndToken(username, token, url)
 	if err != nil {
 		return errors.Wrap(err, "creating git credentials")
 	}
@@ -136,7 +181,7 @@ func (o *StepGitCredentialsOptions) CreateGitCredentialsFile(fileName string, co
 }
 
 // CreateGitCredentials creates the git credentials using the auth config service
-func (o *StepGitCredentialsOptions) CreateGitCredentials(authConfigSvc auth.ConfigService) ([]byte, error) {
+func (o *StepGitCredentialsOptions) CreateGitCredentialsFromAuthService(authConfigSvc auth.ConfigService) ([]byte, error) {
 	cfg := authConfigSvc.Config()
 	if cfg == nil {
 		return nil, errors.New("no git auth config found")
@@ -185,5 +230,26 @@ func (o *StepGitCredentialsOptions) CreateGitCredentials(authConfigSvc auth.Conf
 			buffer.WriteString(u.String() + "\n")
 		}
 	}
+	return buffer.Bytes(), nil
+}
+
+// CreateGitCredentials creates the git credentials using the auth config service
+func (o *StepGitCredentialsOptions) CreateGitCredentialsFromUsernameAndToken(username string, token string, serverURL string) ([]byte, error) {
+	var buffer bytes.Buffer
+
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		log.Logger().Warnf("Ignoring invalid git service URL %q", serverURL)
+		return nil, err
+	}
+
+	u.User = url.UserPassword(username, token)
+	buffer.WriteString(u.String() + "\n")
+	// Write the https protocol in case only https is set for completeness
+	if u.Scheme == "http" {
+		u.Scheme = "https"
+	}
+
+	buffer.WriteString(u.String() + "\n")
 	return buffer.Bytes(), nil
 }

--- a/pkg/cmd/step/verify/step_verify_behavior.go
+++ b/pkg/cmd/step/verify/step_verify_behavior.go
@@ -31,9 +31,10 @@ import (
 type BehaviorOptions struct {
 	*opts.CommonOptions
 
-	SourceGitURL string
-	Branch       string
-	NoImport     bool
+	SourceGitURL      string
+	Branch            string
+	NoImport          bool
+	CredentialsSecret string
 }
 
 var (
@@ -70,6 +71,7 @@ func NewCmdStepVerifyBehavior(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.SourceGitURL, "git-url", "u", "https://github.com/jenkins-x/bdd-jx.git", "The git URL of the BDD tests pipeline")
 	cmd.Flags().StringVarP(&options.Branch, "branch", "", "master", "The git branch to use to run the BDD tests")
 	cmd.Flags().BoolVarP(&options.NoImport, "no-import", "", false, "Create the pipeline directly, don't import the repository")
+	cmd.Flags().StringVarP(&options.CredentialsSecret, "credentials-secret", "", "", "The name of the secret to generate the bdd credentials from, if not specified, the default git auth will be used")
 	return cmd
 }
 
@@ -216,6 +218,10 @@ func (o *BehaviorOptions) runPipelineDirectly(owner string, repo string, sourceU
 
 	pullRefData := metapipeline.NewPullRef(sourceURL, branch, "")
 	envVars := map[string]string{}
+	if o.CredentialsSecret != "" {
+		envVars["JX_CREDENTIALS_FROM_SECRET"] = o.CredentialsSecret
+	}
+
 	pipelineCreateParam := metapipeline.PipelineCreateParam{
 		PullRef:      pullRefData,
 		PipelineKind: kind,

--- a/pkg/cmd/step/verify/step_verify_behavior.go
+++ b/pkg/cmd/step/verify/step_verify_behavior.go
@@ -228,6 +228,7 @@ func (o *BehaviorOptions) runPipelineDirectly(owner string, repo string, sourceU
 		DefaultImage:        "",
 		EnvVariables:        envVars,
 		UseBranchAsRevision: true,
+		NoReleasePrepare:    true,
 	}
 
 	c, err := metapipeline.NewMetaPipelineClient()

--- a/pkg/tekton/metapipeline/client.go
+++ b/pkg/tekton/metapipeline/client.go
@@ -38,6 +38,9 @@ type PipelineCreateParam struct {
 	// UseBranchAsRevision forces step_create_task to use the branch it's passed as the revision to checkout for release
 	// pipelines, rather than use the version tag
 	UseBranchAsRevision bool
+
+	// NoReleasePrepare do not prepare the release, this passes the --no-release-prepare flag to `jx step create task`
+	NoReleasePrepare bool
 }
 
 // Client defines the interface for meta pipeline creation and application.

--- a/pkg/tekton/metapipeline/clientfactory.go
+++ b/pkg/tekton/metapipeline/clientfactory.go
@@ -139,6 +139,7 @@ func (c *clientFactory) Create(param PipelineCreateParam) (kube.PromoteStepActiv
 		VersionsDir:         c.versionDir,
 		GitInfo:             *gitInfo,
 		UseBranchAsRevision: param.UseBranchAsRevision,
+		NoReleasePrepare:    param.NoReleasePrepare,
 	}
 
 	return c.createActualCRDs(buildNumber, branchIdentifier, param.Context, param.PullRef, crdCreationParams)

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -57,6 +57,7 @@ type CRDCreationParameters struct {
 	Apps                []jenkinsv1.App
 	VersionsDir         string
 	UseBranchAsRevision bool
+	NoReleasePrepare    bool
 }
 
 // createMetaPipelineCRDs creates the Tekton CRDs needed to execute the meta pipeline.
@@ -261,6 +262,9 @@ func stepCreateTektonCRDs(params CRDCreationParameters) syntax.Step {
 	}
 	if params.UseBranchAsRevision {
 		args = append(args, "--branch-as-revision")
+	}
+	if params.NoReleasePrepare {
+		args = append(args, "--no-release-prepare")
 	}
 	for k, v := range params.Labels {
 		args = append(args, "--label", fmt.Sprintf("%s=%s", k, v))


### PR DESCRIPTION
This is to attempt to fix https://github.com/cloudbees/arcalos/issues/567, in this configuration we run the bdd tests from inside the cluster, but the user that the tests should run as is a local user (configured via a secret) rather than the pipeline user (the default)