### PR TITLE
fix: Don't use anonymous GitHub API for dev env repo creation and get quickstarts

### DIFF
--- a/pkg/cmd/opts/quickstarts.go
+++ b/pkg/cmd/opts/quickstarts.go
@@ -65,17 +65,13 @@ func (o *CommonOptions) LoadQuickStartsFromLocations(locations []v1.QuickStartLo
 				kind = gits.KindGitHub
 			}
 
-			var gitProvider gits.GitProvider
-			var err error
-
-			// If this is a default quickstart location but there's no github.com credentials, fall back to anonymous
+			// If this is a default quickstart location but there's no github.com credentials, skip and rely on the version stream alone.
 			server := config.GetOrCreateServer(gitURL)
 			userAuth := config.CurrentUser(server, o.InCluster())
 			if kube.IsDefaultQuickstartLocation(location) && (userAuth == nil || userAuth.IsInvalid()) {
-				gitProvider, err = gits.NewAnonymousGitHubProvider(server, nil)
-			} else {
-				gitProvider, err = o.GitProviderForGitServerURL(gitURL, kind, "")
+				continue
 			}
+			gitProvider, err := o.GitProviderForGitServerURL(gitURL, kind, "")
 			if err != nil {
 				return model, err
 			}

--- a/pkg/gits/helpers_test.go
+++ b/pkg/gits/helpers_test.go
@@ -1662,38 +1662,6 @@ func TestDuplicateGitRepoFromCommitish(t *testing.T) {
 				"LICENSE": []byte("TODO"),
 			},
 		},
-		{
-			name: "wrongDifferentProvider",
-			args: args{
-				toOrg:         "coyote",
-				toName:        "wile",
-				fromGitURL:    "https://fake.git/acme/roadrunner.git",
-				fromCommitish: "master",
-				toBranch:      "master",
-				gitter:        gitter,
-			},
-			useOtherProvider: true,
-			want: &gits.GitRepository{
-				Name:             "wile",
-				AllowMergeCommit: false,
-				HTMLURL:          "https://fake.git/coyote/wile",
-				CloneURL:         "",
-				SSHURL:           "",
-				Language:         "",
-				Fork:             false,
-				Stars:            0,
-				URL:              "https://fake.git/coyote/wile.git",
-				Scheme:           "https",
-				Host:             "fake.git",
-				Organisation:     "coyote",
-				Project:          "",
-				Private:          false,
-			},
-			wantErr: "organization 'acme' not found",
-			wantFiles: map[string][]byte{
-				"README": []byte("Hello!"),
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1708,13 +1676,12 @@ func TestDuplicateGitRepoFromCommitish(t *testing.T) {
 			}
 			tt.provider = provider
 
-			var fromProvider *gits.FakeProvider
+			var fromRepo *gits.GitRepository
 			if tt.useOtherProvider {
-				fromProvider = gits.NewFakeProvider(otherProviderRepo)
-				fromProvider.Gitter = gitter
+				fromRepo = otherProviderRepo.GitRepo
 			}
 
-			got, err := gits.DuplicateGitRepoFromCommitish(tt.args.toOrg, tt.args.toName, tt.args.fromGitURL, tt.args.fromCommitish, tt.args.toBranch, false, tt.provider, tt.args.gitter, fromProvider)
+			got, err := gits.DuplicateGitRepoFromCommitish(tt.args.toOrg, tt.args.toName, tt.args.fromGitURL, tt.args.fromCommitish, tt.args.toBranch, false, tt.provider, tt.args.gitter, fromRepo)
 			if tt.wantErr != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

As described in #6539, I forgot just how stingy the anonymous GitHub API rate limit is. So let's refactor both the `jx step verify environments` logic for getting the required info about the upstream `jenkins-x-boot-config` and `LoadQuickStartsModel`'s logic for loading quickstart information work to not use anonymous GitHub API calls after all. The required information should be available in both cases without needing to make those API calls, thanks to `https://github.com/jenkins-x/jenkins-x-boot-config.git` actually having everything that's needed in its own URL, and the default quickstarts being in the version stream.

#### Special notes for the reviewer(s)

Starting out on WIP to make sure the non-required `boot-lh-ghe` test...well, doesn't pass, since it'll run into https://github.com/jenkins-x/lighthouse/issues/462, but at least gets past that.

#### Which issue this PR fixes

fixes #6539