### PR TITLE
fix: lets always use the dev namespace for applying schedules

### DIFF
--- a/pkg/cmd/step/scheduler/step_scheduler_config_apply.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_apply.go
@@ -1,6 +1,8 @@
 package scheduler
 
 import (
+	"fmt"
+
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
@@ -62,13 +64,16 @@ func (o *StepSchedulerConfigApplyOptions) Run() error {
 	gitOps, devEnv := o.GetDevEnv()
 	switch o.Agent {
 	case "prow":
-		jxClient, ns, err := o.JXClient()
+		jxClient, ns, err := o.JXClientAndDevNamespace()
 		if err != nil {
 			return errors.WithStack(err)
 		}
 		teamSettings, err := o.TeamSettings()
 		if err != nil {
 			return err
+		}
+		if teamSettings == nil {
+			return fmt.Errorf("no TeamSettings for namespace %s", ns)
 		}
 		cfg, plugs, err := pipelinescheduler.GenerateProw(gitOps, true, jxClient, ns, teamSettings.DefaultScheduler.Name, devEnv, nil)
 		if err != nil {


### PR DESCRIPTION
also add extra validation check to ensure team settings are created

Signed-off-by: James Strachan <james.strachan@gmail.com>