### PR TITLE
fix: Lower-case dir placeholder replacements from build pack

### DIFF
--- a/pkg/cmd/step/syntax/step_syntax_effective_test.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective_test.go
@@ -814,9 +814,10 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 			},
 		},
 	}, {
-		name:         "overrides-with-buildpack-using-jenkins-x-syntax",
-		pack:         "jx-syntax-in-buildpack",
-		repoName:     "jx-demo-qs",
+		name: "overrides-with-buildpack-using-jenkins-x-syntax",
+		pack: "jx-syntax-in-buildpack",
+		// Upper-casing to verify fix for #6983
+		repoName:     "Jx-demo-qs",
 		organization: "abayer",
 		branch:       "master",
 		expected: &config.ProjectConfig{

--- a/pkg/tekton/syntax/pipeline.go
+++ b/pkg/tekton/syntax/pipeline.go
@@ -1167,10 +1167,10 @@ func replacePlaceholdersInDir(originalDir *string, args StepPlaceholderReplaceme
 	// Replace the Go buildpack path with the correct location for Tekton builds.
 	dir = strings.Replace(dir, "/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME", args.WorkspaceDir, -1)
 
-	dir = strings.Replace(dir, util.PlaceHolderAppName, args.GitName, -1)
-	dir = strings.Replace(dir, util.PlaceHolderOrg, args.GitOrg, -1)
+	dir = strings.Replace(dir, util.PlaceHolderAppName, strings.ToLower(args.GitName), -1)
+	dir = strings.Replace(dir, util.PlaceHolderOrg, strings.ToLower(args.GitOrg), -1)
 	dir = strings.Replace(dir, util.PlaceHolderGitProvider, strings.ToLower(args.GitHost), -1)
-	dir = strings.Replace(dir, util.PlaceHolderDockerRegistryOrg, args.DockerRegistryOrg, -1)
+	dir = strings.Replace(dir, util.PlaceHolderDockerRegistryOrg, strings.ToLower(args.DockerRegistryOrg), -1)
 
 	if strings.HasPrefix(dir, "./") {
 		dir = args.WorkspaceDir + strings.TrimPrefix(dir, ".")


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

We lower-case the app name etc when generating directories (like `charts/(app name)`) in `jx import`, but had not been doing so when replacing `REPLACE_ME_APP_NAME` etc placeholders in directories configured in build packs. We should be using the same case there that we use in generating the directories in the first place.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6983 
