### PR TITLE
fix: Use builder-go-maven for make release due to new tests needing maven/java

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -82,7 +82,7 @@ pipelineConfig:
               - name: release
                 #image: docker.io/golang:1.11.5
                 # needs helm in the image for install_gitops_integration_test.go
-                image: gcr.io/jenkinsxio/builder-go
+                image: gcr.io/jenkinsxio/builder-go-maven
                 command: make
                 args: ['release']
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Release build tests are failing with 
```
=== Failed
=== FAIL: pkg/cmd/importcmd TestImportProjectNextGenPipelineWithDeploy (3.20s)
=== PAUSE TestImportProjectNextGenPipelineWithDeploy
=== CONT  TestImportProjectNextGenPipelineWithDeploy
    import_deploy_integration_test.go:195: 
        	Error Trace:	import_deploy_integration_test.go:195
        	            				import_deploy_integration_test.go:177
        	            				import_deploy_integration_test.go:60
        	            				import_deploy_integration_test.go:125
        	Error:      	Received unexpected error:
        	            	Failed to update maven deploy plugin: Command failed 'mvn io.jenkins.updatebot:updatebot-maven-plugin:RELEASE:plugin -Dartifact=maven-deploy-plugin -Dversion=2.8.2': Picked up _JAVA_OPTIONS: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms1G -Xmx4G
        	            	Unrecognized VM option 'UseCGroupMemoryLimitForHeap'
        	            	Error: Could not create the Java Virtual Machine.
        	            	Error: A fatal exception has occurred. Program will exit. exit status 1
        	            	 output: 
        	Test:       	TestImportProjectNextGenPipelineWithDeploy
        	Messages:   	Failed team-enable-knative-canary-and-hpa with Failed to update maven deploy plugin: Command failed 'mvn io.jenkins.updatebot:updatebot-maven-plugin:RELEASE:plugin -Dartifact=maven-deploy-plugin -Dversion=2.8.2': Picked up _JAVA_OPTIONS: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms1G -Xmx4G
        	            	Unrecognized VM option 'UseCGroupMemoryLimitForHeap'
        	            	Error: Could not create the Java Virtual Machine.
        	            	Error: A fatal exception has occurred. Program will exit. exit status 1
        	            	 output: 
    import_deploy_integration_test.go:133: 
        	Error Trace:	import_deploy_integration_test.go:133
        	Error:      	Received unexpected error:
        	            	Failed to update maven deploy plugin: Command failed 'mvn io.jenkins.updatebot:updatebot-maven-plugin:RELEASE:plugin -Dartifact=maven-deploy-plugin -Dversion=2.8.2': Picked up _JAVA_OPTIONS: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms1G -Xmx4G
        	            	Unrecognized VM option 'UseCGroupMemoryLimitForHeap'
        	            	Error: Could not create the Java Virtual Machine.
        	            	Error: A fatal exception has occurred. Program will exit. exit status 1
        	            	 output: 
        	Test:       	TestImportProjectNextGenPipelineWithDeploy
        	Messages:   	failed to run test team-enable-knative-canary-and-hpa
```
Which makes me think we need to use the `builder-go-maven` image there now.

#### Special notes for the reviewer(s)

Once this gets approved, I'm going to just override the test contexts since the only change here is to the release `jenkins-x.yml`.

#### Which issue this PR fixes

n/a