### PR TITLE
fix: handle correctly ctrl+c on confirmation

### DIFF
--- a/pkg/cloud/gke/vault/vault_backend.go
+++ b/pkg/cloud/gke/vault/vault_backend.go
@@ -91,9 +91,9 @@ func CreateBucket(gcloud gke.GClouder, vaultName, bucketName string, projectID, 
 		if batchMode {
 			log.Logger().Warnf("We are deleting the Vault bucket %s so that Vault will install cleanly", bucketName)
 		} else {
-			if !util.Confirm(fmt.Sprintf("We are about to delete bucket %q, so we can install a clean Vault. Are you sure: ", bucketName),
-				true, "We recommend you delete the Vault bucket on install to ensure Vault starts up reliably", handles) {
-				return bucketName, nil
+			if answer, err := util.Confirm(fmt.Sprintf("We are about to delete bucket %q, so we can install a clean Vault. Are you sure: ", bucketName),
+				true, "We recommend you delete the Vault bucket on install to ensure Vault starts up reliably", handles); !answer {
+				return bucketName, err
 			}
 		}
 		err = gcloud.DeleteAllObjectsInBucket(bucketName)

--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -64,9 +64,9 @@ var (
 		jx create cluster gke --skip-installation
 
 		# now lets boot up Jenkins X installing/upgrading whatever is needed
-		jx boot 
+		jx boot
 
-		# if we have already booted and just want to apply some environment changes without 
+		# if we have already booted and just want to apply some environment changes without
         # re-applying ingress and so forth we can start at the environment step:
 		jx boot --start-step install-env
 `)
@@ -187,7 +187,9 @@ func (o *BootOptions) Run() error {
 
 			help := "A git clone of a Jenkins X Boot source repository is required for 'jx boot'"
 			message := "Do you want to clone the Jenkins X Boot Git repository?"
-			if !util.Confirm(message, true, help, o.GetIOFileHandles()) {
+			if answer, err := util.Confirm(message, true, help, o.GetIOFileHandles()); err != nil {
+				return err
+			} else if !answer {
 				return fmt.Errorf("Please run this command again inside a git clone from a Jenkins X Boot repository")
 			}
 		}

--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -1795,7 +1795,9 @@ func (options *InstallOptions) applyGitOpsDevEnvironmentConfig(gitOpsEnvDir stri
 	if options.Flags.GitOpsMode && !options.Flags.NoGitOpsEnvApply {
 		applyEnv := true
 		if !options.BatchMode {
-			if !util.Confirm("Would you like to setup the Development Environment from the source code now?", true, "Do you want to apply the development environment helm charts now?", options.GetIOFileHandles()) {
+			if answer, err := util.Confirm("Would you like to setup the Development Environment from the source code now?", true, "Do you want to apply the development environment helm charts now?", options.GetIOFileHandles()); err != nil {
+				return err
+			} else if !answer {
 				applyEnv = false
 			}
 		}

--- a/pkg/cmd/deletecmd/delete_application.go
+++ b/pkg/cmd/deletecmd/delete_application.go
@@ -44,7 +44,7 @@ var (
 	deleteApplicationLong = templates.LongDesc(`
 		Deletes one or more Applications
 
-		Note that this command does not remove the underlying Git Repositories. 
+		Note that this command does not remove the underlying Git Repositories.
 
 		For that see the [jx delete repo](https://jenkins-x.io/commands/jx_delete_repo/) command.
 
@@ -52,9 +52,9 @@ var (
 
 	deleteApplicationExample = templates.Examples(`
 		# prompt for the available applications to delete
-		jx delete application 
+		jx delete application
 
-		# delete a specific app 
+		# delete a specific app
 		jx delete application cheese
 	`)
 )
@@ -339,7 +339,7 @@ func (o *DeleteApplicationOptions) deleteJenkinsApplication() (deletedApplicatio
 	deleteMessage := strings.Join(args, ", ")
 
 	if !o.BatchMode {
-		if !util.Confirm("You are about to delete these Applications from Jenkins: "+deleteMessage, false, "The list of Applications names to be deleted from Jenkins", o.GetIOFileHandles()) {
+		if answer, err := util.Confirm("You are about to delete these Applications from Jenkins: "+deleteMessage, false, "The list of Applications names to be deleted from Jenkins", o.GetIOFileHandles()); !answer {
 			return deletedApplications, err
 		}
 	}

--- a/pkg/cmd/deletecmd/delete_devpod.go
+++ b/pkg/cmd/deletecmd/delete_devpod.go
@@ -102,8 +102,10 @@ func (o *DeleteDevPodOptions) Run() error {
 
 	deletePods := strings.Join(devPods, ", ")
 
-	if !o.BatchMode && !util.Confirm("You are about to delete the DevPods: "+deletePods, false, "The list of DevPods names to be deleted", o.GetIOFileHandles()) {
-		return nil
+	if !o.BatchMode {
+		if answer, err := util.Confirm("You are about to delete the DevPods: "+deletePods, false, "The list of DevPods names to be deleted", o.GetIOFileHandles()); !answer {
+			return err
+		}
 	}
 	for _, name := range devPods {
 		if util.StringArrayIndex(names, name) < 0 {

--- a/pkg/cmd/deletecmd/delete_extension.go
+++ b/pkg/cmd/deletecmd/delete_extension.go
@@ -164,10 +164,12 @@ func (o *DeleteExtensionOptions) Run() error {
 	}
 
 	// TODO display the extensions to delete in a tree view
-	if !o.BatchMode && !util.Confirm(fmt.Sprintf("You are about to delete the Extensions: %s",
-		strings.Join(extensionsToDeleteStrings, ", ")), false,
-		"The list of Extensions to be deleted", o.GetIOFileHandles()) {
-		return nil
+	if !o.BatchMode {
+		if answer, err := util.Confirm(fmt.Sprintf("You are about to delete the Extensions: %s",
+			strings.Join(extensionsToDeleteStrings, ", ")), false,
+			"The list of Extensions to be deleted", o.GetIOFileHandles()); !answer {
+			return err
+		}
 	}
 	deletedExtensions := make([]string, 0)
 	for _, ext := range extensionsToDelete {

--- a/pkg/cmd/deletecmd/delete_preview.go
+++ b/pkg/cmd/deletecmd/delete_preview.go
@@ -85,13 +85,13 @@ func (o *DeletePreviewOptions) Run() error {
 				log.Logger().Warn("\nYou did not select any preview environments to delete\n")
 				log.Logger().Infof("Press the %s to select a preview environment to delete\n", util.ColorInfo("[space bar]"))
 
-				if !util.Confirm("Do you want to pick a preview environment to delete?", true, "Use the space bar to select previews", o.GetIOFileHandles()) {
-					return nil
+				if answer, err := util.Confirm("Do you want to pick a preview environment to delete?", true, "Use the space bar to select previews", o.GetIOFileHandles()); !answer {
+					return err
 				}
 			}
 			deletePreviews := strings.Join(selected, ", ")
-			if !util.Confirm("You are about to delete the Preview environments: "+deletePreviews, false, "The list of Preview Environments to be deleted", o.GetIOFileHandles()) {
-				return nil
+			if answer, err := util.Confirm("You are about to delete the Preview environments: "+deletePreviews, false, "The list of Preview Environments to be deleted", o.GetIOFileHandles()); !answer {
+				return err
 			}
 
 			for _, name := range selected {

--- a/pkg/cmd/edit/edit.go
+++ b/pkg/cmd/edit/edit.go
@@ -112,7 +112,7 @@ func addTeamSettingsCommandsFromTags(baseCmd *cobra.Command, options *EditOption
 					if structField.Type.String() == "string" {
 						value, err = util.PickValue(commandUsage+":", field.String(), true, "", options.GetIOFileHandles())
 					} else if structField.Type.String() == "bool" {
-						value = util.Confirm(commandUsage+":", field.Bool(), "", options.GetIOFileHandles())
+						value, err = util.Confirm(commandUsage+":", field.Bool(), "", options.GetIOFileHandles())
 					}
 					helper.CheckErr(err)
 				} else {

--- a/pkg/cmd/edit/edit_addon.go
+++ b/pkg/cmd/edit/edit_addon.go
@@ -105,7 +105,10 @@ func (o *EditAddonOptions) Run() error {
 		}
 		config.Enabled = value
 	} else {
-		config.Enabled = util.Confirm("Enable addon "+o.Name, config.Enabled, "If an addon is enabled it is installed when using 'jx create cluster' or 'jx install'", o.GetIOFileHandles())
+		config.Enabled, err = util.Confirm("Enable addon "+o.Name, config.Enabled, "If an addon is enabled it is installed when using 'jx create cluster' or 'jx install'", o.GetIOFileHandles())
+		if err != nil {
+			return err
+		}
 	}
 
 	return addonConfig.Save()

--- a/pkg/cmd/opts/cert_manager.go
+++ b/pkg/cmd/opts/cert_manager.go
@@ -25,11 +25,14 @@ func (o *CommonOptions) EnsureCertManager() error {
 	if err != nil {
 		ok := true
 		if !o.BatchMode {
-			ok = util.Confirm(
+			ok, err = util.Confirm(
 				"CertManager deployment not found, shall we install it now?",
 				true,
 				"CertManager automatically configures Ingress rules with TLS using signed certificates from LetsEncrypt",
 				o.GetIOFileHandles())
+			if err != nil {
+				return err
+			}
 		}
 		if ok {
 			log.Logger().Info("Installing cert-manager...")

--- a/pkg/cmd/opts/install.go
+++ b/pkg/cmd/opts/install.go
@@ -301,7 +301,9 @@ func (o *CommonOptions) Installhyperv() error {
 
 		message := fmt.Sprintf("Would you like to restart your computer?")
 
-		if util.Confirm(message, true, "Please indicate if you would like to restart your computer.", o.GetIOFileHandles()) {
+		if answer, err := util.Confirm(message, true, "Please indicate if you would like to restart your computer.", o.GetIOFileHandles()); err != nil {
+			return err
+		} else if answer {
 
 			err = o.RunCommand("powershell", "Enable-WindowsOptionalFeature", "-Online", "-FeatureName", "Microsoft-Hyper-V", "-All", "-NoRestart")
 			if err != nil {

--- a/pkg/cmd/opts/upgrade/upgrade_ingress.go
+++ b/pkg/cmd/opts/upgrade/upgrade_ingress.go
@@ -93,7 +93,9 @@ For more documentation on Ingress configuration see: [https://jenkins-x.io/docs/
 
 	// confirm values
 	if !o.BatchMode {
-		if !util.Confirm(fmt.Sprintf("Using config values %v, ok?", o.IngressConfig), true, "", o.GetIOFileHandles()) {
+		if answer, err := util.Confirm(fmt.Sprintf("Using config values %v, ok?", o.IngressConfig), true, "", o.GetIOFileHandles()); err != nil {
+			return err
+		} else if !answer {
 			log.Logger().Infof("Terminating")
 			return nil
 		}
@@ -270,7 +272,9 @@ func (o *UpgradeIngressOptions) updateResources(previousWebHookEndpoint string) 
 	log.Logger().Infof("Updated webhook endpoint %s", updatedWebHookEndpoint)
 	updateWebHooks := true
 	if !o.BatchMode {
-		if !util.Confirm("Do you want to update all existing webhooks?", true, "", o.GetIOFileHandles()) {
+		if answer, err := util.Confirm("Do you want to update all existing webhooks?", true, "", o.GetIOFileHandles()); err != nil {
+			return err
+		} else if !answer {
 			updateWebHooks = false
 		}
 	}
@@ -457,7 +461,10 @@ func (o *UpgradeIngressOptions) confirmExposecontrollerConfig() error {
 
 		if !strings.HasSuffix(o.IngressConfig.Domain, "nip.io") {
 			if !o.BatchMode {
-				o.IngressConfig.TLS = util.Confirm("If your network is publicly available would you like to enable cluster wide TLS?", true, "Enables cert-manager and configures TLS with signed certificates from LetsEncrypt", o.GetIOFileHandles())
+				o.IngressConfig.TLS, err = util.Confirm("If your network is publicly available would you like to enable cluster wide TLS?", true, "Enables cert-manager and configures TLS with signed certificates from LetsEncrypt", o.GetIOFileHandles())
+				if err != nil {
+					return err
+				}
 			}
 
 			if o.IngressConfig.TLS {

--- a/pkg/cmd/step/report/step_report_image_version.go
+++ b/pkg/cmd/step/report/step_report_image_version.go
@@ -263,9 +263,9 @@ func (o *StepReportImageVersionOptions) generateReport(imagesDir string) error {
 			return nil
 		}
 		if !o.BatchMode {
-			if !util.Confirm(fmt.Sprintf("are you ready to delete the Job %s", job.Name), true,
-				"we should delete the job when it is finished", o.GetIOFileHandles()) {
-				return nil
+			if answer, err := util.Confirm(fmt.Sprintf("are you ready to delete the Job %s", job.Name), true,
+				"we should delete the job when it is finished", o.GetIOFileHandles()); !answer {
+				return err
 			}
 		}
 		err = jobs.Delete(job.Name, nil)

--- a/pkg/cmd/step/verify/step_verify_packages.go
+++ b/pkg/cmd/step/verify/step_verify_packages.go
@@ -142,7 +142,9 @@ func (o *StepVerifyPackagesOptions) verifyJXVersion(resolver *versionstream.Vers
 	} else {
 		log.Logger().Info("\n")
 		message := fmt.Sprintf("Would you like to upgrade to the %s version?", info("jx"))
-		if util.Confirm(message, true, "Please indicate if you would like to upgrade the binary version.", o.GetIOFileHandles()) {
+		if answer, err := util.Confirm(message, true, "Please indicate if you would like to upgrade the binary version.", o.GetIOFileHandles()); err != nil {
+			return err
+		} else if answer {
 			options := &upgrade.UpgradeCLIOptions{
 				CreateOptions: options.CreateOptions{
 					CommonOptions: o.CommonOptions,

--- a/pkg/cmd/stop/stop_pipeline.go
+++ b/pkg/cmd/stop/stop_pipeline.go
@@ -211,8 +211,8 @@ func (o *StopPipelineOptions) cancelPipelineRun() error {
 			return err
 		}
 
-		if !util.Confirm(fmt.Sprintf("cancel pipeline %s", name), true, "you can always restart a cancelled pipeline with 'jx start pipeline'", o.GetIOFileHandles()) {
-			return nil
+		if answer, err := util.Confirm(fmt.Sprintf("cancel pipeline %s", name), true, "you can always restart a cancelled pipeline with 'jx start pipeline'", o.GetIOFileHandles()); !answer {
+			return err
 		}
 		args = []string{name}
 	}

--- a/pkg/cmd/uninstall/uninstall.go
+++ b/pkg/cmd/uninstall/uninstall.go
@@ -87,10 +87,9 @@ func (o *UninstallOptions) Run() error {
 				help += "\n " + envNamespace
 			}
 
-			uninstall := util.Confirm("Uninstall JX - this command will remove all JX components and delete all namespaces created by Jenkins X. Do you wish to continue?", false,
-				help, o.GetIOFileHandles())
-			if !uninstall {
-				return nil
+			if answer, err := util.Confirm("Uninstall JX - this command will remove all JX components and delete all namespaces created by Jenkins X. Do you wish to continue?", false,
+				help, o.GetIOFileHandles()); !answer {
+				return err
 			}
 		}
 		if o.BatchMode || o.Context != "" {

--- a/pkg/cmd/upgrade/upgrade_addon_prow.go
+++ b/pkg/cmd/upgrade/upgrade_addon_prow.go
@@ -30,7 +30,7 @@ var (
 `)
 
 	upgradeAddonProwExample = templates.Examples(`
-		# Upgrades the Jenkins X platform 
+		# Upgrades the Jenkins X platform
 		jx upgrade addon prow
 	`)
 )
@@ -117,8 +117,8 @@ func (o *UpgradeAddonProwOptions) Run() error {
 					"you like to install the latest Knative Build?\nWARNING: this will remove the previous version and " +
 					"install the latest, any existing builds or custom changes to BuildTemplate resources will be lost"
 
-				if !util.Confirm(message, false, "", o.GetIOFileHandles()) {
-					return nil
+				if answer, err := util.Confirm(message, false, "", o.GetIOFileHandles()); !answer {
+					return err
 				}
 
 				// delete knative build

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -120,7 +120,9 @@ func (o *VersionOptions) upgradeCliIfNeeded(resolver *versionstream.VersionResol
 		} else {
 			log.Logger().Info("\n")
 			message := fmt.Sprintf("Would you like to upgrade to the %s version?", app)
-			if util.Confirm(message, true, "Please indicate if you would like to upgrade the binary version.", o.GetIOFileHandles()) {
+			if answer, err := util.Confirm(message, true, "Please indicate if you would like to upgrade the binary version.", o.GetIOFileHandles()); err != nil {
+				return err
+			} else if answer {
 				options := &upgrade.UpgradeCLIOptions{
 					CreateOptions: options.CreateOptions{
 						CommonOptions: o.CommonOptions,

--- a/pkg/github/github_app.go
+++ b/pkg/github/github_app.go
@@ -60,8 +60,11 @@ func (gh *GithubApp) Install(owner string, repo string, fileHandles util.IOFileH
 		fmt.Fprintf(fileHandles.Out, "Please install '%s' Github App into your organisation/account %s and allow access to repository %s. Click this url \n%s\n\n", util.ColorInfo(appName), owner, repo, util.ColorInfo(url))
 	}
 	if !accessToRepo {
-		accessToRepo = util.Confirm(fmt.Sprintf("Does the '%s' Github App have access to repository", util.ColorInfo(appName)), false,
+		accessToRepo, err = util.Confirm(fmt.Sprintf("Does the '%s' Github App have access to repository", util.ColorInfo(appName)), false,
 			fmt.Sprintf("Please install '%s' Github App into your organisation and grant access to repositories", util.ColorInfo(appName)), fileHandles)
+		if err != nil {
+			return false, err
+		}
 	}
 	if !accessToRepo {
 		return false, errors.New(fmt.Sprintf("Please install '%s' Github App", util.ColorInfo(appName)))

--- a/pkg/gits/features/disable_features.go
+++ b/pkg/gits/features/disable_features.go
@@ -173,8 +173,9 @@ Wiki Pages: %s
 			} else {
 
 				if !batchMode {
-					proceed := util.Confirm(fmt.Sprintf("Are you sure you want to disable %s on %s", strings.Join(toClose, ","), util.ColorInfo(fmt.Sprintf("%s/%s", c.Organisation, c.Name))), true, "", handles)
-					if !proceed {
+					if answer, err := util.Confirm(fmt.Sprintf("Are you sure you want to disable %s on %s", strings.Join(toClose, ","), util.ColorInfo(fmt.Sprintf("%s/%s", c.Organisation, c.Name))), true, "", handles); err != nil {
+						return err
+					} else if !answer {
 						continue
 					}
 				}

--- a/pkg/kube/env.go
+++ b/pkg/kube/env.go
@@ -167,8 +167,12 @@ func CreateEnvironmentSurvey(batchMode bool, authConfigSvc auth.ConfigService, d
 
 	data.Spec.RemoteCluster = config.Spec.RemoteCluster
 	if !batchMode {
-		data.Spec.RemoteCluster = util.Confirm("Environment in separate cluster to Dev Environment:",
+		var err error
+		data.Spec.RemoteCluster, err = util.Confirm("Environment in separate cluster to Dev Environment:",
 			data.Spec.RemoteCluster, " Is this Environment going to be in a different cluster to the Development environment. For help on Multi Cluster support see: https://jenkins-x.io/getting-started/multi-cluster/", handles)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if config.Spec.Cluster != "" {
 		data.Spec.Cluster = config.Spec.Cluster

--- a/pkg/util/pickers.go
+++ b/pkg/util/pickers.go
@@ -159,7 +159,7 @@ func SelectNames(names []string, message string, selectAll bool, help string, ha
 }
 
 // Confirm prompts the user to confirm something
-func Confirm(message string, defaultValue bool, help string, handles IOFileHandles) bool {
+func Confirm(message string, defaultValue bool, help string, handles IOFileHandles) (bool, error) {
 	answer := defaultValue
 	prompt := &survey.Confirm{
 		Message: message,
@@ -167,7 +167,10 @@ func Confirm(message string, defaultValue bool, help string, handles IOFileHandl
 		Help:    help,
 	}
 	surveyOpts := survey.WithStdio(handles.In, handles.Out, handles.Err)
-	survey.AskOne(prompt, &answer, nil, surveyOpts)
+	err := survey.AskOne(prompt, &answer, nil, surveyOpts)
+	if err != nil {
+		return false, err
+	}
 	log.Blank()
-	return answer
+	return answer, nil
 }


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Prior to this commit, while a confirmation was required, `ctrl+c` would confirm the default value instead of stopping the program.
This could have the unintended purpose of confirming that a pipeline should be stopped instead of cancelling the operation.

#### Special notes for the reviewer(s)

On issue #5627 the answer was that it wasn't due to `jx` but the the library it's using. But `jx` ignores the error from the library: https://github.com/jenkins-x/jx/blob/master/pkg/util/pickers.go#L170

#### Which issue this PR fixes

fixes #5627, fixes #3291
