### PR TITLE
fix: make PipelineResource names have a random suffix

### DIFF
--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -302,9 +302,7 @@ func (o *StepCreateTaskOptions) Run() error {
 		return errors.Wrap(err, "Unable to load pod templates")
 	}
 
-	// resourceName is shared across all builds of a branch, while the pipelineName is unique for each build.
-	resourceName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline.String(), false)
-	pipelineName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline.String(), true)
+	pipelineName := tekton.PipelineResourceNameFromGitInfo(o.GitInfo, o.Branch, o.Context, tekton.BuildPipeline.String())
 
 	exists, err = o.effectiveProjectConfigExists()
 	if err != nil {
@@ -334,7 +332,7 @@ func (o *StepCreateTaskOptions) Run() error {
 	}
 
 	log.Logger().Debug("Creating Tekton CRDs")
-	tektonCRDs, err := o.generateTektonCRDs(effectiveProjectConfig, ns, pipelineName, resourceName)
+	tektonCRDs, err := o.generateTektonCRDs(effectiveProjectConfig, ns, pipelineName)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate Tekton CRDs")
 	}
@@ -628,7 +626,7 @@ func (o *StepCreateTaskOptions) createEffectiveProjectConfig(packsDir string, pr
 }
 
 // GenerateTektonCRDs creates the Pipeline, Task, PipelineResource, PipelineRun, and PipelineStructure CRDs that will be applied to actually kick off the pipeline
