### PR TITLE
fix: Use requirements gitServer as default for import, create env

### DIFF
--- a/pkg/cmd/create/install.go
+++ b/pkg/cmd/create/install.go
@@ -398,7 +398,7 @@ func (options *InstallOptions) AddInstallFlags(cmd *cobra.Command, includesInit 
 	cmd.Flags().BoolVar(&options.SkipAuthSecretsMerge, opts.OptionSkipAuthSecMerge, false, "Skips merging the secrets from local files with the secrets from Kubernetes cluster")
 
 	bindInstallConfigToFlags(cmd)
-	opts.AddGitRepoOptionsArguments(cmd, &options.GitRepositoryOptions)
+	opts.AddGitRepoOptionsArgumentsWithGithubDefault(cmd, &options.GitRepositoryOptions)
 	options.HelmValuesConfig.AddExposeControllerValues(cmd, true)
 	options.AdminSecretsService.AddAdminSecretsValues(cmd)
 	options.InitOptions.AddInitFlags(cmd)

--- a/pkg/cmd/opts/git.go
+++ b/pkg/cmd/opts/git.go
@@ -145,9 +145,19 @@ func (o *CommonOptions) DiscoverGitURL(gitConf string) (string, error) {
 	return url, nil
 }
 
-// AddGitRepoOptionsArguments adds common git flags to the given cobra command
+// AddGitRepoOptionsArgumentsWithGithubDefault adds common git flags with a default provider URL of github.com to the given cobra command
+func AddGitRepoOptionsArgumentsWithGithubDefault(cmd *cobra.Command, repositoryOptions *gits.GitRepositoryOptions) {
+	AddGitRepoOptionsArgumentsWithDefaultProviderURL(cmd, repositoryOptions, "https://github.com")
+}
+
+// AddGitRepoOptionsArguments adds common git flags with no default provider URL to the given cobra command
 func AddGitRepoOptionsArguments(cmd *cobra.Command, repositoryOptions *gits.GitRepositoryOptions) {
-	cmd.Flags().StringVarP(&repositoryOptions.ServerURL, "git-provider-url", "", "https://github.com", "The Git server URL to create new Git repositories inside")
+	AddGitRepoOptionsArgumentsWithDefaultProviderURL(cmd, repositoryOptions, "")
+}
+
+// AddGitRepoOptionsArgumentsWithDefaultProviderURL adds common git flags with the given default provider URL to the given cobra command
+func AddGitRepoOptionsArgumentsWithDefaultProviderURL(cmd *cobra.Command, repositoryOptions *gits.GitRepositoryOptions, defaultProviderURL string) {
+	cmd.Flags().StringVarP(&repositoryOptions.ServerURL, "git-provider-url", "", defaultProviderURL, "The Git server URL to create new Git repositories inside")
 	cmd.Flags().StringVarP(&repositoryOptions.ServerKind, "git-provider-kind", "", "",
 		"Kind of Git server. If not specified, kind of server will be autodetected from Git provider URL. Possible values: bitbucketcloud, bitbucketserver, gitea, gitlab, github, fakegit")
 	cmd.Flags().StringVarP(&repositoryOptions.Username, "git-username", "", "", "The Git username to use for creating new Git repositories")

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -153,6 +153,8 @@ func (o *StepVerifyEnvironmentsOptions) storeRequirementsInTeamSettings(requirem
 			return errors.Wrap(err, "there was a problem marshalling the requirements file to include it in the TeamSettings")
 		}
 		env.Spec.TeamSettings.BootRequirements = string(reqBytes)
+		// Also set the gitServer from the requirements.
+		env.Spec.TeamSettings.GitServer = requirements.Cluster.GitServer
 		return nil
 	})
 	if err != nil {

--- a/pkg/cmd/step/verify/step_verify_environments_test.go
+++ b/pkg/cmd/step/verify/step_verify_environments_test.go
@@ -37,7 +37,7 @@ func TestStepVerifyEnvironmentsOptions_StoreRequirementsInTeamSettings(t *testin
 		},
 	}
 
-	requirementsYamlFile := path.Join("test_data", "preinstall", "no_tls", "jx-requirements.yml")
+	requirementsYamlFile := path.Join("test_data", "verify_environments", "default", "jx-requirements.yml")
 	exists, err := util.FileExists(requirementsYamlFile)
 	assert.NoError(t, err)
 	assert.True(t, exists)
