### PR TITLE
feat: add a command to get the custom resource counts in a cluster

### DIFF
--- a/pkg/cmd/clients/factory.go
+++ b/pkg/cmd/clients/factory.go
@@ -2,6 +2,11 @@ package clients
 
 import (
 	"fmt"
+
+	"github.com/heptio/sonobuoy/pkg/client"
+	sonoboy_dynamic "github.com/heptio/sonobuoy/pkg/dynamic"
+	"k8s.io/client-go/dynamic"
+
 	"io"
 	"net/url"
 	"os"
@@ -22,8 +27,6 @@ import (
 	kubevault "github.com/jenkins-x/jx/pkg/kube/vault"
 	"github.com/jenkins-x/jx/pkg/log"
 
-	"github.com/heptio/sonobuoy/pkg/client"
-	"github.com/heptio/sonobuoy/pkg/dynamic"
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -626,7 +629,7 @@ func (f *factory) CreateTektonClient() (tektonclient.Interface, string, error) {
 	return f.jxFactory.CreateTektonClient()
 }
 
-func (f *factory) CreateDynamicClient() (*dynamic.APIHelper, string, error) {
+func (f *factory) CreateDynamicClient() (dynamic.Interface, string, error) {
 	config, err := f.CreateKubeConfig()
 	if err != nil {
 		return nil, "", err
@@ -636,7 +639,7 @@ func (f *factory) CreateDynamicClient() (*dynamic.APIHelper, string, error) {
 		return nil, "", err
 	}
 	ns := kube.CurrentNamespace(kubeConfig)
-	client, err := dynamic.NewAPIHelperFromRESTConfig(config)
+	client, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, ns, err
 	}
@@ -715,7 +718,7 @@ func (f *factory) CreateComplianceClient() (*client.SonobuoyClient, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "compliance client failed to load the Kubernetes configuration")
 	}
-	skc, err := dynamic.NewAPIHelperFromRESTConfig(config)
+	skc, err := sonoboy_dynamic.NewAPIHelperFromRESTConfig(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "compliance dynamic client failed to be created")
 	}

--- a/pkg/cmd/clients/interface.go
+++ b/pkg/cmd/clients/interface.go
@@ -8,22 +8,21 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/jenkins-x/jx/pkg/vault"
 
-	"github.com/heptio/sonobuoy/pkg/dynamic"
 	"github.com/jenkins-x/jx/pkg/helm"
 
+	vaultoperatorclient "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 	"github.com/heptio/sonobuoy/pkg/client"
 	"github.com/jenkins-x/jx/pkg/auth"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/table"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-
-	vaultoperatorclient "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 	certmngclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	kserve "github.com/knative/serving/pkg/client/clientset/versioned"
 	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
 	prowjobclient "k8s.io/test-infra/prow/client/clientset/versioned"
 
@@ -115,7 +114,7 @@ type Factory interface {
 	CreateApiExtensionsClient() (apiextensionsclientset.Interface, error)
 
 	// CreateDynamicClient creates a new Kubernetes Dynamic client
-	CreateDynamicClient() (*dynamic.APIHelper, string, error)
+	CreateDynamicClient() (dynamic.Interface, string, error)
 
 	// CreateMetricsClient creates a new Kubernetes metrics client
 	CreateMetricsClient() (metricsclient.Interface, error)

--- a/pkg/cmd/clients/mocks/factory.go
+++ b/pkg/cmd/clients/mocks/factory.go
@@ -10,7 +10,6 @@ import (
 
 	versioned "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 	client "github.com/heptio/sonobuoy/pkg/client"
-	dynamic "github.com/heptio/sonobuoy/pkg/dynamic"
 	golang_jenkins "github.com/jenkins-x/golang-jenkins"
 	auth "github.com/jenkins-x/jx/pkg/auth"
 	versioned0 "github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -26,6 +25,7 @@ import (
 	pegomock "github.com/petergtz/pegomock"
 	versioned3 "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	dynamic "k8s.io/client-go/dynamic"
 	kubernetes "k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"
 	versioned4 "k8s.io/metrics/pkg/client/clientset/versioned"
@@ -199,18 +199,18 @@ func (mock *MockFactory) CreateCustomJenkinsClient(_param0 kubernetes.Interface,
 	return ret0, ret1
 }
 
-func (mock *MockFactory) CreateDynamicClient() (*dynamic.APIHelper, string, error) {
+func (mock *MockFactory) CreateDynamicClient() (dynamic.Interface, string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockFactory().")
 	}
 	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateDynamicClient", params, []reflect.Type{reflect.TypeOf((**dynamic.APIHelper)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 *dynamic.APIHelper
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CreateDynamicClient", params, []reflect.Type{reflect.TypeOf((*dynamic.Interface)(nil)).Elem(), reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 dynamic.Interface
 	var ret1 string
 	var ret2 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(*dynamic.APIHelper)
+			ret0 = result[0].(dynamic.Interface)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(string)

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -81,6 +81,7 @@ func NewCmdGet(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.AddCommand(NewCmdGetChat(commonOpts))
 	cmd.AddCommand(NewCmdGetConfig(commonOpts))
 	cmd.AddCommand(NewCmdGetCluster(commonOpts))
+	cmd.AddCommand(NewCmdGetCRDCount(commonOpts))
 	cmd.AddCommand(NewCmdGetCVE(commonOpts))
 	cmd.AddCommand(NewCmdGetDevPod(commonOpts))
 	cmd.AddCommand(NewCmdGetEks(commonOpts))

--- a/pkg/cmd/get/get_crd_counts.go
+++ b/pkg/cmd/get/get_crd_counts.go
@@ -1,0 +1,165 @@
+package get
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/util"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/jenkins-x/jx/pkg/cmd/helper"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/templates"
+)
+
+// CRDCountOptions the command line options
+type CRDCountOptions struct {
+	*opts.CommonOptions
+}
+
+type tableLine struct {
+	name      string
+	version   string
+	count     int
+	namespace string
+}
+
+var (
+	getCrdCountLong = templates.LongDesc(`
+		Count the number of resources for all custom resources definitions
+
+`)
+
+	getCrdCountExample = templates.Examples(`
+
+		# Count the number of resources for all custom resources definitions
+		jx get crd count
+	`)
+)
+
+// NewCmdGetCRDCount creates the command object
+func NewCmdGetCRDCount(commonOpts *opts.CommonOptions) *cobra.Command {
+	options := &CRDCountOptions{
+		CommonOptions: commonOpts,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "crd count",
+		Short:   "Display resources count for all custom resources",
+		Long:    getCrdCountLong,
+		Example: getCrdCountExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			helper.CheckErr(err)
+		},
+	}
+	return cmd
+}
+
+// Run implements this command
+func (o *CRDCountOptions) Run() error {
+	results, err := o.getCustomResourceCounts()
+	if err != nil {
+		return errors.Wrap(err, "cannot get custom resource counts")
+	}
+
+	table := o.CreateTable()
+	table.AddRow("NAME", "VERSION", "COUNT", "NAMESPACE")
+
+	for _, r := range results {
+		table.AddRow(r.name, r.version, strconv.Itoa(r.count), r.namespace)
+	}
+
+	table.Render()
+	return nil
+}
+
+func (o *CRDCountOptions) getCustomResourceCounts() ([]tableLine, error) {
+
+	exClient, err := o.ApiExtensionsClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get api extensions client")
+	}
+	dynamicClient, _, err := o.GetFactory().CreateDynamicClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get dynamic client")
+	}
+
+	// lets loop over each arg and validate they are resources, note we could have "--all"
+	crdList, err := exClient.ApiextensionsV1beta1().CustomResourceDefinitions().List(v1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get a list of custom resource definitions")
+	}
+
+	kclient, _, err := o.GetFactory().CreateKubeClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get kubernetes client")
+	}
+
+	// get the list of namespaces the user has access to
+	namespaces, err := kclient.CoreV1().Namespaces().List(v1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list namespaces")
+	}
+
+	log.Logger().Info("Looking for cluster wide custom resource counts and namespaced custom resources in these namespaces:")
+	for _, namespace := range namespaces.Items {
+		log.Logger().Infof("%s", util.ColorInfo(namespace.Name))
+	}
+	log.Logger().Info("this operation may take a while depending on how many custom resources exist")
+
+	var results []tableLine
+	// loop over each crd and check how many resources exist for them
+	for _, crd := range crdList.Items {
+		// each crd can have multiple versions
+		for _, v := range crd.Spec.Versions {
+			r := schema.GroupVersionResource{Group: crd.Spec.Group, Version: v.Name, Resource: crd.Spec.Names.Plural}
+
+			if crd.Spec.Scope == v1beta1.ClusterScoped {
+				// get cluster scoped resources
+				resources, err := dynamicClient.Resource(r).List(v1.ListOptions{})
+				if err != nil {
+					return nil, errors.Wrapf(err, "finding resource %s.%s %s", crd.Spec.Names.Plural, crd.Spec.Group, v.Name)
+				}
+
+				results = o.addLine(crd, v, resources, results, "cluster scoped")
+			} else if crd.Spec.Scope == v1beta1.NamespaceScoped {
+				// get namespaced scoped resources
+				for _, n := range namespaces.Items {
+
+					resources, err := dynamicClient.Resource(r).Namespace(n.Name).List(v1.ListOptions{})
+					if err != nil {
+						return nil, errors.Wrapf(err, "finding resource %s.%s %s", crd.Spec.Names.Plural, crd.Spec.Group, v.Name)
+					}
+
+					results = o.addLine(crd, v, resources, results, n.Name)
+				}
+			}
+		}
+	}
+	// sort the entries so resources with the most come at the bottom as it's clearer to see after running the command
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].count < results[j].count
+	})
+	return results, nil
+}
+
+func (o *CRDCountOptions) addLine(crd v1beta1.CustomResourceDefinition, v v1beta1.CustomResourceDefinitionVersion, resources *unstructured.UnstructuredList, results []tableLine, namespace string) []tableLine {
+	line := tableLine{
+		name:      fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, crd.Spec.Group),
+		version:   v.Name,
+		count:     len(resources.Items),
+		namespace: namespace,
+	}
+	return append(results, line)
+}

