### PR TITLE
feat: list pods instead of namespaces to avoid needing a cluster-wide permission

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -567,11 +567,10 @@ func (o *BootOptions) verifyRequirements(requirements *config.RequirementsConfig
 }
 
 func (o *BootOptions) verifyClusterConnection() error {
-	client, err := o.KubeClient()
+	client, ns, err := o.KubeClientAndNamespace()
 	if err == nil {
-		_, err = client.CoreV1().Namespaces().List(metav1.ListOptions{})
+		_, err = client.CoreV1().Pods(ns).List(metav1.ListOptions{})
 	}
-
 	if err != nil {
 		return fmt.Errorf("You are not currently connected to a cluster, please connect to the cluster that you intend to %s\n"+
 			"Alternatively create a new cluster using %s", util.ColorInfo("jx boot"), util.ColorInfo("jx create cluster"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Listing namespaces requires a `clusterrole`. It will fail for clusters with tight permission restrictions, so we should list a resource that is local to a namespace.

#### Which issue this PR fixes

fixes #7060 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
