### PR TITLE
fix: various problem due to non-conventional github repository name

### DIFF
--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -655,7 +655,8 @@ func (o *PreviewOptions) Run() error {
 
 // findPreviewURL finds the preview URL
 func (o *PreviewOptions) findPreviewURL(kubeClient kubernetes.Interface, kserveClient kserve.Interface) (string, []string, error) {
-	appNames := []string{o.Application, o.ReleaseName, o.Namespace + "-preview", o.ReleaseName + "-" + o.Application}
+	app := naming.ToValidName(o.Application)
+	appNames := []string{app, o.ReleaseName, o.Namespace + "-preview", o.ReleaseName + "-" + app}
 	url := ""
 	var err error
 	fn := func() (bool, error) {
@@ -682,7 +683,7 @@ func (o *PreviewOptions) RunPostPreviewSteps(kubeClient kubernetes.Interface, ns
 		return err
 	}
 
-	scheme, port, err := services.FindServiceSchemePort(kubeClient, ns, application)
+	scheme, port, err := services.FindServiceSchemePort(kubeClient, ns, naming.ToValidName(application))
 	if err != nil {
 		log.Logger().Warnf("Failed to find the service %s : %s", application, err)
 	}

--- a/pkg/cmd/promote/promote.go
+++ b/pkg/cmd/promote/promote.go
@@ -1064,7 +1064,7 @@ func (o *PromoteOptions) CommentOnIssues(targetNS string, environment *v1.Enviro
 	appNames := []string{app, o.ReleaseName, ens + "-" + app}
 	url := ""
 	for _, n := range appNames {
-		url, err = services.FindServiceURL(kubeClient, ens, n)
+		url, err = services.FindServiceURL(kubeClient, ens, naming.ToValidName(n))
 		if url != "" {
 			break
 		}

--- a/pkg/cmd/step/step_tag.go
+++ b/pkg/cmd/step/step_tag.go
@@ -263,7 +263,7 @@ func (o *StepTagOptions) defaultChartValueRepository() string {
 		appName = gitInfo.Name
 	}
 	if dockerRegistry != "" && dockerRegistryOrg != "" && appName != "" {
-		return dockerRegistry + "/" + dockerRegistryOrg + "/" + appName
+		return dockerRegistry + "/" + dockerRegistryOrg + "/" + naming.ToValidName(appName)
 	}
 	log.Logger().Warnf("could not generate chart repository name for GetDockerRegistry %s, GetDockerRegistryOrg %s, appName %s", dockerRegistry, dockerRegistryOrg, appName)
 	return ""

--- a/pkg/cmd/step/step_tag_test.go
+++ b/pkg/cmd/step/step_tag_test.go
@@ -1,14 +1,13 @@
 // +build unit
 
-package step_test
+package step
 
 import (
 	"path/filepath"
 	"strings"
 	"testing"
 
-	step2 "github.com/jenkins-x/jx/pkg/cmd/opts/step"
-	"github.com/jenkins-x/jx/pkg/cmd/step"
+	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
 
 	"io/ioutil"
 	"os"
@@ -25,6 +24,7 @@ func TestStepTagCharts(t *testing.T) {
 	t.Parallel()
 	f, err := ioutil.TempDir("", "test-step-tag-charts")
 	assert.NoError(t, err)
+	defer os.RemoveAll(f)
 
 	testData := path.Join("test_data", "step_tag_project")
 	_, err = os.Stat(testData)
@@ -40,8 +40,8 @@ func TestStepTagCharts(t *testing.T) {
 	chartFile := filepath.Join(chartsDir, "Chart.yaml")
 	valuesFile := filepath.Join(chartsDir, "values.yaml")
 
-	o := step.StepTagOptions{
-		StepOptions: step2.StepOptions{
+	o := StepTagOptions{
+		StepOptions: step.StepOptions{
 			CommonOptions: &opts.CommonOptions{},
 		},
 	}
@@ -71,16 +71,16 @@ func TestStepTagCharts(t *testing.T) {
 		if strings.HasPrefix(line, "anotherImage:") {
 			anotherImage = true
 		}
-		if strings.HasPrefix(line, step.ValuesYamlRepositoryPrefix) {
-			value := strings.TrimSpace(strings.TrimPrefix(line, step.ValuesYamlRepositoryPrefix))
+		if strings.HasPrefix(line, ValuesYamlRepositoryPrefix) {
+			value := strings.TrimSpace(strings.TrimPrefix(line, ValuesYamlRepositoryPrefix))
 			if anotherImage {
 				assert.Equal(t, "anotherImageRepoValue", value, "values.yaml anotherImage.repository: attribute")
 			} else {
 				foundRepo = true
 				assert.Equal(t, expectedImageName, value, "values.yaml repository: attribute")
 			}
-		} else if strings.HasPrefix(line, step.ValuesYamlTagPrefix) {
-			value := strings.TrimSpace(strings.TrimPrefix(line, step.ValuesYamlTagPrefix))
+		} else if strings.HasPrefix(line, ValuesYamlTagPrefix) {
+			value := strings.TrimSpace(strings.TrimPrefix(line, ValuesYamlTagPrefix))
 			if anotherImage {
 				assert.Equal(t, "anotherImageTagValue", value, "values.yaml anotherImage.tag: attribute")
 			} else {
@@ -90,6 +90,44 @@ func TestStepTagCharts(t *testing.T) {
 		}
 	}
 
-	assert.True(t, foundRepo, "Failed to find tag '%s' in file %s", step.ValuesYamlRepositoryPrefix, valuesFile)
-	assert.True(t, foundVersion, "Failed to find tag '%s' in file %s", step.ValuesYamlTagPrefix, valuesFile)
+	assert.True(t, foundRepo, "Failed to find tag '%s' in file %s", ValuesYamlRepositoryPrefix, valuesFile)
+	assert.True(t, foundVersion, "Failed to find tag '%s' in file %s", ValuesYamlTagPrefix, valuesFile)
+}
+
+func TestDefaultChartValueRepositoryValidName(t *testing.T) {
+	f, err := ioutil.TempDir("", "test-step-tag-valid-name")
+	assert.NoError(t, err)
+	defer os.RemoveAll(f)
+
+	if app, clean := os.LookupEnv("APP_NAME"); clean {
+		assert.NoError(t, os.Unsetenv("APP_NAME"))
+		defer os.Setenv("APP_NAME", app)
+	}
+	if app, clean := os.LookupEnv("REPO_NAME"); clean {
+		assert.NoError(t, os.Unsetenv("REPO_NAME"))
+		defer os.Setenv("REPO_NAME", app)
+	}
+
+	testData := path.Join("test_data", "step_tag_project")
+	_, err = os.Stat(testData)
+	assert.NoError(t, err)
+
+	err = util.CopyDir(testData, f, true)
+	assert.NoError(t, err)
+
+	expectedImageName := "docker.io/jenkinsxio/my-awesome-project-org"
+
+	o := StepTagOptions{
+		StepOptions: step.StepOptions{
+			CommonOptions: &opts.CommonOptions{},
+		},
+	}
+	chartsDir := filepath.Join(f, "charts", "mydemo")
+	o.Flags.Dir = f
+	o.Flags.ChartsDir = chartsDir
+	git := gits.GitFake{}
+	git.SetRemoteURL("", "origin", "https://github.com/My_Self/My_Awesome_Project.org")
+	o.SetGit(&git)
+
+	assert.Equal(t, expectedImageName, o.defaultChartValueRepository())
 }

--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jenkins-x/jx/pkg/cloud/buckets"
 	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 
 	"github.com/fatih/color"
 	"github.com/google/uuid"
@@ -150,11 +151,15 @@ func createPipelineActivityName(labels map[string]string, buildNumber string) st
 	if repository == "" {
 		repository = labels["repo"]
 	}
-	baseName := strings.ToLower(fmt.Sprintf("%s/%s/%s #%s", labels[v1.LabelOwner], repository, labels[v1.LabelBranch], buildNumber))
+	baseName := fmt.Sprintf("%s/%s/%s #%s",
+		naming.ToValidName(labels[v1.LabelOwner]),
+		naming.ToValidName(repository),
+		naming.ToValidName(labels[v1.LabelBranch]),
+		strings.ToLower(buildNumber))
 
 	context := labels[v1.LabelContext]
 	if context != "" {
-		return strings.ToLower(fmt.Sprintf("%s %s", baseName, context))
+		return fmt.Sprintf("%s %s", baseName, naming.ToValidName(context))
 	}
 
 	return baseName

--- a/pkg/logs/test_data/invalid_name/activity.yml
+++ b/pkg/logs/test_data/invalid_name/activity.yml
@@ -1,0 +1,69 @@
+apiVersion: jenkins.io/v1
+kind: PipelineActivity
+metadata:
+  creationTimestamp: "2020-01-15T09:55:11Z"
+  generation: 10
+  labels:
+    branch: PR-2
+    build: "1"
+    context: fakecontext
+    lastCommitSha: dad79b3e2fa702742b8342a0a6e34990ff4497ec
+    owner: myself
+    provider: github
+    repository: My-Awesome-Project.org
+  name: myself-my-awesome-project-org-pr-2-1
+  namespace: jx
+  resourceVersion: "30291961"
+  selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/myself-my-awesome-project-org-pr-2-1
+  uid: 1ea74216-377d-11ea-a7cc-42010a94005e
+spec:
+  author: myself
+  batchPipelineActivity: {}
+  build: "1"
+  context: fakecontext
+  gitBranch: PR-2
+  gitOwner: myself
+  gitRepository: My_Awesome_Project.org
+  gitUrl: https://github.com/myself/My_Awesome_Project.org.git
+  lastCommitSHA: dad79b3e2fa702742b8342a0a6e34990ff4497ec
+  pipeline: myself/My_Awesome_Project.org/PR-2
+  pullTitle: test
+  startedTimestamp: "2020-01-15T09:55:12Z"
+  status: Running
+  steps:
+  - kind: Stage
+    stage:
+      name: meta pipeline
+      startedTimestamp: "2020-01-15T09:55:12Z"
+      status: Running
+      steps:
+      - completedTimestamp: "2020-01-15T09:55:12Z"
+        name: Credential Initializer 7n9f7
+        startedTimestamp: "2020-01-15T09:55:12Z"
+        status: Succeeded
+      - completedTimestamp: "2020-01-15T09:55:13Z"
+        name: Working Dir Initializer Ckdff
+        startedTimestamp: "2020-01-15T09:55:12Z"
+        status: Succeeded
+      - completedTimestamp: "2020-01-15T09:55:14Z"
+        name: Place Tools
+        startedTimestamp: "2020-01-15T09:55:13Z"
+        status: Succeeded
+      - completedTimestamp: "2020-01-15T09:55:21Z"
+        description: https://github.com/myself/My_Awesome_Project.org.git
+        name: Git Source Meta Olli Ai My Awesome Project 9lttp
+        startedTimestamp: "2020-01-15T09:55:14Z"
+        status: Succeeded
+      - completedTimestamp: "2020-01-15T09:55:24Z"
+        name: Git Merge
+        startedTimestamp: "2020-01-15T09:55:21Z"
+        status: Succeeded
+      - completedTimestamp: "2020-01-15T09:55:26Z"
+        name: Merge Pull Refs
+        startedTimestamp: "2020-01-15T09:55:24Z"
+        status: Succeeded
+      - name: Create Effective Pipeline
+        startedTimestamp: "2020-01-15T09:55:26Z"
+        status: Running
+      - name: Create Tekton Crds
+        status: Pending

--- a/pkg/logs/test_data/invalid_name/pipelineruns.yml
+++ b/pkg/logs/test_data/invalid_name/pipelineruns.yml
@@ -1,0 +1,88 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRunList
+metadata: {}
+items:
+- metadata:
+    creationTimestamp: "2020-01-15T09:55:50Z"
+    generation: 1
+    labels:
+      branch: PR-2
+      build: "1"
+      context: fakecontext
+      created-by-prow: "true"
+      jenkins.io/pipelineType: build
+      owner: myself
+      prowJobName: 1e897d5c-377d-11ea-b5b3-c25f558c47ed
+      repository: My_Awesome_Project.org
+      tekton.dev/pipeline: myself-my-awesome-project-org-5p6j6-1
+    name: myself-my-awesome-project-org-5p6j6-1
+    namespace: jx
+    resourceVersion: "30292258"
+    selfLink: /apis/tekton.dev/v1alpha1/namespaces/jx/pipelineruns/myself-my-awesome-project-org-5p6j6-1
+    uid: 35baea13-377d-11ea-a7cc-42010a94005e
+  spec:
+    params:
+    - name: version
+      value: 0.0.0-SNAPSHOT-PR-2-1
+    - name: build_id
+      value: "1"
+    pipelineRef:
+      apiVersion: tekton.dev/v1alpha1
+      name: myself-my-awesome-project-org-5p6j6-1
+    resources:
+    - name: myself-my-awesome-project-org
+      resourceRef:
+        apiVersion: tekton.dev/v1alpha1
+        name: myself-my-awesome-project-org
+    serviceAccount: tekton-bot
+    timeout: 240h0m0s
+  status:
+    conditions:
+    - lastTransitionTime: "2020-01-15T09:55:50Z"
+      message: Not all Tasks in the Pipeline have finished executing
+      reason: Running
+      status: Unknown
+      type: Succeeded
+    startTime: "2020-01-15T09:55:50Z"
+    taskRuns:
+      myself-my-awesome-project-org-5p6j6-1-from-build-pack-5nm9n:
+        pipelineTaskName: from-build-pack
+        status:
+          conditions:
+          - lastTransitionTime: "2020-01-15T09:56:05Z"
+            message: Not all Steps in the Task have finished executing
+            reason: Building
+            status: Unknown
+            type: Succeeded
+          podName: myself-my-awesome-project-org-5p6j6-1-from-build-pack-5nm9n-pod-2c6480
+          startTime: "2020-01-15T09:55:50Z"
+          steps:
+          - name: git-merge
+            terminated:
+              containerID: docker://8f6b0372ae2cb4e429911ddc1e3c5905a4ae6f817e57e49f0a3836440496ecd1
+              exitCode: 0
+              finishedAt: "2020-01-15T09:56:05Z"
+              reason: Completed
+              startedAt: "2020-01-15T09:55:55Z"
+          - name: build-make-linux
+            running:
+              startedAt: "2020-01-15T09:55:56Z"
+          - name: build-container-build
+            running:
+              startedAt: "2020-01-15T09:55:56Z"
+          - name: postbuild-post-build
+            running:
+              startedAt: "2020-01-15T09:55:56Z"
+          - name: promote-make-preview
+            running:
+              startedAt: "2020-01-15T09:55:57Z"
+          - name: promote-jx-preview
+            running:
+              startedAt: "2020-01-15T09:55:57Z"
+          - name: git-source-myself-my-awesome-project-org-27pv2
+            terminated:
+              containerID: docker://d338f3322f21d56c4a54368efe2ed73470ff7ddbc61799b5af980a750802f3ec
+              exitCode: 0
+              finishedAt: "2020-01-15T09:56:02Z"
+              reason: Completed
+              startedAt: "2020-01-15T09:55:55Z"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Prior to this commit, the following problems where happening when a repository had a name not made of [a-z-] characters
- `jx step tag` would write the wrong docker image name (`strings.ToLower` was used (via `ToValidImageName`) instead of `naming.ToValidName`)
- `jx get build logs` would fail to list the running pipelines. This is a weird error, due to the fact that the labels of the `PipelineRun` and the `PipelineActivity` are not formatted the same way.
- `jx preview` and `jx promote` would fail to recognize the service (no formatting was performed)

#### Special notes for the reviewer(s)

Hopefully, non conventional repo names should work fine now.