### PR TITLE
fix: enforce vault GCP service account minimum name length

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2020-03-30T20:19:03Z",
+  "generated_at": "2020-04-03T04:31:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -119,7 +119,7 @@
       {
         "hashed_secret": "2978f389a32111504f1c3b39df2123be5c453020",
         "is_secret": false,
-        "line_number": 1385,
+        "line_number": 1386,
         "type": "Secret Keyword"
       }
     ],

--- a/pkg/cloud/gke/gcloud.go
+++ b/pkg/cloud/gke/gcloud.go
@@ -14,6 +14,7 @@ import (
 
 	osUser "os/user"
 
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
@@ -1361,7 +1362,7 @@ func (g *GCloud) CreateGCPServiceAccount(kubeClient kubernetes.Interface, servic
 	}
 	defer os.RemoveAll(serviceAccountDir)
 
-	serviceAccountName := ServiceAccountName(clusterName, serviceAbbreviation)
+	serviceAccountName := naming.ToValidGCPServiceAccount(ServiceAccountName(clusterName, serviceAbbreviation))
 
 	serviceAccountPath, err := g.GetOrCreateServiceAccount(serviceAccountName, projectID, serviceAccountDir, serviceAccountRoles)
 	if err != nil {

--- a/pkg/cmd/deletecmd/delete_vault.go
+++ b/pkg/cmd/deletecmd/delete_vault.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
 	"github.com/jenkins-x/jx/pkg/kube"
+	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/kube/serviceaccount"
 	kubevault "github.com/jenkins-x/jx/pkg/kube/vault"
 	"github.com/jenkins-x/jx/pkg/log"
@@ -174,7 +175,7 @@ func (o *DeleteVaultOptions) removeGCPResources(vaultName string) error {
 		o.GKEZone = zone
 	}
 
-	sa := gke.ServiceAccountName(vaultName, gkevault.DefaultVaultAbbreviation)
+	sa := naming.ToValidGCPServiceAccount(gke.ServiceAccountName(vaultName, gkevault.DefaultVaultAbbreviation))
 	err = o.GCloud().DeleteServiceAccount(sa, o.GKEProjectID, gkevault.ServiceAccountRoles)
 	if err != nil {
 		return errors.Wrapf(err, "deleting the GCP service account '%s'", sa)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
fixes failed service account creation during `jx create vault` when a gke cluster name length is 3 characters or less
```
jx create vault 
? Vault name: vault-inf
Unable to find service account cd-vt, checking if we have enough permission to create
Creating service account cd-vt
error: unable to create/update Vault: unable to set cloud provider specific Vault configuration: unable to apply cloud provider config: creating GCP service account: creating the Vault GCP Service Account: creating the service account: failed to run 'gcloud iam service-accounts create cd-vt --project xx-1 --display-name cd-vt' command in directory '', output: 'ERROR: (gcloud.iam.service-accounts.create) argument NAME: Bad value [cd-vt]: Service account name must be between 6 and 30 characters (inclusive), must begin with a lowercase letter, and consist of lowercase alphanumeric characters that can be separated by hyphens.
```

#### Special notes for the reviewer(s)
ref https://github.com/jenkins-x/jx/pull/6911

#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->