### PR TITLE
fix: removing GitHub check verifyPrivateRepos during boot

### DIFF
--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -735,10 +735,7 @@ func (o *StepVerifyPreInstallOptions) gatherGitRequirements(requirements *config
 		if requirements.Cluster.EnvironmentGitPublic {
 			log.Logger().Infof("Environment repos will be %s, if you want to create %s environment repos, please set %s to %s jx-requirements.yml", util.ColorInfo("public"), util.ColorInfo("private"), util.ColorInfo("environmentGitPublic"), util.ColorInfo("false"))
 		} else {
-			err = o.verifyPrivateRepos(requirements)
-			if err != nil {
-				return err
-			}
+			log.Logger().Infof("Environment repos will be %s, if you want to create %s environment repos, please set %s to %s in jx-requirements.yml", util.ColorInfo("private"), util.ColorInfo("public"), util.ColorInfo("environmentGitPublic"), util.ColorInfo("true"))
 		}
 	}
 	if len(requirements.Cluster.DevEnvApprovers) == 0 && !o.BatchMode {
@@ -755,25 +752,6 @@ func (o *StepVerifyPreInstallOptions) gatherGitRequirements(requirements *config
 		}
 		for _, a := range strings.Split(approversString, ",") {
 			requirements.Cluster.DevEnvApprovers = append(requirements.Cluster.DevEnvApprovers, strings.TrimSpace(a))
-		}
-	}
-	return nil
-}
-
-func (o *StepVerifyPreInstallOptions) verifyPrivateRepos(requirements *config.RequirementsConfig) error {
-	log.Logger().Infof("Environment repos will be %s, if you want to create %s environment repos, please set %s to %s in jx-requirements.yml", util.ColorInfo("private"), util.ColorInfo("public"), util.ColorInfo("environmentGitPublic"), util.ColorInfo("true"))
-
-	if o.BatchMode {
-		return nil
-	}
-
-	if requirements.Cluster.GitKind == "github" {
-		message := fmt.Sprintf("If '%s' is an GitHub organisation it needs to have a paid subscription to create private repos. Do you wish to continue?", requirements.Cluster.EnvironmentGitOwner)
-		help := fmt.Sprint("GitHub organisation on a free plan cannot create private repositories. You either need to upgrade, use a GitHub user instead or use public repositories.")
-		if answer, err := util.Confirm(message, false, help, o.GetIOFileHandles()); err != nil {
-			return err
-		} else if !answer {
-			return errors.New("cannot continue without completed git requirements")
 		}
 	}
 	return nil

--- a/pkg/cmd/step/verify/step_verify_preinstall_test.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall_test.go
@@ -25,62 +25,6 @@ import (
 
 var timeout = 1 * time.Second
 
-func Test_verifyPrivateRepos_returns_nil_in_batch_mode(t *testing.T) {
-	t.Parallel()
-	log.SetOutput(ioutil.Discard)
-
-	testOptions := &StepVerifyPreInstallOptions{
-		StepVerifyOptions: StepVerifyOptions{
-			StepOptions: step.StepOptions{
-				CommonOptions: &opts.CommonOptions{
-					BatchMode: true,
-				},
-			},
-		},
-	}
-
-	testConfig := &config.RequirementsConfig{}
-
-	assert.NoError(t, testOptions.verifyPrivateRepos(testConfig))
-}
-
-func Test_confirm_private_repos_with_github_provider(t *testing.T) {
-	t.Parallel()
-	log.SetOutput(ioutil.Discard)
-
-	console := tests.NewTerminal(t, &timeout)
-	defer console.Cleanup()
-
-	testOptions := &StepVerifyPreInstallOptions{
-		StepVerifyOptions: StepVerifyOptions{
-			StepOptions: step.StepOptions{
-				CommonOptions: &opts.CommonOptions{
-					In:  console.In,
-					Out: console.Out,
-					Err: console.Err,
-				},
-			},
-		},
-	}
-
-	testConfig := &config.RequirementsConfig{}
-	testConfig.Cluster.GitKind = "github"
-	testConfig.Cluster.EnvironmentGitOwner = "acme"
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		console.ExpectString("If 'acme' is an GitHub organisation it needs to have a paid subscription to create private repos. Do you wish to continue?")
-		console.SendLine("Y")
-		console.ExpectEOF()
-	}()
-	err := testOptions.verifyPrivateRepos(testConfig)
-	console.Close()
-	<-done
-
-	assert.NoError(t, err)
-}
-
 func Test_doesnt_ask_for_confirmation_when_in_gke(t *testing.T) {
 	r, fakeStdout, _ := os.Pipe()
 	log.SetOutput(fakeStdout)
@@ -184,44 +128,6 @@ func Test_asks_for_confirmation_when_not_in_batch_mode_and_with_different_provid
 	testOptions.gatherRequirements(testConfig, "")
 	console.Close()
 	<-done
-}
-
-func Test_abort_private_repos_with_github_provider(t *testing.T) {
-	t.Parallel()
-	log.SetOutput(ioutil.Discard)
-
-	console := tests.NewTerminal(t, &timeout)
-	defer console.Cleanup()
-
-	testOptions := &StepVerifyPreInstallOptions{
-		StepVerifyOptions: StepVerifyOptions{
-			StepOptions: step.StepOptions{
-				CommonOptions: &opts.CommonOptions{
-					In:  console.In,
-					Out: console.Out,
-					Err: console.Err,
-				},
-			},
-		},
-	}
-
-	testConfig := &config.RequirementsConfig{}
-	testConfig.Cluster.GitKind = "github"
-	testConfig.Cluster.EnvironmentGitOwner = "acme"
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		console.ExpectString("If 'acme' is an GitHub organisation it needs to have a paid subscription to create private repos. Do you wish to continue?")
-		console.SendLine("N")
-		console.ExpectEOF()
-	}()
-	err := testOptions.verifyPrivateRepos(testConfig)
-	console.Close()
-	<-done
-
-	assert.Error(t, err)
-	assert.Equal(t, "cannot continue without completed git requirements", err.Error())
 }
 
 func TestGatherRequirements_PreserveEnvironmentGitOwnerCase(t *testing.T) {


### PR DESCRIPTION
- Even free Github organisations can now create private repositories

fixes #7059

