### PR TITLE
feat: don't register the CRDs on controllers the installations take care of that already

### DIFF
--- a/pkg/cmd/controller/controller.go
+++ b/pkg/cmd/controller/controller.go
@@ -3,10 +3,9 @@ package controller
 import (
 	"github.com/jenkins-x/jx/pkg/cmd/controller/pipeline"
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
-	"github.com/spf13/cobra"
-
 	"github.com/jenkins-x/jx/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/pkg/cmd/templates"
+	"github.com/spf13/cobra"
 )
 
 // ControllerOptions contains the CLI options

--- a/pkg/cmd/controller/controller_build.go
+++ b/pkg/cmd/controller/controller_build.go
@@ -147,15 +147,6 @@ func NewCmdControllerBuild(commonOpts *opts.CommonOptions) *cobra.Command {
 
 // Run implements this command
 func (o *ControllerBuildOptions) Run() error {
-	apisClient, err := o.ApiExtensionsClient()
-	if err != nil {
-		return err
-	}
-	err = kube.RegisterPipelineActivityCRD(apisClient)
-	if err != nil {
-		return err
-	}
-
 	jxClient, devNs, err := o.JXClientAndDevNamespace()
 	if err != nil {
 		return err

--- a/pkg/cmd/controller/controller_role.go
+++ b/pkg/cmd/controller/controller_role.go
@@ -89,19 +89,6 @@ func NewCmdControllerRole(commonOpts *opts.CommonOptions) *cobra.Command {
 }
 
 func (o *ControllerRoleOptions) Run() error {
-	apiClient, err := o.ApiExtensionsClient()
-	if err != nil {
-		return err
-	}
-	err = kube.RegisterEnvironmentCRD(apiClient)
-	if err != nil {
-		return err
-	}
-	err = kube.RegisterEnvironmentRoleBindingCRD(apiClient)
-	if err != nil {
-		return err
-	}
-
 	jxClient, ns, err := o.JXClientAndDevNamespace()
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
It doesn't make sense to register CRDs again when we are running the controllers in a boot cluster as there's already a step that updates the CRDs in the Boot Pipeline.

This is making the controller fail when running in Openshift because the `ServiceAccounts` don't and shouldn't have any cluster wide permissions.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes
 
fixes #7058

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
