### PR TITLE
fix: Handle Terraform SA display name format in gc_gke

### DIFF
--- a/pkg/cmd/gc/gc_gke.go
+++ b/pkg/cmd/gc/gc_gke.go
@@ -49,7 +49,7 @@ var (
 		jx gc gke
 `)
 
-	ServiceAccountSuffixes = []string{"-vt", "-ko", "-tf", "-dn", "-ex", "-jb", "-st", "-tk", "-vo", "-bc"}
+	ServiceAccountSuffixes = []string{"-vt", "-ko", "-tf", "-dn", "-ex", "-jb", "-st", "-tk", "-vo", "-bc", "-tekton"}
 )
 
 type Rules struct {
@@ -507,12 +507,16 @@ func (o *GCGKEOptions) getServiceAccounts() ([]serviceAccount, error) {
 		return nil, err
 	}
 
+	var modifiedSAs []serviceAccount
 	for _, sa := range serviceAccounts {
-		if sa.DisplayName == "" {
+		// If there isn't a display name or the display name contains spaces, which is the case for Terraform-created
+		// SAs, just split the email instead.
+		if sa.DisplayName == "" || strings.Contains(sa.DisplayName, " ") {
 			sa.DisplayName = sa.Email[:strings.IndexByte(sa.Email, '@')]
 		}
+		modifiedSAs = append(modifiedSAs, sa)
 	}
-	return serviceAccounts, nil
+	return modifiedSAs, nil
 }
 
 func (o *GCGKEOptions) clusterExistsWithPrefix(clusters []cluster, clusterNamePrefix string) bool {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

The `displayName` in our boot-created SAs is like `pr-206-5-boot-gke-vt`, but the ones created via Terraform end up as `Velero service account for cluster pr-7065-46-tf-boot`. Which is fine! Except that our GC keys on `displayName` having a known suffix, and these...don't. So let's fall back on parsing the name from the email when there are spaces in the `displayName`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a