### PR TITLE
feat: split repo label into 4 labels (scheme, host, org and name parts)

### DIFF
--- a/pkg/kube/naming/names.go
+++ b/pkg/kube/naming/names.go
@@ -36,6 +36,12 @@ func ToValidNameTruncated(name string, maxLength int) string {
 	return toValidName(name, false, maxLength)
 }
 
+// ToValidNameWithDotsTruncated converts the given string into a valid Kubernetes resource name,
+// truncating the result if it is more than maxLength characters.
+func ToValidNameWithDotsTruncated(name string, maxLength int) string {
+	return toValidName(name, true, maxLength)
+}
+
 // ToValidGCPServiceAccount converts the given string into a valid GCP service account name,
 // truncating the result if it is more than 30 characters.
 func ToValidGCPServiceAccount(name string) string {


### PR DESCRIPTION
 If you have a large git host name and a large repo name then maybe you get error creating devpod because the label of the kubernetes resources is very large.

With this patch we try to reduce the label name & value getting only the first part of the git host name if the label name reach the 63 characters limit.