-func (o *StepCreateTaskOptions) generateTektonCRDs(effectiveProjectConfig *config.ProjectConfig, ns string, pipelineName string, resourceName string) (*tekton.CRDWrapper, error) {
+func (o *StepCreateTaskOptions) generateTektonCRDs(effectiveProjectConfig *config.ProjectConfig, ns string, pipelineName string) (*tekton.CRDWrapper, error) {
 	if effectiveProjectConfig == nil {
 		return nil, errors.New("effective project config cannot be nil")
 	}
@@ -641,7 +639,6 @@ func (o *StepCreateTaskOptions) generateTektonCRDs(effectiveProjectConfig *confi
 	crdParams := syntax.CRDsFromPipelineParams{
 		PipelineIdentifier: pipelineName,
 		BuildIdentifier:    o.BuildNumber,
-		ResourceIdentifier: resourceName,
 		Namespace:          ns,
 		PodTemplates:       o.PodTemplates,
 		VersionsDir:        o.VersionResolver.VersionsDir,
@@ -657,7 +654,7 @@ func (o *StepCreateTaskOptions) generateTektonCRDs(effectiveProjectConfig *confi
 	}
 
 	tasks, pipeline = o.enhanceTasksAndPipeline(tasks, pipeline, effectiveProjectConfig.PipelineConfig.Env)
-	resources := []*pipelineapi.PipelineResource{tekton.GenerateSourceRepoResource(resourceName, o.GitInfo, o.Revision)}
+	resources := []*pipelineapi.PipelineResource{tekton.GenerateSourceRepoResource(pipelineName, o.GitInfo, o.Revision)}
 
 	var timeout *metav1.Duration
 	if effectivePipeline.Options != nil && effectivePipeline.Options.Timeout != nil {

--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -516,9 +516,8 @@ func TestGenerateTektonCRDs(t *testing.T) {
 					assert.NoError(t, err)
 				}
 
-				resourceName := tekton.PipelineResourceNameFromGitInfo(createTask.GitInfo, createTask.Branch, createTask.Context, tekton.BuildPipeline.String(), false)
-				pipelineName := tekton.PipelineResourceNameFromGitInfo(createTask.GitInfo, createTask.Branch, createTask.Context, tekton.BuildPipeline.String(), true)
-				crds, err := createTask.generateTektonCRDs(effectiveProjectConfig, ns, pipelineName, resourceName)
+				pipelineName := tekton.PipelineResourceNameFromGitInfo(createTask.GitInfo, createTask.Branch, createTask.Context, tekton.BuildPipeline.String())
+				crds, err := createTask.generateTektonCRDs(effectiveProjectConfig, ns, pipelineName)
 				if tt.generateError != nil {
 					if err == nil {
 						t.Fatalf("Expected an error %s generating CRDs, did not see it", tt.generateError)

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-golang-qs-test-master
+  - name: abayer-golang-qs-test-master-dfq8f
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-golang-qs-test-master
+        resource: abayer-golang-qs-test-master-dfq8f
     taskRef:
       name: abayer-golang-qs-test-master-dfq8f-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-golang-qs-test-master
+    name: abayer-golang-qs-test-master-dfq8f
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-golang-qs-test-master-dfq8f-1
   podTemplate: {}
   resources:
-  - name: abayer-golang-qs-test-master
+  - name: abayer-golang-qs-test-master-dfq8f
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-golang-qs-test-master
+      name: abayer-golang-qs-test-master-dfq8f
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-h42ks
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-h42ks
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-h42ks
     taskRef:
       name: abayer-js-test-repo-really-long-h42ks-build-a-really-long-sta-1
   - name: second
@@ -43,7 +43,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-h42ks
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-h42ks
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-really-long-h42ks-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-h42ks
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-h42ks
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-tbl2p
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-jx-demo-qs-master
+        resource: abayer-jx-demo-qs-master-tbl2p
     taskRef:
       name: abayer-jx-demo-qs-master-tbl2p-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-tbl2p
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-jx-demo-qs-master-tbl2p-1
   podTemplate: {}
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-tbl2p
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-jx-demo-qs-master
+      name: abayer-jx-demo-qs-master-tbl2p
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-vt9mj
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-vt9mj
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-vt9mj
     retries: 5
     taskRef:
       name: abayer-js-test-repo-really-long-vt9mj-build-a-really-long-sta-1
@@ -44,7 +44,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-vt9mj
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-vt9mj
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-really-long-vt9mj-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-vt9mj
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-vt9mj
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-b5j7r
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-jx-demo-qs-master
+        resource: abayer-jx-demo-qs-master-b5j7r
     taskRef:
       name: abayer-jx-demo-qs-master-b5j7r-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-b5j7r
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-jx-demo-qs-master-b5j7r-1
   podTemplate: {}
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-b5j7r
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-jx-demo-qs-master
+      name: abayer-jx-demo-qs-master-b5j7r
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-hvpvf
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-jx-demo-qs-master
+        resource: abayer-jx-demo-qs-master-hvpvf
     taskRef:
       name: abayer-jx-demo-qs-master-hvpvf-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-hvpvf
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-jx-demo-qs-master-hvpvf-1
   podTemplate: {}
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-hvpvf
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-jx-demo-qs-master
+      name: abayer-jx-demo-qs-master-hvpvf
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-fzfnf
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-fzfnf
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-fzfnf
     taskRef:
       name: abayer-js-test-repo-really-long-fzfnf-build-a-really-long-sta-1
   - name: second
@@ -43,7 +43,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-fzfnf
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-fzfnf
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-really-long-fzfnf-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-fzfnf
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-fzfnf
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-golang-qs-test-master
+  - name: abayer-golang-qs-test-master-sn8zf
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-golang-qs-test-master
+        resource: abayer-golang-qs-test-master-sn8zf
     taskRef:
       name: abayer-golang-qs-test-master-sn8zf-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-golang-qs-test-master
+    name: abayer-golang-qs-test-master-sn8zf
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-golang-qs-test-master-sn8zf-1
   podTemplate: {}
   resources:
-  - name: abayer-golang-qs-test-master
+  - name: abayer-golang-qs-test-master-sn8zf
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-golang-qs-test-master
+      name: abayer-golang-qs-test-master-sn8zf
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-mjxbm
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-mjxbm
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-mjxbm
     taskRef:
       name: abayer-js-test-repo-really-long-mjxbm-build-a-really-long-sta-1
   - name: second
@@ -43,7 +43,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-mjxbm
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-mjxbm
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-really-long-mjxbm-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-mjxbm
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-mjxbm
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-m97mw
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-m97mw
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-m97mw
     taskRef:
       name: abayer-js-test-repo-really-long-m97mw-build-a-really-long-sta-1
   - name: second
@@ -43,7 +43,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-m97mw
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-m97mw
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/pipelinerun.yml
@@ -30,10 +30,10 @@ spec:
               way-too-long-a-label-seriously-this-just-goes-on-for-so-many-ch: this-hasinvalidcharacters
           topologyKey: kubernetes.io/hostname
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-m97mw
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-m97mw
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-shnql
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-shnql
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-shnql
     taskRef:
       name: abayer-js-test-repo-really-long-shnql-build-a-really-long-sta-1
   - name: second
@@ -43,7 +43,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-shnql
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-shnql
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/pipelinerun.yml
@@ -25,10 +25,10 @@ spec:
               tekton.dev/pipelineRun: abayer-js-test-repo-really-long-shnql-1
           topologyKey: kubernetes.io/hostname
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-shnql
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-shnql
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-mssqb
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-mssqb
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-mssqb
     taskRef:
       name: abayer-js-test-repo-really-long-mssqb-build-a-really-long-sta-1
   - name: second
@@ -43,7 +43,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-mssqb
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-mssqb
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-really-long-mssqb-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-mssqb
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-mssqb
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-build-pack
+  - name: abayer-js-test-repo-build-pack-9l9zj
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-build-pack
+        resource: abayer-js-test-repo-build-pack-9l9zj
     taskRef:
       name: abayer-js-test-repo-build-pack-9l9zj-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-build-pack
+    name: abayer-js-test-repo-build-pack-9l9zj
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-build-pack-9l9zj-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-build-pack
+  - name: abayer-js-test-repo-build-pack-9l9zj
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-build-pack
+      name: abayer-js-test-repo-build-pack-9l9zj
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: jenkins-x-jx-fix-kaniko-special
+  - name: jenkins-x-jx-fix-kaniko-special-6nl7g
     type: git
   tasks:
   - name: ci
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: jenkins-x-jx-fix-kaniko-special
+        resource: jenkins-x-jx-fix-kaniko-special-6nl7g
     taskRef:
       name: jenkins-x-jx-fix-kaniko-special-6nl7g-ci-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: jenkins-x-jx-fix-kaniko-special
+    name: jenkins-x-jx-fix-kaniko-special-6nl7g
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: jenkins-x-jx-fix-kaniko-special-6nl7g-1
   podTemplate: {}
   resources:
-  - name: jenkins-x-jx-fix-kaniko-special
+  - name: jenkins-x-jx-fix-kaniko-special-6nl7g
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: jenkins-x-jx-fix-kaniko-special
+      name: jenkins-x-jx-fix-kaniko-special-6nl7g
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-mnq6l
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-jx-demo-qs-master
+        resource: abayer-jx-demo-qs-master-mnq6l
     taskRef:
       name: abayer-jx-demo-qs-master-mnq6l-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-mnq6l
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-jx-demo-qs-master-mnq6l-1
   podTemplate: {}
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-mnq6l
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-jx-demo-qs-master
+      name: abayer-jx-demo-qs-master-mnq6l
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-mz4c7
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-jx-demo-qs-master
+        resource: abayer-jx-demo-qs-master-mz4c7
     taskRef:
       name: abayer-jx-demo-qs-master-mz4c7-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-mz4c7
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-jx-demo-qs-master-mz4c7-1
   podTemplate: {}
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-mz4c7
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-jx-demo-qs-master
+      name: abayer-jx-demo-qs-master-mz4c7
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-override-de
+  - name: abayer-js-test-repo-override-de-vr6ds
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-override-de
+        resource: abayer-js-test-repo-override-de-vr6ds
     taskRef:
       name: abayer-js-test-repo-override-de-vr6ds-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-override-de
+    name: abayer-js-test-repo-override-de-vr6ds
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-override-de-vr6ds-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-override-de
+  - name: abayer-js-test-repo-override-de-vr6ds
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-override-de
+      name: abayer-js-test-repo-override-de-vr6ds
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-golang-qs-test-master
+  - name: abayer-golang-qs-test-master-klrgx
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-golang-qs-test-master
+        resource: abayer-golang-qs-test-master-klrgx
     taskRef:
       name: abayer-golang-qs-test-master-klrgx-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-golang-qs-test-master
+    name: abayer-golang-qs-test-master-klrgx
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-golang-qs-test-master-klrgx-1
   podTemplate: {}
   resources:
-  - name: abayer-golang-qs-test-master
+  - name: abayer-golang-qs-test-master-klrgx
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-golang-qs-test-master
+      name: abayer-golang-qs-test-master-klrgx
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-kbptp
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-kbptp
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-kbptp
     taskRef:
       name: abayer-js-test-repo-really-long-kbptp-build-a-really-long-sta-1
   - name: second
@@ -43,7 +43,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-kbptp
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-kbptp
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-really-long-kbptp-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-kbptp
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-kbptp
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-l22wn
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-jx-demo-qs-master
+        resource: abayer-jx-demo-qs-master-l22wn
     taskRef:
       name: abayer-jx-demo-qs-master-l22wn-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-l22wn
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-jx-demo-qs-master-l22wn-1
   podTemplate: {}
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-l22wn
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-jx-demo-qs-master
+      name: abayer-jx-demo-qs-master-l22wn
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-golang-qs-test-master
+  - name: abayer-golang-qs-test-master-twkr2
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-golang-qs-test-master
+        resource: abayer-golang-qs-test-master-twkr2
     taskRef:
       name: abayer-golang-qs-test-master-twkr2-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-golang-qs-test-master
+    name: abayer-golang-qs-test-master-twkr2
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-golang-qs-test-master-twkr2-1
   podTemplate: {}
   resources:
-  - name: abayer-golang-qs-test-master
+  - name: abayer-golang-qs-test-master-twkr2
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-golang-qs-test-master
+      name: abayer-golang-qs-test-master-twkr2
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-golang-qs-test-master
+  - name: abayer-golang-qs-test-master-78c5n
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-golang-qs-test-master
+        resource: abayer-golang-qs-test-master-78c5n
     taskRef:
       name: abayer-golang-qs-test-master-78c5n-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-golang-qs-test-master
+    name: abayer-golang-qs-test-master-78c5n
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-golang-qs-test-master-78c5n-1
   podTemplate: {}
   resources:
-  - name: abayer-golang-qs-test-master
+  - name: abayer-golang-qs-test-master-78c5n
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-golang-qs-test-master
+      name: abayer-golang-qs-test-master-78c5n
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-j9gz7
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-j9gz7
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-j9gz7
     taskRef:
       name: abayer-js-test-repo-really-long-j9gz7-build-a-really-long-sta-1
   - name: second
@@ -43,7 +43,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-j9gz7
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-j9gz7
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-really-long-j9gz7-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-j9gz7
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-j9gz7
   serviceAccountName: tekton-bot
   timeout: 10h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-x9hlq
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-x9hlq
     taskRef:
       name: abayer-js-test-repo-really-long-x9hlq-build-a-really-long-sta-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-x9hlq
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-really-long-x9hlq-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-x9hlq
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-x9hlq
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-l72kq
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-jx-demo-qs-master
+        resource: abayer-jx-demo-qs-master-l72kq
     taskRef:
       name: abayer-jx-demo-qs-master-l72kq-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-l72kq
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-jx-demo-qs-master-l72kq-1
   podTemplate: {}
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-l72kq
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-jx-demo-qs-master
+      name: abayer-jx-demo-qs-master-l72kq
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-62hjz
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-62hjz
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-62hjz
     taskRef:
       name: abayer-js-test-repo-really-long-62hjz-build-a-really-long-sta-1
   - name: second
@@ -43,7 +43,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-62hjz
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-62hjz
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-really-long-62hjz-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-62hjz
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-62hjz
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-mxcdj
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-jx-demo-qs-master
+        resource: abayer-jx-demo-qs-master-mxcdj
     taskRef:
       name: abayer-jx-demo-qs-master-mxcdj-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-mxcdj
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-jx-demo-qs-master-mxcdj-1
   podTemplate: {}
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-mxcdj
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-jx-demo-qs-master
+      name: abayer-jx-demo-qs-master-mxcdj
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-no-default
+  - name: abayer-js-test-repo-no-default-j2tds
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-no-default
+        resource: abayer-js-test-repo-no-default-j2tds
     taskRef:
       name: abayer-js-test-repo-no-default-j2tds-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-no-default
+    name: abayer-js-test-repo-no-default-j2tds
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-js-test-repo-no-default-j2tds-1
   podTemplate: {}
   resources:
-  - name: abayer-js-test-repo-no-default
+  - name: abayer-js-test-repo-no-default-j2tds
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-no-default
+      name: abayer-js-test-repo-no-default-j2tds
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-xw5r5
     type: git
   tasks:
   - name: build-a-really-long-stage-name-please-but-not-too-long-thanks
@@ -28,10 +28,10 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-xw5r5
       outputs:
       - name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-xw5r5
     taskRef:
       name: abayer-js-test-repo-really-long-xw5r5-build-a-really-long-sta-1
   - name: second
@@ -43,7 +43,7 @@ spec:
       - from:
         - build-a-really-long-stage-name-please-but-not-too-long-thanks
         name: workspace
-        resource: abayer-js-test-repo-really-long
+        resource: abayer-js-test-repo-really-long-xw5r5
     runAfter:
     - build-a-really-long-stage-name-please-but-not-too-long-thanks
     taskRef:

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-js-test-repo-really-long
+    name: abayer-js-test-repo-really-long-xw5r5
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/pipelinerun.yml
@@ -22,10 +22,10 @@ spec:
       key: some-key
       operator: Exists
   resources:
-  - name: abayer-js-test-repo-really-long
+  - name: abayer-js-test-repo-really-long-xw5r5
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-js-test-repo-really-long
+      name: abayer-js-test-repo-really-long-xw5r5
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipeline.yml
@@ -18,7 +18,7 @@ spec:
     name: version
     type: string
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-lxm9g
     type: git
   tasks:
   - name: from-build-pack
@@ -28,7 +28,7 @@ spec:
     resources:
       inputs:
       - name: workspace
-        resource: abayer-jx-demo-qs-master
+        resource: abayer-jx-demo-qs-master-lxm9g
     taskRef:
       name: abayer-jx-demo-qs-master-lxm9g-from-build-pack-1
 status: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelineresources.yml
@@ -3,7 +3,7 @@ items:
   kind: PipelineResource
   metadata:
     creationTimestamp: null
-    name: abayer-jx-demo-qs-master
+    name: abayer-jx-demo-qs-master-lxm9g
   spec:
     params:
     - name: revision

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/pipelinerun.yml
@@ -18,10 +18,10 @@ spec:
     name: abayer-jx-demo-qs-master-lxm9g-1
   podTemplate: {}
   resources:
-  - name: abayer-jx-demo-qs-master
+  - name: abayer-jx-demo-qs-master-lxm9g
     resourceRef:
       apiVersion: tekton.dev/v1alpha1
-      name: abayer-jx-demo-qs-master
+      name: abayer-jx-demo-qs-master-lxm9g
   serviceAccountName: tekton-bot
   timeout: 240h0m0s
 status: {}

--- a/pkg/tekton/metapipeline/clientfactory.go
+++ b/pkg/tekton/metapipeline/clientfactory.go
@@ -105,9 +105,7 @@ func (c *clientFactory) Create(param PipelineCreateParam) (kube.PromoteStepActiv
 		return kube.PromoteStepActivityKey{}, tekton.CRDWrapper{}, errors.Wrap(err, "unable to create branch identifier")
 	}
 
-	// resourceName is shared across all builds of a branch, while the pipelineName is unique for each build.
-	resourceName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String(), false)
-	pipelineName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String(), true)
+	pipelineName := tekton.PipelineResourceNameFromGitInfo(gitInfo, branchIdentifier, param.Context, tekton.MetaPipeline.String())
 	buildNumber, err := tekton.GenerateNextBuildNumber(c.tektonClient, c.jxClient, c.ns, gitInfo, branchIdentifier, retryDuration, param.Context, param.UseActivityForNextBuildNumber)
 	if err != nil {
 		return kube.PromoteStepActivityKey{}, tekton.CRDWrapper{}, errors.Wrap(err, "unable to determine next build number")
@@ -124,7 +122,6 @@ func (c *clientFactory) Create(param PipelineCreateParam) (kube.PromoteStepActiv
 		Namespace:           c.ns,
 		Context:             param.Context,
 		PipelineName:        pipelineName,
-		ResourceName:        resourceName,
 		PipelineKind:        param.PipelineKind,
 		BuildNumber:         buildNumber,
 		BranchIdentifier:    branchIdentifier,

--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -42,7 +42,6 @@ type CRDCreationParameters struct {
 	Namespace           string
 	Context             string
 	PipelineName        string
-	ResourceName        string
 	PipelineKind        PipelineKind
 	BuildNumber         string
 	GitInfo             gits.GitRepository
@@ -79,7 +78,6 @@ func createMetaPipelineCRDs(params CRDCreationParameters) (*tekton.CRDWrapper, e
 	crdParams := syntax.CRDsFromPipelineParams{
 		PipelineIdentifier: params.PipelineName,
 		BuildIdentifier:    params.BuildNumber,
-		ResourceIdentifier: params.ResourceName,
 		Namespace:          params.Namespace,
 		PodTemplates:       params.PodTemplates,
 		VersionsDir:        params.VersionsDir,
@@ -97,7 +95,7 @@ func createMetaPipelineCRDs(params CRDCreationParameters) (*tekton.CRDWrapper, e
 	if revision == "" {
 		revision = params.PullRef.BaseBranch()
 	}
-	resources := []*pipelineapi.PipelineResource{tekton.GenerateSourceRepoResource(params.ResourceName, &params.GitInfo, revision)}
+	resources := []*pipelineapi.PipelineResource{tekton.GenerateSourceRepoResource(params.PipelineName, &params.GitInfo, revision)}
 	run := tekton.CreatePipelineRun(resources, pipeline.Name, pipeline.APIVersion, labels, params.ServiceAccount, nil, nil, nil, nil)
 
 	tektonCRDs, err := tekton.NewCRDWrapper(pipeline, tasks, resources, structure, run)

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -152,7 +152,7 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 	}
 
 	pri := &PipelineRunInfo{
-		Name:        PipelineResourceName(pr.Labels[LabelOwner], pr.Labels[LabelRepo], pr.Labels[LabelBranch], pr.Labels[LabelContext], pr.Labels[LabelType], false) + "-" + pr.Labels[LabelBuild],
+		Name:        possiblyUniquePipelineResourceName(pr.Labels[LabelOwner], pr.Labels[LabelRepo], pr.Labels[LabelBranch], pr.Labels[LabelContext], pr.Labels[LabelType], false) + "-" + pr.Labels[LabelBuild],
 		PipelineRun: pr.Name,
 		Pipeline:    pr.Spec.PipelineRef.Name,
 		Type:        pipelineType.String(),

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -1718,7 +1718,6 @@ func PipelineRunName(pipelineIdentifier string, buildIdentifier string) string {
 type CRDsFromPipelineParams struct {
 	PipelineIdentifier string
 	BuildIdentifier    string
-	ResourceIdentifier string
 	Namespace          string
 	PodTemplates       map[string]*corev1.Pod
 	VersionsDir        string
@@ -1761,7 +1760,7 @@ func (j *ParsedPipeline) GenerateCRDs(params CRDsFromPipelineParams) (*tektonv1a
 		Spec: tektonv1alpha1.PipelineSpec{
 			Resources: []tektonv1alpha1.PipelineDeclaredResource{
 				{
-					Name: params.ResourceIdentifier,
+					Name: params.PipelineIdentifier,
 					Type: tektonv1alpha1.PipelineResourceTypeGit,
 				},
 			},

--- a/pkg/tekton/syntax/pipeline_test.go
+++ b/pkg/tekton/syntax/pipeline_test.go
@@ -1417,7 +1417,6 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 			crdParams := syntax.CRDsFromPipelineParams{
 				PipelineIdentifier: "somepipeline",
 				BuildIdentifier:    "1",
-				ResourceIdentifier: "somepipeline",
 				Namespace:          "jx",
 				VersionsDir:        testVersionsDir,
 				SourceDir:          "source",


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We already do this with the other Tekton CRDs, so let's do it here too and hopefully avoid some edge case collisions where multiple builds of different repositories in an org with a very long name kick off at nearly the exact same moment, and they end up both building the same repo/branch, not different repos.

Also adds owner references to `PipelineResource` so it gets GCed with `PipelineActivity`s.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

fixes #6610 
