### PR TITLE
fix: Use same image in integration test as make release

### DIFF
--- a/jenkins-x-integration.yml
+++ b/jenkins-x-integration.yml
@@ -49,14 +49,14 @@ pipelineConfig:
               - name: build
                 #image: docker.io/golang:1.11.5
                 # needs helm in the image for install_gitops_integration_test.go
-                image: gcr.io/jenkinsxio/builder-go:0.1.639
+                image: gcr.io/jenkinsxio/builder-go-maven
                 command: make
                 args: ['build']
 
               - name: test-integration
                 #image: docker.io/golang:1.11.5
                 # needs helm in the image for install_gitops_integration_test.go
-                image: gcr.io/jenkinsxio/builder-go:0.1.639
+                image: gcr.io/jenkinsxio/builder-go-maven
                 command: make
                 args: ['test-slow-integration']
 

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -29,10 +29,6 @@ pipelineConfig:
                 value: /workspace/go
               - name: GOPROXY
                 value: http://jenkins-x-athens-proxy
-              - name: MAVEN_OPTS
-                value: -Xmx4g
-              - name: _JAVA_OPTIONS
-                value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms1G -Xmx4G
               - name: PARALLEL_BUILDS
                 value: "2"
               - name: DISABLE_TEST_CACHING

--- a/pkg/cmd/step/step_wait_for_artifact.go
+++ b/pkg/cmd/step/step_wait_for_artifact.go
@@ -23,7 +23,7 @@ const (
 	optionArtifact          = "artifact"
 	optionVersion           = "version"
 	optionPollTime          = "poll-time"
-	DefaultMavenCentralRepo = "http://central.maven.org/maven2/"
+	DefaultMavenCentralRepo = "https://repo1.maven.org/maven2/"
 )
 
 // StepWaitForArtifactOptions contains the command line flags

--- a/pkg/maven/cli.go
+++ b/pkg/maven/cli.go
@@ -35,7 +35,7 @@ func InstallMavenIfRequired() error {
 		return nil
 	}
 	// lets assume maven is not installed so lets download it
-	clientURL := fmt.Sprintf("http://central.maven.org/maven2/org/apache/maven/apache-maven/%s/apache-maven-%s-bin.zip", MavenVersion, MavenVersion)
+	clientURL := fmt.Sprintf("https://repo1.maven.org/maven2/org/apache/maven/apache-maven/%s/apache-maven-%s-bin.zip", MavenVersion, MavenVersion)
 
 	log.Logger().Infof("Apache Maven is not installed so lets download: %s", util.ColorInfo(clientURL))
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

To make sure that we don't end up with tests passing in the integration context that fail in the release context due to image differences.

#### Special notes for the reviewer(s)

Followup to #6530

#### Which issue this PR fixes

n/a