### PR TITLE
fix: support finding a plugin in the plugins dir

### DIFF
--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/jenkins-x/jx-logging/pkg/log"
@@ -83,4 +84,14 @@ func TestLoggingSetup(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestFindPluginBinary(t *testing.T) {
+	pluginsDir := filepath.Join("test_data", "binary_plugins_dir")
+
+	path := FindPluginBinary(pluginsDir, "jx-dummy-plugin")
+	assert.Equal(t, filepath.Join(pluginsDir, "jx-dummy-plugin-1.2.3"), path, "should have found binary plugin")
+
+	path = FindPluginBinary(pluginsDir, "jx-does-not-exist")
+	assert.Equal(t, "", path, "should have not have found binary plugin")
 }

--- a/pkg/cmd/test_data/binary_plugins_dir/jx-dummy-plugin-1.2.3
+++ b/pkg/cmd/test_data/binary_plugins_dir/jx-dummy-plugin-1.2.3
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "hello world!"


### PR DESCRIPTION
Signed-off-by: James Strachan <james.strachan@gmail.com>

binary plugins can't be found if you are connected to a kubernetes cluster which has no `Plugin` CRD installed.

This PR makes binary plugins installed into the `~/.jx/plugins/bin` dir equivalent to adding `jx-foo` to your `$PATH`; it lets folks install binary plugins without having to add them to your `$PATH`

see #7176