### PR TITLE
fix: Various BitBucket Server fixes

### DIFF
--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -278,7 +278,7 @@ func (o *CreateDevPodOptions) Run() error {
 			log.Logger().Warnf("could not find git URL in dir %s due to: %s", dir, err.Error())
 		} else {
 			gitKind, _ := o.GitServerKind(gitInfo)
-			importURL = gitInfo.HttpCloneURL(gitKind)
+			importURL = gits.HttpCloneURL(gitInfo, gitKind)
 		}
 	}
 	label := o.Label

--- a/pkg/cmd/create/create_devpod.go
+++ b/pkg/cmd/create/create_devpod.go
@@ -277,7 +277,8 @@ func (o *CreateDevPodOptions) Run() error {
 		if err != nil {
 			log.Logger().Warnf("could not find git URL in dir %s due to: %s", dir, err.Error())
 		} else {
-			importURL = gitInfo.HttpCloneURL()
+			gitKind, _ := o.GitServerKind(gitInfo)
+			importURL = gitInfo.HttpCloneURL(gitKind)
 		}
 	}
 	label := o.Label

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -1035,7 +1035,7 @@ func (options *ImportOptions) addProwConfig(gitURL string, gitKind string) error
 				sr.Spec.URL = gitInfo.HttpsURL()
 			}
 			if sr.Spec.HTTPCloneURL == "" {
-				sr.Spec.HTTPCloneURL = gitInfo.HttpCloneURL(gitKind)
+				sr.Spec.HTTPCloneURL = gits.HttpCloneURL(gitInfo, gitKind)
 			}
 			if sr.Spec.SSHCloneURL == "" {
 				sr.Spec.SSHCloneURL = gitInfo.SSHURL

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -1035,7 +1035,7 @@ func (options *ImportOptions) addProwConfig(gitURL string, gitKind string) error
 				sr.Spec.URL = gitInfo.HttpsURL()
 			}
 			if sr.Spec.HTTPCloneURL == "" {
-				sr.Spec.HTTPCloneURL = gitInfo.HttpCloneURL()
+				sr.Spec.HTTPCloneURL = gitInfo.HttpCloneURL(gitKind)
 			}
 			if sr.Spec.SSHCloneURL == "" {
 				sr.Spec.SSHCloneURL = gitInfo.SSHURL

--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -887,7 +887,7 @@ func (o *PreviewOptions) DefaultValues(ns string, warnMissingName bool) error {
 			log.Logger().Warnf("Could not parse the git URL %s due to %s", o.SourceURL, err)
 		} else {
 			gitKind, _ := o.GitServerKind(o.GitInfo)
-			o.SourceURL = o.GitInfo.HttpCloneURL(gitKind)
+			o.SourceURL = gits.HttpCloneURL(o.GitInfo, gitKind)
 			if o.PullRequestURL == "" {
 				if o.PullRequest == "" {
 					if warnMissingName {

--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -886,7 +886,8 @@ func (o *PreviewOptions) DefaultValues(ns string, warnMissingName bool) error {
 		if err != nil {
 			log.Logger().Warnf("Could not parse the git URL %s due to %s", o.SourceURL, err)
 		} else {
-			o.SourceURL = o.GitInfo.HttpCloneURL()
+			gitKind, _ := o.GitServerKind(o.GitInfo)
+			o.SourceURL = o.GitInfo.HttpCloneURL(gitKind)
 			if o.PullRequestURL == "" {
 				if o.PullRequest == "" {
 					if warnMissingName {

--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -366,7 +366,7 @@ func (o *StepCreateTaskOptions) Run() error {
 			o.waitForPreviousPipeline(tektonClient, ns, 10*time.Minute)
 		}
 		log.Logger().Infof("Applying changes ")
-		err := tekton.ApplyPipeline(jxClient, tektonClient, tektonCRDs, ns, activityKey)
+		err := tekton.ApplyPipeline(jxClient, kubeClient, tektonClient, tektonCRDs, ns, activityKey)
 		if err != nil {
 			return errors.Wrapf(err, "failed to apply Tekton CRDs")
 		}

--- a/pkg/cmd/step/step_changelog.go
+++ b/pkg/cmd/step/step_changelog.go
@@ -386,7 +386,7 @@ func (o *StepChangelogOptions) Run() error {
 			GitOwner:      gitInfo.Organisation,
 			GitRepository: gitInfo.Name,
 			GitHTTPURL:    gitInfo.HttpsURL(),
-			GitCloneURL:   gitInfo.HttpCloneURL(),
+			GitCloneURL:   gitInfo.HttpCloneURL(gitKind),
 			Commits:       []v1.CommitSummary{},
 			Issues:        []v1.IssueSummary{},
 			PullRequests:  []v1.IssueSummary{},

--- a/pkg/cmd/step/step_changelog.go
+++ b/pkg/cmd/step/step_changelog.go
@@ -386,7 +386,7 @@ func (o *StepChangelogOptions) Run() error {
 			GitOwner:      gitInfo.Organisation,
 			GitRepository: gitInfo.Name,
 			GitHTTPURL:    gitInfo.HttpsURL(),
-			GitCloneURL:   gitInfo.HttpCloneURL(gitKind),
+			GitCloneURL:   gits.HttpCloneURL(gitInfo, gitKind),
 			Commits:       []v1.CommitSummary{},
 			Issues:        []v1.IssueSummary{},
 			PullRequests:  []v1.IssueSummary{},

--- a/pkg/cmd/step/step_custom_pipeline.go
+++ b/pkg/cmd/step/step_custom_pipeline.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jenkins-x/jx/pkg/cmd/opts/step"
+	"github.com/jenkins-x/jx/pkg/gits"
 
 	"github.com/jenkins-x/jx/pkg/cmd/helper"
 
@@ -160,7 +161,7 @@ func (o *StepCustomPipelineOptions) Run() error {
 				return err
 			}
 		} else {
-			gitURL := gitInfo.HttpCloneURL(gitKind)
+			gitURL := gits.HttpCloneURL(gitInfo, gitKind)
 			log.Logger().Infof("Using git URL %s and branch %s", util.ColorInfo(gitURL), util.ColorInfo(branch))
 
 			err = o.Retry(3, time.Second*10, func() error {

--- a/pkg/cmd/step/step_custom_pipeline.go
+++ b/pkg/cmd/step/step_custom_pipeline.go
@@ -106,6 +106,11 @@ func (o *StepCustomPipelineOptions) Run() error {
 		return err
 	}
 
+	gitKind, err := o.GitServerKind(gitInfo)
+	if err != nil {
+		return err
+	}
+
 	branch, err := o.Git().Branch(o.Dir)
 	if err != nil {
 		return err
@@ -155,7 +160,7 @@ func (o *StepCustomPipelineOptions) Run() error {
 				return err
 			}
 		} else {
-			gitURL := gitInfo.HttpCloneURL()
+			gitURL := gitInfo.HttpCloneURL(gitKind)
 			log.Logger().Infof("Using git URL %s and branch %s", util.ColorInfo(gitURL), util.ColorInfo(branch))
 
 			err = o.Retry(3, time.Second*10, func() error {

--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -1143,8 +1143,11 @@ func (b *BitbucketServerProvider) GetRelease(org string, name string, tag string
 }
 
 func (b *BitbucketServerProvider) AddCollaborator(user string, organisation string, repo string) error {
-	log.Logger().Infof("Automatically adding the pipeline user as a collaborator is currently not implemented for bitbucket. Please add user: %v as a collaborator to this project.", user)
-	return nil
+	options := make(map[string]interface{})
+	options["name"] = user
+	options["permission"] = "REPO_WRITE"
+	_, err := b.Client.DefaultApi.SetPermissionForUser(organisation, repo, options)
+	return err
 }
 
 func (b *BitbucketServerProvider) ListInvitations() ([]*github.RepositoryInvitation, *github.Response, error) {

--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -473,10 +473,17 @@ func getMergeCommitSHAFromPRActivity(prActivity map[string]interface{}) *string 
 	var activity []map[string]interface{}
 	var mergeCommit map[string]interface{}
 
-	mapstructure.Decode(prActivity["values"], &activity)     //nolint:errcheck
-	mapstructure.Decode(activity[0]["commit"], &mergeCommit) //nolint:errcheck
-	commitSHA := mergeCommit["id"].(string)
-
+	mapstructure.Decode(prActivity["values"], &activity) //nolint:errcheck
+	for _, act := range activity {
+		if act["action"] == "MERGED" {
+			mapstructure.Decode(act["commit"], &mergeCommit) //nolint:errcheck
+			break
+		}
+	}
+	commitSHA := ""
+	if _, ok := mergeCommit["id"]; ok {
+		commitSHA = mergeCommit["id"].(string)
+	}
 	return &commitSHA
 }
 

--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -424,6 +424,7 @@ func (b *BitbucketServerProvider) CreatePullRequest(data *GitPullRequestArgument
 		Repo:   bPR.ToRef.Repository.Name,
 		Number: &bPR.ID,
 		State:  &bPR.State,
+		Title:  bPR.Title,
 	}, nil
 }
 
@@ -571,6 +572,7 @@ func (b *BitbucketServerProvider) toPullRequest(bPR bitbucket.PullRequest) *GitP
 		State:         &bPR.State,
 		Author:        author,
 		LastCommitSha: bPR.FromRef.LatestCommit,
+		Title:         bPR.Title,
 	}
 	return answer
 }

--- a/pkg/gits/bitbucket_server.go
+++ b/pkg/gits/bitbucket_server.go
@@ -860,7 +860,7 @@ func (b *BitbucketServerProvider) CreateWebHook(data *GitWebHookArguments) error
 		"url":    data.URL,
 		"name":   "Jenkins X Web Hook",
 		"active": true,
-		"events": []string{"repo:refs_changed", "repo:modified", "repo:forked", "repo:comment:added", "repo:comment:edited", "repo:comment:deleted", "pr:opened", "pr:reviewer:approved", "pr:reviewer:unapproved", "pr:reviewer:needs_work", "pr:merged", "pr:declined", "pr:deleted", "pr:comment:added", "pr:comment:edited", "pr:comment:deleted"},
+		"events": []string{"repo:refs_changed", "repo:modified", "repo:forked", "repo:comment:added", "repo:comment:edited", "repo:comment:deleted", "pr:opened", "pr:reviewer:approved", "pr:reviewer:unapproved", "pr:reviewer:needs_work", "pr:merged", "pr:declined", "pr:deleted", "pr:comment:added", "pr:comment:edited", "pr:comment:deleted", "pr:from_ref_updated", "pr:modified"},
 	}
 
 	if data.Secret != "" {

--- a/pkg/gits/bitbucket_server_test.go
+++ b/pkg/gits/bitbucket_server_test.go
@@ -227,6 +227,7 @@ func (suite *BitbucketServerProviderTestSuite) TestCreatePullRequest() {
 	suite.Require().NotNil(pr)
 	suite.Require().Nil(err)
 	suite.Require().Equal(*pr.State, "OPEN")
+	suite.Require().Equal(pr.Title, args.Title)
 }
 
 func (suite *BitbucketServerProviderTestSuite) TestUpdatePullRequestStatus() {
@@ -257,6 +258,7 @@ func (suite *BitbucketServerProviderTestSuite) TestGetPullRequest() {
 
 	suite.Require().Nil(err)
 	suite.Require().Equal(*pr.Number, 1)
+	suite.Require().Equal(pr.Title, "Test Pull Request")
 }
 
 func (suite *BitbucketServerProviderTestSuite) TestPullRequestCommits() {

--- a/pkg/gits/bitbucket_server_test.go
+++ b/pkg/gits/bitbucket_server_test.go
@@ -251,7 +251,7 @@ func (suite *BitbucketServerProviderTestSuite) TestUpdatePullRequestStatus() {
 func (suite *BitbucketServerProviderTestSuite) TestGetPullRequest() {
 
 	pr, err := suite.provider.GetPullRequest(
-		"test-user",
+		"TEST-ORG",
 		&gits.GitRepository{Name: "test-repo", Project: "TEST-ORG"},
 		1,
 	)
@@ -262,7 +262,7 @@ func (suite *BitbucketServerProviderTestSuite) TestGetPullRequest() {
 }
 
 func (suite *BitbucketServerProviderTestSuite) TestPullRequestCommits() {
-	commits, err := suite.provider.GetPullRequestCommits("test-user", &gits.GitRepository{
+	commits, err := suite.provider.GetPullRequestCommits("TEST-ORG", &gits.GitRepository{
 		URL:     "https://auth.example.com/projects/TEST-ORG/repos/test-repo",
 		Name:    "test-repo",
 		Project: "TEST-ORG",

--- a/pkg/gits/bitbucket_server_test.go
+++ b/pkg/gits/bitbucket_server_test.go
@@ -50,8 +50,20 @@ var bitbucketServerRouter = util.Router{
 		"GET": "pr.json",
 		"PUT": "pr.json",
 	},
+	"/rest/api/1.0/projects/TEST-ORG/repos/test-repo/pull-requests/7": util.MethodMap{
+		"GET": "pr-merge-success.json",
+	},
 	"/rest/api/1.0/projects/TEST-ORG/repos/test-repo/pull-requests/1/commits": util.MethodMap{
 		"GET": "pr-commits.json",
+	},
+	"/rest/api/1.0/projects/TEST-ORG/repos/test-repo/pull-requests/7/commits": util.MethodMap{
+		"GET": "pr-commits.json",
+	},
+	"/rest/api/1.0/projects/TEST-ORG/repos/test-repo/pull-requests/1/activities": util.MethodMap{
+		"GET": "pr-activity.json",
+	},
+	"/rest/api/1.0/projects/TEST-ORG/repos/test-repo/pull-requests/7/activities": util.MethodMap{
+		"GET": "pr-activity.json",
 	},
 	"/rest/api/1.0/projects/TEST-ORG/repos/test-repo/pull-requests/1/merge": util.MethodMap{
 		"POST": "pr-merge-success.json",
@@ -316,6 +328,17 @@ func (suite *BitbucketServerProviderTestSuite) TestMergePullRequest() {
 	err := suite.provider.MergePullRequest(pr, "Merging from unit tests")
 
 	suite.Require().Nil(err)
+
+	pr2, err := suite.provider.GetPullRequest(
+		"TEST-ORG",
+		&gits.GitRepository{Name: "test-repo", Project: "TEST-ORG"},
+		7,
+	)
+
+	suite.Require().Nil(err)
+	suite.Require().Equal(*pr2.Number, 7)
+	suite.T().Logf("PR: %+v", pr2)
+	suite.Require().Equal(*pr2.Merged, true)
 }
 
 func (suite *BitbucketServerProviderTestSuite) TestJenkinsWebHookPath() {

--- a/pkg/gits/bitbucket_server_test.go
+++ b/pkg/gits/bitbucket_server_test.go
@@ -84,6 +84,9 @@ var bitbucketServerRouter = util.Router{
 	"/rest/build-status/1.0/commits/d6f24ee03d76a2caf0a4e1975fb43e8f61759b9c": util.MethodMap{
 		"GET": "build-statuses.json",
 	},
+	"/rest/api/1.0/projects/test-org/repos/repo/permissions/users": util.MethodMap{
+		"PUT": "user.json",
+	},
 }
 
 func (suite *BitbucketServerProviderTestSuite) SetupSuite() {

--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -26,7 +26,15 @@ func (i *GitRepository) PullRequestURL(prName string) string {
 }
 
 // HttpCloneURL returns the HTTPS git URL this repository
-func (i *GitRepository) HttpCloneURL() string {
+func (i *GitRepository) HttpCloneURL(kind string) string {
+	if kind == KindBitBucketServer {
+		host := i.Host
+		if !strings.Contains(host, ":/") {
+			host = "https://" + host
+		}
+		return util.UrlJoin(host, "scm", i.Organisation, i.Name) + ".git"
+
+	}
 	return i.HttpsURL() + ".git"
 }
 

--- a/pkg/gits/git_url.go
+++ b/pkg/gits/git_url.go
@@ -25,19 +25,6 @@ func (i *GitRepository) PullRequestURL(prName string) string {
 	return util.UrlJoin("https://"+i.Host, i.Organisation, i.Name, "pull", prName)
 }
 
-// HttpCloneURL returns the HTTPS git URL this repository
-func (i *GitRepository) HttpCloneURL(kind string) string {
-	if kind == KindBitBucketServer {
-		host := i.Host
-		if !strings.Contains(host, ":/") {
-			host = "https://" + host
-		}
-		return util.UrlJoin(host, "scm", i.Organisation, i.Name) + ".git"
-
-	}
-	return i.HttpsURL() + ".git"
-}
-
 // HttpURL returns the URL to browse this repository in a web browser
 func (i *GitRepository) HttpURL() string {
 	host := i.Host
@@ -270,4 +257,17 @@ func SaasGitKind(gitServiceUrl string) string {
 		}
 		return ""
 	}
+}
+
+// HttpCloneURL returns the HTTPS git URL this repository
+func HttpCloneURL(repo *GitRepository, kind string) string {
+	if kind == KindBitBucketServer {
+		host := repo.Host
+		if !strings.Contains(host, ":/") {
+			host = "https://" + host
+		}
+		return util.UrlJoin(host, "scm", repo.Organisation, repo.Name) + ".git"
+
+	}
+	return repo.HttpsURL() + ".git"
 }

--- a/pkg/gits/git_url_test.go
+++ b/pkg/gits/git_url_test.go
@@ -237,7 +237,7 @@ func TestGitInfoHttpCloneURL(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.gitInfo.HttpCloneURL(tc.kind)
+			result := gits.HttpCloneURL(tc.gitInfo, tc.kind)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/pkg/gits/git_url_test.go
+++ b/pkg/gits/git_url_test.go
@@ -175,3 +175,70 @@ func TestGitInfoProviderURL(t *testing.T) {
 		assert.Equal(t, "https://github.com", info.ProviderURL(), "ProviderURL() for %s", u)
 	}
 }
+
+func TestGitInfoHttpCloneURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		gitInfo  *gits.GitRepository
+		kind     string
+		expected string
+	}{
+		{
+			name: "github.com",
+			gitInfo: &gits.GitRepository{
+				Name:         "some-repo",
+				Host:         "github.com",
+				Organisation: "some-org",
+			},
+			kind:     gits.KindGitHub,
+			expected: "https://github.com/some-org/some-repo.git",
+		},
+		{
+			name: "github enterprise",
+			gitInfo: &gits.GitRepository{
+				Name:         "some-repo",
+				Host:         "somewhereelse.com",
+				Organisation: "some-org",
+			},
+			kind:     gits.KindGitHub,
+			expected: "https://somewhereelse.com/some-org/some-repo.git",
+		},
+		{
+			name: "gitlab",
+			gitInfo: &gits.GitRepository{
+				Name:         "some-repo",
+				Host:         "gitlab.com",
+				Organisation: "some-org",
+			},
+			kind:     gits.KindGitlab,
+			expected: "https://gitlab.com/some-org/some-repo.git",
+		},
+		{
+			name: "bitbucket server",
+			gitInfo: &gits.GitRepository{
+				Name:         "some-repo",
+				Host:         "bbs.something.com",
+				Organisation: "some-org",
+			},
+			kind:     gits.KindBitBucketServer,
+			expected: "https://bbs.something.com/scm/some-org/some-repo.git",
+		},
+		{
+			name: "no kind",
+			gitInfo: &gits.GitRepository{
+				Name:         "some-repo",
+				Host:         "whatever.com",
+				Organisation: "some-org",
+			},
+			expected: "https://whatever.com/some-org/some-repo.git",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.gitInfo.HttpCloneURL(tc.kind)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/pkg/tekton/metapipeline/clientfactory.go
+++ b/pkg/tekton/metapipeline/clientfactory.go
@@ -156,7 +156,7 @@ func (c *clientFactory) createActualCRDs(buildNumber string, branchIdentifier st
 
 // Apply takes the given CRDs to process them, usually applying them to the cluster.
 func (c *clientFactory) Apply(pipelineActivity kube.PromoteStepActivityKey, crds tekton.CRDWrapper) error {
-	err := tekton.ApplyPipeline(c.jxClient, c.tektonClient, &crds, c.ns, &pipelineActivity)
+	err := tekton.ApplyPipeline(c.jxClient, c.kubeClient, c.tektonClient, &crds, c.ns, &pipelineActivity)
 	if err != nil {
 		return errors.Wrapf(err, "failed to apply Tekton CRDs")
 	}

--- a/pkg/tekton/pipelines.go
+++ b/pkg/tekton/pipelines.go
@@ -447,7 +447,7 @@ func ApplyPipeline(jxClient versioned.Interface, kubeClient kubernetes.Interface
 			return errors.Wrapf(err, "failed to create/update PipelineResource %s in namespace %s", resource.Name, ns)
 		}
 		if resource.Spec.Type == pipelineapi.PipelineResourceTypeGit {
-			gitURL := activityKey.GitInfo.HttpCloneURL(gitKind)
+			gitURL := gits.HttpCloneURL(activityKey.GitInfo, gitKind)
 			log.Logger().Infof("upserted PipelineResource %s for the git repository %s", info(resource.Name), info(gitURL))
 		} else {
 			log.Logger().Infof("upserted PipelineResource %s", info(resource.Name))


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

* Makes sure that whenever we call `*GitRepository.HttpCloneURL`, we pass the git kind to it so that we can determine if the clone URL needs `/scm` added to it for BitBucket Server.
* Include the PR title in the returned `GitPullRequest` from various BitBucket Server functions.
* Make use of owner/org/project in BitBucket Server provider consistent with GitHub and GitLab providers.
* Populate PR data properly.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #6828 
fixes #7184 
fixes #7187 
fixes #7188
