### PR TITLE
feat: allow extra labels to be added to generated PRs

### DIFF
--- a/pkg/cmd/step/create/pr/step_create_pr.go
+++ b/pkg/cmd/step/create/pr/step_create_pr.go
@@ -31,6 +31,7 @@ type StepCreatePrOptions struct {
 	DryRun        bool
 	SkipCommit    bool
 	SkipAutoMerge bool
+	Labels        []string
 }
 
 // NewCmdStepCreatePr Steps a command object for the "step" command
@@ -81,6 +82,7 @@ func AddStepCreatePrFlags(cmd *cobra.Command, o *StepCreatePrOptions) {
 	cmd.Flags().StringVarP(&o.Version, "version", "v", "", "The version to change. If no version is supplied the latest version is found")
 	cmd.Flags().BoolVarP(&o.DryRun, "dry-run", "", false, "Perform a dry run, the change will be generated and committed, but not pushed or have a PR created")
 	cmd.Flags().BoolVarP(&o.SkipAutoMerge, "skip-auto-merge", "", false, "Disable auto merge of the PR if status checks pass")
+	cmd.Flags().StringArrayVarP(&o.Labels, "repo", "", []string{}, "Labels to add to the created PR")
 }
 
 // ValidateOptions validates the common options for all PR creation steps
@@ -144,6 +146,7 @@ func (o *StepCreatePrOptions) createPullRequestOperation() operations.PullReques
 		DryRun:        o.DryRun,
 		SkipCommit:    o.SkipCommit,
 		SkipAutoMerge: o.SkipAutoMerge,
+		Labels:        o.Labels,
 	}
 	authorName, authorEmail, err := gits.EnsureUserAndEmailSetup(o.Git())
 	if err != nil {

--- a/pkg/cmd/step/create/pr/step_create_pr.go
+++ b/pkg/cmd/step/create/pr/step_create_pr.go
@@ -82,7 +82,7 @@ func AddStepCreatePrFlags(cmd *cobra.Command, o *StepCreatePrOptions) {
 	cmd.Flags().StringVarP(&o.Version, "version", "v", "", "The version to change. If no version is supplied the latest version is found")
 	cmd.Flags().BoolVarP(&o.DryRun, "dry-run", "", false, "Perform a dry run, the change will be generated and committed, but not pushed or have a PR created")
 	cmd.Flags().BoolVarP(&o.SkipAutoMerge, "skip-auto-merge", "", false, "Disable auto merge of the PR if status checks pass")
-	cmd.Flags().StringArrayVarP(&o.Labels, "repo", "", []string{}, "Labels to add to the created PR")
+	cmd.Flags().StringArrayVarP(&o.Labels, "labels", "", []string{}, "Labels to add to the created PR")
 }
 
 // ValidateOptions validates the common options for all PR creation steps

--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -383,14 +383,10 @@ func PushRepoAndCreatePullRequest(dir string, upstreamRepo *GitRepository, forkR
 
 	err = addLabelsToPullRequest(prInfo, prDetails.Labels)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to add labels %+v to PR %s", prDetails.Labels, prInfo.PullRequest.URL)
+		return nil, errors.Wrapf(err, "failed to add labels %+v to PR %s", prDetails.Labels, pr.URL)
 	}
 
-	return &PullRequestInfo{
-		GitProvider:          provider,
-		PullRequest:          pr,
-		PullRequestArguments: gha,
-	}, nil
+	return prInfo, nil
 }
 
 // addLabelsToPullRequest adds the provided labels, if not already present, to the provided pull request

--- a/pkg/gits/operations/pull_request_op.go
+++ b/pkg/gits/operations/pull_request_op.go
@@ -48,6 +48,7 @@ type PullRequestOperation struct {
 	AuthorName    string
 	AuthorEmail   string
 	SkipAutoMerge bool
+	Labels        []string
 }
 
 // ChangeFilesFn is the function called to create the pull request
@@ -84,6 +85,9 @@ func (o *PullRequestOperation) CreatePullRequest(kind string, update ChangeFiles
 		labels := []string{}
 		if !o.SkipAutoMerge {
 			labels = append(labels, "updatebot")
+		}
+		if len(o.Labels) > 0 {
+			labels = append(labels, o.Labels...)
 		}
 		filter := &gits.PullRequestFilter{
 			Labels: labels,

--- a/pkg/gits/provider_fake.go
+++ b/pkg/gits/provider_fake.go
@@ -234,11 +234,13 @@ func (f *FakeProvider) CreatePullRequest(data *GitPullRequestArguments) (*GitPul
 	repo.issueCount += 1
 	number := repo.issueCount
 	labels := make([]*Label, 0)
+
 	for _, l := range data.Labels {
+		labelName := l
 		labels = append(labels, &Label{
 			ID:          nil,
 			URL:         nil,
-			Name:        &l,
+			Name:        &labelName,
 			Color:       nil,
 			Description: nil,
 			Default:     nil,
@@ -976,8 +978,9 @@ func (f *FakeProvider) AddLabelsToIssue(owner, repo string, number int, labels [
 				if util.DereferenceInt(pr.PullRequest.Number) == number {
 					ls := make([]*Label, 0)
 					for _, l := range labels {
+						labelName := l
 						ls = append(ls, &Label{
-							Name: &l,
+							Name: &labelName,
 						})
 					}
 					pr.PullRequest.Labels = ls


### PR DESCRIPTION
#### Description

Allows additional labels to be added to PR's when using `jx step create pr`.
The purpose of this functionality is to avoid unrelated `bump` PRs to be combined in to one PR, which can potential cause a failure in one change blocking the progress of another unrelated change.

#### Which issue this PR fixes

fixes #
