### PR TITLE
fix: allow `jx boot --no-update-git` to not mess with git

### DIFF
--- a/pkg/boot/constants.go
+++ b/pkg/boot/constants.go
@@ -14,4 +14,8 @@ const (
 	VersionsRepoURLEnvVarName = "VERSIONS_REPO_URL"
 	// VersionsRepoBaseRefEnvVarName is the env var name used in the pipeline to reference the ref of versions repo
 	VersionsRepoBaseRefEnvVarName = "VERSIONS_BASE_REF"
+	// DisablePushUpdatesToDevEnvironment is the env var name used to disable pushing changes to the local git clone
+	// of the dev environment to the master branch of the git repository in the `jx step verify env` command
+	// e.g. to test out local changes to git in a local fork of the boot config with `jx boot --no-update-git`
+	DisablePushUpdatesToDevEnvironment = "JX_NO_DEV_GIT_UPDATES"
 )

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -339,7 +339,7 @@ func (o *StepVerifyEnvironmentsOptions) createEnvironmentRepository(name string,
 	}
 
 	if name == kube.LabelValueDevEnvironment || environment.Spec.Kind == v1.EnvironmentKindTypeDevelopment {
-		if o.IsJXBoot() && requirements.GitOps {
+		if o.IsJXBoot() && requirements.GitOps && os.Getenv(boot.DisablePushUpdatesToDevEnvironment) != "true" {
 			provider, err := envGitInfo.CreateProviderForUser(server, userAuth, gitKind, gitter)
 			if err != nil {
 				return errors.Wrap(err, "unable to create git provider")

--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -96,6 +96,11 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 		return err
 	}
 
+	err = o.ConfigureCommonOptions(requirements)
+	if err != nil {
+		return err
+	}
+
 	requirements, err = o.gatherRequirements(requirements, requirementsFileName)
 	if err != nil {
 		return err


### PR DESCRIPTION
when testing out a possible PR on the git boot repository referenced in the `jx-requirements.yml` even using `--no-update-git` I was finding that boot would:

* lookup my local fork of the git repository and since its not in the version stream assume 'master' was the branch I wanted (despite being in a fork/branch already
* re-apply all changes from master to my local checkout causing merge hell
* then `jx step verify env` tries to push to master the local changes merged with upstream causing merge conflicts etc.

This PR fixes this by disabling the bit of `jx boot` which switches from the current gitRef -> `master` if the `--no-update-git` is provided. That flag also passes in an env var so that `jx step verify env` doesn't try to push local changes to master of the dev repo (which is only really intended for real installs from the real upstream git repo - not from local forks trying changes out in boot config).

There's an additional minor change for helmfile to disable lazily creating the dev Environment if helmfile is used; which breaks helmfile/helm 3 which wants to create/update that resource via helm

Signed-off-by: James Strachan <james.strachan@gmail.com>