### PR TITLE
fix: #6483 - boot should not show warning as first impression

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -135,7 +135,7 @@ func (o *BootOptions) Run() error {
 
 	gitURL, gitRef, err := gits.GetGitInfoFromDirectory(o.Dir, o.Git())
 	if err != nil {
-		log.Logger().Warnf("there was a problem obtaining the boot config repository git configuration, falling back to defaults. Error: %s", err.Error())
+		log.Logger().Info("Creating boot config with defaults, as not in an existing boot directory with a git repository.")
 		gitURL = config.DefaultBootRepository
 		gitRef = config.DefaultVersionsRef
 	}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

First impressions count - and with boot the first thing people see is a big ugly warning with an error, when really it is just falling back to defaults. 

#### Special notes for the reviewer(s)

@rawlingsj may override this with a rethink of the UX of the CLI  which is fine, but I thought this was a simple thing. 

#### Which issue this PR fixes

fixes #6483

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
