### PR TITLE
fix(cli): avoid creating dev environment in arbitrary namespace

### DIFF
--- a/pkg/cmd/get/get_build_logs.go
+++ b/pkg/cmd/get/get_build_logs.go
@@ -142,7 +142,10 @@ func (o *GetBuildLogsOptions) Run() error {
 		return err
 	}
 
-	devEnv, err := kube.GetEnrichedDevEnvironment(kubeClient, jxClient, ns)
+	devEnv, err := kube.GetDevEnvironment(jxClient, ns)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get dev environment in namespace %s", ns)
+	}
 	if devEnv == nil {
 		return fmt.Errorf("No development environment found for namespace %s", ns)
 	}


### PR DESCRIPTION
jx get build log invokes the GetEnrichedDevEnvironment function which creates a dev environment. Instead it to use GetDevEnvironment which does not have this sideeffect. Creating a dev environment in any namespace will lead to unexpected results (for instance creating dev env in certmanager/kubesystem ns), and seems unnecessary

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
This PR fixes the side-effect of creating a dev environment in any namespace when executing `jx get build log`

#### Which issue this PR fixes

fixes #6482 
