### PR TITLE
fix: UrlWithoutUser return correct URL when using ssh URL starting with git@

### DIFF
--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -77,6 +77,9 @@ func (i *GitRepository) HostURL() string {
 func (i *GitRepository) URLWithoutUser() string {
 	u := i.URL
 	if u != "" {
+		if strings.HasPrefix(u, gitPrefix) {
+			return u
+		}
 		u2, err := url.Parse(u)
 		if err == nil {
 			u2.User = nil


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Internal function UrlWithoutUser fails with urls that start with "@git"

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6767 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
