### PR TITLE
fix: Fall back to not using provider for dev env creation in more cases

### DIFF
--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -432,13 +432,14 @@ func (o *StepVerifyEnvironmentsOptions) createDevEnvironmentRepository(gitInfo *
 		log.Logger().Debugf("set commitish to '%s'", commitish)
 	}
 
+	fromGitInfo, err := gits.ParseGitURL(fromGitURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse upstream boot config URL %s", fromGitURL)
+	}
+
 	var fromRepo *gits.GitRepository
-	// If the to URL isn't github.com, and the fromGitURL is the default boot repository, use a non-authenticated github.com provider for the from provider.
-	if !gitInfo.IsGitHub() && isDefaultBootURL {
-		fromGitInfo, err := gits.ParseGitURL(fromGitURL)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to parse upstream boot config URL %s", fromGitURL)
-		}
+	// If the to URL and from URL aren't on the same host, pass in a simple repo info to duplicate rather than using the provider.
+	if fromGitInfo.Host != gitInfo.Host {
 		fromRepo = fromGitInfo
 		fromRepo.CloneURL = fromGitURL
 		fromRepo.HTMLURL = strings.TrimSuffix(fromGitURL, ".git")


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

The specific issue prompting this was a GHE user with a custom boot config upstream forked in github.com. That slipped through, since we were specifically looking for cases where the destination wasn't github.com and the origin was the default boot config repository, but when I think about it more, it makes more sense to just fall back to the simpler non-provider-driven approach to the origin for all cases where the git host for the origin and destination repository URLs differ.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6551
