### PR TITLE
fix: check helm version instead of binary for timeout

### DIFF
--- a/pkg/helm/helm_cli.go
+++ b/pkg/helm/helm_cli.go
@@ -448,7 +448,7 @@ func (h *HelmCLI) UpgradeChart(chart string, releaseName string, ns string, vers
 		args = append(args, "--force")
 	}
 	if timeout != -1 {
-		if h.Binary == "helm3" {
+		if h.BinVersion == V3 {
 			args = append(args, "--timeout", fmt.Sprintf("%ss", strconv.Itoa(timeout)))
 		} else {
 			args = append(args, "--timeout", strconv.Itoa(timeout))


### PR DESCRIPTION
Signed-off-by: Youssef El Houti <youssef.elhouti@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)
This problem just appeared today be cause of jx-labs updating helm binary (helm) to version 3, and we should check for version instead of binary name

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
