### PR TITLE
fix: lets just log a warning if the alpha commands can't be found

### DIFF
--- a/pkg/cmd/alpha/alpha.go
+++ b/pkg/cmd/alpha/alpha.go
@@ -37,7 +37,7 @@ var (
 )
 
 // NewCmdAlpha creates the "jx alpha" command
-func NewCmdAlpha(commonOpts *opts.CommonOptions) (*cobra.Command, error) {
+func NewCmdAlpha(commonOpts *opts.CommonOptions) *cobra.Command {
 	options := &Options{
 		CommonOptions: commonOpts,
 	}
@@ -56,7 +56,7 @@ func NewCmdAlpha(commonOpts *opts.CommonOptions) (*cobra.Command, error) {
 
 	plugins, err := options.getPluginSpecs()
 	if err != nil {
-		return cmd, err
+		log.Logger().Warnf("failed to discover alpha commands from github: %s", err.Error())
 	}
 	for i := range plugins {
 		c := plugins[i]
@@ -71,7 +71,7 @@ func NewCmdAlpha(commonOpts *opts.CommonOptions) (*cobra.Command, error) {
 		}
 		cmd.AddCommand(subCmd)
 	}
-	return cmd, err
+	return cmd
 }
 
 // Run implements this command

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -134,10 +134,7 @@ func NewJXCommand(f clients.Factory, in terminal.FileReader, out terminal.FileWr
 	}
 	environmentsCommands = append(environmentsCommands, findCommands("environment", createCommands, deleteCommands, editCommands, getCommands)...)
 
-	alphaCommand, err2 := alpha.NewCmdAlpha(commonOpts)
-	if err2 != nil {
-		log.Logger().Errorf("failed to load alpha commands: %s", err2.Error())
-	}
+	alphaCommand := alpha.NewCmdAlpha(commonOpts)
 
 	groups := templates.CommandGroups{
 		{


### PR DESCRIPTION
this can happen if github is having issues or there are firewall problems accessing github

this avoids failing on all jx commands which is pretty fatal

Signed-off-by: James Strachan <james.strachan@gmail.com>