### PR TITLE
fix: Check if the requirements config was read from the existing file

### DIFF
--- a/pkg/cmd/edit/requirements/requirements_test.go
+++ b/pkg/cmd/edit/requirements/requirements_test.go
@@ -9,13 +9,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/jenkins-x/jx/pkg/cmd/clients/fake"
 	"github.com/jenkins-x/jx/pkg/cmd/edit/requirements"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/util"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCmdEditRequirements(t *testing.T) {
@@ -63,16 +64,19 @@ func TestCmdEditRequirements(t *testing.T) {
 				assert.Equal(t, "gs://foo", req.Storage.Logs.URL, "req.Storage.Logs.URL")
 				assert.True(t, req.Storage.Logs.Enabled, "req.Storage.Logs.Enabled")
 			},
+			initialFile: gitOpsEnabled,
 		},
 		{
-			name: "bad-git-kind",
-			args: []string{"--git-kind=gitlob"},
-			fail: true,
+			name:        "bad-git-kind",
+			args:        []string{"--git-kind=gitlob"},
+			fail:        true,
+			initialFile: gitOpsEnabled,
 		},
 		{
-			name: "bad-secret",
-			args: []string{"--secret=vaulx"},
-			fail: true,
+			name:        "bad-secret",
+			args:        []string{"--secret=vaulx"},
+			fail:        true,
+			initialFile: gitOpsEnabled,
 		},
 	}
 

--- a/pkg/cmd/opts/common.go
+++ b/pkg/cmd/opts/common.go
@@ -8,43 +8,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jenkins-x/jx/pkg/config"
-
-	"github.com/jenkins-x/jx/pkg/kube/cluster"
-
-	gojenkins "github.com/jenkins-x/golang-jenkins"
-	"github.com/jenkins-x/jx/pkg/cloud/gke"
-	"github.com/jenkins-x/jx/pkg/prow"
-	"github.com/jenkins-x/jx/pkg/versionstream"
-	"github.com/spf13/viper"
-
-	"github.com/jenkins-x/jx/pkg/secreturl"
-	"github.com/spf13/pflag"
-
-	"github.com/heptio/sonobuoy/pkg/client"
-	"github.com/jenkins-x/jx/pkg/cmd/clients"
-	"github.com/jenkins-x/jx/pkg/io/secrets"
-	"github.com/jenkins-x/jx/pkg/vault"
-
-	"github.com/jenkins-x/jx/pkg/kube/resources"
-	"github.com/jenkins-x/jx/pkg/kube/services"
-	"github.com/pkg/errors"
-
 	vaultoperatorclient "github.com/banzaicloud/bank-vaults/operator/pkg/client/clientset/versioned"
-	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
-	"github.com/jenkins-x/jx/pkg/auth"
-	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
-	"github.com/jenkins-x/jx/pkg/gits"
-	"github.com/jenkins-x/jx/pkg/helm"
-	"github.com/jenkins-x/jx/pkg/kube"
-	"github.com/jenkins-x/jx/pkg/kustomize"
-	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/jenkins-x/jx/pkg/table"
-	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/heptio/sonobuoy/pkg/client"
 	certmngclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	istioclient "github.com/knative/pkg/client/clientset/versioned"
 	kserve "github.com/knative/serving/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"gopkg.in/AlecAivazis/survey.v1"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
@@ -52,6 +24,29 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	prowjobclient "k8s.io/test-infra/prow/client/clientset/versioned"
+
+	gojenkins "github.com/jenkins-x/golang-jenkins"
+	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/auth"
+	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
+	"github.com/jenkins-x/jx/pkg/cloud/gke"
+	"github.com/jenkins-x/jx/pkg/cmd/clients"
+	"github.com/jenkins-x/jx/pkg/config"
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/helm"
+	"github.com/jenkins-x/jx/pkg/io/secrets"
+	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/cluster"
+	"github.com/jenkins-x/jx/pkg/kube/resources"
+	"github.com/jenkins-x/jx/pkg/kube/services"
+	"github.com/jenkins-x/jx/pkg/kustomize"
+	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/prow"
+	"github.com/jenkins-x/jx/pkg/secreturl"
+	"github.com/jenkins-x/jx/pkg/table"
+	"github.com/jenkins-x/jx/pkg/util"
+	"github.com/jenkins-x/jx/pkg/vault"
+	"github.com/jenkins-x/jx/pkg/versionstream"
 )
 
 // LogLevel represents the logging level when reporting feedback
