### PR TITLE
fix: add a CLI argument to disable boot messing with the local git clone

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -49,6 +49,9 @@ type BootOptions struct {
 	RequirementsFile string
 
 	AttemptRestore bool
+
+	// UpgradeGit if we want to automaticalaly upgrade this boot clone if there have been changes since the current clone
+	NoUpgradeGit bool
 }
 
 var (
@@ -101,6 +104,7 @@ func NewCmdBoot(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.HelmLogLevel, "helm-log", "v", "", "sets the helm logging level from 0 to 9. Passed into the helm CLI via the '-v' argument. Useful to diagnose helm related issues")
 	cmd.Flags().StringVarP(&options.RequirementsFile, "requirements", "r", "", "requirements file which will overwrite the default requirements file")
 	cmd.Flags().BoolVarP(&options.AttemptRestore, "attempt-restore", "a", false, "attempt to boot from an existing dev environment repository")
+	cmd.Flags().BoolVarP(&options.NoUpgradeGit, "no-update-git", "", false, "disables any attempt to update the local git clone if its old")
 
 	return cmd
 }
@@ -279,7 +283,7 @@ func (o *BootOptions) Run() error {
 	}
 
 	// only update boot if the a GitRef has not been supplied
-	if o.GitRef == "" {
+	if o.GitRef == "" && !o.NoUpgradeGit {
 		err = o.updateBootCloneIfOutOfDate(gitRef)
 		if err != nil {
 			return err


### PR DESCRIPTION
if you are developing boot and working on a local set of changes for a boot config repo you don't want `jx boot` to suddenly change your `~/.git/config` and try auto-merge stuff and generally mess everything up.

So lets add a `-no-upgrade-git` to avoid boot deciding that your local clone is behind and messing up your local source code

Signed-off-by: James Strachan <james.strachan@gmail.com>