### PR TITLE
fix(sync): use commit sha instead of tag for ksync image

### DIFF
--- a/pkg/cmd/sync/sync.go
+++ b/pkg/cmd/sync/sync.go
@@ -100,13 +100,16 @@ func NewCmdSync(commonOpts *opts.CommonOptions) *cobra.Command {
 func (o *SyncOptions) Run() error {
 
 	// ksync is installed to the jx/bin dir, so we can add it for the user
-	os.Setenv("PATH", util.PathWithBinary())
+	err := os.Setenv("PATH", util.PathWithBinary())
+	if err != nil {
+		return err
+	}
 
 	client, err := o.KubeClient()
 	if err != nil {
 		return err
 	}
-	version, err := ksync.InstallKSync()
+	sha, err := ksync.InstallKSync()
 	if err != nil {
 		return err
 	}
@@ -115,9 +118,12 @@ func (o *SyncOptions) Run() error {
 		flag, err := kube.IsDaemonSetExists(client, "ksync", "kube-system")
 		if !flag || err != nil {
 			log.Logger().Infof("Initialising ksync")
-			// Deal with https://github.com/vapor-ware/ksync/issues/218
-			err = o.RunCommandInteractive(true, "ksync", "init", "--upgrade", "--image",
-				fmt.Sprintf("vaporio/ksync:%s", version))
+			kcli, err := ksync.NewCLI()
+			if err != nil {
+				return err
+			}
+			// Deal with https://github.com/ksync/ksync/issues/218
+			_, err = kcli.Init("--upgrade", "--image", fmt.Sprintf("ksync/ksync:git-%s", sha))
 			if err != nil {
 				return err
 			}

--- a/pkg/ksync/cli.go
+++ b/pkg/ksync/cli.go
@@ -11,51 +11,150 @@ import (
 	"github.com/jenkins-x/jx/pkg/util"
 )
 
-// InstallKSync install ksync
-func InstallKSync() (string, error) {
-	binDir, err := util.JXBinLocation()
-	if err != nil {
-		return "", err
-	}
-	binary := "ksync"
-	fileName, flag, err := packages.ShouldInstallBinary(binary)
-	if err != nil || !flag {
-		// Exec `ksync` to find the version
-		ksyncCmd := util.Command{
-			Name: fileName,
-			Args: []string{
-				"version",
-			},
-		}
-		// Explicitly ignore any errors from ksync version, as we just need the output!
-		res, _ := ksyncCmd.RunWithoutRetry()
-		lines := strings.Split(res, "\n")
-		for _, line := range lines {
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "Git Tag:") {
-				return strings.TrimSpace(strings.TrimPrefix(line, "Git Tag:")), nil
-			}
-		}
+var commit string
+var binary = "ksync"
 
-		return "", fmt.Errorf("unable to find version of ksync")
-	}
-	latestVersion, err := util.GetLatestVersionFromGitHub("vapor-ware", "ksync")
+// CLI implements the command ksync commands contained in KSyncer.
+type CLI struct {
+	Runner util.Commander
+}
+
+// NewCLI creates a new KsyncCLI instance configured to use the provided ksync CLI in the given current working directory
+func NewCLI() (*CLI, error) {
+	path, err := util.JXBinLocation()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	clientURL := fmt.Sprintf("https://github.com/vapor-ware/ksync/releases/download/%s/ksync_%s_%s", latestVersion, runtime.GOOS, runtime.GOARCH)
+	runner := &util.Command{
+		Name: fmt.Sprintf("%s/ksync", path),
+	}
+	cli := &CLI{
+		Runner: runner,
+	}
+	return cli, nil
+}
+
+// isInstalled checks if the binary is installed
+func isInstalled(binary string) (bool, error) {
+	_, flag, err := packages.ShouldInstallBinary(binary)
+	return flag, err
+}
+
+// getTag returns the latest full tag from github given the owner and repo, and installs
+func getTag(owner, repo string) (string, string, error) {
+	latestTag, err := util.GetLatestFullTagFromGithub(owner, repo)
+	if err != nil {
+		return "", "", err
+	}
+	latestVersion := *latestTag.Name
+	// This will return the shortsha, the first 7 characters associated with the git commit
+	latestSha := (*latestTag.Commit.SHA)[:7]
+	return latestSha, latestVersion, nil
+}
+
+// install downloads and installs the ksync package
+func install(latestVersion, binDir, fileName string) error {
+	clientURL := fmt.Sprintf("https://github.com/ksync/ksync/releases/download/%s/ksync_%s_%s", latestVersion, runtime.GOOS, runtime.GOARCH)
 	if runtime.GOOS == "windows" {
 		clientURL += ".exe"
 	}
 	fullPath := filepath.Join(binDir, fileName)
 	tmpFile := fullPath + ".tmp"
-	err = packages.DownloadFile(clientURL, tmpFile)
+	err := packages.DownloadFile(clientURL, tmpFile)
 	if err != nil {
-		return "", err
+		return err
 	}
 	err = util.RenameFile(tmpFile, fullPath)
 	if err != nil {
+		return err
+	}
+	err = os.Chmod(fullPath, 0755)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Version prints out the version of the local component of ksync
+func (kcli *CLI) Version() (string, error) {
+	args := []string{"version"}
+	kcli.Runner.SetArgs(args)
+	out, err := kcli.Runner.RunWithoutRetry()
+	if err != nil {
 		return "", err
 	}
-	return latestVersion.String(), os.Chmod(fullPath, 0755)
+	return out, nil
+}
+
+// Init installs the server side component of ksync - the daemonsets
+func (kcli *CLI) Init(flags ...string) (string, error) {
+	args := []string{"init"}
+	args = append(args, flags...)
+	kcli.Runner.SetArgs(args)
+	out, err := kcli.Runner.RunWithoutRetry()
+	if err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+// Clean removes the ksync pods
+func (kcli *CLI) Clean() (string, error) {
+	args := []string{"clean"}
+	kcli.Runner.SetArgs(args)
+	out, err := kcli.Runner.RunWithoutRetry()
+	if err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+// InstallKSync installs ksync, it returns the sha of the latest commit
+func InstallKSync() (string, error) {
+	binDir, err := util.JXBinLocation()
+	if err != nil {
+		return "", err
+	}
+
+	download, err := isInstalled(binary)
+	if err != nil || !download {
+		// Exec `ksync` to find the version
+
+		kcli, err := NewCLI()
+		if err != nil {
+			return "", err
+		}
+		res, err := kcli.Version()
+		if err != nil {
+			return "", err
+		}
+
+		commit = getCommitShaFromVersion(res)
+		if commit != "" {
+			return commit, nil
+		}
+		return "", fmt.Errorf("unable to find version of ksync")
+	}
+	latestSha, latestVersion, err := getTag("ksync", "ksync")
+	if err != nil {
+		return "", err
+	}
+
+	err = install(latestVersion, binDir, packages.BinaryWithExtension(binary))
+	if err != nil {
+		return "", err
+	}
+
+	return latestSha, nil
+}
+
+func getCommitShaFromVersion(result string) string {
+	lines := strings.Split(result, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Git Commit:") {
+			commit = strings.TrimSpace(strings.TrimPrefix(line, "Git Commit:"))
+		}
+	}
+	return commit
 }

--- a/pkg/ksync/interface.go
+++ b/pkg/ksync/interface.go
@@ -1,0 +1,8 @@
+package ksync
+
+// KSyncer contains the ksync commands
+type KSyncer interface {
+	Version() (string, error)
+	Init(...string) (string, error)
+	Clean() (string, error)
+}

--- a/pkg/ksync/ksync_integration_test.go
+++ b/pkg/ksync/ksync_integration_test.go
@@ -1,0 +1,33 @@
+// +build integration
+
+package ksync_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/cmd/testhelpers"
+	"github.com/jenkins-x/jx/pkg/ksync"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jenkins-x/jx/pkg/log"
+)
+
+// TestInstallKsync tests that Ksync gets properly installed into JX_HOME
+func TestInstallKsync(t *testing.T) {
+	origJXHome, testJXHome, err := testhelpers.CreateTestJxHomeDir()
+	assert.NoError(t, err, "failed to create a test JX Home directory")
+
+	defer func() {
+		err = testhelpers.CleanupTestJxHomeDir(origJXHome, testJXHome)
+		if err != nil {
+			log.Logger().Warnf("unable to remove temporary directory %s: %s", testJXHome, err)
+		}
+		log.Logger().Info("Deleted temporary jx home directory")
+	}()
+
+	// Test installing ksync locally
+	_, err = ksync.InstallKSync()
+	assert.NoError(t, err, "error installing ksync")
+	assert.FileExists(t, filepath.Join(testJXHome, "bin", "ksync"))
+}

--- a/pkg/packages/install.go
+++ b/pkg/packages/install.go
@@ -179,25 +179,25 @@ func ShouldInstallBinary(name string) (fileName string, download bool, err error
 	pgmPath, err := exec.LookPath(fileName)
 	if err == nil {
 		log.Logger().Debugf("%s is already available on your PATH at %s", util.ColorInfo(fileName), util.ColorInfo(pgmPath))
-		return
+		return fileName, download, nil
 	}
 
 	binDir, err := util.JXBinLocation()
 	if err != nil {
-		return
+		return fileName, download, err
 	}
 
 	// lets see if its been installed but just is not on the PATH
 	exists, err := util.FileExists(filepath.Join(binDir, fileName))
 	if err != nil {
-		return
+		return fileName, download, err
 	}
 	if exists {
 		log.Logger().Debugf("Please add %s to your PATH", util.ColorInfo(binDir))
-		return
+		return fileName, download, err
 	}
 	download = true
-	return
+	return fileName, download, err
 }
 
 // BinaryShouldBeInstalled appends the binary to the deps array if it cannot be found on the $PATH

--- a/pkg/util/downloads.go
+++ b/pkg/util/downloads.go
@@ -189,19 +189,19 @@ func getLatestReleaseFromHostUsingHttpRedirect(host, githubOwner, githubRepo str
 
 // GetLatestFullTagFromGithub gets the latest 'full' tag from a specific github repo. This (at present) ignores releases
 // with a hyphen in it, usually used with -SNAPSHOT, or -RC1 or -beta
-func GetLatestFullTagFromGithub(githubOwner, githubRepo string) (string, error) {
+func GetLatestFullTagFromGithub(githubOwner, githubRepo string) (*github.RepositoryTag, error) {
 	tags, err := GetTagsFromGithub(githubOwner, githubRepo)
 	if err == nil {
 		// Iterate over the tags to find the first that doesn't contain any hyphens in it (so is just x.y.z)
 		for _, tag := range tags {
 			name := *tag.Name
 			if !strings.ContainsRune(name, '-') {
-				return name, nil
+				return tag, nil
 			}
 		}
-		return "", errors.Errorf("No Full releases found for %s/%s", githubOwner, githubRepo)
+		return nil, errors.Errorf("No Full releases found for %s/%s", githubOwner, githubRepo)
 	}
-	return "", err
+	return nil, err
 }
 
 // GetLatestTagFromGithub gets the latest (in github order) tag from a specific github repo
@@ -234,7 +234,7 @@ func preamble() (*github.Client, *github.RepositoryRelease, *github.Response, er
 			ts := oauth2.StaticTokenSource(
 				&oauth2.Token{AccessToken: token},
 			)
-			tc = oauth2.NewClient(oauth2.NoContext, ts)
+			tc = oauth2.NewClient(context.TODO(), ts)
 		}
 		githubClient = github.NewClient(tc)
 	}

--- a/pkg/vault/cli.go
+++ b/pkg/vault/cli.go
@@ -22,12 +22,12 @@ func InstallVaultCli() error {
 	if err != nil || !flag {
 		return err
 	}
-	latestVersion, err := util.GetLatestFullTagFromGithub("hashicorp", "vault")
+	latestTag, err := util.GetLatestFullTagFromGithub("hashicorp", "vault")
 	if err != nil {
 		return err
 	}
 	// Strip the v off the beginning of the version number
-	latestVersion = strings.Replace(latestVersion, "v", "", 1)
+	latestVersion := strings.Replace(*latestTag.Name, "v", "", 1)
 
 	clientURL := fmt.Sprintf("https://releases.hashicorp.com/vault/%s/vault_%s_%s_%s.zip", latestVersion, latestVersion, runtime.GOOS, runtime.GOARCH)
 	fullPath := filepath.Join(binDir, fileName)


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
* use git commit as tags for ksync docker image
* refactor InstallSync to add tests
* improve error handling

#### Special notes for the reviewer(s)
/cc @hferentschik @abayer 
* If ksync is installed, jx will try to parse the git commit from the output of the command `ksync version`. 
* If ksync is not installed, then jx will get the commit sha for the latest tag/release for ksync.
It will use this commit sha (short sha of the first 7 characters) to pull the right ksync docker image 
#### Which issue this PR fixes
fixes #6262 and #6123 