### PR TITLE
[wip] feat: install helm2 as a binary plugin

### DIFF
--- a/pkg/cmd/clients/factory.go
+++ b/pkg/cmd/clients/factory.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/heptio/sonobuoy/pkg/client"
 	sonoboy_dynamic "github.com/heptio/sonobuoy/pkg/dynamic"
+	"github.com/jenkins-x/jx/pkg/extensions"
 	"k8s.io/client-go/dynamic"
 
 	"io"
@@ -754,6 +755,14 @@ func (f *factory) CreateHelm(verbose bool,
 	}
 	if verbose {
 		log.Logger().Debugf("Using helmBinary %s with feature flag: %s", util.ColorInfo(helmBinary), util.ColorInfo(featureFlag))
+	}
+	if helmBinary == "helm" {
+		path, err := extensions.GetHelmBinary(extensions.HelmVersion)
+		if err != nil {
+			log.Logger().Warnf("failed to download helm 2 plugin: %s", err.Error())
+		} else {
+			helmBinary = path
+		}
 	}
 	helmCLI := helm.NewHelmCLIWithCompatibilityCheck(helmBinary, helm.V2, "", verbose)
 	var h helm.Helmer = helmCLI

--- a/pkg/extensions/helpers.go
+++ b/pkg/extensions/helpers.go
@@ -1,0 +1,99 @@
+package extensions
+
+import (
+	"fmt"
+	"strings"
+
+	jenkinsv1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Platform represents a platform for binaries
+type Platform struct {
+	Goarch string
+	Goos   string
+}
+
+const (
+	// HelmPluginName the default name of the helm plugin
+	HelmPluginName = "helm"
+)
+
+var (
+	defaultPlatforms = []Platform{
+		{
+			Goarch: "amd64",
+			Goos:   "Windows",
+		},
+		{
+			Goarch: "amd64",
+			Goos:   "Darwin",
+		},
+		{
+			Goarch: "amd64",
+			Goos:   "Linux",
+		},
+		{
+			Goarch: "arm",
+			Goos:   "Linux",
+		},
+		{
+			Goarch: "386",
+			Goos:   "Linux",
+		},
+	}
+)
+
+// Extension returns the default distribution extension; `tar.gz` or `zip` for windows
+func (p Platform) Extension() string {
+	if p.Goos == "Windows" {
+		return "zip"
+	}
+	return "tar.gz"
+}
+
+// GetHelmBinary returns the path to the locally installed helm 3 extension
+func GetHelmBinary(version string) (string, error) {
+	if version == "" {
+		version = HelmVersion
+	}
+	plugin := CreateHelmPlugin(version)
+	return EnsurePluginInstalled(plugin)
+}
+
+// CreateHelmPlugin creates the helm plugin
+func CreateHelmPlugin(version string) jenkinsv1.Plugin {
+	binaries := CreateBinaries(func(p Platform) string {
+		return fmt.Sprintf("https://get.helm.sh/helm-v%s-%s-%s.%s", version, strings.ToLower(p.Goos), strings.ToLower(p.Goarch), p.Extension())
+	})
+
+	plugin := jenkinsv1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: HelmPluginName,
+		},
+		Spec: jenkinsv1.PluginSpec{
+			SubCommand:  "helm",
+			Binaries:    binaries,
+			Description: "helm 2 binary",
+			Name:        HelmPluginName,
+			Version:     version,
+		},
+	}
+	return plugin
+}
+
+// CreateBinaries a helper function to create the binary resources for the platforms for a given callback
+func CreateBinaries(createURLFn func(Platform) string) []jenkinsv1.Binary {
+	answer := []jenkinsv1.Binary{}
+	for _, p := range defaultPlatforms {
+		u := createURLFn(p)
+		if u != "" {
+			answer = append(answer, jenkinsv1.Binary{
+				Goarch: p.Goarch,
+				Goos:   p.Goos,
+				URL:    u,
+			})
+		}
+	}
+	return answer
+}

--- a/pkg/extensions/helpers_test.go
+++ b/pkg/extensions/helpers_test.go
@@ -1,0 +1,35 @@
+// +build unit
+
+package extensions_test
+
+import (
+	"testing"
+
+	"github.com/jenkins-x/jx/pkg/extensions"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlugins(t *testing.T) {
+	t.Parallel()
+
+	plugin := extensions.CreateHelmPlugin("2.14.3")
+
+	assert.Equal(t, extensions.HelmPluginName, plugin.Name, "plugin.Name")
+	assert.Equal(t, extensions.HelmPluginName, plugin.Spec.Name, "plugin.Spec.Name")
+
+	foundLinux := false
+	foundWindows := false
+	for _, b := range plugin.Spec.Binaries {
+		if b.Goos == "Linux" && b.Goarch == "amd64" {
+			foundLinux = true
+			assert.Equal(t, "https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz", b.URL, "URL for linux binary")
+			t.Logf("found linux binary URL %s", b.URL)
+		} else if b.Goos == "Windows" && b.Goarch == "amd64" {
+			foundWindows = true
+			assert.Equal(t, "https://get.helm.sh/helm-v2.14.3-windows-amd64.zip", b.URL, "URL for windows binary")
+			t.Logf("found windows binary URL %s", b.URL)
+		}
+	}
+	assert.True(t, foundLinux, "did not find a linux binary in the plugin %#v", plugin)
+	assert.True(t, foundWindows, "did not find a windows binary in the plugin %#v", plugin)
+}

--- a/pkg/extensions/versions.go
+++ b/pkg/extensions/versions.go
@@ -1,0 +1,6 @@
+package extensions
+
+const (
+	// HelmVersion the default version of helm to use
+	HelmVersion = "2.14.3"
+)


### PR DESCRIPTION
Install helm2 as a binary plugin to avoid issues of incorrect versions on user's paths