### PR TITLE
fix: Lookup git service URL kind from jx-auth-config as well

### DIFF
--- a/pkg/cmd/opts/git.go
+++ b/pkg/cmd/opts/git.go
@@ -182,7 +182,19 @@ func (o *CommonOptions) GitServerHostURLKind(hostURL string) (string, error) {
 		return "", err
 	}
 
-	kind, err := kube.GetGitServiceKind(jxClient, kubeClient, devNs, hostURL)
+	var clusterAuthConfig *auth.AuthConfig
+
+	// Pass the in-cluster git auth config to GetGitServiceKind
+	clusterAuthConfigSvc, err := o.GitAuthConfigService()
+	if err != nil {
+		return "", errors.Wrapf(err, "getting cluster-based auth configmap for checking kind of git url %s", hostURL)
+	}
+	if clusterAuthConfigSvc != nil {
+		clusterAuthConfig = clusterAuthConfigSvc.Config()
+	}
+
+	kind, err := kube.GetGitServiceKind(jxClient, kubeClient, devNs, clusterAuthConfig, hostURL)
+
 	if err != nil {
 		return kind, err
 	}

--- a/pkg/kube/git_services_test.go
+++ b/pkg/kube/git_services_test.go
@@ -1,14 +1,20 @@
 package kube_test
 
 import (
+	"io/ioutil"
+	"path"
 	"testing"
 
+	"github.com/jenkins-x/jx/pkg/auth"
 	v1fake "github.com/jenkins-x/jx/pkg/client/clientset/versioned/fake"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/secreturl/fakevault"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/yaml"
 )
 
 const serviceURL = "https://github.beescloud.com"
@@ -58,12 +64,66 @@ func TestGitServiceKindFromSecretsWithMissingKind(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset(secret)
 	jxClient := v1fake.NewSimpleClientset()
 
-	foundServiceKind, err := kube.GetGitServiceKind(jxClient, kubeClient, ns, serviceURL)
+	foundServiceKind, err := kube.GetGitServiceKind(jxClient, kubeClient, ns, nil, serviceURL)
 
 	t.Logf("found service kind %s for URL %s\n\n", foundServiceKind, serviceURL)
 
 	assert.NoError(t, err, "should find a service kind without any error")
 	assert.Equal(t, serviceKind, foundServiceKind, "should find a service kind equal with '%s'", serviceKind)
+}
+
+func TestGitServiceKindFromClusterAuthConfig(t *testing.T) {
+	t.Parallel()
+
+	ns := "jx"
+	expectedServiceKind := "bitbucketserver"
+	bbsServerURL := "https://bitbucket.example.com"
+
+	authFile := path.Join("test_data", "git_service_kind", "configmap_vault_auth.yaml")
+	data, err := ioutil.ReadFile(authFile)
+	require.NoError(t, err)
+
+	var expectedAuthConfig auth.AuthConfig
+	err = yaml.Unmarshal(data, &expectedAuthConfig)
+	require.NoError(t, err)
+
+	namespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ns,
+		},
+	}
+	config := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "jx-auth",
+			Namespace: ns,
+			Labels: map[string]string{
+				"jenkins.io/config-type": "auth",
+			},
+		},
+		Data: map[string]string{
+			secretName: string(data),
+		},
+	}
+	kubeClient := fake.NewSimpleClientset(namespace, config)
+	jxClient := v1fake.NewSimpleClientset()
+	configMapInterface := kubeClient.CoreV1().ConfigMaps(ns)
+
+	vaultClient := fakevault.NewFakeClient()
+	_, err = vaultClient.Write("test-cluster/pipelineUser", map[string]interface{}{"token": "test"})
+	require.NoError(t, err)
+	expectedAuthConfig.Servers[0].Users[0].ApiToken = "test"
+
+	handler := auth.NewConfigMapVaultConfigHandler(secretName, configMapInterface, vaultClient)
+	authConfig, err := handler.LoadConfig()
+
+	assert.NoError(t, err, "auth config should be loaded")
+	assert.NotNil(t, authConfig, "auth config should be set")
+	assert.EqualValues(t, expectedAuthConfig, *authConfig)
+
+	foundServiceKind, err := kube.GetGitServiceKind(jxClient, kubeClient, ns, authConfig, bbsServerURL)
+
+	assert.NoError(t, err, "should find a service kind without any error")
+	assert.Equal(t, expectedServiceKind, foundServiceKind, "should find a service kind equal with '%s'", expectedServiceKind)
 }
 
 func TestGitServiceKindFromSecretsWithoutURL(t *testing.T) {

--- a/pkg/kube/test_data/git_service_kind/configmap_vault_auth.yaml
+++ b/pkg/kube/test_data/git_service_kind/configmap_vault_auth.yaml
@@ -1,0 +1,13 @@
+currentserver: test
+defaultusername: "test"
+pipelineserver: "test"
+pipelineusername: "test"
+servers:
+- currentuser: "test"
+  kind: bitbucketserver
+  name: bs
+  url: https://bitbucket.example.com
+  users:
+  - apitoken: "vault:test-cluster/pipelineUser:token"
+    bearertoken: ""
+    username: "test"


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We're looking for this in a simple set of patterns, secrets, and `GitServices`, but once the `jx-auth-config` configmap is present (i.e., via a combination of boot/vault/gitops), we won't be able to find the kind for something that doesn't match one of the patterns we check first, since the `jx-pipeline-git-` secrets won't exist any more. So if we're in a cluster with `jx-auth-config`, let's look up there too, before we check secrets or `GitServices`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6589

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
