### PR TITLE
feat: Handling git credentials via credential helper

### DIFF
--- a/hack/jxDebug.sh
+++ b/hack/jxDebug.sh
@@ -1,3 +1,4 @@
-#!/bin/sh
-echo "Debugging jx"
-dlv --listen=:2345 --headless=true --api-version=2 exec ./build/jx -- $*
+#!/usr/bin/env sh
+
+dir=$(dirname "$0")
+dlv --log-dest 2 --listen=:2345 --headless=true --api-version=2 exec "${dir}/../build/jx" -- "$@" > /dev/null 2>&1

--- a/pkg/gits/credentialhelper/git_credential.go
+++ b/pkg/gits/credentialhelper/git_credential.go
@@ -1,0 +1,125 @@
+package credentialhelper
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
+
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/pkg/errors"
+)
+
+// GitCredential represents the different parts of a git credential URL
+// See also https://git-scm.com/docs/git-credential
+type GitCredential struct {
+	Protocol string
+	Host     string
+	Path     string
+	Username string
+	Password string
+}
+
+// CreateGitCredential creates a CreateGitCredential instance from a slice of strings where each element is a key/value pair
+// separated by '='.
+func CreateGitCredential(lines []string) (GitCredential, error) {
+	var credential GitCredential
+
+	if lines == nil {
+		return credential, errors.New("no data lines provided")
+	}
+
+	fieldMap, err := util.ExtractKeyValuePairs(lines, "=")
+	if err != nil {
+		return credential, errors.Wrap(err, "unable to extract git credential parameters")
+	}
+
+	data, err := json.Marshal(fieldMap)
+	if err != nil {
+		return GitCredential{}, errors.Wrapf(err, "unable to marshal git credential data")
+	}
+
+	err = json.Unmarshal(data, &credential)
+	if err != nil {
+		return GitCredential{}, errors.Wrapf(err, "unable unmarshal git credential data")
+	}
+
+	return credential, nil
+}
+
+// CreateGitCredentialFromURL creates a CreateGitCredential instance from a URL and optional username and password.
+func CreateGitCredentialFromURL(gitURL string, username string, password string) (GitCredential, error) {
+	var credential GitCredential
+
+	if gitURL == "" {
+		return credential, errors.New("url cannot be empty")
+	}
+
+	u, err := url.Parse(gitURL)
+	if err != nil {
+		return credential, errors.Wrapf(err, "unable to parse URL %s", gitURL)
+	}
+
+	credential.Protocol = u.Scheme
+	credential.Host = u.Host
+	credential.Path = u.Path
+	if username != "" {
+		credential.Username = username
+	}
+
+	if password != "" {
+		credential.Password = password
+	}
+
+	return credential, nil
+}
+
+// String returns a string representation of this instance according to the expected format of git credential helpers.
+// See also https://git-scm.com/docs/git-credential
+func (g *GitCredential) String() string {
+	answer := ""
+
+	value := reflect.ValueOf(g).Elem()
+	typeOfT := value.Type()
+
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Field(i)
+		answer = answer + fmt.Sprintf("%s=%v\n", strings.ToLower(typeOfT.Field(i).Name), field.Interface())
+	}
+
+	answer = answer + "\n"
+
+	return answer
+}
+
+// Clone clones this GitCredential instance
+func (g *GitCredential) Clone() GitCredential {
+	clone := GitCredential{}
+
+	value := reflect.ValueOf(g).Elem()
+	typeOfT := value.Type()
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Field(i)
+		value := field.String()
+		v := reflect.ValueOf(&clone).Elem().FieldByName(typeOfT.Field(i).Name)
+		v.SetString(value)
+	}
+
+	return clone
+}
+
+// URL returns a URL from the data of this instance. If not enough information exist an error is returned
+func (g *GitCredential) URL() (url.URL, error) {
+	urlAsString := g.Protocol + "://" + g.Host
+	if g.Path != "" {
+		urlAsString = urlAsString + "/" + g.Path
+	}
+	u, err := url.Parse(urlAsString)
+	if err != nil {
+		return url.URL{}, errors.Wrap(err, "unable to construct URL")
+	}
+
+	u.User = url.UserPassword(g.Username, g.Password)
+	return *u, nil
+}

