### PR TITLE
fix(prow): postsubmit jobs branches should be regexp

### DIFF
--- a/pkg/prow/prow_test.go
+++ b/pkg/prow/prow_test.go
@@ -492,6 +492,7 @@ func TestGetPostSubmitJob(t *testing.T) {
 
 	assert.NotEmpty(t, job.Name, "job name is empty")
 	assert.Equal(t, "release", job.Name)
+	assert.Contains(t, job.Branches, "^master$")
 }
 
 func getProwConfig(t *testing.T, o TestOptions) (*config.Config, error) {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

the `master` branch should be set as `^master$` in prow's postsubmit job, to avoid matching every branch with "master" in it.
this avoids triggering the release branch on non-master branches.

#### Special notes for the reviewer(s)

I haven't check if there is the same issue with lighthouse

#### Which issue this PR fixes

fixes #6710
