### PR TITLE
fix(aks): check for missing azure config when registry is empty

### DIFF
--- a/pkg/cmd/step/create/step_create_values.go
+++ b/pkg/cmd/step/create/step_create_values.go
@@ -181,7 +181,6 @@ func (o *StepCreateValuesOptions) Run() error {
 		return err
 	}
 
-	fmt.Println()
 	err = o.CreateValuesFile(secretURLClient)
 	if err != nil {
 		return errors.WithStack(err)
@@ -197,7 +196,6 @@ func (o *StepCreateValuesOptions) Run() error {
 		return errors.Wrap(err, "error creating the secret for local secret scheme")
 	}
 
-	fmt.Println()
 	return nil
 }
 
@@ -263,6 +261,9 @@ func (o *StepCreateValuesOptions) verifyRegistryConfig(requirements *config.Requ
 				return errors.Wrap(err, "getting cluster from Azure")
 			}
 			registryID := ""
+			if requirements.Cluster.AzureConfig == nil {
+				return errors.New("no azure registry subscription specified in 'jx-requirements.yml' at cluster.azure")
+			}
 			azureRegistrySubscription := requirements.Cluster.AzureConfig.RegistrySubscription
 			if azureRegistrySubscription == "" {
 				log.Logger().Info("no azure registry subscription is specified in 'jx-requirements.yml' at cluster.azure.registrySubscription")


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>


#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Special notes for the reviewer(s)
I did not refactor the code because I think it should be another PR. I can write tests once I have refactored it. For instance:
```
type AzureRunner struct {
	Runner util.Commander
}
```
can be made an empty struct and we can just use the snippet below to make the codebase a bit more consistent:
```
cmd := util.Command{
	Name: "az",
	Args: args,
}
output, err := cmd.RunWithoutRetry()
```
The code can be decoupled from external dependencies to make it more testable. 
/cc @hferentschik 

#### Which issue this PR fixes

fixes #6394 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