@@ -554,7 +549,10 @@ func (o *CommonOptions) Helm() helm.Helmer {
 
 			// check helmfile featureflag but default to existing behaviour if there's any issues
 			var helmer helm.Helmer
-			r, _, _ := config.LoadRequirementsConfig("")
+			r, _, err := config.LoadRequirementsConfig("")
+			if err != nil {
+				r = config.NewRequirementsConfig()
+			}
 			if r.Helmfile {
 				helmer = o.NewHelm(false, "helm", true, false)
 			} else {

--- a/pkg/cmd/step/expose/step_expose.go
+++ b/pkg/cmd/step/expose/step_expose.go
@@ -9,6 +9,15 @@ import (
 	"text/template"
 
 	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/helm/pkg/chartutil"
+
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
@@ -18,14 +27,6 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/helm/pkg/chartutil"
 )
 
 var (
@@ -107,6 +108,10 @@ func (o *StepExposeOptions) Run() error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to load requirements YAML")
 	}
+	if requirements == nil {
+		return errors.Errorf("unable to find requirements file in '%s'", o.Dir)
+	}
+
 	if requirements.Cluster.Namespace == "" {
 		requirements.Cluster.Namespace = ns
 	}

--- a/pkg/cmd/step/expose/test_data/http/jx-requirements.yml
+++ b/pkg/cmd/step/expose/test_data/http/jx-requirements.yml
@@ -1,0 +1,6 @@
+cluster:
+  namespace: jx-staging
+webhook: prow
+secretStorage: local
+ingress:
+  namespaceSubDomain: ""

--- a/pkg/cmd/step/expose/test_data/https/jx-requirements.yml
+++ b/pkg/cmd/step/expose/test_data/https/jx-requirements.yml
@@ -1,0 +1,6 @@
+cluster:
+  namespace: jx-staging
+webhook: prow
+secretStorage: local
+ingress:
+  namespaceSubDomain: ""

--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -7,12 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
-	"github.com/jenkins-x/jx/pkg/platform"
-
 	"github.com/google/uuid"
+	"github.com/mholt/archiver"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/gits"
@@ -22,12 +24,10 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/platform"
 	"github.com/jenkins-x/jx/pkg/secreturl/fakevault"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/jenkins-x/jx/pkg/vault"
-	"github.com/mholt/archiver"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 )
 
 // StepHelmApplyOptions contains the command line flags
@@ -393,10 +393,6 @@ func (o *StepHelmApplyOptions) getRequirements() (*config.RequirementsConfig, st
 	// Try to load first the requirements from current directory
 	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir)
 
-	_, err = os.Stat(requirementsFileName)
-	if os.IsNotExist(err) {
-		_, err = os.Stat(filepath.Join(o.Dir, requirementsFileName))
-	}
 	if err == nil {
 		return requirements, requirementsFileName, nil
 	}

--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -248,7 +248,7 @@ func (o *StepHelmApplyOptions) Run() error {
 	}
 
 	requirements, requirementsFileName, err := o.getRequirements()
-	if err != nil {
+	if err != nil || requirements == nil {
 		return errors.Wrap(err, "loading the requirements")
 	}
 
@@ -392,6 +392,11 @@ func (o *StepHelmApplyOptions) Run() error {
 func (o *StepHelmApplyOptions) getRequirements() (*config.RequirementsConfig, string, error) {
 	// Try to load first the requirements from current directory
 	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir)
+
+	_, err = os.Stat(requirementsFileName)
+	if os.IsNotExist(err) {
+		_, err = os.Stat(filepath.Join(o.Dir, requirementsFileName))
+	}
 	if err == nil {
 		return requirements, requirementsFileName, nil
 	}
@@ -400,11 +405,11 @@ func (o *StepHelmApplyOptions) getRequirements() (*config.RequirementsConfig, st
 	if err != nil {
 		return nil, "", errors.Wrap(err, "getting the jx client")
 	}
-	teamSetttings, err := kube.GetDevEnvTeamSettings(jxClient, ns)
+	teamSettings, err := kube.GetDevEnvTeamSettings(jxClient, ns)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "getting the team setting from the cluster")
 	}
-	requirements, err = config.GetRequirementsConfigFromTeamSettings(teamSetttings)
+	requirements, err = config.GetRequirementsConfigFromTeamSettings(teamSettings)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "getting the requirements from team settings")
 	}

