### PR TITLE
feat: get environment urlTemplate from requirements when running JX Boot for the first time

### DIFF
--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -541,7 +541,7 @@ func (o *StepVerifyEnvironmentsOptions) createEnvironmentHelmValues(requirements
 				Exposer:     exposer,
 				HTTP:        useHTTP,
 				TLSAcme:     tlsAcme,
-				URLTemplate: config.ExposeDefaultURLTemplate,
+				URLTemplate: getEnvironmentURLTemplate(envCfg),
 			},
 			Production: envCfg.Ingress.TLS.Production,
 		},
@@ -561,6 +561,13 @@ func (o *StepVerifyEnvironmentsOptions) createEnvironmentHelmValues(requirements
 	}
 
 	return helmValues, nil
+}
+
+func getEnvironmentURLTemplate(envCfg *config.EnvironmentConfig) string {
+	if envCfg.URLTemplate != "" {
+		return envCfg.URLTemplate
+	}
+	return config.ExposeDefaultURLTemplate
 }
 
 func (o *StepVerifyEnvironmentsOptions) updateEnvironmentIngressConfig(requirements *config.RequirementsConfig, requirementsFileName string, env *v1.Environment) error {

--- a/pkg/cmd/step/verify/step_verify_environments_test.go
+++ b/pkg/cmd/step/verify/step_verify_environments_test.go
@@ -250,6 +250,23 @@ func Test_ModifyPipelineGitEnvVars(t *testing.T) {
 	assert.Equal(t, expectedEmail, pipelineEnvValueForKey(pipelineEnv, gitCommitterEmailEnvKey))
 }
 
+func Test_getEnvironmentURLTemplate(t *testing.T) {
+	var tests = []struct {
+		name             string
+		cfg              *config.EnvironmentConfig
+		expectedTemplate string
+	}{
+		{"Default Template Test", &config.EnvironmentConfig{}, config.ExposeDefaultURLTemplate},
+		{"Custom Template Test", &config.EnvironmentConfig{URLTemplate: "NewTemplate"}, "NewTemplate"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedTemplate, getEnvironmentURLTemplate(test.cfg), "The returned template should be the expected based on input")
+		})
+	}
+}
+
 func pipelineEnvValueForKey(envVars []corev1.EnvVar, key string) string {
 	for _, entry := range envVars {
 		if entry.Name == key {

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -216,6 +216,8 @@ type EnvironmentConfig struct {
 	RemoteCluster bool `json:"remoteCluster,omitempty"`
 	// PromotionStrategy what kind of promotion strategy to use
 	PromotionStrategy v1.PromotionStrategyType `json:"promotionStrategy,omitempty"`
+	// URLTemplate is the template to use for your environment's exposecontroller generated URLs
+	URLTemplate string `json:"urlTemplate,omitempty"`
 }
 
 // IngressConfig contains dns specific requirements


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Define the desired URLTemplate for a given environment in `jx-requirements.yml` so it's configured when creating the environment's git repository.

This way when running the master pipeline it won't wipe the real value from the `exposecontroller` configmap.

#### Which issue this PR fixes

fixes #6648 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
