### PR TITLE
feat: jx create spring accessed via create project.  Install deprecation date change.

### DIFF
--- a/pkg/cmd/deprecation/deprecated.go
+++ b/pkg/cmd/deprecation/deprecated.go
@@ -12,7 +12,7 @@ import (
 var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
 	"install": {
 		replacement: "jx boot",
-		date:        "Feb 1 2020",
+		date:        "Jun 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/setup/boot/")),
 	},
@@ -87,10 +87,10 @@ var deprecatedCommands map[string]deprecationInfo = map[string]deprecationInfo{
 			util.ColorStatus("https://jenkins-x.io/docs/getting-started/first-project/create-quickstart/")),
 	},
 	"create spring": {
-		replacement: "jx create quickstart",
+		replacement: "jx create project",
 		date:        "Feb 1 2020",
 		info: fmt.Sprintf("Please check %s for more details.",
-			util.ColorStatus("https://jenkins-x.io/docs/getting-started/first-project/create-quickstart/")),
+			util.ColorStatus("https://jenkins-x.io/commands/jx_create_project/")),
 	},
 	"create addon knative-build": {
 		date: "Feb 1 2020",


### PR DESCRIPTION
#### Submitter checklist

- [X ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Based on community feedback, `jx install` will remain a bit longer but without any further enhancements or fixes.  `jx create spring` functionality to remain but accessed via `create project`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes
https://github.com/jenkins-x/jx/issues/6439