### PR TITLE
fix: validate AWS parameters to prevent panics

### DIFF
--- a/pkg/vault/create/create.go
+++ b/pkg/vault/create/create.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jenkins-x/jx/pkg/cloud/amazon/session"
-
 	"github.com/banzaicloud/bank-vaults/operator/pkg/apis/vault/v1alpha1"
 	"github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx/pkg/cloud"
+	"github.com/jenkins-x/jx/pkg/cloud/amazon/session"
 	awsvault "github.com/jenkins-x/jx/pkg/cloud/amazon/vault"
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	gkevault "github.com/jenkins-x/jx/pkg/cloud/gke/vault"
@@ -117,16 +116,45 @@ func (p *VaultCreationParam) validate() error {
 		}
 	}
 
+	if p.KubeProvider == cloud.AWS {
+		if p.AWS == nil {
+			validationErrors = append(validationErrors, errors.Errorf("%s selected as kube provider, but no %s specific parameters provided", cloud.AWS, cloud.AWS))
+		}
+		if err := p.AWS.validate(); err != nil {
+			validationErrors = append(validationErrors, err)
+		}
+	}
+
 	return util.CombineErrors(validationErrors...)
 }
 
 func (p *GKEParam) validate() error {
 	var validationErrors []error
+	if p == nil {
+		return nil
+	}
 	if p.ProjectID == "" {
 		validationErrors = append(validationErrors, errors.New("the GKE project ID needs to be provided"))
 	}
 	if p.Zone == "" {
 		validationErrors = append(validationErrors, errors.New("the GKE zone needs to be provided"))
+	}
+	return util.CombineErrors(validationErrors...)
+}
+
+func (p *AWSParam) validate() error {
+	var validationErrors []error
+	if p == nil {
+		return nil
+	}
+	if p.TemplatesDir == "" {
+		validationErrors = append(validationErrors, errors.New("the cloud formation template dir needs to be provided"))
+	}
+	if p.AccessKeyID == "" {
+		validationErrors = append(validationErrors, errors.New("the AccessKeyID needs to be provided"))
+	}
+	if p.SecretAccessKey == "" {
+		validationErrors = append(validationErrors, errors.New("the SecretAccessKey needs to be provided"))
 	}
 	return util.CombineErrors(validationErrors...)
 }


### PR DESCRIPTION
Signed-off-by: Rafal Korepta <rafal.korepta@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Issue #6555 shows that cloud provider AWS panic when a user wants to create a vault.

#### Special notes for the reviewer(s)

This PR remove panic from the jx program flow and handle gracefully the not valid parameters. The main issue isn't resolved yet.

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
