### PR TITLE
fix: set ContentType when uploading files to s3

### DIFF
--- a/pkg/cloud/amazon/storage/bucket_provider.go
+++ b/pkg/cloud/amazon/storage/bucket_provider.go
@@ -151,9 +151,10 @@ func (b *AmazonBucketProvider) UploadFileToBucket(reader io.Reader, outputName s
 	}
 	bucketURL = strings.TrimPrefix(bucketURL, "s3://")
 	output, err := uploader.Upload(&s3manager.UploadInput{
-		Bucket: aws.String(bucketURL),
-		Key:    aws.String("/" + outputName),
-		Body:   reader,
+		Bucket:      aws.String(bucketURL),
+		Key:         aws.String("/" + outputName),
+		ContentType: aws.String(util.ContentTypeForFileName(outputName)),
+		Body:        reader,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Use `util.ContentTypeForFileName` to detect the MIME type of the file being uploaded to S3. When not set, `Content-Type` defaults to `binary/octet-stream` which makes it difficult to build report viewers.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #7032

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
