### PR TITLE
feat: make it possible to configure a different exposer from requirements.yml

### DIFF
--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -534,6 +534,9 @@ func (o *StepVerifyEnvironmentsOptions) createEnvironmentHelmValues(requirements
 		tlsAcme = "true"
 	}
 	exposer := "Ingress"
+	if requirements.Ingress.Exposer != "" {
+		exposer = requirements.Ingress.Exposer
+	}
 	helmValues := config.HelmValuesConfig{
 		ExposeController: &config.ExposeController{
 			Config: config.ExposeControllerConfig{

--- a/pkg/cmd/step/verify/test_data/verify_ingress/exposer/jx-requirements.yml
+++ b/pkg/cmd/step/verify/test_data/verify_ingress/exposer/jx-requirements.yml
@@ -1,0 +1,42 @@
+autoUpdate:
+  enabled: false
+  schedule: ""
+cluster:
+  clusterName: my-cluster-name
+  environmentGitOwner: myorg
+  gitKind: github
+  gitServer: https://github.something.com
+  namespace: jx
+  provider: gke
+ingress:
+  domain: ""
+  externalDNS: false
+  exposer: Route
+  namespaceSubDomain: -jx.
+  tls:
+    email: ""
+    enabled: false
+    production: false
+environments:
+  - key: dev
+repository: nexus
+secretStorage: local
+storage:
+  backup:
+    enabled: false
+    url: ""
+  logs:
+    enabled: false
+    url: ""
+  reports:
+    enabled: false
+    url: ""
+  repository:
+    enabled: false
+    url: ""
+vault: {}
+velero: {}
+versionStream:
+  ref: v1.0.0
+  url: https://github.com/jenkins-x/jenkins-x-versions.git
+webhook: prow


### PR DESCRIPTION
Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
Make it possible to configure expose controller with a different exposer for all environments via `jx-requirements.yml`.

#### Which issue this PR fixes

fixes #7095 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