--- a/pkg/gits/credentialhelper/git_credentialhelper.go
+++ b/pkg/gits/credentialhelper/git_credentialhelper.go
@@ -1,0 +1,111 @@
+package credentialhelper
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// GitCredentialsHelper is used to implement the git credential helper algorithm.
+// See also https://git-scm.com/docs/git-credential.
+type GitCredentialsHelper struct {
+	in               io.Reader
+	out              io.Writer
+	knownCredentials []GitCredential
+}
+
+// CreateGitCredentialsHelper creates an instance of a git credential helper. It needs to get passed the handles to read
+// the git credential data as well as write the response to. It also gets the list og known credentials.
+func CreateGitCredentialsHelper(in io.Reader, out io.Writer, credentials []GitCredential) (*GitCredentialsHelper, error) {
+	if in == nil {
+		return nil, errors.New("in parameter cannot be nil")
+	}
+
+	if out == nil {
+		return nil, errors.New("out parameter cannot be nil")
+	}
+
+	if credentials == nil {
+		return nil, errors.New("credentials parameter cannot be nil")
+	}
+
+	return &GitCredentialsHelper{
+		in:               in,
+		out:              out,
+		knownCredentials: credentials,
+	}, nil
+}
+
+// Run executes the specified git credential helper operation which must be one of get, store or erase.
+// NOTE: Currently only get is implemented.
+func (h *GitCredentialsHelper) Run(op string) error {
+	var err error
+
+	switch op {
+	case "get":
+		err = h.Get()
+	case "store":
+		// not yet implemented (HF)
+		fmt.Println("")
+	case "erase":
+		// not yet implemented (HF)
+		fmt.Println("")
+	default:
+		err = errors.Errorf("invalid git credential operation '%s'", op)
+	}
+
+	return err
+}
+
+// Get implements the get operation of the git credential helper protocol. It reads the authentication query from
+// the reader of this instance and writes the response to the writer (usually this will be stdout and stdin).
+func (h *GitCredentialsHelper) Get() error {
+	var data []string
+	scanner := bufio.NewScanner(h.in)
+	for scanner.Scan() {
+		data = append(data, scanner.Text())
+	}
+
+	if scanner.Err() != nil {
+		return errors.Wrap(scanner.Err(), "unable to read input from stdin")
+	}
+
+	gitCredential, err := CreateGitCredential(data)
+	if err != nil {
+		return errors.Wrap(scanner.Err(), "unable to create GitCredential struct")
+	}
+
+	answer := h.Fill(gitCredential)
+
+	_, err = fmt.Fprintf(h.out, answer.String())
+	if err != nil {
+		return errors.Wrap(err, "unable to write response to stdin")
+	}
+
+	return nil
+}
+
+// Fill creates a GitCredential instance based on a git credential helper request which represented by the passed queryCredential instance.
+// If there is no auth information available an empty credential instance is returned
+func (h *GitCredentialsHelper) Fill(queryCredential GitCredential) GitCredential {
+	for _, authCredential := range h.knownCredentials {
+		if queryCredential.Protocol != authCredential.Protocol {
+			continue
+		}
+
+		if queryCredential.Host != authCredential.Host {
+			continue
+		}
+
+		if queryCredential.Path != authCredential.Path {
+			continue
+		}
+
+		answer := authCredential.Clone()
+		return answer
+	}
+
+	return GitCredential{}
+}

