### PR TITLE
feat: `helm lint` calls pass variables too

### DIFF
--- a/pkg/cmd/opts/helm_test.go
+++ b/pkg/cmd/opts/helm_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 )
 
-// Test_HelmInitRecursiveDependencyBuild_extraction test that chart achives
+// Test_HelmInitRecursiveDependencyBuild_extraction tests that chart achives
 // are properly extracted
 func Test_HelmInitRecursiveDependencyBuild_extraction(t *testing.T) {
 	o := NewCommonOptionsWithFactory(clients.NewFactory())
@@ -63,4 +63,21 @@ func Test_HelmInitRecursiveDependencyBuild_extraction(t *testing.T) {
 		return nil
 	}))
 	require.Equal(t, expected, found, "wrong files extracted")
+}
+
+// Test_HelmInitDependencyBuild_lint tests that the lint phase
+// passes the required variables
+func Test_HelmInitDependencyBuild_lint(t *testing.T) {
+	o := NewCommonOptionsWithFactory(clients.NewFactory())
+
+	dir, err := ioutil.TempDir("", "lint_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	dirChart := filepath.Join(dir, "lint")
+	err = util.CopyDir("test_data/lint", dirChart, true)
+	require.NoError(t, err)
+
+	_, err = o.HelmInitDependencyBuild(dirChart, []string{}, []string{})
+	require.NoError(t, err, "calling HelmInitDependencyBuild")
 }

--- a/pkg/cmd/opts/test_data/lint/Chart.yaml
+++ b/pkg/cmd/opts/test_data/lint/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: lint
+version: v0.1.0

--- a/pkg/cmd/opts/test_data/lint/templates/test.yaml
+++ b/pkg/cmd/opts/test_data/lint/templates/test.yaml
@@ -1,0 +1,12 @@
+{{- /* Check that reading .Values.global.xxx won't fail */ -}}
+{{- if .Values.global.jxPreview -}}
+preview
+{{- else -}}
+no_preview
+{{- end -}}
+: true
+
+{{- /* Check that .Values.global.jxLint is true */ -}}
+{{- if not .Values.global.jxLint -}}
+{{- fail "global.jxLint expected" -}}
+{{- end -}}

--- a/pkg/helm/helm_cli.go
+++ b/pkg/helm/helm_cli.go
@@ -647,7 +647,11 @@ func (h *HelmCLI) StatusReleaseWithOutput(ns string, releaseName string, outputF
 
 // Lint lints the helm chart from the current working directory and returns the warnings in the output
 func (h *HelmCLI) Lint(valuesFiles []string) (string, error) {
-	args := []string{"lint"}
+	args := []string{"lint",
+		"--set", "tags.jx-lint=true",
+		"--set", "global.jxLint=true",
+		"--set-string", "global.jxTypeEnv=lint",
+	}
 	for _, valueFile := range valuesFiles {
 		if valueFile != "" {
 			args = append(args, "--values", valueFile)

--- a/pkg/helm/helm_cli_test.go
+++ b/pkg/helm/helm_cli_test.go
@@ -308,7 +308,11 @@ func TestStatusReleasesForHelm3(t *testing.T) {
 }
 
 func TestLint(t *testing.T) {
-	expectedArgs := []string{"lint"}
+	expectedArgs := []string{"lint",
+		"--set", "tags.jx-lint=true",
+		"--set", "global.jxLint=true",
+		"--set-string", "global.jxTypeEnv=lint",
+	}
 	expectedOutput := "test"
 	helm, runner := createHelm(t, nil, expectedOutput)
 


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Complementary to #6427 and #6682 all calls to `helm lint` (including `jx step helm release`) also pass some variables
- `tags.jx-lint=true`
- `global.jxLint=true`
- `global.jxTypeEnv=lint`

This avoids having `helm lint` errors when the templates are looking for variables like `.Values.global.jxPreview` due to `global` being `nil`
