### PR TITLE
fix: Verify pre install fails with incorrect kubectl or helm version on the path

### DIFF
--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -32,6 +32,7 @@ import (
 	"github.com/jenkins-x/jx/pkg/kube/cluster"
 	"github.com/jenkins-x/jx/pkg/kube/naming"
 	"github.com/jenkins-x/jx/pkg/log"
+	"github.com/jenkins-x/jx/pkg/packages"
 	"github.com/jenkins-x/jx/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -172,6 +173,11 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 	}
 	log.Logger().Info("\n")
 
+	err = o.installMissingDependencies()
+	if err != nil {
+		return err
+	}
+
 	po := &StepVerifyPackagesOptions{}
 	po.CommonOptions = o.CommonOptions
 	po.Packages = []string{"kubectl", "git", "helm"}
@@ -276,6 +282,14 @@ func (o *StepVerifyPreInstallOptions) Run() error {
 	log.Logger().Infof("Cluster looks good, you are ready to '%s' now!", info("jx boot"))
 	fmt.Println()
 	return nil
+}
+
+// installMissingDependencies installs missing deps like helm and kubectl
+func (o *StepVerifyPreInstallOptions) installMissingDependencies() error {
+	var deps []string
+	deps = packages.AddRequiredBinary("kubectl", deps)
+	deps = packages.AddRequiredBinary("helm", deps)
+	return o.DoInstallMissingDependencies(deps)
 }
 
 // EnsureHelm ensures helm is installed

--- a/pkg/util/commands.go
+++ b/pkg/util/commands.go
@@ -266,19 +266,22 @@ func (c *Command) run() (string, error) {
 	return text, err
 }
 
-// PathWithBinary Returns the path to be used to execute a binary from, takes the form JX_HOME/bin:mvnBinDir:customPaths
+//PathWithBinary Returns the path to be used to execute a binary from, takes the form JX_HOME/bin:mvnBinDir:customPaths
 func PathWithBinary(customPaths ...string) string {
 	existingEnvironmentPath := os.Getenv("PATH")
-	mvnBinDir, _ := MavenBinaryLocation()
+
 	extraPaths := ""
-	if mvnBinDir != "" {
-		extraPaths += string(os.PathListSeparator) + mvnBinDir
-	}
 	for _, p := range customPaths {
 		if p != "" {
 			extraPaths += string(os.PathListSeparator) + p
 		}
 	}
+
+	mvnBinDir, _ := MavenBinaryLocation()
+	if mvnBinDir != "" {
+		extraPaths += string(os.PathListSeparator) + mvnBinDir
+	}
 	jxBinDir, _ := JXBinLocation()
+
 	return jxBinDir + string(os.PathListSeparator) + existingEnvironmentPath + extraPaths
 }

--- a/pkg/util/commands.go
+++ b/pkg/util/commands.go
@@ -266,17 +266,19 @@ func (c *Command) run() (string, error) {
 	return text, err
 }
 
-// PathWithBinary Sets the $PATH variable. Accepts an optional slice of strings containing paths to add to $PATH
-func PathWithBinary(paths ...string) string {
-	path := os.Getenv("PATH")
-	binDir, _ := JXBinLocation()
-	answer := path + string(os.PathListSeparator) + binDir
+// PathWithBinary Returns the path to be used to execute a binary from, takes the form JX_HOME/bin:mvnBinDir:customPaths
+func PathWithBinary(customPaths ...string) string {
+	existingEnvironmentPath := os.Getenv("PATH")
 	mvnBinDir, _ := MavenBinaryLocation()
+	extraPaths := ""
 	if mvnBinDir != "" {
-		answer += string(os.PathListSeparator) + mvnBinDir
+		extraPaths += string(os.PathListSeparator) + mvnBinDir
 	}
-	for _, p := range paths {
-		answer += string(os.PathListSeparator) + p
+	for _, p := range customPaths {
+		if p != "" {
+			extraPaths += string(os.PathListSeparator) + p
+		}
 	}
-	return answer
+	jxBinDir, _ := JXBinLocation()
+	return jxBinDir + string(os.PathListSeparator) + existingEnvironmentPath + extraPaths
 }


### PR DESCRIPTION
fixes #7169 

This PR installs helm and kubectl in to ~/.jx/bin as part of `jx step verify preinstall` it also forces ~/.jx/bin to the start of the path.

Signed-off-by: David Conde
