### PR TITLE
fix: trim suffix from semver-ish version text to avoid OS dependant errors

### DIFF
--- a/pkg/versionstream/version_data.go
+++ b/pkg/versionstream/version_data.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -130,7 +131,7 @@ func verifyError(name string, err error) error {
 	return err
 }
 
-// removes any whitespace and `v` prefix from a version string
+// removes any whitespace, `v` prefix and other suffix from a version string
 func convertToVersion(text string) string {
 	answer := strings.TrimSpace(text)
 	answer = strings.TrimPrefix(answer, "v")
@@ -138,6 +139,11 @@ func convertToVersion(text string) string {
 	if len(words) > 1 {
 		answer = words[0]
 	}
+	// Some apps might not exactly follow semver, like for example Git for Windows: 2.23.0.windows.1
+	// we're trimming everything after a semver from the answer
+	// to avoid error described in issue #6825
+	r := regexp.MustCompile(`^([0-9]+\.[0-9]+\.[0-9]+)(.*)`)
+	answer = r.ReplaceAllString(answer, "$1")
 	return answer
 }
 

--- a/pkg/versionstream/version_data_test.go
+++ b/pkg/versionstream/version_data_test.go
@@ -80,6 +80,7 @@ func TestExactPackageVersionRange(t *testing.T) {
 
 	AssertPackageVersion(t, resolver, "git", "2.1.1 (Apple Git-117)", false)
 	AssertPackageVersion(t, resolver, "git", "2.20.1 (Apple Git-117)", true)
+	AssertPackageVersion(t, resolver, "git", "2.23.0.windows.1", true)
 }
 
 func AssertPackageVersion(t *testing.T, resolver *versionstream.VersionResolver, name string, version string, expectedValid bool) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
As Git for Windows doesn't follow semver (as seen for example [here](https://github.com/git-for-windows/git/releases/tag/v2.25.1.windows.1)), the `jx diagnose` command fails, as issued [here](https://github.com/jenkins-x/jx/issues/6825)

This fix trim suffixes from semver-ish version text to avoid errors.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6825 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
