### PR TITLE
fix: jx get applications when helm release == app name

### DIFF
--- a/pkg/kube/version.go
+++ b/pkg/kube/version.go
@@ -122,17 +122,18 @@ func GetAppName(name string, namespaces ...string) string {
 			prefix := ns + "-"
 			if strings.HasPrefix(name, prefix) {
 				name = strings.TrimPrefix(name, prefix)
-
-				// we often have the app name repeated twice!
-				l := len(name) / 2
-				if name[l] == '-' {
-					first := name[0:l]
-					if name[l+1:] == first {
-						return first
-					}
-				}
 			}
 		}
+
+		// we often have the app name repeated twice - particularly when using helm 3
+		l := len(name) / 2
+		if name[l] == '-' {
+			first := name[0:l]
+			if name[l+1:] == first {
+				return first
+			}
+		}
+
 		// The applications seems to be prefixed with jx regardless of the namespace
 		// where they are deployed. Let's remove this prefix.
 		prefix := "jx-"


### PR DESCRIPTION
lets patch the code so that we can still detect the actual app name if we use the app name as the helm release name (and don't use a namespace prefix on the release).

this helps the code work with helm 2 and helm 3