### PR TITLE
feat: create a function to check the current permissions and split the deletion of old resources between cluster and non cluster resources

### DIFF
--- a/pkg/kube/permissions.go
+++ b/pkg/kube/permissions.go
@@ -1,0 +1,65 @@
+package kube
+
+import (
+	"github.com/jenkins-x/jx/pkg/log"
+	v1 "k8s.io/api/authorization/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Resource is the representation of any Kubernetes resource
+type Resource string
+
+// Verb is the representation of the different verbs that can be checked for Kubernetes resources
+type Verb string
+
+const (
+	// ClusterRoleBindings is the clusterrolebindings.rbac.authorization.k8s.io resource
+	ClusterRoleBindings Resource = "clusterrolebindings"
+	// ClusterRoles is the clusterroles.rbac.authorization.k8s.io resource
+	ClusterRoles Resource = "clusterrole"
+	// CustomResourceDefinitions is the customresourcedefinitions.apiextensions.k8s.io resource
+	CustomResourceDefinitions Resource = "customresourcedefinitions"
+	// All is the representation of '*' meaning all resources
+	All Resource = "'*'"
+	// Create represents the create verb
+	Create Verb = "create"
+	// Delete represents the delete verb
+	Delete Verb = "delete"
+	// Get represents the get verb
+	Get Verb = "get"
+	// List represents the list verb
+	List Verb = "list"
+	// Update represents the update verb
+	Update Verb = "use"
+	// Watch represents the watch verb
+	Watch Verb = "watch"
+)
+
+// CanI will take a verb and a list of resources and it will check whether the current user / service account can
+// perform that verb against the resources in the Kubernetes cluster
+func CanI(kubeClient kubernetes.Interface, verb Verb, resources ...Resource) (bool, []error) {
+	var errList []error
+	for _, resource := range resources {
+		result, err := kubeClient.AuthorizationV1().SelfSubjectAccessReviews().Create(&v1.SelfSubjectAccessReview{
+			Spec: v1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &v1.ResourceAttributes{
+					Verb:     string(verb),
+					Resource: string(resource),
+				},
+			},
+		})
+		if err != nil {
+			errList = append(errList, err)
+		} else {
+			if !result.Status.Allowed || result.Status.Denied {
+				log.Logger().Debugf("Authentication evaluation denied due to: %s", result.Status.Reason)
+				return false, errList
+			}
+		}
+	}
+
+	if len(errList) > 0 {
+		return false, errList
+	}
+	return true, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
When adding a Helm chart, we have two "hooks" that will clean any old resources.

One of them attempt to clean cluster wide resources too, for which we may have no permissions to delete.

I'm modifying this to warn on failure instead of erring.


#### Which issue this PR fixes

fixes #7061 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