--- a/pkg/gits/credentialhelper/git_credentialhelper_test.go
+++ b/pkg/gits/credentialhelper/git_credentialhelper_test.go
@@ -1,0 +1,202 @@
+package credentialhelper
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func TestGitCredentialHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GitCredentials Suite")
+}
+
+var _ = Describe("GitCredential", func() {
+	Context("#CreateGitCredential", func() {
+		It("successfully creates GitCredential", func() {
+			data := []string{
+				"Protocol=http",
+				"Host=github.com",
+				"Path=jenkins-x/jx",
+			}
+			credentials, err := CreateGitCredential(data)
+			Expect(err).Should(BeNil())
+			Expect(credentials).To(MatchAllFields(Fields{
+				"Protocol": Equal("http"),
+				"Host":     Equal("github.com"),
+				"Path":     Equal("jenkins-x/jx"),
+				"Username": BeEmpty(),
+				"Password": BeEmpty(),
+			}))
+		})
+
+		It("passing nil fails GitCredential creation", func() {
+			credentials, err := CreateGitCredential(nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(credentials).To(MatchAllFields(Fields{
+				"Protocol": BeEmpty(),
+				"Host":     BeEmpty(),
+				"Path":     BeEmpty(),
+				"Username": BeEmpty(),
+				"Password": BeEmpty(),
+			}))
+		})
+
+		It("missing key value pairs format fails GitCredential creation", func() {
+			data := []string{"foo"}
+			credentials, err := CreateGitCredential(data)
+			Expect(err).ShouldNot(BeNil())
+			Expect(credentials).To(MatchAllFields(Fields{
+				"Protocol": BeEmpty(),
+				"Host":     BeEmpty(),
+				"Path":     BeEmpty(),
+				"Username": BeEmpty(),
+				"Password": BeEmpty(),
+			}))
+		})
+	})
+
+	Context("#CreateGitCredentialFromURL", func() {
+		It("successfully creates GitCredential", func() {
+			credentials, err := CreateGitCredentialFromURL("http://github.com", "johndoe", "1234")
+			Expect(err).Should(BeNil())
+			Expect(credentials).To(MatchAllFields(Fields{
+				"Protocol": Equal("http"),
+				"Host":     Equal("github.com"),
+				"Path":     Equal(""),
+				"Username": Equal("johndoe"),
+				"Password": Equal("1234"),
+			}))
+		})
+	})
+
+	Context("#Clone", func() {
+		var (
+			testCredential GitCredential
+			err            error
+		)
+
+		BeforeEach(func() {
+			data := []string{
+				"Protocol=http",
+				"Host=github.com",
+				"Path=jenkins-x/jx",
+				"Username=johndoe",
+				"Password=1234",
+			}
+			testCredential, err = CreateGitCredential(data)
+			Expect(err).Should(BeNil())
+		})
+
+		It("successful clone", func() {
+			clone := testCredential.Clone()
+			Expect(&clone).ShouldNot(BeIdenticalTo(&testCredential))
+			Expect(clone).To(MatchAllFields(Fields{
+				"Protocol": Equal("http"),
+				"Host":     Equal("github.com"),
+				"Path":     Equal("jenkins-x/jx"),
+				"Username": Equal("johndoe"),
+				"Password": Equal("1234"),
+			}))
+		})
+
+		Context("#String", func() {
+			It("string representation of GitCredential has additional newline (needed by git credential protocol", func() {
+				credential, err := CreateGitCredentialFromURL("http://github.com/jenkins-x", "johndoe", "1234")
+				Expect(err).Should(BeNil())
+				expected := heredoc.Doc(`protocol=http
+                                              host=github.com
+                                              path=/jenkins-x
+                                              username=johndoe
+                                              password=1234
+			    `)
+				expected = expected + "\n"
+				Expect(credential.String()).Should(Equal(expected))
+			})
+		})
+	})
+})
+
+var _ = Describe("GitCredentialsHelper", func() {
+	Context("#CreateGitCredentialsHelper", func() {
+		var (
+			testIn          io.Reader
+			testOut         io.Writer
+			testCredentials []GitCredential
+		)
+
+		BeforeEach(func() {
+			testIn = strings.NewReader("")
+			testOut = bytes.NewBufferString("")
+			testCredentials = []GitCredential{}
+		})
+
+		It("fails with no input writer", func() {
+			helper, err := CreateGitCredentialsHelper(nil, testOut, testCredentials)
+			Expect(err).ShouldNot(BeNil())
+			Expect(helper).Should(BeNil())
+		})
+
+		It("fails with no output writer", func() {
+			helper, err := CreateGitCredentialsHelper(testIn, nil, testCredentials)
+			Expect(err).ShouldNot(BeNil())
+			Expect(helper).Should(BeNil())
+		})
+
+		It("fails with no credentials", func() {
+			helper, err := CreateGitCredentialsHelper(testIn, testOut, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(helper).Should(BeNil())
+		})
+
+		It("succeeds when all parameters are specified", func() {
+			helper, err := CreateGitCredentialsHelper(testIn, testOut, testCredentials)
+			Expect(err).Should(BeNil())
+			Expect(helper).ShouldNot(BeNil())
+		})
+	})
+
+	Context("#Run", func() {
+		var (
+			testIn          io.Reader
+			testOut         *bytes.Buffer
+			testCredentials []GitCredential
+			helper          *GitCredentialsHelper
+			err             error
+		)
+
+		BeforeEach(func() {
+			in := heredoc.Doc(`protocol=https
+                                    host=github.com
+                                    username=jx-bot
+            `)
+			testIn = strings.NewReader(in)
+			testOut = bytes.NewBufferString("")
+			testCredentials = []GitCredential{
+				{Protocol: "https", Host: "github.com", Username: "jx-bot", Password: "1234"},
+			}
+			helper, err = CreateGitCredentialsHelper(testIn, testOut, testCredentials)
+			Expect(err).Should(BeNil())
+		})
+
+		It("succeeds filling credentials", func() {
+			expected := heredoc.Doc(`protocol=https
+                                    host=github.com
+                                    path=
+                                    username=jx-bot
+                                    password=1234
+            `)
+			expected = expected + "\n"
+			err = helper.Run("get")
+			Expect(err).Should(BeNil())
+			Expect(testOut.String()).Should(Equal(expected))
+		})
+	})
+})

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -38,9 +38,12 @@ type GitCLI struct {
 
 // NewGitCLI creates a new GitCLI instance
 func NewGitCLI() *GitCLI {
-	return &GitCLI{
+	cli := &GitCLI{
 		Env: map[string]string{},
 	}
+	// Ensure that error output is in English so parsing work
+	cli.Env["LC_ALL"] = "C"
+	return cli
 }
 
 // FindGitConfigDir tries to find the `.git` directory either in the current directory or in parent directories
@@ -550,8 +553,7 @@ func (g *GitCLI) gitCmd(dir string, args ...string) error {
 		Args: args,
 		Env:  g.Env,
 	}
-	// Ensure that error output is in English so parsing work
-	cmd.Env = map[string]string{"LC_ALL": "C"}
+	log.Logger().Debug(cmd.String())
 	output, err := cmd.RunWithoutRetry()
 	return errors.Wrapf(err, "git output: %s", output)
 }
@@ -561,9 +563,9 @@ func (g *GitCLI) gitCmdWithOutput(dir string, args ...string) (string, error) {
 		Dir:  dir,
 		Name: "git",
 		Args: args,
+		Env:  g.Env,
 	}
-	// Ensure that error output is in English so parsing work
-	cmd.Env = map[string]string{"LC_ALL": "C"}
+	log.Logger().Debug(cmd.String())
 	return cmd.RunWithoutRetry()
 }
 

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -43,7 +43,19 @@ func NewGitCLI() *GitCLI {
 	}
 	// Ensure that error output is in English so parsing work
 	cli.Env["LC_ALL"] = "C"
+	// When jx is called as credential helper we want to make sure that potential debug trace is not interfering with the process
+	cli.Env["JX_LOG_LEVEL"] = "error"
 	return cli
+}
+
+// Config runs a 'git config' command in the specified directory
+func (g *GitCLI) Config(dir string, args ...string) error {
+	if args == nil {
+		args = []string{"config"}
+	} else {
+		args = append([]string{"config"}, args...)
+	}
+	return g.gitCmd(dir, args...)
 }
 
 // FindGitConfigDir tries to find the `.git` directory either in the current directory or in parent directories

--- a/pkg/gits/git_cli_test.go
+++ b/pkg/gits/git_cli_test.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/jenkins-x/jx/pkg/util"
+
 	"github.com/jenkins-x/jx/pkg/gits/testhelpers"
 
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -119,6 +121,29 @@ var _ = Describe("Git CLI", func() {
 		})
 	})
 
