### PR TITLE
fix: lets not fail an update if a depedency asset cannot be found

### DIFF
--- a/pkg/gits/operations/pull_request_op.go
+++ b/pkg/gits/operations/pull_request_op.go
@@ -209,13 +209,13 @@ func (o *PullRequestOperation) updateAndGenerateMessagesAndDependencyMatrix(dir 
 	if upstreamDependencyAsset != nil {
 		updatedPaths, err := AddDependencyMatrixUpdatePaths(upstreamDependencyAsset, updateDependency)
 		if err != nil {
-			return "", nil, errors.Wrap(err, "adding dependency updates")
-		}
-
-		for _, d := range updatedPaths {
-			err = dependencymatrix.UpdateDependencyMatrix(dir, d)
-			if err != nil {
-				return "", nil, errors.Wrapf(err, "updating dependency matrix with upstream dependency %+v", d)
+			log.Logger().Warnf("adding dependency updates: %q", err)
+		} else {
+			for _, d := range updatedPaths {
+				err = dependencymatrix.UpdateDependencyMatrix(dir, d)
+				if err != nil {
+					return "", nil, errors.Wrapf(err, "updating dependency matrix with upstream dependency %+v", d)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If for some reason a dependency asset is unavailable then the update fails completely, this change enables the update to continue and outputs a warning if a release asset is not available.

fixes #6923 