### PR TITLE
fix: better validation of helm

### DIFF
--- a/pkg/helm/helm_cli.go
+++ b/pkg/helm/helm_cli.go
@@ -90,7 +90,11 @@ func (h *HelmCLI) checkCompatibility() {
 		return
 	}
 
-	if os.Getenv("JX_HELM3") == "true" {
+	if h.BinVersion == V3 {
+		if v.Major != 3 {
+			log.Logger().Fatalf("Your current helm version v%d is not supported. Please upgrade to helm v3.", v.Major)
+		}
+	} else if os.Getenv("JX_HELM3") == "true" {
 		if v.Major != 3 {
 			log.Logger().Fatalf("You have set $JX_HELM3=true but your helm client version is %d", v.Major)
 		}


### PR DESCRIPTION
if we have configured helm 3 on the helmer then lets use that version to validate helm, rather than barfing that helm 2 is required

Signed-off-by: James Strachan <james.strachan@gmail.com>