### PR TITLE
fix: Gitlab (12?) namespace should use path in GitRepository

### DIFF
--- a/pkg/gits/gitlab.go
+++ b/pkg/gits/gitlab.go
@@ -123,7 +123,7 @@ func GetOwnerNamespaceID(g *gitlab.Client, owner string) (int, error) {
 func fromGitlabProject(p *gitlab.Project) *GitRepository {
 	org := ""
 	if p.Namespace != nil {
-		org = p.Namespace.Name
+		org = p.Namespace.Path
 	}
 	return &GitRepository{
 		Organisation: org,


### PR DESCRIPTION
There appears to be a typo and `GitRepository` should be using `path` instead of `Name`. Creating PRs with [Gitlab user kind namespaces](https://docs.gitlab.com/ee/api/namespaces.html) `404` fails for me otherwise:

```
error: failed to create Pull Request on the development environment git repository `https://***git`: unable to create pull request: failed to create PR for base master and head branch bump-resource-version-75be7a50-9467-11ea-8f26-a44cc83868d9 from temp dir /tmp/create-pr135132813: finding existing PRs using filter updatebot on repo Steffan, Andreas/***: listing open pull requests on Steffan, Andreas/*: GET https://***/api/v4/users/Steffan, Andreas/projects: 404 {message: 404 User Not Found}
```
In my case, `Name` resolves to my full name `Steffan, Andreas`. 

fixes #7181 