### PR TITLE
fix: Properly set BaseSHA on activities

### DIFF
--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -768,6 +768,11 @@ func (o *ControllerBuildOptions) updatePipelineActivityForRun(kubeClient kuberne
 		}
 	}
 
+	// Set the base SHA if present in the run info
+	if pri.BaseSHA != "" && spec.BaseSHA != pri.BaseSHA {
+		spec.BaseSHA = pri.BaseSHA
+	}
+
 	// TODO this is a tactical approach until we move all the reporting of tekton pipelines into tekton outputs
 	o.reportStatus(kubeClient, ns, activity, pri, pod)
 
@@ -1213,11 +1218,6 @@ func (o *ControllerBuildOptions) reportStatus(kubeClient kubernetes.Interface, n
 			sha = activity.Labels[v1.LabelLastCommitSha]
 		}
 		activity.Spec.LastCommitSHA = sha
-	}
-	baseSHA := activity.Spec.BaseSHA
-	if baseSHA == "" {
-		baseSHA = pri.BaseSHA
-		activity.Spec.BaseSHA = baseSHA
 	}
 	owner := activity.Spec.GitOwner
 	repo := activity.Spec.GitRepository

--- a/pkg/cmd/controller/test_data/controller_build/completed_generated/expected/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_generated/expected/activity.yml
@@ -16,6 +16,7 @@ metadata:
   selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
   uid: 8461830a-d3f2-11e9-82fc-42010a840132
 spec:
+  baseSHA: 0708469b9e463bfd8df21af92dc4afe82ac0b581
   batchPipelineActivity: {}
   build: "1"
   completedTimestamp: "2019-09-10T17:11:30Z"

--- a/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/expected/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/completed_metapipeline/expected/activity.yml
@@ -16,6 +16,7 @@ metadata:
   selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
   uid: 8461830a-d3f2-11e9-82fc-42010a840132
 spec:
+  baseSHA: 0708469b9e463bfd8df21af92dc4afe82ac0b581
   batchPipelineActivity: {}
   build: "1"
   gitBranch: master

--- a/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/expected/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_metapipeline/expected/activity.yml
@@ -16,6 +16,7 @@ metadata:
   selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
   uid: 8461830a-d3f2-11e9-82fc-42010a840132
 spec:
+  baseSHA: 0708469b9e463bfd8df21af92dc4afe82ac0b581
   batchPipelineActivity: {}
   build: "1"
   completedTimestamp: "2019-09-10T17:08:20Z"

--- a/pkg/cmd/controller/test_data/controller_build/failed_multistage_generated/expected/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/failed_multistage_generated/expected/activity.yml
@@ -16,6 +16,7 @@ metadata:
   selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
   uid: 8461830a-d3f2-11e9-82fc-42010a840132
 spec:
+  baseSHA: 0708469b9e463bfd8df21af92dc4afe82ac0b581
   batchPipelineActivity: {}
   build: "1"
   completedTimestamp: "2019-09-10T17:11:30Z"

--- a/pkg/cmd/controller/test_data/controller_build/running_generated/expected/activity.yml
+++ b/pkg/cmd/controller/test_data/controller_build/running_generated/expected/activity.yml
@@ -16,6 +16,7 @@ metadata:
   selfLink: /apis/jenkins.io/v1/namespaces/jx/pipelineactivities/cb-kubecd-bdd-spring-1568135191-master-1
   uid: 8461830a-d3f2-11e9-82fc-42010a840132
 spec:
+  baseSHA: 0708469b9e463bfd8df21af92dc4afe82ac0b581
   batchPipelineActivity: {}
   build: "1"
   gitBranch: master

--- a/pkg/tekton/pipeline_info.go
+++ b/pkg/tekton/pipeline_info.go
@@ -135,6 +135,7 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 	repo := ""
 	build := ""
 	pullRefs := ""
+	pullBaseSha := ""
 	shaRegexp, err := regexp.Compile("\b[a-z0-9]{40}\b")
 	if err != nil {
 		log.Logger().Warnf("Failed to compile regexp because %s", err)
@@ -199,7 +200,7 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 				}
 			}
 		}
