### PR TITLE
fix: switched from env var to requirements flag

### DIFF
--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/cloud/amazon/session"
-	"github.com/jenkins-x/jx/pkg/features"
 	"github.com/jenkins-x/jx/pkg/prow"
 	"sigs.k8s.io/yaml"
 
@@ -186,7 +185,7 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 		return err
 	}
 	log.Logger().Info("\n")
-	if !o.DisableVerifyHelm && !features.IsHelmfile() {
+	if !o.DisableVerifyHelm && !requirements.Helmfile {
 		err = o.verifyHelm(ns)
 		if err != nil {
 			return err
@@ -1003,7 +1002,7 @@ func (o *StepVerifyPreInstallOptions) SaveConfig(c *config.RequirementsConfig, f
 		return errors.Wrapf(err, "failed to save file %s", fileName)
 	}
 
-	if features.IsHelmfile() {
+	if c.Helmfile {
 		y := config.RequirementsValues{
 			RequirementsConfig: c,
 		}

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -12,13 +12,11 @@ import (
 
 	"github.com/vrischmann/envconfig"
 
-	"github.com/imdario/mergo"
-	"github.com/jenkins-x/jx/pkg/cloud/gke"
-	"github.com/jenkins-x/jx/pkg/features"
-
 	"github.com/ghodss/yaml"
+	"github.com/imdario/mergo"
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/cloud"
+	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/pkg/errors"
 
@@ -477,6 +475,9 @@ type RequirementsConfig struct {
 	// GitOps if enabled we will setup a webhook in the boot configuration git repository so that we can
 	// re-run 'jx boot' when changes merge to the master branch
 	GitOps bool `json:"gitops,omitempty"`
+	// Indicates if we are using helmfile and helm 3 to spin up environments. This is currently an experimental
+	// feature flag used to implement better Multi-Cluster support. See https://github.com/jenkins-x/jx/issues/6442
+	Helmfile bool `json:"helmfile,omitempty"`
 	// Kaniko whether to enable kaniko for building docker images
 	Kaniko bool `json:"kaniko,omitempty"`
 	// Ingress contains ingress specific requirements
@@ -648,7 +649,7 @@ func (c *RequirementsConfig) SaveConfig(fileName string) error {
 		return errors.Wrapf(err, "failed to save file %s", fileName)
 	}
 
-	if features.IsHelmfile() {
+	if c.Helmfile {
 		y := RequirementsValues{
 			RequirementsConfig: c,
 		}

--- a/pkg/config/install_requirements_test.go
+++ b/pkg/config/install_requirements_test.go
@@ -102,6 +102,7 @@ func TestRequirementsConfigMarshalExistingFileKanikoFalse(t *testing.T) {
 
 	err = requirements.SaveConfig(file)
 	assert.NoError(t, err, "failed to save file %s", file)
+	t.Logf("saved file %s", file)
 
 	requirements, fileName, err := config.LoadRequirementsConfig(dir)
 	assert.NoError(t, err, "failed to load requirements file in dir %s", dir)
@@ -353,7 +354,7 @@ func TestHelmfileRequirementValues(t *testing.T) {
 	valuesFileExists, err := util.FileExists(valuesFile)
 	assert.False(t, valuesFileExists, "file %s should not exist", valuesFile)
 
-	os.Setenv("JX_HELMFILE", "true")
+	requirements.Helmfile = true
 	err = requirements.SaveConfig(file)
 	assert.NoError(t, err, "failed to save file %s", file)
 	assert.FileExists(t, file)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -2,7 +2,6 @@ package features
 
 import (
 	"errors"
-	"os"
 	"strings"
 
 	"reflect"
@@ -149,9 +148,4 @@ func IsEnabled(cmd *cobra.Command) error {
 		}
 	}
 	return nil
-}
-
-// IsHelmfile returns true if the helmfile feature flag env var is set
-func IsHelmfile() bool {
-	return os.Getenv("JX_HELMFILE") == "true"
 }


### PR DESCRIPTION
lets switch from using an environment variable to enable the experimental helmfile mode to using an optional boolean on the requirements file as its hard to enforce environment variables being consistently set across pipelines/shells/CLI invocations/steps.

The new flag is only marshalled to YAML if its set to true so has no backwards compatibility issues. Its also clearly marked as experimental in the generated reference docs

See: #6442

Signed-off-by: James Strachan <james.strachan@gmail.com>