@@ -68,7 +68,7 @@ func TestStepVerifyEnvironmentsOptions_StoreRequirementsConfigMapWithModificatio
 	options := &commonOpts
 	testhelpers.ConfigureTestOptions(options, options.Git(), options.Helm())
 
-	requirementsYamlFile := path.Join("test_data", "preinstall", "no_tls", "jx-requirements.yml")
+	requirementsYamlFile := path.Join("test_data", "verify_environments", "ghe", "jx-requirements.yml")
 	exists, err := util.FileExists(requirementsYamlFile)
 	assert.NoError(t, err)
 	assert.True(t, exists)
@@ -104,6 +104,8 @@ func TestStepVerifyEnvironmentsOptions_StoreRequirementsConfigMapWithModificatio
 
 	teamSettings, err := testOptions.TeamSettings()
 	assert.NoError(t, err)
+
+	assert.Equal(t, requirements.Cluster.GitServer, teamSettings.GitServer, "the GitServer field should be set to the requirements.cluster.gitServer value")
 
 	requirementsCm := teamSettings.BootRequirements
 	assert.NotEqual(t, "", requirementsCm, "the BootRequirements field should be present and not empty")

--- a/pkg/cmd/step/verify/test_data/verify_environments/default/jx-requirements.yml
+++ b/pkg/cmd/step/verify/test_data/verify_environments/default/jx-requirements.yml
@@ -1,0 +1,42 @@
+autoUpdate:
+  enabled: false
+  schedule: ""
+cluster:
+  clusterName: my-cluster-name
+  environmentGitOwner: myorg
+  gitKind: github
+  gitName: github
+  gitServer: https://github.com
+  namespace: jx
+  project: foo
+  provider: gke
+  zone: myzone
+ingress:
+  domain: ""
+  externalDNS: false
+  namespaceSubDomain: -jx.
+  tls:
+    email: ""
+    enabled: false
+    production: false
+repository: nexus
+secretStorage: local
+storage:
+  backup:
+    enabled: false
+    url: ""
+  logs:
+    enabled: false
+    url: ""
+  reports:
+    enabled: false
+    url: ""
+  repository:
+    enabled: false
+    url: ""
+vault: {}
+velero: {}
+versionStream:
+  ref: v1.0.0
+  url: https://github.com/jenkins-x/jenkins-x-versions.git
+webhook: prow

--- a/pkg/cmd/step/verify/test_data/verify_environments/ghe/jx-requirements.yml
+++ b/pkg/cmd/step/verify/test_data/verify_environments/ghe/jx-requirements.yml
@@ -1,0 +1,42 @@
+autoUpdate:
+  enabled: false
+  schedule: ""
+cluster:
+  clusterName: my-cluster-name
+  environmentGitOwner: myorg
+  gitKind: github
+  gitName: ghe
+  gitServer: https://github.something.com
+  namespace: jx
+  project: foo
+  provider: gke
+  zone: myzone
+ingress:
+  domain: ""
+  externalDNS: false
+  namespaceSubDomain: -jx.
+  tls:
+    email: ""
+    enabled: false
+    production: false
+repository: nexus
+secretStorage: local
+storage:
+  backup:
+    enabled: false
+    url: ""
+  logs:
+    enabled: false
+    url: ""
+  reports:
+    enabled: false
+    url: ""
+  repository:
+    enabled: false
+    url: ""
+vault: {}
+velero: {}
+versionStream:
+  ref: v1.0.0
+  url: https://github.com/jenkins-x/jenkins-x-versions.git
+webhook: prow


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

`opts.AddGitRepoOptionsArguments` defaults `--git-provider-url` to `https://github.com`, no matter what the actual default should be for the cluster. This makes sense for some of the cases where it's used (i.e., `jx install`, `jx create cluster`, `jx create terraform`, etc), but not for others (`jx import` (and therefore `jx create quickstart`), `jx edit env`, and `jx create env`). In those cases, we should default it to the `gitServer` in the team settings.

Except we don't actually set that with `jx boot`! It just stays on `https://github.com`. So we also need to set that from the requirements.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6579 
