### PR TITLE
fix: fill organisation and other fields for bitbucketcloud

### DIFF
--- a/pkg/gits/bitbucket_cloud.go
+++ b/pkg/gits/bitbucket_cloud.go
@@ -113,12 +113,15 @@ func BitbucketRepositoryToGitRepository(bRepo bitbucket.Repository) *GitReposito
 		httpCloneURL = sshURL
 	}
 	return &GitRepository{
-		Name:     bRepo.Name,
-		HTMLURL:  bRepo.Links.Html.Href,
-		CloneURL: httpCloneURL,
-		SSHURL:   sshURL,
-		Language: bRepo.Language,
-		Fork:     isFork,
+		Name:         bRepo.Name,
+		HTMLURL:      bRepo.Links.Html.Href,
+		CloneURL:     httpCloneURL,
+		SSHURL:       sshURL,
+		Language:     bRepo.Language,
+		Fork:         isFork,
+		Organisation: bRepo.Owner.Username,
+		Project:      bRepo.Project.Name,
+		Private:      bRepo.IsPrivate,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
PRs used fail when using organisation since it wasn't populated from bitbucketCloud API answer

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6688

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
