### PR TITLE
fix: Sleep five seconds after GitHub repo creation

### DIFF
--- a/pkg/gits/github.go
+++ b/pkg/gits/github.go
@@ -343,6 +343,8 @@ func (p *GitHubProvider) CreateRepository(owner string, name string, private boo
 		}
 		return nil, errors.New(msg)
 	}
+	// Sleep 5 seconds to ensure repository exists enough to be pushed to.
+	time.Sleep(5 * time.Second)
 	return toGitHubRepo(name, owner, repo), nil
 }
 
@@ -418,6 +420,8 @@ func (p *GitHubProvider) ForkRepository(originalOrg string, name string, destina
 			return nil, fmt.Errorf("failed to fork repository %s/%s%s due to: %s", originalOrg, name, msg, err)
 		}
 	}
+	// Sleep 5 seconds to ensure repository exists enough to be pushed to.
+	time.Sleep(5 * time.Second)
 	answer := &GitRepository{
 		Name:             name,
 		AllowMergeCommit: util.DereferenceBool(repo.AllowMergeCommit),


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

This should prevent errors caused by GitHub not yet actually having the git repo proper ready and exposed.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #7129 
