### PR TITLE
fix: jx upgrade boot failure when duplicate commits

### DIFF
--- a/pkg/cmd/upgrade/upgrade_boot.go
+++ b/pkg/cmd/upgrade/upgrade_boot.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/jx/pkg/boot"
+
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
@@ -436,7 +437,8 @@ func (o *UpgradeBootOptions) cherryPickCommits(cloneDir, fromSha, toSha string) 
 		commitSha := cmts[i].SHA
 		commitMsg := cmts[i].Subject()
 
-		err := o.Git().CherryPickTheirs(o.Dir, commitSha)
+		// cherry-pick commits preserving redundant commits to avoid error
+		err := o.Git().CherryPickTheirsKeepRedundantCommits(o.Dir, commitSha)
 		if err != nil {
 			msg := fmt.Sprintf("commit %s is a merge but no -m option was given.", commitSha)
 			if !strings.Contains(err.Error(), msg) {

--- a/pkg/gits/git_cli.go
+++ b/pkg/gits/git_cli.go
@@ -1223,6 +1223,11 @@ func (g *GitCLI) CherryPickTheirs(dir string, commitish string) error {
 	return g.gitCmd(dir, "cherry-pick", commitish, "--strategy=recursive", "-X", "theirs")
 }
 
+// CherryPickTheirsKeepRedundantCommits does a git cherry-pick of commit
+func (g *GitCLI) CherryPickTheirsKeepRedundantCommits(dir string, commitish string) error {
+	return g.gitCmd(dir, "cherry-pick", commitish, "--strategy=recursive", "-X", "theirs", "--keep-redundant-commits")
+}
+
 // Describe does a git describe of commitish, optionally adding the abbrev arg if not empty, falling back to just the commit ref if it's untagged
 func (g *GitCLI) Describe(dir string, contains bool, commitish string, abbrev string, fallback bool) (string, string, error) {
 	args := []string{"describe", commitish}

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -675,6 +675,11 @@ func (g *GitFake) CherryPickTheirs(dir string, commit string) error {
 	return nil
 }
 
+// CherryPickTheirsKeepRedundantCommits does a git cherry-pick of commit
+func (g *GitFake) CherryPickTheirsKeepRedundantCommits(dir string, commit string) error {
+	return nil
+}
+
 // Describe does a git describe of commitish, optionally adding the abbrev arg if not empty
 func (g *GitFake) Describe(dir string, contains bool, commitish string, abbrev string, fallback bool) (string, string, error) {
 	return "", "", nil

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -529,6 +529,11 @@ func (g *GitLocal) CherryPickTheirs(dir string, commit string) error {
 	return g.GitCLI.CherryPickTheirs(dir, commit)
 }
 
+// CherryPickTheirsKeepRedundantCommits does a git cherry-pick of commit
+func (g *GitLocal) CherryPickTheirsKeepRedundantCommits(dir string, commit string) error {
+	return g.GitCLI.CherryPickTheirsKeepRedundantCommits(dir, commit)
+}
+
 // Describe does a git describe of commitish, optionally adding the abbrev arg if not empty
 func (g *GitLocal) Describe(dir string, contains bool, commitish string, abbrev string, fallback bool) (string, string, error) {
 	return g.GitCLI.Describe(dir, false, commitish, abbrev, fallback)

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -247,6 +247,7 @@ type Gitter interface {
 	RebaseTheirs(dir string, upstream string, branch string, skipEmpty bool) error
 	CherryPick(dir string, commitish string) error
 	CherryPickTheirs(dir string, commitish string) error
+	CherryPickTheirsKeepRedundantCommits(dir string, commitish string) error
 
 	StashPush(dir string) error
 	StashPop(dir string) error

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -201,6 +201,21 @@ func (mock *MockGitter) CherryPickTheirs(_param0 string, _param1 string) error {
 	return ret0
 }
 
+func (mock *MockGitter) CherryPickTheirsKeepRedundantCommits(_param0 string, _param1 string) error {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0, _param1}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CherryPickTheirsKeepRedundantCommits", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(error)
+		}
+	}
+	return ret0
+}
+
 func (mock *MockGitter) CleanForce(_param0 string, _param1 string) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -2077,6 +2092,37 @@ func (c *MockGitter_CherryPickTheirs_OngoingVerification) GetCapturedArguments()
 }
 
 func (c *MockGitter_CherryPickTheirs_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) CherryPickTheirsKeepRedundantCommits(_param0 string, _param1 string) *MockGitter_CherryPickTheirsKeepRedundantCommits_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CherryPickTheirsKeepRedundantCommits", params, verifier.timeout)
+	return &MockGitter_CherryPickTheirsKeepRedundantCommits_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_CherryPickTheirsKeepRedundantCommits_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_CherryPickTheirsKeepRedundantCommits_OngoingVerification) GetCapturedArguments() (string, string) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
+}
+
+func (c *MockGitter_CherryPickTheirsKeepRedundantCommits_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(c.methodInvocations))


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>
#### Description

`jx upgrade boot` fails with the following error if there are duplicate commit's 

```
error: failed to update boot configuration: failed to cherry pick upgrade commits: cherry-picking <commit_id>: git output: The previous cherry-pick is now empty, possibly due to conflict resolution.
If you wish to commit it anyway, use:

    git commit --allow-empty

Otherwise, please use 'git reset'
On branch <branch_name>
You are currently cherry-picking commit <commit_id>.
```

fixes #6970