### PR TITLE
[wip] fix: Add expiration time for token to UserAuth when using k8s secrets

### DIFF
--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"time"
+
 	"github.com/jenkins-x/jx/pkg/secreturl"
 	"github.com/jenkins-x/jx/pkg/vault"
 	"k8s.io/client-go/kubernetes"
@@ -25,6 +27,9 @@ type UserAuth struct {
 	// GithubAppOwner if using GitHub Apps this represents the owner organisation/user which owns this token.
 	// we need to maintain a different token per owner
 	GithubAppOwner string `json:"appOwner,omitempty"`
+
+	// ExpiresAt can be set to the time at which the authorisation information for this user expires. Can be nil.
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
 }
 
 type AuthConfig struct {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This will allow for `GitProvider` implementations to check if the token they're configured with has expired, and if so, reload their auth config. I'll have a follow-up supporting this for GitHub shortly. As mentioned on the issue, we need to eventually support defining expiration time with Vault-stored git auth secrets as well, but I wanted to start with the simplest proof of concept.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6963 
