### PR TITLE
fix: prevent concurrent build to edit the same namespace

### DIFF
--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -189,6 +189,12 @@ func (o *StepHelmApplyOptions) Run() error {
 		defer os.RemoveAll(rootTmpDir)
 	}
 
+	if release, err := kube.AcquireBuildLock(kubeClient, devNs, ns); err != nil {
+		return errors.Wrapf(err, "fail to acquire the lock")
+	} else {
+		defer release()
+	}
+
 	// lets use the same child dir name as the original as helm is quite particular about the name of the directory it runs from
 	_, name := filepath.Split(dir)
 	if name == "" {

--- a/pkg/kube/build_lock.go
+++ b/pkg/kube/build_lock.go
@@ -1,0 +1,499 @@
+package kube
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jenkins-x/jx/pkg/log"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Labels required to be a lock. Anything else should be ignored.
+var buildLockLabels map[string]string = map[string]string{
+	"jenkins-x.io/kind": "build-lock",
+}
+var buildLockExpires time.Duration = time.Hour
+var buildLockPhaseRunning map[v1.PodPhase]bool = map[v1.PodPhase]bool{
+	v1.PodPending: true,
+	v1.PodRunning: true,
+	v1.PodUnknown: true,
+}
+
+// AcquireBuildLock acquires a build lock, to avoid other builds to edit the
+// same namespace while a deployment is already running, other deployments
+// can negotiate which one should run after, by editing its data.
+// Returns a function to release the lock (to be called in a defer)
+// Returns an error if a newer build is already running, or if an error happened
+func AcquireBuildLock(kubeClient kubernetes.Interface, devNamespace, namespace string) (func() error, error) {
+	// Only lock if running in Tekton
+	if ok, err := IsTektonEnabled(kubeClient, devNamespace); err != nil {
+		log.Logger().Warnf("error while looking for Tekton: %s\n", err.Error())
+		return nil, err
+	} else if !ok {
+		log.Logger().Infof("lock cancelled because not running in tekton")
+		return func() error { return nil }, nil
+	}
+	// Create the lock object
+	lock, err := makeBuildLock(kubeClient, devNamespace, namespace)
+	if err != nil {
+		return nil, err
+	}
+	// this loop continuously tries to create the lock
+Create:
+	for {
+		// no pod to follow, set an expiration date
+		if len(lock.OwnerReferences) == 0 {
+			expires := time.Now().UTC().Add(buildLockExpires).Format(time.RFC3339)
+			lock.Annotations["expires"] = expires
+			lock.Data["expires"] = expires
+		}
+		log.Logger().Infof("creating the lock configmap %s", lock.Name)
+		// create the lock
+		new, err := kubeClient.CoreV1().ConfigMaps(devNamespace).Create(lock)
+		if err != nil {
+			status, ok := err.(*errors.StatusError)
+			// an error while creating the lock
+			if !ok || status.Status().Reason != metav1.StatusReasonAlreadyExists {
+				log.Logger().Warnf("failed to create the lock configmap %s: %s\n", lock.Name, err.Error())
+				return nil, err
+			}
+			// there is already a similat lock
+			log.Logger().Infof("lock configmap %s already exists", lock.Name)
+		} else {
+			// the lock is created, can now perform the updates
+			log.Logger().Infof("lock configmap %s created", lock.Name)
+			// returns a function that releases the lock
+			return func() error {
+				log.Logger().Infof("cleaning the lock configmap %s", lock.Name)
+				err := kubeClient.CoreV1().ConfigMaps(devNamespace).Delete(lock.Name,
+					&metav1.DeleteOptions{
+						Preconditions: &metav1.Preconditions{
+							UID: &new.UID,
+						},
+					})
+				if err != nil {
+					log.Logger().Warnf("failed to cleanup the lock configmap %s: %s\n", lock.Name, err.Error())
+				}
+				return err
+			}, nil
+		}
+		// create these variables outside, to be able to edit them before the next loop
+		var old *v1.ConfigMap
+		var pod *v1.Pod
+	Read:
+		for {
+			// get the current lock if not already provided
+			if old == nil {
+				old, err = kubeClient.CoreV1().ConfigMaps(devNamespace).Get(lock.Name, metav1.GetOptions{})
+				if err != nil {
+					status, ok := err.(*errors.StatusError)
+					// the lock does not exist anymore, try to create it
+					if ok && status.Status().Reason == metav1.StatusReasonNotFound {
+						log.Logger().Infof("lock configmap %s deleted", lock.Name)
+						continue Create
+					}
+					// an error getting the lock
+					log.Logger().Warnf("failed to get the lock configmap %s: %s\n", lock.Name, err.Error())
+					return nil, err
+				}
+			}
+			// get the locking pod
+			var remove bool
+			remove, pod, err = getLockingPod(kubeClient, namespace, old, pod)
+			if err != nil {
+				return nil, err
+				// the lock should simply be removed
+			} else if remove {
+				log.Logger().Infof("cleaning the old lock configmap %s", lock.Name)
+				err := kubeClient.CoreV1().ConfigMaps(devNamespace).Delete(lock.Name,
+					&metav1.DeleteOptions{
+						Preconditions: &metav1.Preconditions{
+							UID: &old.UID,
+						},
+					})
+				// removed, now try to create it
+				if err == nil {
+					continue Create
+				}
+				status, ok := err.(*errors.StatusError)
+				// already deleted, try to create it
+				if ok && status.Status().Reason == metav1.StatusReasonNotFound {
+					continue Create
+					// the lock changed, read it again
+				} else if ok && status.Status().Reason == metav1.StatusReasonConflict {
+					log.Logger().Infof("lock configmap %s changed", lock.Name)
+					old = nil
+					continue Read
+					// an error while removing the pod
+				} else {
+					log.Logger().Warnf("failed to cleanup the old lock configmap %s: %s\n", lock.Name, err.Error())
+					return nil, err
+				}
+			}
+			// compare the builds
+			if data, err := compareBuildLocks(old.Data, lock.Data); err != nil {
+				return nil, err
+				// should update the build to wait
+			} else if data != nil {
+				old.Data = data
+				old, err = kubeClient.CoreV1().ConfigMaps(devNamespace).Update(old)
+				if err != nil {
+					status, ok := err.(*errors.StatusError)
+					// the lock does not exist anymore, try to create it
+					if ok && status.Status().Reason == metav1.StatusReasonNotFound {
+						log.Logger().Infof("lock configmap %s deleted", lock.Name)
+						continue Create
+						// the lock has changed, read it again
+					} else if ok && status.Status().Reason == metav1.StatusReasonConflict {
+						log.Logger().Infof("lock configmap %s changed", lock.Name)
+						old = nil
+						continue Read
+					}
+					// an error updating the lock
+					log.Logger().Warnf("failed to update the lock configmap %s: %s\n", lock.Name, err.Error())
+					return nil, err
+				}
+			}
+			// watch the lock for updates
+			if old, err = watchBuildLock(kubeClient, old, pod, lock.Data); err != nil {
+				return nil, err
+				// lock configmap was updated, read it again
+			} else if old != nil {
+				continue Read
+				// lock configmap was (probably) deleted, try to create it again
+			} else {
+				continue Create
+			}
+		}
+	}
+}
+
+// makeBuildLock make the lock configmap of the current build
+func makeBuildLock(kubeClient kubernetes.Interface, devNamespace, namespace string) (*v1.ConfigMap, error) {
+	// Get infos from the headers
+	now := time.Now().UTC().Format(time.RFC3339)
+	owner := os.Getenv("REPO_OWNER")
+	if owner == "" {
+		log.Logger().Warnf("no REPO_OWNER provided")
+		return nil, fmt.Errorf("no REPO_OWNER provided")
+	}
+	repository := os.Getenv("REPO_NAME")
+	if repository == "" {
+		log.Logger().Warnf("no REPO_NAME provided")
+		return nil, fmt.Errorf("no REPO_NAME provided")
+	}
+	branch := os.Getenv("BRANCH_NAME")
+	if branch == "" {
+		log.Logger().Warnf("no BRANCH_NAME provided")
+		return nil, fmt.Errorf("no BRANCH_NAME provided")
+	}
+	build := os.Getenv("BUILD_NUMBER")
+	if _, err := strconv.Atoi(build); err != nil {
+		log.Logger().Warnf("no BUILD_NUMBER provided: %s\n", err.Error())
+		return nil, err
+	}
+	interpret := os.Getenv("JX_INTERPRET_PIPELINE") == "true"
+	// Create the lock object
+	lock := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("jx-lock-%s", namespace),
+			Namespace: devNamespace,
+			Labels: map[string]string{
+				"namespace":  namespace,
+				"owner":      owner,
+				"repository": repository,
+				"branch":     branch,
+				"build":      build,
+			},
+			Annotations: map[string]string{
+				"jenkins-x.io/created-by": "Jenkins X",
+				"warning":                 "DO NOT REMOVE",
+				"purpose": fmt.Sprintf("This is a deployment lock for the "+
+					"namespace \"%s\". It prevents several deployments to "+
+					"edit the same namespace at the same time. It will "+
+					"automatically be removed once the deployemnt is "+
+					"finished, or replaced by the next deployemnt to run.",
+					namespace),
+			},
+		},
+		Data: map[string]string{
+			"namespace":  namespace,
+			"owner":      owner,
+			"repository": repository,
+			"branch":     branch,
+			"build":      build,
+			"timestamp":  now,
+		},
+	}
+	for k, v := range buildLockLabels {
+		lock.Labels[k] = v
+	}
+	// Find our pod
+	if !interpret {
+		podList, err := kubeClient.CoreV1().Pods(devNamespace).List(metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("owner=%s,repository=%s,branch=%s,build=%s,jenkins.io/pipelineType=build", owner, repository, branch, build),
+		})
+		if err != nil {
+			return nil, err
+		} else if len(podList.Items) != 1 {
+			return nil, fmt.Errorf("%d pods found for this job (owner=%s,repository=%s,branch=%s,build=%s,jenkins.io/pipelineType=build)",
+				len(podList.Items), owner, repository, branch, build)
+		}
+		pod := &podList.Items[0]
+		// kubernetes library seems to forget APIVersoin and Kind
+		// fill those if they're missing
+		if pod.APIVersion == "" {
+			pod.APIVersion = "v1"
+		}
+		if pod.Kind == "" {
+			pod.Kind = "Pod"
+		}
+		lock.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: pod.APIVersion,
+			Kind:       pod.Kind,
+			Name:       pod.Name,
+			UID:        pod.UID,
+		}}
+		lock.Data["pod"] = pod.Name
+	}
+	return lock, nil
+}
+
+// getLockingPod checks the lock and return its locking pod
+// receives the previously known pod, to avoid refreshing it if not needed
+// Returns true if the lock should be removed (because the lock is invalid,
+// or its pod is missing or finished)
+// Returns the pod if one is running, or nil if running locally
+func getLockingPod(kubeClient kubernetes.Interface, namespace string, lock *v1.ConfigMap, pod *v1.Pod) (bool, *v1.Pod, error) {
+	// check the lock
+	for k, v := range buildLockLabels {
+		if lock.Labels[k] != v {
+			log.Logger().Warnf("the lock %s should have annotation \"%s: %s\"", lock.Name, k, v)
+			return true, nil, nil
+		}
+	}
+	if lock.Labels["namespace"] != namespace {
+		log.Logger().Warnf("the lock %s should have label \"namespace: %s\"", lock.Name, namespace)
+		return true, nil, nil
+	}
+	// the lock has no owner, check the timeout
+	if len(lock.OwnerReferences) == 0 {
+		expires, err := time.Parse(time.RFC3339, lock.Annotations["expires"])
+		if err != nil {
+			log.Logger().Warnf("cannot parse the lock's annotation \"expires: %s\": %s\n", lock.Annotations["expires"], err.Error())
+			return false, nil, err
+		} else if !expires.After(time.Now()) {
+			log.Logger().Infof("the lock %s has expired", lock.Name)
+			return true, nil, nil
+		}
+		return false, nil, nil
+	}
+
+	var owner *metav1.OwnerReference
+	if len(lock.OwnerReferences) != 1 {
+		err := fmt.Errorf("the lock %s has %d OwnerReferences", lock.Name, len(lock.OwnerReferences))
+		log.Logger().Warnf(err.Error())
+		return false, nil, err
+	} else if owner = &lock.OwnerReferences[0]; owner.Kind != "Pod" || owner.Name == "" {
+		err := fmt.Errorf("the lock %s has invalid OwnerReference %v", lock.Name, owner)
+		log.Logger().Warn(err.Error())
+		return false, nil, err
+	}
+	// get the current locking pod if not already provided
+	if pod == nil || pod.Name != owner.Name {
+		var err error
+		pod, err = kubeClient.CoreV1().Pods(lock.Namespace).Get(owner.Name, metav1.GetOptions{})
+		if err != nil {
+			status, ok := err.(*errors.StatusError)
+			// the pod does not exist anymore, the lock should be removed
+			if ok && status.Status().Reason == metav1.StatusReasonNotFound {
+				log.Logger().Infof("locking pod %s finished", owner.Name)
+				return true, nil, nil
+				// an error while getting the pod
+			} else {
+				log.Logger().Warnf("failed to get the locking pod %s: %s\n", lock.Data["pod"], err.Error())
+				return false, nil, err
+			}
+		}
+	}
+	// check the pod's phase
+	log.Logger().Infof("locking pod %s is in phase %s", pod.Name, pod.Status.Phase)
+	if !buildLockPhaseRunning[pod.Status.Phase] {
+		return true, nil, nil
+	}
+	return false, pod, nil
+}
+
+// watchBuildLock watches a lock configmap and its locking pod to detect any change
+// Returns nil if the lock was deleted, or is expected to be deleted
+// Returns the new lock configmap if another build is waiting
+func watchBuildLock(kubeClient kubernetes.Interface, lock *v1.ConfigMap, pod *v1.Pod, build map[string]string) (*v1.ConfigMap, error) {
+	log.Logger().Infof("waiting for updates on the lock configmap %s", lock.Name)
+	// watch a timer for expiration
+	var expChan <-chan time.Time
+	if pod == nil {
+		expires, err := time.Parse(time.RFC3339, lock.Annotations["expires"])
+		if err != nil {
+			log.Logger().Warnf("cannot parse the lock's annotation \"expires: %s\": %s\n", lock.Annotations["expires"], err.Error())
+			return nil, err
+		}
+		remaining := expires.Sub(time.Now())
+		// the lock has already expired, no need to wait for anything
+		if remaining <= time.Duration(0) {
+			return lock, nil
+		}
+		log.Logger().Infof("waiting for the lock configmap %s for %s. "+
+			"if you are sure that the local build %s/%s #%s has finished, "+
+			"you can clean the lock with\n\t`kubectl delete configmap -n %s %s`",
+			lock.Name, remaining.Round(time.Second), lock.Labels["repository"],
+			lock.Labels["branch"], lock.Labels["build"], lock.Namespace, lock.Name)
+		timer := time.NewTimer(remaining)
+		defer timer.Stop()
+		expChan = timer.C
+	} else {
+		expChan = make(chan time.Time)
+	}
+	// watch the lock for updates
+	lockWatch, err := kubeClient.CoreV1().ConfigMaps(lock.Namespace).Watch(metav1.SingleObject(lock.ObjectMeta))
+	if err != nil {
+		log.Logger().Warnf("cannot watch the lock configmap %s: %s\n", lock.Name, err.Error())
+		return nil, err
+	}
+	defer lockWatch.Stop()
+	lockChan := lockWatch.ResultChan()
+	// watch the pod for updates
+	var podChan <-chan watch.Event
+	if pod != nil {
+		podWatch, err := kubeClient.CoreV1().Pods(pod.Namespace).Watch(metav1.SingleObject(pod.ObjectMeta))
+		if err != nil {
+			log.Logger().Warnf("cannot watch the locking pod %s: %s\n", pod.Name, err.Error())
+			return nil, err
+		}
+		defer podWatch.Stop()
+		podChan = podWatch.ResultChan()
+	} else {
+		podChan = make(chan watch.Event)
+	}
+	for {
+		select {
+		// an event about the lock
+		case event := <-lockChan:
+			switch event.Type {
+			// the lock has changed
+			case watch.Added, watch.Modified:
+				lock = event.Object.(*v1.ConfigMap)
+				// if the waiting build has changed, read again
+				if next, err := compareBuildLocks(lock.Data, build); err != nil {
+					return nil, err
+				} else if next != nil {
+					return lock, nil
+				}
+			// the lock is deleted, try to create it
+			case watch.Deleted:
+				return nil, nil
+			// an error
+			case watch.Error:
+				err := errors.FromObject(event.Object)
+				log.Logger().Warnf("cannot watch the lock configmap %s: %s\n", lock.Name, err.Error())
+				return nil, err
+			}
+		// an event about the locking pod
+		case event := <-podChan:
+			switch event.Type {
+			// the pod has changed, if its phase has changed,
+			// let's assume that the configmap has been deleted
+			case watch.Added, watch.Modified:
+				pod = event.Object.(*v1.Pod)
+				if !buildLockPhaseRunning[pod.Status.Phase] {
+					return nil, nil
+				}
+			// the pod was deleted, let's assume the configmap too
+			case watch.Deleted:
+				return nil, nil
+			// an error
+			case watch.Error:
+				err := errors.FromObject(event.Object)
+				log.Logger().Warnf("cannot watch the locking pod %s: %s\n", pod.Name, err.Error())
+				return nil, err
+			}
+		// the lock has expired
+		case <-expChan:
+			return lock, nil
+		}
+	}
+}
+
+// compareBuildLocks compares two builds
+// If next is nil, the build is already waiting
+// if next is not nil, the build should wait by updating the lock with these data
+func compareBuildLocks(old, new map[string]string) (map[string]string, error) {
+	sameRepo := true
+	for _, k := range [3]string{"owner", "repository", "branch"} {
+		if old[k] != new[k] {
+			sameRepo = false
+		}
+	}
+	// both are deplying the same repo and branch, compare build number
+	if sameRepo {
+		// same build and pod, we're already waiting
+		if old["build"] == new["build"] && old["pod"] == new["pod"] && old["expires"] == new["expires"] {
+			return nil, nil
+		}
+		// parse the builds
+		if oldBuild, err := strconv.Atoi(old["build"]); err != nil {
+			log.Logger().Warnf("cannot parse the lock's build number %s: %s\n", old["build"], err.Error())
+			return nil, err
+		} else if newBuild, err := strconv.Atoi(new["build"]); err != nil {
+			log.Logger().Warnf("cannot parse the lock's build number %s: %s\n", new["build"], err.Error())
+			return nil, err
+			// older build, give up
+		} else if oldBuild >= newBuild {
+			log.Logger().Warnf("newer build %d is waiting already", oldBuild)
+			return nil, fmt.Errorf("newer build %d is waiting already", oldBuild)
+		}
+		// parse the timestamps in order to keep th newest one
+		if oldTime, err := time.Parse(time.RFC3339, old["timestamp"]); err != nil {
+			log.Logger().Warnf("cannot parse the lock's timestamp %s: %s\n", old["timestamp"], err.Error())
+			return nil, err
+		} else if newTime, err := time.Parse(time.RFC3339, new["timestamp"]); err != nil {
+			log.Logger().Warnf("cannot parse the lock's timestamp %s: %s\n", new["timestamp"], err.Error())
+			return nil, err
+			// keep increasing the timestamp, for consistency reasons
+		} else if oldTime.After(newTime) {
+			next := map[string]string{}
+			for k, v := range new {
+				next[k] = v
+			}
+			next["timestamp"] = old["timestamp"]
+			return next, nil
+			// timestamp already right
+		} else {
+			return new, nil
+		}
+		// both are deploying different repos, keep the newest one
+		// it is a corner case for consistency
+		// but should not happen on a standard cluster
+	} else {
+		// parse the timestamps
+		if oldTime, err := time.Parse(time.RFC3339, old["timestamp"]); err != nil {
+			log.Logger().Warnf("cannot parse the lock's timestamp %s: %s\n", old["timestamp"], err.Error())
+			return nil, err
+		} else if newTime, err := time.Parse(time.RFC3339, new["timestamp"]); err != nil {
+			log.Logger().Warnf("cannot parse the lock's timestamp %s: %s\n", new["timestamp"], err.Error())
+			return nil, err
+			// newer deployment, wait
+		} else if newTime.After(oldTime) {
+			return new, nil
+			// older deployment, give up
+		} else {
+			return nil, fmt.Errorf("newer build %s is waiting already", oldTime)
+		}
+	}
+}