--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -173,6 +173,7 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 	po := &StepVerifyPackagesOptions{}
 	po.CommonOptions = o.CommonOptions
 	po.Packages = []string{"kubectl", "git", "helm"}
+	po.Dir = o.Dir
 	if !o.DisableVerifyPackages {
 		err = po.Run()
 		if err != nil {

--- a/pkg/cmd/step/verify/test_data/verify_ingress/jx-requirements.yml
+++ b/pkg/cmd/step/verify/test_data/verify_ingress/jx-requirements.yml
@@ -1,0 +1,2 @@
+webhook: prow
+secretStorage: local

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -10,16 +10,15 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/vrischmann/envconfig"
-
 	"github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
+	"github.com/pkg/errors"
+	"github.com/vrischmann/envconfig"
+
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/cloud"
 	"github.com/jenkins-x/jx/pkg/cloud/gke"
 	"github.com/jenkins-x/jx/pkg/log"
-	"github.com/pkg/errors"
-
 	"github.com/jenkins-x/jx/pkg/util"
 )
 
@@ -516,90 +515,50 @@ func LoadRequirementsConfig(dir string) (*RequirementsConfig, string, error) {
 	if dir != "" {
 		fileName = filepath.Join(dir, fileName)
 	}
-	originalFileName := fileName
-	exists, err := util.FileExists(fileName)
-	if err != nil || !exists {
-		path, err := filepath.Abs(fileName)
-		if err != nil {
-			config, _ := LoadRequirementsConfigFile(fileName)
-			return config, fileName, err
-		}
-		subDir := GetParentDir(path)
 
-		// lets walk up the directory tree to see if we can find a requirements file in a parent dir
-		// if by the end we have not found a requirements file lets use the original filename
-		for {
-			subDir = GetParentDir(subDir)
-			if subDir == "" || subDir == "/" {
-				break
-			}
-			fileName = filepath.Join(subDir, RequirementsConfigFileName)
-			exists, _ := util.FileExists(fileName)
-			if exists {
-				config, err := LoadRequirementsConfigFile(fileName)
-				return config, fileName, err
-			}
+	absolute, err := filepath.Abs(fileName)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "creating absolute path")
+	}
+	sub := filepath.Dir(absolute)
+	for sub != "" && sub != "." && sub != "/" {
+		fileName = filepath.Join(sub, RequirementsConfigFileName)
+		config, err := LoadRequirementsConfigFile(fileName)
+		if err == nil {
+			return config, fileName, nil
 		}
-		// set back to the original filename
-		fileName = originalFileName
+		sub = filepath.Dir(sub)
 	}
-	config, err := LoadRequirementsConfigFile(fileName)
-	return config, fileName, err
-}
-
-// LoadActiveInstallProfile loads the active install profile
-func LoadActiveInstallProfile() string {
-	jxHome, err := util.ConfigDir()
-	if err == nil {
-		profileSettingsFile := filepath.Join(jxHome, DefaultProfileFile)
-		exists, err := util.FileExists(profileSettingsFile)
-		if err == nil && exists {
-			jxProfle := JxInstallProfile{}
-			data, err := ioutil.ReadFile(profileSettingsFile)
-			err = yaml.Unmarshal(data, &jxProfle)
-			if err == nil {
-				return jxProfle.InstallType
-			}
-		}
-	}
-	return OpenSourceProfile
-}
-
-// GetParentDir returns the parent directory without a trailing separator
-func GetParentDir(path string) string {
-	subDir, _ := filepath.Split(path)
-	if subDir == "" {
-		return ""
-	}
-	i := len(subDir) - 1
-	if os.IsPathSeparator(subDir[i]) {
-		subDir = subDir[0:i]
-	}
-	return subDir
+	return nil, "", errors.New("jx-requirements.yml file not found")
 }
 
 // LoadRequirementsConfigFile loads a specific project YAML configuration file
 func LoadRequirementsConfigFile(fileName string) (*RequirementsConfig, error) {
-	config := NewRequirementsConfig()
-	exists, err := util.FileExists(fileName)
-	if err != nil || !exists {
-		return config, err
+	config := &RequirementsConfig{}
+	_, err := os.Stat(fileName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "checking if file %s exists", fileName)
 	}
+
 	data, err := ioutil.ReadFile(fileName)
 	if err != nil {
-		return config, fmt.Errorf("Failed to load file %s due to %s", fileName, err)
+		return nil, fmt.Errorf("failed to load file %s due to %s", fileName, err)
 	}
+
 	validationErrors, err := util.ValidateYaml(config, data)
 	if err != nil {
-		return config, fmt.Errorf("failed to validate YAML file %s due to %s", fileName, err)
+		return nil, fmt.Errorf("failed to validate YAML file %s due to %s", fileName, err)
 	}
+
 	if len(validationErrors) > 0 {
-		return config, fmt.Errorf("Validation failures in YAML file %s:\n%s", fileName, strings.Join(validationErrors, "\n"))
+		return nil, fmt.Errorf("validation failures in YAML file %s:\n%s", fileName, strings.Join(validationErrors, "\n"))
 	}
+
 	err = yaml.Unmarshal(data, config)
 	if err != nil {
-		return config, fmt.Errorf("Failed to unmarshal YAML file %s due to %s", fileName, err)
+		return nil, fmt.Errorf("failed to unmarshal YAML file %s due to %s", fileName, err)
 	}
+
 	config.addDefaults()
 	config.handleDeprecation()
 	return config, nil

--- a/pkg/config/install_requirements_test.go
+++ b/pkg/config/install_requirements_test.go
@@ -120,15 +120,9 @@ func TestRequirementsConfigMarshalInEmptyDir(t *testing.T) {
 	dir, err := ioutil.TempDir("", "test-requirements-config-empty-")
 
 	requirements, fileName, err := config.LoadRequirementsConfig(dir)
-	assert.NoError(t, err, "failed to load requirements file in dir %s", dir)
-
-	exists, err := util.FileExists(fileName)
-	assert.NoError(t, err, "failed to check file exists %s", fileName)
-	assert.False(t, exists, "file should not exist %s", fileName)
-
-	assert.Equal(t, config.WebhookTypeProw, requirements.Webhook, "requirements.WebhookTypeProw")
-	assert.Equal(t, false, requirements.Kaniko, "requirements.Kaniko")
-	assert.Equal(t, config.SecretStorageTypeLocal, requirements.SecretStorage, "requirements.SecretStorage")
+	assert.Error(t, err)
+	assert.Empty(t, fileName)
+	assert.Nil(t, requirements)
 }
 
 func TestRequirementsConfigIngressAutoDNS(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description

The [LoadRequirementsConfig ](https://github.com/jenkins-x/jx/blob/6f606365f4ce912207b1b822f8426e7e037e9f6c/pkg/config/install_requirements.go#L514) API does not return an error when the `jx-requirements.yaml` file does not exist. Instead, it returns a [default RequirementsConfig struct](https://github.com/jenkins-x/jx/blob/master/pkg/config/install_requirements.go#L503-L509) and not valid file path. This PR tries to fix the issue so that [getRequirements](https://github.com/jenkins-x/jx/blob/6f606365f4ce912207b1b822f8426e7e037e9f6c/pkg/cmd/step/helm/step_helm_apply.go#L388-L409) loads team dev environement requirements, when `jx-requirements.yaml` file does not exist.

#### Special notes for the reviewer(s)



#### Which issue this PR fixes

fixes #6653

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
