### PR TITLE
fix: Fetch k8s.io openapi dependencies as modules

### DIFF
--- a/cmd/codegen/app/generate_openapi.go
+++ b/cmd/codegen/app/generate_openapi.go
@@ -79,12 +79,12 @@ func NewCmdCreateClientOpenAPI(genOpts GenerateOptions) *cobra.Command {
 	}
 
 	openAPIDependencies := []string{
-		"k8s.io/apimachinery:pkg/apis:meta:v1",
-		"k8s.io/apimachinery:pkg/api:resource:",
-		"k8s.io/apimachinery:pkg/util:intstr:",
-		"k8s.io/api::batch:v1",
-		"k8s.io/api::core:v1",
-		"k8s.io/api::rbac:v1",
+		"k8s.io/apimachinery?modules:pkg/apis:meta:v1",
+		"k8s.io/apimachinery?modules:pkg/api:resource:",
+		"k8s.io/apimachinery?modules:pkg/util:intstr:",
+		"k8s.io/api?modules::batch:v1",
+		"k8s.io/api?modules::core:v1",
+		"k8s.io/api?modules::rbac:v1",
 	}
 
 	moduleName := strings.TrimPrefix(strings.TrimPrefix(wd, filepath.Join(build.Default.GOPATH, "src")), "/")


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

https://github.com/googleapis/gnostic/commit/896953e6749863beec38e27029c804e88c3144b8 broke at least `k8s.io/apimachinery`'s dependency on `github.com/googleapis/gnostic/OpenAPIv2`, so we need to fetch at least `k8s.io/apimachinery` as modules to get it to pick up the right version of `github.com/googleapis/gnostic`, and just to be safe, I did the same for `k8s.io/api` as well.

I am not...happy with this, but it seems to work and doesn't seem to have side effects that I can see.

#### Special notes for the reviewer(s)

/assign @pmuir 
/assign @ccojocar 

#### Which issue this PR fixes

fixes #6679