--- a/pkg/kube/build_lock_test.go
+++ b/pkg/kube/build_lock_test.go
@@ -1,0 +1,889 @@
+// +build unit
+
+package kube
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_compareBuildLocks(t *testing.T) {
+	time1 := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	time2 := time.Date(2000, 1, 1, 0, 0, 0, 200000000, time.UTC).Format(time.RFC3339Nano)
+	time3 := time.Date(2000, 1, 1, 0, 0, 0, 210000000, time.UTC).Format(time.RFC3339Nano)
+	examples := []struct {
+		name string
+		old  map[string]string
+		new  map[string]string
+		ret  map[string]string
+		err  bool
+	}{{
+		"same build",
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "123",
+			"pod":        "build-pod-123",
+			"timestamp":  time2,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "123",
+			"pod":        "build-pod-123",
+			"timestamp":  time2,
+		},
+		nil,
+		false,
+	}, {
+		"same build but different pod (for some reason)",
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "123",
+			"pod":        "build-pod-123",
+			"timestamp":  time2,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "123",
+			"pod":        "other-pod-123",
+			"timestamp":  time2,
+		},
+		nil,
+		true,
+	}, {
+		"lower build",
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "101",
+			"pod":        "build-pod-101",
+			"timestamp":  time2,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "99",
+			"pod":        "build-pod-99",
+			"timestamp":  time1,
+		},
+		nil,
+		true,
+	}, {
+		"higher build",
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "101",
+			"pod":        "build-pod-101",
+			"timestamp":  time1,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "103",
+			"pod":        "build-pod-103",
+			"timestamp":  time2,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "103",
+			"pod":        "build-pod-103",
+			"timestamp":  time2,
+		},
+		false,
+	}, {
+		"higher build but lower timestamp",
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "101",
+			"pod":        "build-pod-101",
+			"timestamp":  time3,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "103",
+			"pod":        "build-pod-103",
+			"timestamp":  time2,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "103",
+			"pod":        "build-pod-103",
+			"timestamp":  time3,
+		},
+		false,
+	}, {
+		"other build, same timestamp",
+		map[string]string{
+			"owner":      "other-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "111",
+			"pod":        "build-pod-111",
+			"timestamp":  time2,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "123",
+			"pod":        "other-pod-123",
+			"timestamp":  time2,
+		},
+		nil,
+		true,
+	}, {
+		"other build, lower timestamp",
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "other-repository",
+			"branch":     "my-branch",
+			"build":      "111",
+			"pod":        "build-pod-111",
+			"timestamp":  time2,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "123",
+			"pod":        "other-pod-123",
+			"timestamp":  time1,
+		},
+		nil,
+		true,
+	}, {
+		"other build, higher timestamp",
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "other-branch",
+			"build":      "111",
+			"pod":        "build-pod-111",
+			"timestamp":  time2,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "123",
+			"pod":        "other-pod-123",
+			"timestamp":  time3,
+		},
+		map[string]string{
+			"owner":      "my-owner",
+			"repository": "my-repository",
+			"branch":     "my-branch",
+			"build":      "123",
+			"pod":        "other-pod-123",
+			"timestamp":  time3,
+		},
+		false,
+	}}
+	for _, example := range examples {
+		ret, err := compareBuildLocks(example.old, example.new)
+		assert.Equal(t, example.ret, ret, example.name)
+		if example.err {
+			assert.Error(t, err, example.name)
+		} else {
+			assert.NoError(t, err, example.name)
+		}
+	}
+}
+
+// buildLock_Client creates a fake client with a fake tekton deployment
+func buildLock_Client(t *testing.T) *fake.Clientset {
+	client := fake.NewSimpleClientset()
+	_, err := client.AppsV1().Deployments("jx").Create(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentTektonController,
+			Namespace: "jx",
+		},
+	})
+	require.NoError(t, err)
+	return client
+}
+
+// buildLock_CountWatch count watchers for synchronization reasons
+func buildLock_CountWatch(client *fake.Clientset) chan int {
+	c := make(chan int, 100)
+	count := 0
+	client.PrependWatchReactor("*", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+		count++
+		c <- count
+		return false, nil, nil
+	})
+	return c
+}
+
+var buildLock_UID int = 1 << 20 // the pid of out fake pods
+// buildLock_Pod creates a running pod, looking close enough to a pipeline pod
+func buildLock_Pod(t *testing.T, client kubernetes.Interface, owner, repository, branch, build string) *v1.Pod {
+	buildLock_UID++
+	pod, err := client.CoreV1().Pods("jx").Create(&v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("pipeline-%s-%s-%s-%s", owner, repository, branch, build),
+			Namespace: "jx",
+			Labels: map[string]string{
+				"owner":                   owner,
+				"repository":              repository,
+				"branch":                  branch,
+				"build":                   build,
+				"jenkins.io/pipelineType": "build",
+			},
+			UID: types.UID(fmt.Sprintf("%d", buildLock_UID)),
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	})
+	require.NoError(t, err)
+	return pod
+}
+
+// buildLock_Lock creates a lock
+func buildLock_Lock(t *testing.T, client kubernetes.Interface, namespace, owner, repository, branch, build string, minutes int, expires time.Duration) *v1.ConfigMap {
+	exp := time.Now().UTC().Add(expires).Format(time.RFC3339Nano)
+	lock, err := client.CoreV1().ConfigMaps("jx").Create(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "jx-lock-my-namespace",
+			Namespace: "jx",
+			Labels: map[string]string{
+				"namespace":         namespace,
+				"owner":             owner,
+				"repository":        repository,
+				"branch":            branch,
+				"build":             build,
+				"jenkins-x.io/kind": "build-lock",
+			},
+			Annotations: map[string]string{
+				"expires": exp,
+			},
+		},
+		Data: map[string]string{
+			"namespace":  namespace,
+			"owner":      owner,
+			"repository": repository,
+			"branch":     branch,
+			"build":      build,
+			"timestamp":  buildLock_Timestamp(minutes),
+			"expires":    exp,
+		},
+	})
+	require.NoError(t, err)
+	return lock
+}
+
+// buildLock_LockFromPod creates a lock that matches a pod
+func buildLock_LockFromPod(t *testing.T, client kubernetes.Interface, namespace string, pod *v1.Pod, minutes int) *v1.ConfigMap {
+	lock, err := client.CoreV1().ConfigMaps("jx").Create(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "jx-lock-my-namespace",
+			Namespace: "jx",
+			Labels: map[string]string{
+				"namespace":         namespace,
+				"owner":             pod.Labels["owner"],
+				"repository":        pod.Labels["repository"],
+				"branch":            pod.Labels["branch"],
+				"build":             pod.Labels["build"],
+				"jenkins-x.io/kind": "build-lock",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Name:       pod.Name,
+				UID:        pod.UID,
+			}},
+		},
+		Data: map[string]string{
+			"namespace":  namespace,
+			"owner":      pod.Labels["owner"],
+			"repository": pod.Labels["repository"],
+			"branch":     pod.Labels["branch"],
+			"build":      pod.Labels["build"],
+			"pod":        pod.Name,
+			"timestamp":  buildLock_Timestamp(minutes),
+		},
+	})
+	require.NoError(t, err)
+	return lock
+}
+
+// buildLock_Timestamp create the timestamp for a lock, now plus or minus some minutes
+func buildLock_Timestamp(minutes int) string {
+	now := time.Now().UTC()
+	now = now.Add(time.Duration(minutes) * time.Minute)
+	return now.Format(time.RFC3339Nano)
+}
+
+// buildLock_Env prepares the environment for calling AcquireBuildLock
+// returns a defer function to restore the environment
+func buildLock_Env(t *testing.T, owner, repository, branch, build string, interpret bool) func() {
+	v := ""
+	if interpret {
+		v = "true"
+	}
+	env := map[string]string{
+		"REPO_OWNER":            owner,
+		"REPO_NAME":             repository,
+		"BRANCH_NAME":           branch,
+		"BUILD_NUMBER":          build,
+		"JX_INTERPRET_PIPELINE": v,
+	}
+	old := map[string]string{}
+	for k, v := range env {
+		value, ok := os.LookupEnv(k)
+		if ok {
+			old[k] = value
+		}
+		var err error
+		if v == "" {
+			err = os.Unsetenv(k)
+		} else {
+			err = os.Setenv(k, v)
+		}
+		require.NoError(t, err)
+	}
+	return func() {
+		for k := range env {
+			v, ok := old[k]
+			var err error
+			if ok {
+				err = os.Setenv(k, v)
+			} else {
+				err = os.Unsetenv(k)
+			}
+			assert.NoError(t, err)
+		}
+	}
+}
+
+// buildLock_Acquire calls AcquireBuildLock with arguments
+// returns a defer function to restore the environment
+// returns a chan that is filled once AcquireBuildLock returns
+// its item will perform some check and call the callback
+// its item is nil on timeout
+func buildLock_Acquire(t *testing.T, client kubernetes.Interface, namespace, owner, repository, branch, build string, fails bool) (func(), chan func()) {
+	c := make(chan func(), 2)
+	clean := buildLock_Env(t, owner, repository, branch, build, true)
+	go func() {
+		callback, err := AcquireBuildLock(client, "jx", namespace)
+		c <- func() {
+			if !fails {
+				require.NoError(t, err)
+				assert.NoError(t, callback())
+			} else {
+				require.Error(t, err)
+			}
+		}
+	}()
+	go func() {
+		time.Sleep(time.Duration(5) * time.Second)
+		c <- nil
+	}()
+	return clean, c
+}
+
+// buildLock_AcquireFromPod calls AcquireBuildLock with arguments matching a pod
+// returns a defer function to restore the environment
+// returns a chan that is filled once AcquireBuildLock returns
+// its item will perform some check and call the callback
+// its item is nil on timeout
+func buildLock_AcquireFromPod(t *testing.T, client kubernetes.Interface, namespace string, pod *v1.Pod, fails bool) (func(), chan func()) {
+	c := make(chan func(), 2)
+	clean := buildLock_Env(t, pod.Labels["owner"], pod.Labels["repository"], pod.Labels["branch"], pod.Labels["build"], false)
+	go func() {
+		callback, err := AcquireBuildLock(client, "jx", namespace)
+		c <- func() {
+			if !fails {
+				require.NoError(t, err)
+				assert.NoError(t, callback())
+			} else {
+				require.Error(t, err)
+			}
+		}
+	}()
+	go func() {
+		time.Sleep(time.Duration(5) * time.Second)
+		c <- nil
+	}()
+	return clean, c
+}
+
+func buildLock_AssertNoLock(t *testing.T, client kubernetes.Interface, namespace string) {
+	lock, err := client.CoreV1().ConfigMaps("jx").Get("jx-lock-"+namespace, metav1.GetOptions{})
+	assert.Nil(t, lock)
+	if assert.Error(t, err) {
+		require.IsType(t, &errors.StatusError{}, err)
+		status := err.(*errors.StatusError)
+		require.Equal(t, metav1.StatusReasonNotFound, status.Status().Reason)
+	}
+}
+
+// buildLock_AssertLock checks if the lock configmap is correct
+func buildLock_AssertLock(t *testing.T, client kubernetes.Interface, namespace, owner, repository, branch, build string) {
+	lock, err := client.CoreV1().ConfigMaps("jx").Get("jx-lock-"+namespace, metav1.GetOptions{})
+	require.NoError(t, err)
+	if assert.NotNil(t, lock) {
+		assert.Equal(t, "build-lock", lock.Labels["jenkins-x.io/kind"])
+		assert.Equal(t, namespace, lock.Labels["namespace"])
+		assert.Equal(t, owner, lock.Labels["owner"])
+		assert.Equal(t, repository, lock.Labels["repository"])
+		assert.Equal(t, branch, lock.Labels["branch"])
+		assert.Equal(t, build, lock.Labels["build"])
+		assert.Empty(t, lock.OwnerReferences)
+		assert.Equal(t, namespace, lock.Data["namespace"])
+		assert.Equal(t, owner, lock.Data["owner"])
+		assert.Equal(t, repository, lock.Data["repository"])
+		assert.Equal(t, branch, lock.Data["branch"])
+		assert.Equal(t, build, lock.Data["build"])
+		assert.Equal(t, "", lock.Data["pod"])
+		ts, err := time.Parse(time.RFC3339Nano, lock.Data["timestamp"])
+		if assert.NoError(t, err) {
+			assert.True(t, ts.Before(time.Now().Add(time.Minute)))
+			assert.True(t, ts.After(time.Now().Add(time.Duration(-1)*time.Minute)))
+		}
+		ts, err = time.Parse(time.RFC3339Nano, lock.Annotations["expires"])
+		if assert.NoError(t, err) {
+			// tighter check to be sure that expires is updated
+			assert.True(t, ts.Before(time.Now().Add(buildLockExpires+time.Duration(1500)*time.Millisecond)))
+			assert.True(t, ts.After(time.Now().Add(buildLockExpires+time.Duration(-1500)*time.Millisecond)))
+			assert.Equal(t, lock.Annotations["expires"], lock.Data["expires"])
+		}
+	}
+}
+
+// buildLock_AssertLockFromPod checks if the lock configmap is matching the given pod
+func buildLock_AssertLockFromPod(t *testing.T, client kubernetes.Interface, namespace string, pod *v1.Pod) {
+	lock, err := client.CoreV1().ConfigMaps("jx").Get("jx-lock-"+namespace, metav1.GetOptions{})
+	require.NoError(t, err)
+	if assert.NotNil(t, lock) {
+		assert.Equal(t, "build-lock", lock.Labels["jenkins-x.io/kind"])
+		assert.Equal(t, namespace, lock.Labels["namespace"])
+		assert.Equal(t, pod.Labels["owner"], lock.Labels["owner"])
+		assert.Equal(t, pod.Labels["repository"], lock.Labels["repository"])
+		assert.Equal(t, pod.Labels["branch"], lock.Labels["branch"])
+		assert.Equal(t, pod.Labels["build"], lock.Labels["build"])
+		assert.Equal(t, []metav1.OwnerReference{{
+			APIVersion: pod.APIVersion,
+			Kind:       pod.Kind,
+			Name:       pod.Name,
+			UID:        pod.UID,
+		}}, lock.OwnerReferences)
+		assert.Equal(t, "", lock.Annotations["expires"])
+		assert.Equal(t, namespace, lock.Data["namespace"])
+		assert.Equal(t, pod.Labels["owner"], lock.Data["owner"])
+		assert.Equal(t, pod.Labels["repository"], lock.Data["repository"])
+		assert.Equal(t, pod.Labels["branch"], lock.Data["branch"])
+		assert.Equal(t, pod.Labels["build"], lock.Data["build"])
+		assert.Equal(t, pod.Name, lock.Data["pod"])
+		ts, err := time.Parse(time.RFC3339Nano, lock.Data["timestamp"])
+		if assert.NoError(t, err) {
+			assert.True(t, ts.Before(time.Now().Add(time.Minute)))
+			assert.True(t, ts.After(time.Now().Add(time.Duration(-1)*time.Minute)))
+		}
+		assert.Equal(t, "", lock.Data["expires"])
+	}
+}
+
+func TestAcquireBuildLock(t *testing.T) {
+	// just acquire a lock when no lock exists
+	client := buildLock_Client(t)
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, false)
+	defer clean()
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	buildLock_AssertLockFromPod(t, client, "my-namespace", pod)
+	callback()
+	buildLock_AssertNoLock(t, client, "my-namespace")
+}
+
+func TestAcquireBuildLock_interpret(t *testing.T) {
+	// acquire a lock with an intepreted pipeline
+	client := buildLock_Client(t)
+	clean := buildLock_Env(t, "my-owner", "my-repository", "my-branch", "13", true)
+	defer clean()
+	channel := make(chan func(), 2)
+	go func() {
+		callback, err := AcquireBuildLock(client, "jx", "my-namespace")
+		channel <- func() {
+			require.NoError(t, err)
+			assert.NoError(t, callback())
+		}
+	}()
+	go func() {
+		time.Sleep(time.Duration(5) * time.Second)
+		channel <- nil
+	}()
+
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	buildLock_AssertLock(t, client, "my-namespace", "my-owner", "my-repository", "my-branch", "13")
+	callback()
+	buildLock_AssertNoLock(t, client, "my-namespace")
+}
+
+func TestAcquireBuildLock_invalidLock(t *testing.T) {
+	// acquire a lock when the previous lock is invalid
+	client := buildLock_Client(t)
+	previous := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "42")
+	lock := buildLock_LockFromPod(t, client, "my-namespace", previous, -42)
+	lock.Labels["jenkins-x.io/kind"] = "other-lock"
+	_, err := client.CoreV1().ConfigMaps("jx").Update(lock)
+	require.NoError(t, err)
+
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, false)
+	defer clean()
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	buildLock_AssertLockFromPod(t, client, "my-namespace", pod)
+	callback()
+	buildLock_AssertNoLock(t, client, "my-namespace")
+}
+
+func TestAcquireBuildLock_previousNotFound(t *testing.T) {
+	// acquire a lock when the locking pod does not exist
+	client := buildLock_Client(t)
+	previous := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "42")
+	buildLock_LockFromPod(t, client, "my-namespace", previous, 42)
+	err := client.CoreV1().Pods("jx").Delete(previous.Name, &metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, false)
+	defer clean()
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	buildLock_AssertLockFromPod(t, client, "my-namespace", pod)
+	callback()
+	buildLock_AssertNoLock(t, client, "my-namespace")
+}
+
+func TestAcquireBuildLock_previousFinished(t *testing.T) {
+	// acquire a lock when the locking pod has finished
+	client := buildLock_Client(t)
+	previous := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "42")
+	buildLock_LockFromPod(t, client, "my-namespace", previous, 42)
+	previous.Status.Phase = v1.PodFailed
+	_, err := client.CoreV1().Pods("jx").Update(previous)
+	require.NoError(t, err)
+
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, false)
+	defer clean()
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	buildLock_AssertLockFromPod(t, client, "my-namespace", pod)
+	callback()
+	buildLock_AssertNoLock(t, client, "my-namespace")
+}
+
+func TestAcquireBuildLock_expired(t *testing.T) {
+	// acquire a lock when the previous lock has expired
+	client := buildLock_Client(t)
+	buildLock_Lock(t, client, "my-namespace", "my-owner", "my-repository", "my-branch", "42", 42, time.Duration(-1)*time.Minute)
+
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, false)
+	defer clean()
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	buildLock_AssertLockFromPod(t, client, "my-namespace", pod)
+	callback()
+	buildLock_AssertNoLock(t, client, "my-namespace")
+}
+
+func TestAcquireBuildLock_higherRuns(t *testing.T) {
+	// fails at acquiring the lock because an higher build is running
+	client := buildLock_Client(t)
+	previous := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "42")
+	buildLock_LockFromPod(t, client, "my-namespace", previous, -42)
+
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, true)
+	defer clean()
+	callback := <-channel
+	callback()
+}
+
+func TestAcquireBuildLock_laterRuns(t *testing.T) {
+	// fails at acquiring the lock because a later build is running
+	client := buildLock_Client(t)
+	previous := buildLock_Pod(t, client, "other-owner", "other-repository", "other-branch", "42")
+	buildLock_LockFromPod(t, client, "my-namespace", previous, 42)
+
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, true)
+	defer clean()
+	callback := <-channel
+	callback()
+}
+
+func TestAcquireBuildLock_waitLowerPodDeleted(t *testing.T) {
+	// wait for a lower build to be deleted
+	client := buildLock_Client(t)
+	counter := buildLock_CountWatch(client)
+	previous := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "11")
+	old := buildLock_LockFromPod(t, client, "my-namespace", previous, 11)
+	// should update the lock
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, false)
+	defer clean()
+	// wait for AcquireBuildLock to be waiting
+	for {
+		count := 0
+		select {
+		case count = <-counter:
+		case callback := <-channel:
+			require.NotNil(t, callback, "timeout")
+			assert.Fail(t, "TestAcquireBuildLock returned")
+			callback()
+			return
+		}
+		if count == 2 {
+			break
+		}
+	}
+	// check the lock
+	lock, err := client.CoreV1().ConfigMaps("jx").Get(old.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, old.ObjectMeta, lock.ObjectMeta)
+	assert.Equal(t, "my-namespace", lock.Data["namespace"])
+	assert.Equal(t, "my-owner", lock.Data["owner"])
+	assert.Equal(t, "my-repository", lock.Data["repository"])
+	assert.Equal(t, "my-branch", lock.Data["branch"])
+	assert.Equal(t, "13", lock.Data["build"])
+	assert.Equal(t, pod.Name, lock.Data["pod"])
+	assert.Equal(t, old.Data["timestamp"], lock.Data["timestamp"])
+	// should acquire the lock
+	err = client.CoreV1().Pods("jx").Delete(previous.Name, &metav1.DeleteOptions{})
+	require.NoError(t, err)
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	buildLock_AssertLockFromPod(t, client, "my-namespace", pod)
+	callback()
+	buildLock_AssertNoLock(t, client, "my-namespace")
+}
+
+func TestAcquireBuildLock_waitLowerLockDeleted(t *testing.T) {
+	// wait for a lower build lock to be deleted
+	client := buildLock_Client(t)
+	counter := buildLock_CountWatch(client)
+	previous := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "11")
+	old := buildLock_LockFromPod(t, client, "my-namespace", previous, 11)
+	// should update the lock
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, false)
+	defer clean()
+	// wait for AcquireBuildLock to be waiting
+	for {
+		count := 0
+		select {
+		case count = <-counter:
+		case callback := <-channel:
+			require.NotNil(t, callback, "timeout")
+			assert.Fail(t, "TestAcquireBuildLock returned")
+			callback()
+			return
+		}
+		if count == 2 {
+			break
+		}
+	}
+	// check the lock
+	lock, err := client.CoreV1().ConfigMaps("jx").Get(old.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, old.ObjectMeta, lock.ObjectMeta)
+	assert.Equal(t, "my-namespace", lock.Data["namespace"])
+	assert.Equal(t, "my-owner", lock.Data["owner"])
+	assert.Equal(t, "my-repository", lock.Data["repository"])
+	assert.Equal(t, "my-branch", lock.Data["branch"])
+	assert.Equal(t, "13", lock.Data["build"])
+	assert.Equal(t, pod.Name, lock.Data["pod"])
+	assert.Equal(t, old.Data["timestamp"], lock.Data["timestamp"])
+	// should acquire the lock
+	err = client.CoreV1().ConfigMaps("jx").Delete(old.Name, &metav1.DeleteOptions{})
+	require.NoError(t, err)
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	buildLock_AssertLockFromPod(t, client, "my-namespace", pod)
+	callback()
+	buildLock_AssertNoLock(t, client, "my-namespace")
+}
+
+func TestAcquireBuildLock_waitEarlierFinished(t *testing.T) {
+	// wait for a lower build to finish
+	client := buildLock_Client(t)
+	counter := buildLock_CountWatch(client)
+	previous := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "11")
+	old := buildLock_LockFromPod(t, client, "my-namespace", previous, 11)
+	// should update the lock
+	clean, channel := buildLock_Acquire(t, client, "my-namespace", "my-owner", "my-repository", "my-branch", "13", false)
+	defer clean()
+	// wait for AcquireBuildLock to be waiting
+	for {
+		count := 0
+		select {
+		case count = <-counter:
+		case callback := <-channel:
+			require.NotNil(t, callback, "timeout")
+			assert.Fail(t, "TestAcquireBuildLock returned")
+			callback()
+			return
+		}
+		if count == 1 {
+			break
+		}
+	}
+	// check the lock
+	lock, err := client.CoreV1().ConfigMaps("jx").Get(old.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, old.ObjectMeta, lock.ObjectMeta)
+	assert.Equal(t, "my-namespace", lock.Data["namespace"])
+	assert.Equal(t, "my-owner", lock.Data["owner"])
+	assert.Equal(t, "my-repository", lock.Data["repository"])
+	assert.Equal(t, "my-branch", lock.Data["branch"])
+	assert.Equal(t, "13", lock.Data["build"])
+	assert.Equal(t, "", lock.Data["pod"])
+	assert.Equal(t, old.Data["timestamp"], lock.Data["timestamp"])
+	// should acquire the lock
+	previous.Status.Phase = v1.PodSucceeded
+	_, err = client.CoreV1().Pods("jx").Update(previous)
+	require.NoError(t, err)
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	buildLock_AssertLock(t, client, "my-namespace", "my-owner", "my-repository", "my-branch", "13")
+	callback()
+	buildLock_AssertNoLock(t, client, "my-namespace")
+}
+
+func TestAcquireBuildLock_waitLowerExpired(t *testing.T) {
+	// wait for a lock to expire
+	client := buildLock_Client(t)
+	counter := buildLock_CountWatch(client)
+	old := buildLock_Lock(t, client, "my-namespace", "my-owner", "my-repository", "my-branch", "11", 11, time.Duration(2)*time.Second)
+	// should update the lock
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, false)
+	defer clean()
+	// wait for AcquireBuildLock to be waiting
+	for {
+		count := 0
+		select {
+		case count = <-counter:
+		case callback := <-channel:
+			require.NotNil(t, callback, "timeout")
+			assert.Fail(t, "TestAcquireBuildLock returned")
+			callback()
+			return
+		}
+		if count == 1 {
+			break
+		}
+	}
+	// check the lock
+	lock, err := client.CoreV1().ConfigMaps("jx").Get(old.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, old.ObjectMeta, lock.ObjectMeta)
+	assert.Equal(t, "my-namespace", lock.Data["namespace"])
+	assert.Equal(t, "my-owner", lock.Data["owner"])
+	assert.Equal(t, "my-repository", lock.Data["repository"])
+	assert.Equal(t, "my-branch", lock.Data["branch"])
+	assert.Equal(t, "13", lock.Data["build"])
+	assert.Equal(t, pod.Name, lock.Data["pod"])
+	assert.Equal(t, old.Data["timestamp"], lock.Data["timestamp"])
+	// should acquire the lock after 2 seconds
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	buildLock_AssertLockFromPod(t, client, "my-namespace", pod)
+	callback()
+	buildLock_AssertNoLock(t, client, "my-namespace")
+}
+
+func TestAcquireBuildLock_waitButHigher(t *testing.T) {
+	// wait for a lower run to finish, but an higher run appears
+	client := buildLock_Client(t)
+	counter := buildLock_CountWatch(client)
+	previous := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "11")
+	old := buildLock_LockFromPod(t, client, "my-namespace", previous, -11)
+	// should update the lock
+	pod := buildLock_Pod(t, client, "my-owner", "my-repository", "my-branch", "13")
+	clean, channel := buildLock_AcquireFromPod(t, client, "my-namespace", pod, true)
+	defer clean()
+	// wait for AcquireBuildLock to be waiting
+	for {
+		count := 0
+		select {
+		case count = <-counter:
+		case callback := <-channel:
+			require.NotNil(t, callback, "timeout")
+			assert.Fail(t, "TestAcquireBuildLock returned")
+			callback()
+			return
+		}
+		if count == 2 {
+			break
+		}
+	}
+	// check the lock
+	lock, err := client.CoreV1().ConfigMaps("jx").Get(old.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, old.ObjectMeta, lock.ObjectMeta)
+	assert.Equal(t, "my-namespace", lock.Data["namespace"])
+	assert.Equal(t, "my-owner", lock.Data["owner"])
+	assert.Equal(t, "my-repository", lock.Data["repository"])
+	assert.Equal(t, "my-branch", lock.Data["branch"])
+	assert.Equal(t, "13", lock.Data["build"])
+	ts, err := time.Parse(time.RFC3339Nano, lock.Data["timestamp"])
+	if assert.NoError(t, err) {
+		assert.True(t, ts.Before(time.Now().Add(time.Minute)))
+		assert.True(t, ts.After(time.Now().Add(time.Duration(-1)*time.Minute)))
+	}
+	// update the lock and expect failure
+	lock.Data["build"] = "21"
+	_, err = client.CoreV1().ConfigMaps("jx").Update(lock)
+	require.NoError(t, err)
+	callback := <-channel
+	require.NotNil(t, callback, "timeout")
+	callback()
+}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This PR prevents builds to edit the same namespace at the same time. Such a behavior could lead to a namespace to be accidentally wiped out.

