### PR TITLE
fix(eks): wrong cloud constant for eks

### DIFF
--- a/pkg/cmd/create/create_cluster_eks.go
+++ b/pkg/cmd/create/create_cluster_eks.go
@@ -77,7 +77,7 @@ var (
 // NewCmdCreateClusterEKS creates the command
 func NewCmdCreateClusterEKS(commonOpts *opts.CommonOptions) *cobra.Command {
 	options := CreateClusterEKSOptions{
-		CreateClusterOptions: createCreateClusterOptions(commonOpts, cloud.AKS),
+		CreateClusterOptions: createCreateClusterOptions(commonOpts, cloud.EKS),
 	}
 	cmd := &cobra.Command{
 		Use:     "eks",


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>


#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
Wrong cloud constant is passed to CreateClusterOptions. 

#### Special notes for the reviewer(s)


#### Which issue this PR fixes
fixes #7164 