-		var pullPullSha, pullBaseSha string
+		var pullPullSha string
 		for _, v := range container.Env {
 			if v.Value == "" {
 				continue
@@ -261,6 +262,8 @@ func CreatePipelineRunInfo(prName string, podList *corev1.PodList, ps *v1.Pipeli
 	if err != nil {
 		buildNumber = 1
 	}
+
+	pri.BaseSHA = pullBaseSha
 
 	if lastCommitSha == "" {
 		idx := strings.LastIndex(pullRefs, ":")

--- a/pkg/tekton/test_data/pipeline_info/pr-yaml/pods.yml
+++ b/pkg/tekton/test_data/pipeline_info/pr-yaml/pods.yml
@@ -110,6 +110,14 @@ items:
         value: pr-build
       - name: PIPELINE_KIND
         value: pullrequest
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 441de50841eb31130c8a59ae0edc00d97f6b7b97
+      - name: PULL_NUMBER
+        value: "1"
+      - name: PULL_PULL_SHA
+        value: c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: PULL_REFS
         value: master:441de50841eb31130c8a59ae0edc00d97f6b7b97,1:c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: REPO_NAME
@@ -231,6 +239,14 @@ items:
         value: pr-build
       - name: PIPELINE_KIND
         value: pullrequest
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 441de50841eb31130c8a59ae0edc00d97f6b7b97
+      - name: PULL_NUMBER
+        value: "1"
+      - name: PULL_PULL_SHA
+        value: c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: PULL_REFS
         value: master:441de50841eb31130c8a59ae0edc00d97f6b7b97,1:c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: REPO_NAME
@@ -335,6 +351,14 @@ items:
         value: pr-build
       - name: PIPELINE_KIND
         value: pullrequest
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 441de50841eb31130c8a59ae0edc00d97f6b7b97
+      - name: PULL_NUMBER
+        value: "1"
+      - name: PULL_PULL_SHA
+        value: c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: PULL_REFS
         value: master:441de50841eb31130c8a59ae0edc00d97f6b7b97,1:c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: REPO_NAME
@@ -439,6 +463,14 @@ items:
         value: pr-build
       - name: PIPELINE_KIND
         value: pullrequest
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 441de50841eb31130c8a59ae0edc00d97f6b7b97
+      - name: PULL_NUMBER
+        value: "1"
+      - name: PULL_PULL_SHA
+        value: c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: PULL_REFS
         value: master:441de50841eb31130c8a59ae0edc00d97f6b7b97,1:c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: REPO_NAME
@@ -547,6 +579,14 @@ items:
         value: pr-build
       - name: PIPELINE_KIND
         value: pullrequest
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 441de50841eb31130c8a59ae0edc00d97f6b7b97
+      - name: PULL_NUMBER
+        value: "1"
+      - name: PULL_PULL_SHA
+        value: c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: PULL_REFS
         value: master:441de50841eb31130c8a59ae0edc00d97f6b7b97,1:c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: REPO_NAME
@@ -656,6 +696,14 @@ items:
         value: pr-build
       - name: PIPELINE_KIND
         value: pullrequest
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 441de50841eb31130c8a59ae0edc00d97f6b7b97
+      - name: PULL_NUMBER
+        value: "1"
+      - name: PULL_PULL_SHA
+        value: c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: PULL_REFS
         value: master:441de50841eb31130c8a59ae0edc00d97f6b7b97,1:c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: REPO_NAME
@@ -760,6 +808,14 @@ items:
         value: pr-build
       - name: PIPELINE_KIND
         value: pullrequest
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 441de50841eb31130c8a59ae0edc00d97f6b7b97
+      - name: PULL_NUMBER
+        value: "1"
+      - name: PULL_PULL_SHA
+        value: c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: PULL_REFS
         value: master:441de50841eb31130c8a59ae0edc00d97f6b7b97,1:c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: REPO_NAME
@@ -864,6 +920,14 @@ items:
         value: pr-build
       - name: PIPELINE_KIND
         value: pullrequest
+      - name: PULL_BASE_REF
+        value: master
+      - name: PULL_BASE_SHA
+        value: 441de50841eb31130c8a59ae0edc00d97f6b7b97
+      - name: PULL_NUMBER
+        value: "1"
+      - name: PULL_PULL_SHA
+        value: c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: PULL_REFS
         value: master:441de50841eb31130c8a59ae0edc00d97f6b7b97,1:c6bd3e0221a122dca3a00e87cb9188daed2e1d44
       - name: REPO_NAME


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

First, make sure we set it even if we're not doing status reporting, because that's just cleaner.

But more importantly, the preexisting logic would only set the `BaseSHA` on the run info (and from there the activity) if the last commit SHA wasn't already set by the presence of 
`PULL_PULL_REF` or `PULL_BASE_REF` environment variables. Which...are actually present
now in Lighthouse, via https://github.com/jenkins-x/lighthouse/issues/542. So let's handle that correctly, and consistently with when we're on Prow.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes https://github.com/jenkins-x/lighthouse/issues/547
