### PR TITLE
fix: secure the endpoints exposed by the DevPod

### DIFF
--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -302,7 +302,7 @@ func (o *CreateDevPodOptions) Run() error {
 
 		editEnv, err = o.getOrCreateEditEnvironment()
 		if err != nil {
-			return errors.Wrap(err, "getting or creating the edit edit environment")
+			return errors.Wrap(err, "getting or creating the edit environment")
 		}
 
 		// If the user passed in Image Pull Secrets, patch them in to the edit env's default service account

--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -972,7 +972,11 @@ func (o *CreateDevPodOptions) isAutoExposeSecure(client kubernetes.Interface, ns
 
 	help := "TLS doesn't seem to be enabled in the ingress-config. This setup is insecure to use with a basic auth password."
 	message := "Do you want to use an insecure connection to expose the DevPod?"
-	return util.Confirm(message, false, help, o.GetIOFileHandles())
+	confirmed, err := util.Confirm(message, false, help, o.GetIOFileHandles())
+	if confirmed && err == nil {
+		return true
+	}
+	return false
 }
 
 func (o *CreateDevPodOptions) getOrCreateEditEnvironment() (*v1.Environment, error) {

--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -137,7 +137,7 @@ func NewCmdCreateDevPod(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.Reuse, "reuse", "", true, "Reuse an existing DevPod if a suitable one exists. The DevPod will be selected based on the label (or current working directory)")
 	cmd.Flags().BoolVarP(&options.Sync, "sync", "", false, "Also synchronise the local file system into the DevPod")
 	cmd.Flags().IntSliceVarP(&options.Ports, "ports", "p", []int{}, "Container ports exposed by the DevPod")
-	cmd.Flags().BoolVarP(&options.AutoExpose, "auto-expose", "", false, "Automatically expose useful ports as services such as the debug port, as well as any ports specified using --ports")
+	cmd.Flags().BoolVarP(&options.AutoExpose, "auto-expose", "", false, "Automatically expose useful ports via ingresses such as the ide port, debug port, as well as any ports specified using --ports")
 	cmd.Flags().BoolVarP(&options.Persist, "persist", "", false, "Persist changes made to the DevPod. Cannot be used with --sync")
 	cmd.Flags().StringVarP(&options.ImportURL, "import-url", "u", "", "Clone a Git repository into the DevPod. Cannot be used with --sync")
 	cmd.Flags().BoolVarP(&options.Import, "import", "", true, "Detect if there is a Git repository in the current directory and attempt to clone it into the DevPod. Ignored if used with --sync")

--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -799,7 +799,7 @@ func (o *CreateDevPodOptions) Run() error {
 				o.NotifyProgress(opts.LogWarning, "Could not find service with name %s in namespace %s\n", ideServiceName, curNs)
 			}
 		} else {
-			exposeCmd := fmt.Sprintf("kubectl port-forward 80:8080 svc/%s", ideServiceName)
+			exposeCmd := fmt.Sprintf("kubectl port-forward svc/%s 8080:80", ideServiceName)
 			log.Logger().Info("\nYou can access the Web IDE to edit your app with command:")
 			log.Logger().Infof("* %s", util.ColorInfo(exposeCmd))
 		}
@@ -835,7 +835,7 @@ func (o *CreateDevPodOptions) Run() error {
 		localPort := 8081
 		log.Logger().Info("\nYou can access the DevPod locally with the following commands:")
 		for _, svcName := range exposePortServices {
-			exposeCmd := fmt.Sprintf("kubectl port-forward 80:%d svc/%s", localPort, svcName)
+			exposeCmd := fmt.Sprintf("kubectl port-forward svc/%s %d:80", svcName, localPort)
 			log.Logger().Infof("* %s", util.ColorInfo(exposeCmd))
 			localPort += 1
 		}

--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -837,7 +837,7 @@ func (o *CreateDevPodOptions) Run() error {
 		for _, svcName := range exposePortServices {
 			exposeCmd := fmt.Sprintf("kubectl port-forward svc/%s %d:80", svcName, localPort)
 			log.Logger().Infof("* %s", util.ColorInfo(exposeCmd))
-			localPort += 1
+			localPort++
 		}
 		log.Logger().Info("")
 	}

--- a/pkg/cmd/deletecmd/delete_devpod.go
+++ b/pkg/cmd/deletecmd/delete_devpod.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/kube/naming"
+	"github.com/pkg/errors"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
@@ -72,20 +73,20 @@ func (o *DeleteDevPodOptions) Run() error {
 
 	client, curNs, err := o.KubeClientAndNamespace()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting the kubernetes client")
 	}
 	ns, _, err := kube.GetDevNamespace(client, curNs)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting the dev namespace")
 	}
 	userName, err := o.GetUsername(o.CommonDevPodOptions.Username)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting the current user")
 	}
 	name := naming.ToValidName(userName)
 	names, err := kube.GetPodNames(client, ns, name)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting the pod names")
 	}
 
 	info := util.ColorInfo
@@ -96,7 +97,7 @@ func (o *DeleteDevPodOptions) Run() error {
 	if len(devPods) == 0 {
 		devPods, err = util.PickNames(names, "Pick DevPod:", "", o.GetIOFileHandles())
 		if err != nil {
-			return err
+			return errors.Wrap(err, "picking the DevPod names")
 		}
 	}
 
@@ -114,7 +115,7 @@ func (o *DeleteDevPodOptions) Run() error {
 		log.Logger().Debugf("About to delete Devpod %s", name)
 		err = client.CoreV1().Pods(ns).Delete(name, &metav1.DeleteOptions{})
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "deleting the devpod %q", name)
 		}
 	}
 	log.Logger().Infof("Deleted DevPods %s", util.ColorInfo(deletePods))

--- a/pkg/cmd/get/get_devpod.go
+++ b/pkg/cmd/get/get_devpod.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/pkg/errors"
 
 	"github.com/jenkins-x/jx/pkg/log"
 
@@ -67,14 +68,13 @@ func NewCmdGetDevPod(commonOpts *opts.CommonOptions) *cobra.Command {
 
 // Run implements this command
 func (o *GetDevPodOptions) Run() error {
-
 	client, curNs, err := o.KubeClientAndNamespace()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "get kubernetes client")
 	}
 	ns, _, err := kube.GetDevNamespace(client, curNs)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "get dev namespace")
 	}
 
 	var userName string
@@ -82,14 +82,16 @@ func (o *GetDevPodOptions) Run() error {
 		if o.Username != "" {
 			log.Logger().Warn("getting devpods for all usernames. Explicit username will be ignored")
 		}
-		// Leave userName blank
 	} else {
 		userName, err = o.GetUsername(o.Username)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "getting the current user")
 		}
 	}
 	names, m, err := kube.GetDevPodNames(client, ns, userName)
+	if err != nil {
+		return errors.Wrap(err, "getting the DevPod names")
+	}
 
 	table := o.CreateTable()
 	table.AddRow("NAME", "POD TEMPLATE", "AGE", "STATUS")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This contains the following changes:
- Make the `auto-expose` flag to behave consistently and set it by default to false. This results in not exposing any DevPod port by default.
- Check whether or not the TLS is enabled when the `auto-expose` flag is active, and ask for user confirmation in case it is disable in order to proceed with an insecure setup.
- Configure the basic authentication when the services are exposed.
- Configure the expose-controller to only recreate the ingress resources of the service created by the DevPod, before it was recreating all ingress resources from `jx` namespace. This will prevent that the other ingress resources are accidentally recreated.
- Augment the error messages with more context and also handle some errors which previously were ignored.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6475

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->