+	Describe("#Config", func() {
+		It("should return an error if no repoDir is specified", func() {
+			err := git.Config("")
+			Expect(err).ShouldNot(BeNil())
+		})
+
+		It("should return error if no parameters are passed", func() {
+			err := git.Config(repoDir)
+			Expect(err).ShouldNot(BeNil())
+		})
+
+		It("should apply the specified config", func() {
+			err := git.Config(repoDir, "--local", "credential.helper", "/path/to/jx step git credentials --credential-helper")
+			Expect(err).Should(BeNil())
+
+			filename := filepath.Join(repoDir, ".git", "config")
+			Expect(util.FileExists(filename)).Should(Equal(true))
+			contents, err := ioutil.ReadFile(filename)
+			Expect(err).Should(BeNil())
+			Expect(string(contents)).Should(ContainSubstring("helper = /path/to/jx step git credentials --credential-helper"))
+		})
+	})
+
 	Describe("#GetCommits", func() {
 		var (
 			commitASha string
@@ -195,7 +220,7 @@ var _ = Describe("Git CLI", func() {
 			Specify("an error is returned", func() {
 				_, err := git.GetLatestCommitSha(repoDir)
 				Expect(err).ShouldNot(BeNil())
-				// TODO Currently the error message is returned which seems odd. Should be empty string imo.
+				// TODO Currently the error message is returned which seems odd. Should be empty string imo (HF)
 				//Expect(sha).Should(BeEmpty())
 			})
 		})

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -47,6 +47,10 @@ func NewGitFake() Gitter {
 	return &GitFake{}
 }
 
+func (g *GitFake) Config(dir string, args ...string) error {
+	return nil
+}
+
 // FindGitConfigDir finds the git config dir
 func (g *GitFake) FindGitConfigDir(dir string) (string, string, error) {
 	return dir, dir, nil

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -32,6 +32,10 @@ func (g *GitLocal) FindGitConfigDir(dir string) (string, string, error) {
 	return g.GitCLI.FindGitConfigDir(dir)
 }
 
+func (g *GitLocal) Config(dir string, args ...string) error {
+	return g.GitCLI.Config(dir, args...)
+}
+
 // Clone clones the given git URL into the given directory
 // Faked out
 func (g *GitLocal) Clone(url string, dir string) error {

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -176,6 +176,7 @@ type GitProvider interface {
 // Gitter defines common git actions used by Jenkins X via git cli
 //go:generate pegomock generate github.com/jenkins-x/jx/pkg/gits Gitter -o mocks/gitter.go
 type Gitter interface {
+	Config(dir string, args ...string) error
 	FindGitConfigDir(dir string) (string, string, error)
 	PrintCreateRepositoryGenerateAccessToken(server *auth.AuthServer, username string, o io.Writer)
 

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -291,6 +291,24 @@ func (mock *MockGitter) CommitIfChanges(_param0 string, _param1 string) error {
 	return ret0
 }
 
+func (mock *MockGitter) Config(_param0 string, _param1 ...string) error {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0}
+	for _, param := range _param1 {
+		params = append(params, param)
+	}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("Config", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(error)
+		}
+	}
+	return ret0
+}
+
 func (mock *MockGitter) ConvertToValidBranchName(_param0 string) string {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -2220,6 +2238,45 @@ func (c *MockGitter_CommitIfChanges_OngoingVerification) GetAllCapturedArguments
 		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) Config(_param0 string, _param1 ...string) *MockGitter_Config_OngoingVerification {
+	params := []pegomock.Param{_param0}
+	for _, param := range _param1 {
+		params = append(params, param)
+	}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Config", params, verifier.timeout)
+	return &MockGitter_Config_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_Config_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_Config_OngoingVerification) GetCapturedArguments() (string, []string) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+}
+
+func (c *MockGitter_Config_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([][]string, len(c.methodInvocations))
+		for u := 0; u < len(c.methodInvocations); u++ {
+			_param1[u] = make([]string, len(params)-1)
+			for x := 1; x < len(params); x++ {
+				if params[x][u] != nil {
+					_param1[u][x-1] = params[x][u].(string)
+				}
+			}
 		}
 	}
 	return

--- a/pkg/gits/provider_fake.go
+++ b/pkg/gits/provider_fake.go
@@ -882,6 +882,10 @@ func NewFakeRepository(owner string, repoName string, addFiles func(dir string) 
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
+		err = gitter.SetRemoteURL(cloneDir, "origin", repo.GitRepo.CloneURL)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
 		err = addFiles(cloneDir)
 		if err != nil {
 			return nil, errors.Wrapf(err, "adding files to %s", dir)
@@ -892,6 +896,7 @@ func NewFakeRepository(owner string, repoName string, addFiles func(dir string) 
 		}
 
 		err = gitter.CommitDir(cloneDir, "Initial Commit")
+
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}


### PR DESCRIPTION
The key feature of this pull request is to make `jx` a git credential helper which allows for using our Kube based authentication for retrieving git push/pull/fetch credentials. This is a replacement for adding the password to the remote URL directly or the workaround of generating an authenticated git URL on the fly (which as side effect does not update the remote refs).

Some other changes deal with the fact to allow consecutive execution of `jx boot`, however, this is a temporary solution and does not address the core issues with `jx boot`.  

Note: Now it is possible to have multiple consecutive boot executions and regular commits made on master will be cherry-picked on local `jx boot` execution. This does not change the fact that we should not be using cherry-picking in the first place since it cannot handle merge commits. 

fixes #5772