Only `jx step helm apply` is locked.

#### Special notes for the reviewer(s)

A ConfigMap `jx-lock-{namespace}` is used as a lock. No other build can run while this configmap exists. Waiting builds can edit the data of the ConfigMap in order to be the next one to run. If a build sees that the locking or waiting build is "higher", it will fail. When the build finished, the ConfigMap is removed. A waiting build can also remove the ConfigMap if the lokcing pod has finished.

The algorithm is approximately:
```
    Label: CREATE
    try to create the ConfigMap
    if it succeeds:
        return
    Label: READ
    get the ConfigMap and the locking Pod
    if the locking Pod has finished
        remove the ConfigMap
        goto CREATE
    if the ConfigMap references a "higher" build
        fail
    if the ConfigMap references a "lower" build
        update the ConfigMap
    wait for the ConfigMap or the Pod to be updated
        if the ConfigMap is delete
            goto CREATE
        if the ConfigMap references a different build
            goto READ
        if the Pod has finished
            goto CREATE
```

#### Which issue this PR fixes

fixes #6167

#### Issues

- there is currently no easy way to know which pod `jx` is running in. The pipeline could be changed to give such an info: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
- I currently use the filter `owner={REPO_OWNER},repository={REPO_NAME}s,branch={BRANCH_NAME},build={BUILD_NUMBER},jenkins.io/pipelineType=build`, using the headers. I'm afraid such a filter is specific to specific kind of pipelines.
- I also use those headers to compare builds. If a build has the same owner, repo and branch, I compare the build number. If not, I compare a timestamp (I ensure that the timestamp is always increasing though).
- It could be easily added to other `jx` commands. But I'm not sure which ones need.
- `make lint` made a huge update of `go.mod`. No idea why.