### PR TITLE
fix: Turn off Athens proxy when running "jx step create pr go"

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -129,6 +129,10 @@ pipelineConfig:
                 - "make mod"
                 - --repo
                 - https://github.com/jenkins-x/lighthouse.git
+                # Disable GOPROXY for go module updates to deal with go 1.13 semver resolution issue
+                env:
+                - name: GOPROXY
+                  value: ""
 
               - name: update-jxui-backend
                 image: gcr.io/jenkinsxio/builder-go
@@ -146,3 +150,7 @@ pipelineConfig:
                 - "make build"
                 - --repo
                 - https://github.com/cloudbees/jxui-backend.git
+                # Disable GOPROXY for go module updates to deal with go 1.13 semver resolution issue
+                env:
+                  - name: GOPROXY
+                    value: ""


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This gets around the problem of `v2.0.1285` not resolving to a pseudoversion with go 1.13, which the version of Athens we're now running is using behind the scenes. The underlying problem is #7069, and the long-term fix for that is to go to a proper semver usage, but this should unbork things in the meantime.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a