### PR TITLE
fix: cmd_test_helpers - CreateTestJxHomeDir()

### DIFF
--- a/pkg/cmd/testhelpers/cmd_test_helpers.go
+++ b/pkg/cmd/testhelpers/cmd_test_helpers.go
@@ -151,35 +151,28 @@ func CreateTestJxHomeDir() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	exists, err := util.FileExists(path.Join(originalDir, "gitAuth.yaml"))
+	newDir, err := ioutil.TempDir("", ".jx")
 	if err != nil {
 		return "", "", err
 	}
-	if exists {
-		newDir, err := ioutil.TempDir("", ".jx")
-		if err != nil {
-			return "", "", err
-		}
-		contents, err := ioutil.ReadDir(originalDir)
-		if err != nil {
-			return "", "", err
-		}
-		for _, f := range contents {
-			if strings.HasSuffix(f.Name(), ".yaml") {
-				err = util.CopyFileOrDir(path.Join(originalDir, f.Name()), path.Join(newDir, f.Name()), true)
-				if err != nil {
-					return "", "", err
-				}
+	contents, err := ioutil.ReadDir(originalDir)
+	if err != nil {
+		return "", "", err
+	}
+	for _, f := range contents {
+		if strings.HasSuffix(f.Name(), ".yaml") {
+			err = util.CopyFileOrDir(path.Join(originalDir, f.Name()), path.Join(newDir, f.Name()), true)
+			if err != nil {
+				return "", "", err
 			}
 		}
-		err = os.Setenv("JX_HOME", newDir)
-		if err != nil {
-			os.Unsetenv("JX_HOME")
-			return "", "", err
-		}
-		return originalDir, newDir, nil
 	}
-	return "", "", nil
+	err = os.Setenv("JX_HOME", newDir)
+	if err != nil {
+		os.Unsetenv("JX_HOME")
+		return "", "", err
+	}
+	return originalDir, newDir, nil
 }
 
 // CleanupTestJxHomeDir should be called in a deferred function whenever CreateTestJxHomeDir is called

--- a/pkg/cmd/testhelpers/cmd_test_helpers.go
+++ b/pkg/cmd/testhelpers/cmd_test_helpers.go
@@ -146,7 +146,7 @@ func MockFactoryFakeClients(mockFactory *clients_test.MockFactory) {
 	pegomock.When(mockFactory.CreateKnativeServeClient()).ThenReturn(pegomock.ReturnValue(kservefake.NewSimpleClientset()), pegomock.ReturnValue("jx"), pegomock.ReturnValue(nil))
 }
 
-// CreateTestJxHomeDir creates a temporary JX_HOME directory for the tests, copying over any existing config, returning
+// CreateTestJxHomeDir creates a temporary JX_HOME directory for the tests, returning
 // the original JX_HOME directory, the temporary JX_HOME value, and any error.
 func CreateTestJxHomeDir() (string, string, error) {
 	originalDir, err := util.ConfigDir()

--- a/pkg/cmd/testhelpers/cmd_test_helpers.go
+++ b/pkg/cmd/testhelpers/cmd_test_helpers.go
@@ -157,18 +157,7 @@ func CreateTestJxHomeDir() (string, string, error) {
 	if err != nil {
 		return "", "", errors.Wrap(err, "Unable to create a temporary JX home configuration directory")
 	}
-	contents, err := ioutil.ReadDir(originalDir)
-	if err != nil {
-		return "", "", errors.Wrap(err, "Unable to read JX home configuration directory")
-	}
-	for _, f := range contents {
-		if strings.HasSuffix(f.Name(), ".yaml") {
-			err = util.CopyFileOrDir(path.Join(originalDir, f.Name()), path.Join(newDir, f.Name()), true)
-			if err != nil {
-				return "", "", errors.Wrap(err, "Unable to copy JX home directory to temporary directory ")
-			}
-		}
-	}
+
 	originalDir = os.Getenv("JX_HOME")
 	err = os.Setenv("JX_HOME", newDir)
 	if err != nil {

--- a/pkg/cmd/testhelpers/cmd_test_helpers.go
+++ b/pkg/cmd/testhelpers/cmd_test_helpers.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+
 	//"github.com/jenkins-x/jx/pkg/cmd/controller"
 
 	"github.com/ghodss/yaml"
@@ -149,28 +151,29 @@ func MockFactoryFakeClients(mockFactory *clients_test.MockFactory) {
 func CreateTestJxHomeDir() (string, string, error) {
 	originalDir, err := util.ConfigDir()
 	if err != nil {
-		return "", "", err
+		return "", "", errors.Wrap(err, "Unable to get JX home configuration directory")
 	}
 	newDir, err := ioutil.TempDir("", ".jx")
 	if err != nil {
-		return "", "", err
+		return "", "", errors.Wrap(err, "Unable to create a temporary JX home configuration directory")
 	}
 	contents, err := ioutil.ReadDir(originalDir)
 	if err != nil {
-		return "", "", err
+		return "", "", errors.Wrap(err, "Unable to read JX home configuration directory")
 	}
 	for _, f := range contents {
 		if strings.HasSuffix(f.Name(), ".yaml") {
 			err = util.CopyFileOrDir(path.Join(originalDir, f.Name()), path.Join(newDir, f.Name()), true)
 			if err != nil {
-				return "", "", err
+				return "", "", errors.Wrap(err, "Unable to copy JX home directory to temporary directory ")
 			}
 		}
 	}
+	originalDir = os.Getenv("JX_HOME")
 	err = os.Setenv("JX_HOME", newDir)
 	if err != nil {
-		os.Unsetenv("JX_HOME")
-		return "", "", err
+		err := os.Setenv("JX_HOME", originalDir)
+		return "", "", errors.Wrap(err, "Unable to set JX home directory variable ")
 	}
 	return originalDir, newDir, nil
 }


### PR DESCRIPTION
fix: cmd_test_helpers - CreateTestJxHomeDir() returns empty string if gitAuth.yaml is not present.

fixes #6577