### PR TITLE
fix: Resolve OWNERS merge conflicts in boot upgrade with existing version

### DIFF
--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -1263,3 +1263,32 @@ func (g *GitCLI) IsAncestor(dir string, possibleAncestor string, commitish strin
 	// Default case is that this is an ancestor, since there's no error from the merge-base call.
 	return true, nil
 }
+
+// WriteRepoAttributes writes the given content to .git/info/attributes
+func (g *GitCLI) WriteRepoAttributes(dir string, content string) error {
+	// Read the existing .git/info/attributes if it exists
+	gitAttrFile := filepath.Join(dir, ".git", "info", "attributes")
+
+	err := ioutil.WriteFile(gitAttrFile, []byte(content), util.DefaultFileWritePermissions)
+	if err != nil {
+		return errors.Wrapf(err, "writing new repo-local git attributes to %s", gitAttrFile)
+	}
+	return nil
+}
+
+// ReadRepoAttributes reads the existing content, if any, in .git/info/attributes
+func (g *GitCLI) ReadRepoAttributes(dir string) (string, error) {
+	gitAttrFile := filepath.Join(dir, ".git", "info", "attributes")
+	gaExists, err := util.FileExists(gitAttrFile)
+	if err != nil {
+		return "", errors.Wrapf(err, "checking if repo-local git attributes file %s exists", gitAttrFile)
+	}
+	if gaExists {
+		gaBytes, err := ioutil.ReadFile(gitAttrFile)
+		if err != nil {
+			return "", errors.Wrapf(err, "reading existing repo-local git attributes from %s", gitAttrFile)
+		}
+		return string(gaBytes), nil
+	}
+	return "", nil
+}

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -684,3 +684,13 @@ func (g *GitFake) Describe(dir string, contains bool, commitish string, abbrev s
 func (g *GitFake) IsAncestor(dir string, possibleAncestor string, commitish string) (bool, error) {
 	return false, nil
 }
+
+// WriteRepoAttributes writes the given content to .git/info/attributes
+func (g *GitFake) WriteRepoAttributes(dir string, content string) error {
+	return nil
+}
+
+// ReadRepoAttributes reads the existing content, if any, in .git/info/attributes
+func (g *GitFake) ReadRepoAttributes(dir string) (string, error) {
+	return "", nil
+}

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -538,3 +538,13 @@ func (g *GitLocal) Describe(dir string, contains bool, commitish string, abbrev 
 func (g *GitLocal) IsAncestor(dir string, possibleAncestor string, commitish string) (bool, error) {
 	return g.GitCLI.IsAncestor(dir, possibleAncestor, commitish)
 }
+
+// WriteRepoAttributes writes the given content to .git/info/attributes
+func (g *GitLocal) WriteRepoAttributes(dir string, content string) error {
+	return g.GitCLI.WriteRepoAttributes(dir, content)
+}
+
+// ReadRepoAttributes reads the existing content, if any, in .git/info/attributes
+func (g *GitLocal) ReadRepoAttributes(dir string) (string, error) {
+	return g.GitCLI.ReadRepoAttributes(dir)
+}

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -289,6 +289,9 @@ type Gitter interface {
 	DeleteLocalBranch(dir string, branch string) error
 
 	SetUpstreamTo(dir string, branch string) error
+
+	WriteRepoAttributes(dir string, contents string) error
+	ReadRepoAttributes(dir string) (string, error)
 }
 
 // PullRequestDetails is the details for creating a pull request

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -1237,6 +1237,25 @@ func (mock *MockGitter) PushTag(_param0 string, _param1 string) error {
 	return ret0
 }
 
+func (mock *MockGitter) ReadRepoAttributes(_param0 string) (string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("ReadRepoAttributes", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockGitter) RebaseTheirs(_param0 string, _param1 string, _param2 string, _param3 bool) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -1661,6 +1680,21 @@ func (mock *MockGitter) Version() (string, error) {
 		}
 	}
 	return ret0, ret1
+}
+
+func (mock *MockGitter) WriteRepoAttributes(_param0 string, _param1 string) error {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0, _param1}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("WriteRepoAttributes", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(error)
+		}
+	}
+	return ret0
 }
 
 func (mock *MockGitter) VerifyWasCalledOnce() *VerifierMockGitter {
@@ -3929,6 +3963,33 @@ func (c *MockGitter_PushTag_OngoingVerification) GetAllCapturedArguments() (_par
 	return
 }
 
+func (verifier *VerifierMockGitter) ReadRepoAttributes(_param0 string) *MockGitter_ReadRepoAttributes_OngoingVerification {
+	params := []pegomock.Param{_param0}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "ReadRepoAttributes", params, verifier.timeout)
+	return &MockGitter_ReadRepoAttributes_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_ReadRepoAttributes_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_ReadRepoAttributes_OngoingVerification) GetCapturedArguments() string {
+	_param0 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1]
+}
+
+func (c *MockGitter_ReadRepoAttributes_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+	}
+	return
+}
+
 func (verifier *VerifierMockGitter) RebaseTheirs(_param0 string, _param1 string, _param2 string, _param3 bool) *MockGitter_RebaseTheirs_OngoingVerification {
 	params := []pegomock.Param{_param0, _param1, _param2, _param3}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "RebaseTheirs", params, verifier.timeout)
@@ -4711,4 +4772,35 @@ func (c *MockGitter_Version_OngoingVerification) GetCapturedArguments() {
 }
 
 func (c *MockGitter_Version_OngoingVerification) GetAllCapturedArguments() {
+}
+
+func (verifier *VerifierMockGitter) WriteRepoAttributes(_param0 string, _param1 string) *MockGitter_WriteRepoAttributes_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "WriteRepoAttributes", params, verifier.timeout)
+	return &MockGitter_WriteRepoAttributes_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_WriteRepoAttributes_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_WriteRepoAttributes_OngoingVerification) GetCapturedArguments() (string, string) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+}
+
+func (c *MockGitter_WriteRepoAttributes_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
+		}
+	}
+	return
 }


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Realized this was an issue while thinking about #6465 - we don't commit changes to `OWNERS` from upstream when running `jx upgrade boot`, but we still will hit merge conflicts when cherry-picking if `OWNERS` has changed in both the dev env repo and upstream, so let's use a custom merge driver to ensure that all conflicts for `OWNERS` are automatically resolved in favor of the existing version in the dev env repo, as described in https://stackoverflow.com/a/930495

#### Special notes for the reviewer(s)

I still need to write a unit test for this.

#### Which issue this PR fixes

fixes #6543 
