### PR TITLE
fix: KubeAuthConfigHandler.LoadConfig should never return an empty config

### DIFF
--- a/pkg/auth/kube_config_handler.go
+++ b/pkg/auth/kube_config_handler.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/util"
@@ -101,6 +102,9 @@ func (k *KubeAuthConfigHandler) LoadConfig() (*AuthConfig, error) {
 				}
 			}
 		}
+	}
+	if reflect.DeepEqual(*config, AuthConfig{}) {
+		return nil, fmt.Errorf("no appropriately annotated and labeled secrets found for server kind %q and service kind %q", k.kind, k.serviceKind)
 	}
 	return config, nil
 }


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This is to be consistent with the other config handlers, so we don't need to do special casing anywhere for empty configs returned by `LoadConfig`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6871 
