### PR TITLE
fix: Don't pass target URL to GH status if not an http/https URL

### DIFF
--- a/jx/bdd/boot-lh-ghe/ci.sh
+++ b/jx/bdd/boot-lh-ghe/ci.sh
@@ -73,5 +73,4 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests install \
-    --tests test-quickstart-golang-http \
-    --tests test-app-lifecycle
+    --tests test-quickstart-golang-http

--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -1291,6 +1291,11 @@ func (o *ControllerBuildOptions) reportStatus(kubeClient kubernetes.Interface, n
 		description = fmt.Sprintf("Pipeline running stage(s): %s", strings.Join(runningStages, ", "))
 	}
 
+	gitRepoStatus := &gits.GitRepoStatus{
+		State:       status,
+		Context:     pipelineContext,
+		Description: description,
+	}
 	targetURL := CreateReportTargetURL(o.TargetURLTemplate, ReportParams{
 		Owner:      owner,
 		Repository: repo,
@@ -1300,11 +1305,8 @@ func (o *ControllerBuildOptions) reportStatus(kubeClient kubernetes.Interface, n
 		BaseURL:    strings.TrimRight(o.JobURLBase, "/"),
 		Namespace:  ns,
 	})
-	gitRepoStatus := &gits.GitRepoStatus{
-		State:       status,
-		Context:     pipelineContext,
-		Description: description,
-		TargetURL:   targetURL,
+	if strings.HasPrefix(targetURL, "http://") || strings.HasPrefix(targetURL, "https://") {
+		gitRepoStatus.TargetURL = targetURL
 	}
 
 	gitProvider, err := o.GitProviderForURL(gitURL, "git provider")


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

Otherwise you get an error because the target URL has to be an http/https URL. Sigh. So if the resulting target URL from the template doesn't start with `http://` or `https://`, don't pass a target URL at all.

And yes, this all really needs to be redone. Still in the land of tactical fixes here. I just wanna unblock the version stream right now. =)

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a