--- a/pkg/cmd/get/get_crd_counts_test.go
+++ b/pkg/cmd/get/get_crd_counts_test.go
@@ -1,0 +1,144 @@
+package get
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	cmd_mocks "github.com/jenkins-x/jx/pkg/cmd/clients/mocks"
+	. "github.com/petergtz/pegomock"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextentions_mocks "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dymamic_mocks "k8s.io/client-go/dynamic/fake"
+	kube_mocks "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/jenkins-x/jx/pkg/cmd/opts"
+)
+
+const (
+	group = "wine.io"
+)
+
+func TestRun(t *testing.T) {
+	o := CRDCountOptions{
+		CommonOptions: &opts.CommonOptions{},
+	}
+
+	scheme := runtime.NewScheme()
+
+	// setup mocks
+	factory := cmd_mocks.NewMockFactory()
+	kubernetesInterface := kube_mocks.NewSimpleClientset(getNamespace("cellar"), getNamespace("cellarx"))
+	apiextensionsInterface := apiextentions_mocks.NewSimpleClientset(getClusterScopedCRD(), getNamespaceScopedCRD())
+	dynamicInterface := dymamic_mocks.NewSimpleDynamicClient(scheme)
+	r := schema.GroupVersionResource{Group: group, Version: "v1", Resource: "rioja"}
+
+	_, err := dynamicInterface.Resource(r).Namespace("cellar").Create(getNamespaceResource("test1"), metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = dynamicInterface.Resource(r).Namespace("cellarx").Create(getNamespaceResource("test2"), metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	r = schema.GroupVersionResource{Group: group, Version: "v1", Resource: "shiraz"}
+
+	_, err = dynamicInterface.Resource(r).Create(getClusterResource("test3"), metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// return our fake kubernetes client in the test
+	When(factory.CreateKubeClient()).ThenReturn(kubernetesInterface, "cellar", nil)
+	When(factory.CreateApiExtensionsClient()).ThenReturn(apiextensionsInterface, nil)
+	When(factory.CreateDynamicClient()).ThenReturn(dynamicInterface, "cellar", nil)
+
+	o.SetFactory(factory)
+
+	// run the command
+	rs, err := o.getCustomResourceCounts()
+	assert.NoError(t, err)
+
+	// the order is important here, larger counts should appear at the bottom of the list so we can see them sooner
+	clusterScopedLine := rs[0]
+	namespace1ScopedLine := rs[1]
+	namespace2ScopedLine := rs[2]
+
+	assert.Equal(t, 1, clusterScopedLine.count)
+	assert.Equal(t, 1, namespace1ScopedLine.count)
+	assert.Equal(t, 1, namespace2ScopedLine.count)
+
+}
+
+func getNamespace(name string) *v1.Namespace {
+	return &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: name,
+		},
+	}
+}
+
+func getNamespaceScopedCRD() *v1beta1.CustomResourceDefinition {
+	return &v1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "rioja",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group: group,
+			Versions: []v1beta1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+				},
+			},
+			Scope: v1beta1.NamespaceScoped,
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Plural: "rioja",
+			},
+		},
+	}
+}
+
+func getClusterScopedCRD() *v1beta1.CustomResourceDefinition {
+	return &v1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "shiraz",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group: group,
+			Versions: []v1beta1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+				},
+			},
+			Scope: v1beta1.ClusterScoped,
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Plural: "shiraz",
+			},
+		},
+	}
+}
+
+func getNamespaceResource(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "wine.io/v1",
+			"kind":       "rioja",
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+		},
+	}
+}
+
+func getClusterResource(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "wine.io/v1",
+			"kind":       "shiraz",
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+		},
+	}
+}


### PR DESCRIPTION
There are lots of custom resources that can be created by various applications and it can be hard to keep a handle of how many exist.  This can lead to them growing over time if not managed.  This command allows users to get the counts for each custom resource given their permissions.

Example:
```
➜  ~ jx get crd count
looking for cluster wide custom resource counts and namespaced custom resources in these namespaces:
cert-manager
default
jx
jx-production
jx-staging
kube-node-lease
kube-public
kube-system
this operation may take a while depending on how many custom resources exist
NAME                                         VERSION  COUNT NAMESPACE
apps.jenkins.io                              v1       0     cert-manager
apps.jenkins.io                              v1       0     default
workflows.jenkins.io                         v1       0     kube-public
releases.jenkins.io                          v1       365   jx
pipelineactivities.jenkins.io                v1       1183  jx
prowjobs.prow.k8s.io                         v1       1270  jx
pipelinestructures.jenkins.io                v1       1513  jx
```

Future work could integrate with prometheus for alerting. 

fixes #6596