### PR TITLE
fix(cli): handle errors when doing a jx upgrade boot in non dev namespace

### DIFF
--- a/pkg/cmd/opts/git.go
+++ b/pkg/cmd/opts/git.go
@@ -350,6 +350,9 @@ func (o *CommonOptions) getAuthConfig() (*auth.AuthConfig, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create the git auth config service")
 	}
+	if authConfigSvc == nil {
+		return nil, errors.New("empty auth config")
+	}
 	authConfig := authConfigSvc.Config()
 	if authConfig == nil {
 		return nil, errors.New("empty Git config")

--- a/pkg/cmd/upgrade/upgrade_boot_test.go
+++ b/pkg/cmd/upgrade/upgrade_boot_test.go
@@ -14,10 +14,20 @@ import (
 	"github.com/jenkins-x/jx/pkg/log"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/jenkins-x/jx/pkg/versionstream"
+
+	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	clientfake "github.com/jenkins-x/jx/pkg/cmd/clients/fake"
+	helm_test "github.com/jenkins-x/jx/pkg/helm/mocks"
+	resources_test "github.com/jenkins-x/jx/pkg/kube/resources/mocks"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,12 +42,71 @@ type TestUpgradeBootOptions struct {
 	Dir string
 }
 
-func (o *TestUpgradeBootOptions) setup(bootRequirements string) {
+func (o *TestUpgradeBootOptions) setup(bootRequirements, previewEnvironmentName, sourceURL, namespace string) {
 	dir := bootRequirements
+	// Not setting it to "dev" will overwrite this preview environment with a new one
+	devEnv := kube.NewPreviewEnvironment(previewEnvironmentName)
+	devEnv.Spec.Source.URL = sourceURL
+	commonOpts := &opts.CommonOptions{}
+	commonOpts.SetDevNamespace(namespace)
+
+	factory := clientfake.NewFakeFactory()
+	user := jenkinsv1.User{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "jx",
+			Name:      "test-user",
+		},
+		Spec: jenkinsv1.UserDetails{
+			Name:     "Test",
+			Email:    "test@test.com",
+			Accounts: make([]jenkinsv1.AccountReference, 0),
+		},
+	}
+
+	testhelpers.ConfigureTestOptionsWithResources(commonOpts,
+		[]runtime.Object{},
+		[]runtime.Object{&user, devEnv},
+		&gits.GitFake{CurrentBranch: "job"},
+		&gits.FakeProvider{},
+		helm_test.NewMockHelmer(),
+		resources_test.NewMockInstaller(),
+	)
+
+	commonOpts.SetFactory(factory)
 
 	o.UpgradeBootOptions = UpgradeBootOptions{
-		CommonOptions: &opts.CommonOptions{},
+		CommonOptions: commonOpts,
 		Dir:           dir,
+	}
+}
+
+var clonetests = []struct {
+	desc     string
+	pEnvName string
+	sURL     string
+	ns       string
+	success  bool
+}{
+	{"Test should pass - success", "dev", "https://gitlab.com/ankitm123/environment-mikros-cluster-dev.git", "jx", true},
+	{"non-dev preview environment - fail", "testing", "https://gitlab.com/ankitm123/environment-mikros-cluster-dev.git", "jx", false},
+	{"non-dev ns - fail", "dev", "https://gitlab.com/ankitm123/environment-mikros-cluster-dev.git", "no-jx", false},
+	{"missing application url - fail", "dev", "", "jx", false},
+}
+
+func TestCloneDevEnvironment(t *testing.T) {
+	t.Parallel()
+	for _, tt := range clonetests {
+		t.Run(tt.desc, func(t *testing.T) {
+			o := TestUpgradeBootOptions{}
+			o.setup(defaultBootRequirements, tt.pEnvName, tt.sURL, tt.ns)
+			err := o.cloneDevEnv()
+			if tt.success {
+				require.NoError(t, err, "cloned dev")
+			} else {
+				require.Error(t, err, "could not clone dev")
+			}
+
+		})
 	}
 }
 
@@ -45,7 +114,7 @@ func TestDetermineBootConfigURL(t *testing.T) {
 	t.Parallel()
 
 	o := TestUpgradeBootOptions{}
-	o.setup(defaultBootRequirements)
+	o.setup(defaultBootRequirements, "", "", "")
 
 	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir)
 	require.NoError(t, err, "could not get requirements file")
@@ -60,7 +129,7 @@ func TestRequirementsVersionStream(t *testing.T) {
 	t.Parallel()
 
 	o := TestUpgradeBootOptions{}
-	o.setup(defaultBootRequirements)
+	o.setup(defaultBootRequirements, "", "", "")
 
 	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir)
 	require.NoError(t, err, "could not get requirements file")
@@ -74,7 +143,7 @@ func TestUpdateVersionStreamRef(t *testing.T) {
 	t.Parallel()
 
 	o := TestUpgradeBootOptions{}
-	o.setup(defaultBootRequirements)
+	o.setup(defaultBootRequirements, "", "", "")
 
 	tmpDir := o.createTmpRequirements(t)
 	defer func() {
@@ -97,7 +166,7 @@ func TestUpdatePipelineBuilderImage(t *testing.T) {
 	t.Parallel()
 
 	o := TestUpgradeBootOptions{}
-	o.setup(defaultBootRequirements)
+	o.setup(defaultBootRequirements, "", "", "")
 
 	tmpDir, err := ioutil.TempDir("", "")
 	defer func() {
@@ -126,7 +195,7 @@ func TestUpdateTemplateBuilderImage(t *testing.T) {
 	t.Parallel()
 
 	o := TestUpgradeBootOptions{}
-	o.setup(defaultBootRequirements)
+	o.setup(defaultBootRequirements, "", "", "")
 
 	tmpDir, err := ioutil.TempDir("", "")
 	defer func() {
@@ -170,7 +239,7 @@ func TestDetermineBootConfigURLAlternative(t *testing.T) {
 	t.Parallel()
 
 	o := TestUpgradeBootOptions{}
-	o.setup(alternativeBootRequirements)
+	o.setup(alternativeBootRequirements, "", "", "")
 
 	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir)
 	require.NoError(t, err, "could not get requirements file")
@@ -185,7 +254,7 @@ func TestRequirementsVersionStreamAlternative(t *testing.T) {
 	t.Parallel()
 
 	o := TestUpgradeBootOptions{}
-	o.setup(alternativeBootRequirements)
+	o.setup(alternativeBootRequirements, "", "", "")
 
 	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir)
 	require.NoError(t, err, "could not get requirements file")
@@ -199,7 +268,7 @@ func TestUpdateVersionStreamRefAlternative(t *testing.T) {
 	t.Parallel()
 
 	o := TestUpgradeBootOptions{}
-	o.setup(alternativeBootRequirements)
+	o.setup(alternativeBootRequirements, "", "", "")
 
 	tmpDir := o.createTmpRequirements(t)
 	defer func() {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
`jx upgrade boot` in non-dev namespace results in a panic, this is due to the lack of error handling in the upgrade boot functionality. This PR adds the necessary checks, and some tests to validate it.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6529 