### PR TITLE
fix: Don't warn about static master removal in "jx completion ..."

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -357,6 +357,11 @@ func logWarningForRemovalOfStaticMasters(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	// Just return if this is "jx completion (shell)".
+	if commandHasParentName(cmd, "completion") {
+		return
+	}
+
 	shouldWarn := false
 	if commandHasParentName(cmd, "create cluster") {
 		shouldWarn = isStaticMasterInstall(cmd)


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

This is purely a helper command, so there's no reason to have the warning here, and it results in breaking tab completion.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6975 
