### PR TITLE
fix: use sh instead of /bin/sh in Windows

### DIFF
--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"time"
 
@@ -1401,8 +1402,13 @@ func (o *StepCreateTaskOptions) runStepCommand(step *syntax.Step) error {
 
 	commandText := strings.Replace(step.GetFullCommand(), "\\$", "$", -1)
 
+	name := "/bin/sh"
+	if runtime.GOOS == "windows" {
+		name = "sh"
+	}
+
 	cmd := util.Command{
-		Name: "/bin/sh",
+		Name: name,
 		Args: []string{"-c", commandText},
 		Out:  o.Out,
 		Err:  o.Err,


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Description
Due to windows file struct, We cannot found `/bin/sh` in Windows. 

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes https://github.com/jenkins-x/jx/issues/7035

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
