### PR TITLE
fix: Disable the build lock when running via the env controller

### DIFF
--- a/pkg/cmd/controller/controller_enviornmentcontroller.go
+++ b/pkg/cmd/controller/controller_enviornmentcontroller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/cmd/step/create"
 	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/jenkinsfile"
+	"github.com/jenkins-x/jx/pkg/kube"
 	"github.com/jenkins-x/jx/pkg/kube/services"
 	"github.com/jenkins-x/jx/pkg/log"
 	"github.com/jenkins-x/jx/pkg/util"
@@ -295,6 +296,7 @@ func (o *ControllerEnvironmentOptions) startPipelineRun(w http.ResponseWriter, r
 	pr.Revision = revision
 	pr.RemoteCluster = true
 	pr.DisableConcurrent = true
+	pr.CustomEnvs = append(pr.CustomEnvs, fmt.Sprintf("%s=%s", kube.DisableBuildLockEnvKey, "true"))
 
 	// turn map into string array with = separator to match type of custom labels which are CLI flags
 	for key, value := range o.Labels {

--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -189,9 +189,11 @@ func (o *StepHelmApplyOptions) Run() error {
 		defer os.RemoveAll(rootTmpDir)
 	}
 
-	if release, err := kube.AcquireBuildLock(kubeClient, devNs, ns); err != nil {
-		return errors.Wrapf(err, "fail to acquire the lock")
-	} else {
+	if os.Getenv(kube.DisableBuildLockEnvKey) == "" {
+		release, err := kube.AcquireBuildLock(kubeClient, devNs, ns)
+		if err != nil {
+			return errors.Wrapf(err, "fail to acquire the lock")
+		}
 		defer release()
 	}
 

--- a/pkg/kube/build_lock.go
+++ b/pkg/kube/build_lock.go
@@ -26,6 +26,9 @@ var buildLockPhaseRunning map[v1.PodPhase]bool = map[v1.PodPhase]bool{
 	v1.PodUnknown: true,
 }
 
+// DisableBuildLockEnvKey environment variable used to disable build lock in jx step helm apply
+const DisableBuildLockEnvKey = "JX_DISABLE_BUILD_LOCK"
+
 // AcquireBuildLock acquires a build lock, to avoid other builds to edit the
 // same namespace while a deployment is already running, other deployments
 // can negotiate which one should run after, by editing its data.


### PR DESCRIPTION
fixes: #7106 Introduces a new environmental variable JX_DISABLE_BUILD_LOCK that can be set to disable the locking in `jx step helm apply`

