### PR TITLE
fix: skip the version tagging in the create task when the noReleasePrepare flag is configured in the project

### DIFF
--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -326,7 +326,7 @@ func (o *StepCreateTaskOptions) Run() error {
 	}
 
 	log.Logger().Debug("Setting build version")
-	err = o.setBuildVersion(effectiveProjectConfig.PipelineConfig)
+	err = o.setBuildVersion(effectiveProjectConfig)
 	if err != nil {
 		return errors.Wrapf(err, "failed to set the version on release pipelines")
 	}
@@ -1282,10 +1282,11 @@ func getVersionFromFile(dir string) (string, error) {
 	return "", errors.New("failed to read file " + versionFile)
 }
 
-func (o *StepCreateTaskOptions) setBuildVersion(pipelineConfig *jenkinsfile.PipelineConfig) error {
-	if o.NoReleasePrepare || o.ViewSteps || o.EffectivePipeline {
+func (o *StepCreateTaskOptions) setBuildVersion(projectConfig *config.ProjectConfig) error {
+	if o.NoReleasePrepare || o.ViewSteps || o.EffectivePipeline || projectConfig.NoReleasePrepare {
 		return nil
 	}
+	pipelineConfig := projectConfig.PipelineConfig
 	version := ""
 
 	if o.DryRun {

--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -551,7 +551,7 @@ func TestGenerateTektonCRDs(t *testing.T) {
 				t.Fatalf("Unexpected error generating effective pipeline: %s", err)
 			} else {
 				if effectiveProjectConfig != nil {
-					err = createTask.setBuildVersion(effectiveProjectConfig.PipelineConfig)
+					err = createTask.setBuildVersion(effectiveProjectConfig)
 					assert.NoError(t, err)
 				}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6804

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->