### PR TITLE
chore: add a flag to enable the goproxy when running in cluster

### DIFF
--- a/pkg/cmd/step/verify/step_verify_behavior.go
+++ b/pkg/cmd/step/verify/step_verify_behavior.go
@@ -36,6 +36,7 @@ type BehaviorOptions struct {
 	NoImport          bool
 	CredentialsSecret string
 	GitOrganisation   string
+	UseGoProxy        bool
 }
 
 var (
@@ -74,6 +75,7 @@ func NewCmdStepVerifyBehavior(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.NoImport, "no-import", "", false, "Create the pipeline directly, don't import the repository")
 	cmd.Flags().StringVarP(&options.CredentialsSecret, "credentials-secret", "", "", "The name of the secret to generate the bdd credentials from, if not specified, the default git auth will be used")
 	cmd.Flags().StringVarP(&options.GitOrganisation, "git-organisation", "", "", "Override the git org for the tests rather than reading from teamSettings")
+	cmd.Flags().BoolVarP(&options.UseGoProxy, "use-go-proxy", "", false, "Enable the GoProxy for the bdd tests")
 
 	return cmd
 }
@@ -240,6 +242,10 @@ func (o *BehaviorOptions) runPipelineDirectly(owner string, repo string, sourceU
 
 	if o.GitOrganisation != "" {
 		envVars["GIT_ORGANISATION"] = o.GitOrganisation
+	}
+
+	if o.UseGoProxy {
+		envVars["GOPROXY"] = "https://proxy.golang.org"
 	}
 
 	pipelineCreateParam := metapipeline.PipelineCreateParam{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->