### PR TITLE
chore: adding explicit IsVersionControlled to Gitter interface

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -345,7 +345,7 @@ func (o *BootOptions) createBootClone(bootConfigGitURL string, bootConfigGitRef 
 			return "", errors.Wrapf(err, "setting HEAD to %s", commitish)
 		}
 	} else {
-		log.Logger().Infof("fetching branch %s", bootConfigGitRef)
+		log.Logger().Debugf("fetching branch %s", bootConfigGitRef)
 		err = o.Git().FetchBranch(cloneDir, "origin", bootConfigGitRef)
 		if err != nil {
 			return "", errors.Wrapf(err, "fetching branch %s", bootConfigGitRef)

--- a/pkg/gits/git_fake.go
+++ b/pkg/gits/git_fake.go
@@ -47,6 +47,10 @@ func NewGitFake() Gitter {
 	return &GitFake{}
 }
 
+func (g *GitFake) IsVersionControlled(dir string) (bool, error) {
+	return true, nil
+}
+
 func (g *GitFake) Config(dir string, args ...string) error {
 	return nil
 }
@@ -123,7 +127,7 @@ func (g *GitFake) GetAuthorEmailForCommit(dir string, sha string) (string, error
 			return commit.Author.Email, nil
 		}
 	}
-	return "", errors.New("No commit found with given SHA")
+	return "", errors.New("no commit found with given SHA")
 }
 
 // Init initialises git in a dir

--- a/pkg/gits/git_local.go
+++ b/pkg/gits/git_local.go
@@ -26,6 +26,10 @@ func NewGitLocal() *GitLocal {
 	}
 }
 
+func (g *GitLocal) IsVersionControlled(dir string) (bool, error) {
+	return g.GitCLI.IsVersionControlled(dir)
+}
+
 // FindGitConfigDir tries to find the `.git` directory either in the current directory or in parent directories
 // Faked out
 func (g *GitLocal) FindGitConfigDir(dir string) (string, string, error) {

--- a/pkg/gits/interface.go
+++ b/pkg/gits/interface.go
@@ -176,6 +176,10 @@ type GitProvider interface {
 // Gitter defines common git actions used by Jenkins X via git cli
 //go:generate pegomock generate github.com/jenkins-x/jx/pkg/gits Gitter -o mocks/gitter.go
 type Gitter interface {
+	// IsVersionControlled returns true if the specified directory is under Git version control, otherwise false.
+	// An error is returned for unexpected IO errors.
+	IsVersionControlled(dir string) (bool, error)
+
 	Config(dir string, args ...string) error
 	FindGitConfigDir(dir string) (string, string, error)
 	PrintCreateRepositoryGenerateAccessToken(server *auth.AuthServer, username string, o io.Writer)

--- a/pkg/gits/mocks/gitter.go
+++ b/pkg/gits/mocks/gitter.go
@@ -1049,6 +1049,25 @@ func (mock *MockGitter) IsShallow(_param0 string) (bool, error) {
 	return ret0, ret1
 }
 
+func (mock *MockGitter) IsVersionControlled(_param0 string) (bool, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockGitter().")
+	}
+	params := []pegomock.Param{_param0}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("IsVersionControlled", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 bool
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(bool)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockGitter) ListChangedFilesFromBranch(_param0 string, _param1 string) (string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitter().")
@@ -3592,6 +3611,33 @@ func (c *MockGitter_IsShallow_OngoingVerification) GetCapturedArguments() string
 }
 
 func (c *MockGitter_IsShallow_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockGitter) IsVersionControlled(_param0 string) *MockGitter_IsVersionControlled_OngoingVerification {
+	params := []pegomock.Param{_param0}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "IsVersionControlled", params, verifier.timeout)
+	return &MockGitter_IsVersionControlled_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockGitter_IsVersionControlled_OngoingVerification struct {
+	mock              *MockGitter
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockGitter_IsVersionControlled_OngoingVerification) GetCapturedArguments() string {
+	_param0 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1]
+}
+
+func (c *MockGitter_IsVersionControlled_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(c.methodInvocations))

--- a/pkg/util/commands.go
+++ b/pkg/util/commands.go
@@ -51,6 +51,10 @@ func (c CommandError) Error() string {
 		c.Command.Name, strings.Join(sanitisedArgs, " "), c.Command.Dir, c.Output)
 }
 
+func (c CommandError) Cause() error {
+	return c.cause
+}
+
 // SetName Setter method for Name to enable use of interface instead of Command struct
 func (c *Command) SetName(name string) {
 	c.Name = name


### PR DESCRIPTION
Avoiding confusing WARNING message in helper.go when trying to determine
upstream URL for non git managed directory

fixes #7174

