### PR TITLE
fix: LH reporting: fix target URL, specify UI URL, better running description

### DIFF
--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -42,6 +42,10 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube"
 )
 
+const (
+	defaultTargetURLTemplate = "{{ .BaseURL }}/teams/{{ .Namespace }}/projects/{{ .Owner }}/{{ .Repository }}/{{ .Branch }}/{{ .Build }}"
+)
+
 // ControllerBuildOptions are the flags for the commands
 type ControllerBuildOptions struct {
 	ControllerOptions
@@ -51,6 +55,7 @@ type ControllerBuildOptions struct {
 	GitReporting        bool
 	TargetURLTemplate   string
 	FailIfNoGitProvider bool
+	JobURLBase          string
 
 	EnvironmentCache *kube.EnvironmentNamespaceCache
 
@@ -128,8 +133,9 @@ func NewCmdControllerBuild(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.FailIfNoGitProvider, "fail-on-git-provider-error", "", false, "If enable then lets terminate quickly if we cannot create a git provider")
 
 	// optional git reporting flags
-	cmd.Flags().StringVarP(&options.TargetURLTemplate, "target-url-template", "", "", "The Go template for generating the target URL of pipeline logs/views if git reporting is enabled")
+	cmd.Flags().StringVarP(&options.TargetURLTemplate, "target-url-template", "", "", "The Go template for generating the target URL of pipeline logs/views if git reporting is enabled. If unspecified, a default will be used based on `--job-url-base`.")
 	cmd.Flags().BoolVarP(&options.GitReporting, "git-reporting", "", false, "If enabled then lets report pipeline success/failures to the git provider. Note this is purely tactical until we can do this natively inside tekton")
+	cmd.Flags().StringVarP(&options.JobURLBase, "job-url-base", "", "", "The base URL, such as 'https://dashboard.jenkins-x.live', for generating the target URL for pipeline logs if git reporting is enabled.")
 	return cmd
 }
 
@@ -167,6 +173,9 @@ func (o *ControllerBuildOptions) Run() error {
 	if o.GitReporting {
 		if o.TargetURLTemplate == "" {
 			o.TargetURLTemplate = os.Getenv("TARGET_URL_TEMPLATE")
+		}
+		if o.TargetURLTemplate == "" {
+			o.TargetURLTemplate = defaultTargetURLTemplate
 		}
 	}
 
@@ -1268,18 +1277,36 @@ func (o *ControllerBuildOptions) reportStatus(kubeClient kubernetes.Interface, n
 	if pipelineContext == "" {
 		pipelineContext = "jenkins-x"
 	}
+
+	var runningStages []string
+	for _, stage := range activity.Spec.Steps {
+		if stage.Kind == v1.ActivityStepKindTypeStage {
+			if stage.Stage.Status == v1.ActivityStatusTypeRunning {
+				runningStages = append(runningStages, stage.Stage.Name)
+			}
+		}
+	}
+
 	description := status
+
+	if len(runningStages) > 0 {
+		description = fmt.Sprintf("Running stage(s): %s", strings.Join(runningStages, ", "))
+	}
+
 	targetURL := CreateReportTargetURL(o.TargetURLTemplate, ReportParams{
 		Owner:      owner,
 		Repository: repo,
+		Branch:     activity.Spec.GitBranch,
 		Build:      activity.Spec.Build,
 		Context:    pipelineContext,
+		BaseURL:    strings.TrimRight(o.JobURLBase, "/"),
+		Namespace:  ns,
 	})
 	gitRepoStatus := &gits.GitRepoStatus{
 		State:       status,
 		Context:     pipelineContext,
 		Description: description,
-		URL:         targetURL,
+		TargetURL:   targetURL,
 	}
 
 	gitProvider, err := o.GitProviderForURL(gitURL, "git provider")
@@ -1298,7 +1325,7 @@ func (o *ControllerBuildOptions) reportStatus(kubeClient kubernetes.Interface, n
 
 // ReportParams contains the parameters for target URL templates
 type ReportParams struct {
-	Owner, Repository, Branch, Build, Context string
+	BaseURL, Owner, Repository, Branch, Build, Context, Namespace string
 }
 
 // CreateReportTargetURL creates the target URL for pipeline results/logs from a template

--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -1223,7 +1223,7 @@ func (o *ControllerBuildOptions) reportStatus(kubeClient kubernetes.Interface, n
 	repo := activity.Spec.GitRepository
 	gitURL := activity.Spec.GitURL
 	activityStatus := activity.Spec.Status
-	status := toScmStatus(activityStatus)
+	status, description := toScmStatusAndDescription(activityStatus)
 
 	fields := map[string]interface{}{
 		"name":        activity.Name,
@@ -1287,10 +1287,8 @@ func (o *ControllerBuildOptions) reportStatus(kubeClient kubernetes.Interface, n
 		}
 	}
 
-	description := status
-
 	if len(runningStages) > 0 {
-		description = fmt.Sprintf("Running stage(s): %s", strings.Join(runningStages, ", "))
+		description = fmt.Sprintf("Pipeline running stage(s): %s", strings.Join(runningStages, ", "))
 	}
 
 	targetURL := CreateReportTargetURL(o.TargetURLTemplate, ReportParams{
@@ -1352,16 +1350,16 @@ func CreateReportTargetURL(templateText string, params ReportParams) string {
 	return buf.String()
 }
 
-func toScmStatus(status v1.ActivityStatusType) string {
+func toScmStatusAndDescription(status v1.ActivityStatusType) (string, string) {
 	switch status {
 	case v1.ActivityStatusTypeSucceeded:
-		return "success"
+		return "success", "Pipeline successful"
 	case v1.ActivityStatusTypeRunning, v1.ActivityStatusTypePending:
-		return "pending"
+		return "pending", "Pipeline running"
 	case v1.ActivityStatusTypeError:
-		return "error"
+		return "error", "Error executing pipeline"
 	default:
-		return "failure"
+		return "failure", "Pipeline failed"
 	}
 }
 

--- a/pkg/cmd/controller/controller_build_test.go
+++ b/pkg/cmd/controller/controller_build_test.go
@@ -151,9 +151,11 @@ func TestCreateReportTargetURL(t *testing.T) {
 		Branch:     "PR-5",
 		Build:      "3",
 		Context:    "jenkins-x",
+		Namespace:  "jx",
+		BaseURL:    "https://myconsole.acme.com",
 	}
-	actual := CreateReportTargetURL("https://myconsole.acme.com/{{ .Owner }}/{{ .Repository }}/{{ .Branch }}/{{ .Build }}", params)
-	assert.Equal(t, "https://myconsole.acme.com/jstrachan/myapp/PR-5/3", actual, "created git report URL for params %#v", params)
+	actual := CreateReportTargetURL(defaultTargetURLTemplate, params)
+	assert.Equal(t, "https://myconsole.acme.com/teams/jx/projects/jstrachan/myapp/PR-5/3", actual, "created git report URL for params %#v", params)
 }
 
 func TestUpdateForStagePreTekton051(t *testing.T) {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This isn't the end state - #6793 needs to be dealt with. But this will allow for making changes in `env/jenkins-x-platform/values.tmpl.yaml` to specify a `--job-url-base=https://whatever.whatever` and then that'll be used with a default template for creating the logs URL. Also, we'll actually use the logs URL now. And the "pending" message will now tell you what stage(s) are currently running because I wanted more information there. =)

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6791
fixes #6792
fixes #6794
