### PR TITLE
fix(git): parsing of Bitbucket Server URLs

### DIFF
--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -200,6 +200,12 @@ func parsePath(path string, info *GitRepository, requireRepo bool) (*GitReposito
 	// This is necessary for Bitbucket Server in some cases.
 	trimPath := strings.TrimPrefix(path, "/scm")
 
+	// This is necessary for Bitbucket Server, EG: /projects/ORG/repos/NAME/pull-requests/1/overview
+	reOverview := regexp.MustCompile("/pull-requests/[0-9]+/overview$")
+	if reOverview.MatchString(trimPath) {
+		trimPath = strings.TrimSuffix(trimPath, "/overview")
+	}
+
 	// This is necessary for Bitbucket Server in other cases
 	trimPath = strings.Replace(trimPath, "/projects/", "/", 1)
 	trimPath = strings.Replace(trimPath, "/repos/", "/", 1)

--- a/pkg/gits/git_url_test.go
+++ b/pkg/gits/git_url_test.go
@@ -110,10 +110,16 @@ func TestParseGitURL(t *testing.T) {
 			"git@github.com:bar/foo", "github.com", "bar", "foo",
 		},
 		{
+			"git@github.com:bar/overview", "github.com", "bar", "overview",
+		},
+		{
 			"git@gitlab.com:bar/subgroup/foo", "gitlab.com", "bar", "foo",
 		},
 		{
 			"https://gitlab.com/bar/subgroup/foo", "gitlab.com", "bar", "foo",
+		},
+		{
+			"https://gitlab.com/bar/subgroup/overview", "gitlab.com", "bar", "overview",
 		},
 		{
 			"bar/foo", "github.com", "bar", "foo",
@@ -123,6 +129,9 @@ func TestParseGitURL(t *testing.T) {
 		},
 		{
 			"https://bitbucketserver.com/projects/myproject/repos/foo/pull-requests/1", "bitbucketserver.com", "myproject", "foo",
+		},
+		{
+			"https://bitbucketserver.com/projects/myproject/repos/foo/pull-requests/1/overview", "bitbucketserver.com", "myproject", "foo",
 		},
 	}
 	for _, data := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

The source URL can sometimes look like this in Jenkins:

    /projects/ORG/repos/NAME/pull-requests/1/overview

The /overview causes the git URL parser to think that the project name is "overview" instead of "NAME".

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

Fixes #6419
