### PR TITLE
fix: Get structure for rerun PipelineRun properly

### DIFF
--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -291,7 +291,8 @@ func (o *ControllerBuildOptions) onPipelinePod(obj interface{}, kubeClient kuber
 					log.Logger().Warnf("Error getting PodList for PipelineRun %s: %s", prName, err)
 					return
 				}
-				structure, err := jxClient.JenkinsV1().PipelineStructures(ns).Get(prName, metav1.GetOptions{})
+
+				structure, err := tekton.StructureForPipelineRun(jxClient, ns, pr)
 				if err != nil {
 					log.Logger().Warnf("Error getting PipelineStructure for PipelineRun %s: %s", prName, err)
 					return

--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -251,7 +251,7 @@ func (t TektonLogger) GetRunningBuildLogs(pa *v1.PipelineActivity, buildName str
 
 		// Assuming we have a run to log, go get its logs, looping until we've seen all stages for that run.
 		if runToLog != nil {
-			structure, err := t.JXClient.JenkinsV1().PipelineStructures(pa.Namespace).Get(runToLog.Name, metav1.GetOptions{})
+			structure, err := tekton.StructureForPipelineRun(t.JXClient, pa.Namespace, runToLog)
 			if err != nil {
 				return errors.Wrapf(err, "failed to get pipeline structure for %s in namespace %s", runToLog.Name, pa.Namespace)
 			}

--- a/pkg/tekton/pipelines_test.go
+++ b/pkg/tekton/pipelines_test.go
@@ -4,9 +4,12 @@ package tekton_test
 
 import (
 	"path"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	jxfake "github.com/jenkins-x/jx/pkg/client/clientset/versioned/fake"
 	"github.com/jenkins-x/jx/pkg/cmd/clients/fake"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
@@ -16,6 +19,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/tekton/syntax"
 	"github.com/jenkins-x/jx/pkg/tekton/tekton_helpers_test"
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -215,4 +219,79 @@ func TestGenerateNextBuildNumber(t *testing.T) {
 			assert.Equal(t, tt.expectedBuildNumber, nextBuildNumber)
 		})
 	}
+}
+
+func TestStructureForPipelineRun(t *testing.T) {
+	pipelineName := "some-pipeline-1"
+	unrelatedSuffix := "-not-related"
+
+	existingStructure := &v1.PipelineStructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipelineName,
+			Namespace: ns,
+		},
+	}
+
+	originalRun := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipelineName,
+			Namespace: ns,
+			Labels: map[string]string{
+				pipeline.GroupName + pipeline.PipelineLabelKey: pipelineName,
+			},
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
+				Name: pipelineName,
+			},
+		},
+	}
+
+	secondRun := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipelineName + "-a1b2c",
+			Namespace: ns,
+			Labels: map[string]string{
+				pipeline.GroupName + pipeline.PipelineLabelKey: pipelineName,
+			},
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
+				Name: pipelineName,
+			},
+		},
+	}
+
+	unrelatedRun := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipelineName + unrelatedSuffix,
+			Namespace: ns,
+			Labels: map[string]string{
+				pipeline.GroupName + pipeline.PipelineLabelKey: pipelineName + unrelatedSuffix,
+			},
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
+				Name: pipelineName + unrelatedSuffix,
+			},
+		},
+	}
+
+	jxClient := jxfake.NewSimpleClientset(existingStructure)
+
+	forOriginal, err := tekton.StructureForPipelineRun(jxClient, ns, originalRun)
+	assert.NoError(t, err)
+	if d := cmp.Diff(existingStructure, forOriginal); d != "" {
+		t.Errorf("Generated PipelineStructure for original PipelineRun did not match expected: %s", d)
+	}
+
+	forSecondRun, err := tekton.StructureForPipelineRun(jxClient, ns, secondRun)
+	assert.NoError(t, err)
+	if d := cmp.Diff(existingStructure, forSecondRun); d != "" {
+		t.Errorf("Generated PipelineStructure for second run PipelineRun did not match expected: %s", d)
+	}
+
+	_, err = tekton.StructureForPipelineRun(jxClient, ns, unrelatedRun)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "pipelinestructures.jenkins.io \""+pipelineName+unrelatedSuffix+"\" not found"))
 }


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

If Lighthouse has rerun a `PipelineRun` due to our buddy the Tekton race condition, the new `PipelineRun` has a different name than the original. This means that there's no `PipelineStructure` with the same name, so logging and the build controller don't know what to do with it. So when we're looking up `PipelineStructure`s for a `PipelineRun`, first try to look by the `PipelineRun` name, and then by the `Pipeline` name associated with the `PipelineRun`. The `Pipeline` name will always be the same for the rerun `PipelineRun` as it was for the original, so this will work.

#### Special notes for the reviewer(s)

/assign @hferentschik 

#### Which issue this PR fixes

fixes #6646 
