### PR TITLE
chore: Switch `boot-vault` context to Lighthouse

### DIFF
--- a/jx/bdd/boot-vault/jx-requirements.yml
+++ b/jx/bdd/boot-vault/jx-requirements.yml
@@ -34,7 +34,7 @@ storage:
   repository:
     enabled: false
     url: ""
-webhook: prow
+webhook: lighthouse
 vault:
   disableURLDiscovery: true
 versionStream:


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Since we're now Lighthouse-by-default in `jenkins-x-boot-config`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a