### PR TITLE
fix: Use kube crd name to look up the docker registry image

### DIFF
--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -86,7 +86,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 		{
 			name:         "js_build_pack",
 			language:     "javascript",
-			repoName:     "js-test-repo",
+			repoName:     "js.test.repo",
 			organization: "abayer",
 			branch:       "build-pack",
 			kind:         "release",

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipeline.yml
@@ -7,7 +7,7 @@ metadata:
     build: "1"
     jenkins.io/pipelineType: build
     owner: abayer
-    repository: js-test-repo
+    repository: js.test.repo
   name: abayer-js-test-repo-build-pack-9l9zj-1
   namespace: jx
 spec:

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelineresources.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelineresources.yml
@@ -9,7 +9,7 @@ items:
     - name: revision
       value: v0.0.1
     - name: url
-      value: https://github.com/abayer/js-test-repo
+      value: https://github.com/abayer/js.test.repo
     type: git
   status: {}
 metadata: {}

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelinerun.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/pipelinerun.yml
@@ -7,7 +7,7 @@ metadata:
     build: "1"
     jenkins.io/pipelineType: build
     owner: abayer
-    repository: js-test-repo
+    repository: js.test.repo
   name: abayer-js-test-repo-build-pack-9l9zj-1
 spec:
   params:

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/structure.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/structure.yml
@@ -5,7 +5,7 @@ metadata:
     build: "1"
     jenkins.io/pipelineType: build
     owner: abayer
-    repository: js-test-repo
+    repository: js.test.repo
   name: abayer-js-test-repo-build-pack-9l9zj-1
 pipelineRef: null
 pipelineRunRef: null

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
@@ -9,7 +9,7 @@ items:
       jenkins.io/pipelineType: build
       jenkins.io/task-stage-name: from-build-pack
       owner: abayer
-      repository: js-test-repo
+      repository: js.test.repo
     name: abayer-js-test-repo-build-pack-9l9zj-from-build-pack-1
     namespace: jx
   spec:
@@ -59,11 +59,11 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: JOB_NAME
-        value: abayer/js-test-repo/build-pack
+        value: abayer/js.test.repo/build-pack
       - name: APP_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: BRANCH_NAME
         value: build-pack
       - name: JX_BATCH_MODE
@@ -123,11 +123,11 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: JOB_NAME
-        value: abayer/js-test-repo/build-pack
+        value: abayer/js.test.repo/build-pack
       - name: APP_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: BRANCH_NAME
         value: build-pack
       - name: JX_BATCH_MODE
@@ -187,11 +187,11 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: JOB_NAME
-        value: abayer/js-test-repo/build-pack
+        value: abayer/js.test.repo/build-pack
       - name: APP_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: BRANCH_NAME
         value: build-pack
       - name: JX_BATCH_MODE
@@ -251,11 +251,11 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: JOB_NAME
-        value: abayer/js-test-repo/build-pack
+        value: abayer/js.test.repo/build-pack
       - name: APP_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: BRANCH_NAME
         value: build-pack
       - name: JX_BATCH_MODE
@@ -317,11 +317,11 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: JOB_NAME
-        value: abayer/js-test-repo/build-pack
+        value: abayer/js.test.repo/build-pack
       - name: APP_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: BRANCH_NAME
         value: build-pack
       - name: JX_BATCH_MODE
@@ -383,11 +383,11 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: JOB_NAME
-        value: abayer/js-test-repo/build-pack
+        value: abayer/js.test.repo/build-pack
       - name: APP_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: BRANCH_NAME
         value: build-pack
       - name: JX_BATCH_MODE
@@ -416,7 +416,7 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - cd /workspace/source/charts/js-test-repo && jx step changelog --batch-mode
+      - cd /workspace/source/charts/js.test.repo && jx step changelog --batch-mode
         --version v${VERSION}
       command:
       - /bin/sh
@@ -448,11 +448,11 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: JOB_NAME
-        value: abayer/js-test-repo/build-pack
+        value: abayer/js.test.repo/build-pack
       - name: APP_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: BRANCH_NAME
         value: build-pack
       - name: JX_BATCH_MODE
@@ -481,7 +481,7 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - cd /workspace/source/charts/js-test-repo && jx step helm release
+      - cd /workspace/source/charts/js.test.repo && jx step helm release
       command:
       - /bin/sh
       - -c
@@ -512,11 +512,11 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: JOB_NAME
-        value: abayer/js-test-repo/build-pack
+        value: abayer/js.test.repo/build-pack
       - name: APP_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: BRANCH_NAME
         value: build-pack
       - name: JX_BATCH_MODE
@@ -545,7 +545,7 @@ items:
         readOnly: true
       workingDir: /workspace/source
     - args:
-      - cd /workspace/source/charts/js-test-repo && jx promote -b --all-auto --timeout
+      - cd /workspace/source/charts/js.test.repo && jx promote -b --all-auto --timeout
         1h --version ${VERSION}
       command:
       - /bin/sh
@@ -577,11 +577,11 @@ items:
       - name: REPO_OWNER
         value: abayer
       - name: REPO_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: JOB_NAME
-        value: abayer/js-test-repo/build-pack
+        value: abayer/js.test.repo/build-pack
       - name: APP_NAME
-        value: js-test-repo
+        value: js.test.repo
       - name: BRANCH_NAME
         value: build-pack
       - name: JX_BATCH_MODE

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/jenkins-x/jx/pkg/versionstream"
@@ -1211,7 +1212,7 @@ func (s *Step) modifyStep(params StepPlaceholderReplacementArgs) {
 			sourceDir := params.WorkspaceDir
 			dockerfile := filepath.Join(sourceDir, "Dockerfile")
 			localRepo := params.DockerRegistry
-			destination := params.DockerRegistry + "/" + params.DockerRegistryOrg + "/" + params.GitName
+			destination := params.DockerRegistry + "/" + params.DockerRegistryOrg + "/" + naming.ToValidName(params.GitName)
 
 			args := []string{"--cache=true", "--cache-dir=/workspace",
 				"--context=" + sourceDir,


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
Prior to this commit, we'd use the kubernetes compliant crd name to create the docker registry destination. But then later on in our code, we'd use the Git repository name to look up the docker registry image and it would fail in some cases. 

For example if the Git repo name contained `.`, the kubernetes compliant crd would replace all the dots with hyphens. So if we a customer had a repo called `example.company.repo` would be converted to `example-company-repo`. but then we'd use the wrong name to do the look up.

#### Which issue this PR fixes
fixes #5322 

