### PR TITLE
fix(secreturl): Cluster names can have dots in them

### DIFF
--- a/pkg/secreturl/fakevault/client.go
+++ b/pkg/secreturl/fakevault/client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var fakeURIRegex = regexp.MustCompile(`:[\s"]*vault:[-_\w\/:]*`)
+var fakeURIRegex = regexp.MustCompile(`:[\s"]*vault:[-_.\w\/:]*`)
 
 // FakeClient a local file system based client loading/saving content from the given URL
 type FakeClient struct {

--- a/pkg/secreturl/localvault/client.go
+++ b/pkg/secreturl/localvault/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var localURIRegex = regexp.MustCompile(`:[\s"]*local:[-_\w\/:]*`)
+var localURIRegex = regexp.MustCompile(`:[\s"]*local:[-_.\w\/:]*`)
 
 // CanonicalClusterPath this is the path where the client will fall back when secrets are not found at the standard path
 const CanonicalClusterPath = "currentCluster"

--- a/pkg/vault/fake/client.go
+++ b/pkg/vault/fake/client.go
@@ -16,7 +16,7 @@ const (
 	yamlDataKey = "yaml"
 )
 
-var vaultURIRegex = regexp.MustCompile(`vault:[-_\w\/:]*`)
+var vaultURIRegex = regexp.MustCompile(`vault:[-_.\w\/:]*`)
 
 // FakeVaultClient is an in memory implementation of vault, useful for testing
 type FakeVaultClient struct {

--- a/pkg/vault/vault_client.go
+++ b/pkg/vault/vault_client.go
@@ -16,7 +16,7 @@ const (
 	yamlDataKey = "yaml"
 )
 
-var vaultURIRegex = regexp.MustCompile(`:[\s"]*vault:[-_\w\/:]*`)
+var vaultURIRegex = regexp.MustCompile(`:[\s"]*vault:[-_.\w\/:]*`)
 
 // Client is an interface for interacting with Vault
 //go:generate pegomock generate github.com/jenkins-x/jx/pkg/vault Client -o mocks/vault_client.go


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

If a cluster name has dots in it (EG: `test.kops.k8s.local`) then `jx boot` fails to convert secrets:

```
failed to convert secret URLs in parameters file /path/jx-boot/environment-test.kops.k8s.local-dev/env/parameters.yaml: replacing vault paths in
adminUser:
  password: local:test.kops.k8s.local/adminUser:password
  username: admin
enableDocker: false
pipelineUser:
  email: jx-bot-test@example.com
  token: local:test.kops.k8s.local/pipelineUser:token
  username: test-user
prow:
  hmacToken: local:test.kops.k8s.local/prow:hmacToken
: cannot parse "test" as path:key
error: failed to interpret pipeline file jenkins-x.yml: failed to run '/bin/sh -c jx step create values --name parameters' command in directory 'env', output: ''
``` 

#### Special notes for the reviewer(s)

None

#### Which issue this PR fixes

fixes #5848