### PR TITLE
fix: prevent `jx stop pipeline` from having "failed to cancel pipeline" error

### DIFF
--- a/pkg/cmd/stop/stop_pipeline.go
+++ b/pkg/cmd/stop/stop_pipeline.go
@@ -155,7 +155,8 @@ func (o *StopPipelineOptions) cancelPipelineRun() error {
 	if err != nil {
 		return errors.Wrap(err, "could not create tekton client")
 	}
-	prList, err := tektonClient.TektonV1alpha1().PipelineRuns(ns).List(metav1.ListOptions{})
+	pipelines := tektonClient.TektonV1alpha1().PipelineRuns(ns)
+	prList, err := pipelines.List(metav1.ListOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "failed to list PipelineRuns in namespace %s", ns)
 	}
@@ -220,6 +221,14 @@ func (o *StopPipelineOptions) cancelPipelineRun() error {
 		pr := m[a]
 		if pr == nil {
 			return fmt.Errorf("no PipelineRun found for name %s", a)
+		}
+		pr, err = pipelines.Get(pr.Name, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "getting PipelineRun %s", pr.Name)
+		}
+		if tekton.PipelineRunIsComplete(pr) {
+			log.Logger().Infof("PipelineRun %s has already completed", util.ColorInfo(pr.Name))
+			continue
 		}
 		err = tekton.CancelPipelineRun(tektonClient, ns, pr)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Prior to this commit, `jx stop pipeline` would often have error:
> failed to cancel pipeline ...: the object has been modified; please apply your changes to the latest version and try again

It would happen a handful of time when trying to stop a starting pipeline. Worse, the longer the user took to choose, the more likely it was, forcing the user to choose fast, and potentially making errors.

This was due to the pipeline object not being refreshed after the user took some time choosing which pipeline to stop.

#### Special notes for the reviewer(s)

Another one from my "Grrr" list ...