### PR TITLE
[wip] refactor: refactor jx diagnose

### DIFF
--- a/cmd/jx/app/jx.go
+++ b/cmd/jx/app/jx.go
@@ -5,13 +5,13 @@ package app
 import (
 	"os"
 
-	"github.com/jenkins-x/jx/v2/pkg/cmd"
+	cmd2 "github.com/jenkins-x/jx/v2/pkg/cmd"
 	"github.com/jenkins-x/jx/v2/pkg/cmd/clients"
 )
 
 // Run runs the command, if args are not nil they will be set on the command
 func Run(args []string) error {
-	cmd := cmd.NewJXCommand(clients.NewFactory(), os.Stdin, os.Stdout, os.Stderr, nil)
+	cmd := cmd2.NewJXCommand(clients.NewFactory(), os.Stdin, os.Stdout, os.Stderr, nil)
 	if args != nil {
 		args = args[1:]
 		cmd.SetArgs(args)

--- a/pkg/cmd/diagnose.go
+++ b/pkg/cmd/diagnose.go
@@ -1,9 +1,19 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/jenkins-x/jx/v2/pkg/packages"
+
+	"github.com/jenkins-x/jx/v2/pkg/util/system"
+
+	"github.com/jenkins-x/jx/v2/pkg/cmd/templates"
+
 	"github.com/jenkins-x/jx/v2/pkg/cmd/helper"
 	"github.com/jenkins-x/jx/v2/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/v2/pkg/health"
+	version2 "github.com/jenkins-x/jx/v2/pkg/version"
+
 	"github.com/pkg/errors"
 
 	"github.com/jenkins-x/jx/v2/pkg/log"
@@ -11,10 +21,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func getValidArgs() []string {
+	return []string{"", "version", "status", "pvc", "pods", "ingresses", "secrets", "configmaps", "health"}
+}
+
+var jxDiagnoseExample = templates.Examples(fmt.Sprintf(`
+	# To print diagnostic information about pods in n1 namespace
+	jx diagnose pods -n n1
+	Supported arguments to diagnose are %v
+	
+	Deprecated usage:
+	# To print all information
+	jx diagnose
+	
+	#To print specific resource information 
+	jx diagnose --show=pods --show=version
+`, getValidArgs()))
+
 type DiagnoseOptions struct {
 	*opts.CommonOptions
 	Namespace string
-	Show      []string
+	HelmTLS   bool
+	//Deprecated
+	Show   []string
+	Runner util.Commander
 }
 
 func NewCmdDiagnose(commonOpts *opts.CommonOptions) *cobra.Command {
@@ -22,17 +52,29 @@ func NewCmdDiagnose(commonOpts *opts.CommonOptions) *cobra.Command {
 		CommonOptions: commonOpts,
 	}
 	cmd := &cobra.Command{
-		Use:   "diagnose",
-		Short: "Print diagnostic information about the Jenkins X installation",
+		Use:       "diagnose ARG",
+		Short:     "Print diagnostic information about the Jenkins X installation",
+		Example:   jxDiagnoseExample,
+		ValidArgs: getValidArgs(),
+		//Todo: This will be removed by cobra.ExactValidArgs(1) after --show flag is removed
+		Args: cobra.OnlyValidArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			path, err := util.JXBinLocation()
+			helper.CheckErr(err)
+			runner := &util.Command{
+				Name: fmt.Sprintf("%s/kubectl", path),
+			}
+			options.Runner = runner
 			options.Cmd = cmd
 			options.Args = args
-			err := options.Run()
+			err = options.Run()
 			helper.CheckErr(err)
 		},
 	}
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The namespace to display the kube resources from. If left out, defaults to the current namespace")
 	cmd.Flags().StringArrayVarP(&options.Show, "show", "", []string{"version", "status", "pvc", "pods", "ingresses", "secrets", "configmaps"}, "Determine what information to diagnose")
+	cmd.Flags().BoolVarP(&options.HelmTLS, "helm-tls", "", false, "Whether to use TLS with helm")
+	_ = cmd.Flags().MarkDeprecated("show", "use jx diagnose <object> instead. This will be removed on July 1, 2020")
 	return cmd
 }
 
@@ -43,61 +85,144 @@ func (o *DiagnoseOptions) Run() error {
 		return errors.Wrap(err, "failed to create kubeClient")
 	}
 
+	// Install kubectl
+	err = packages.InstallKubectl(false)
+	if err != nil {
+		return err
+	}
+
 	log.Logger().Infof("Running in namespace: %s", util.ColorInfo(ns))
-	if o.showOption("version") {
-		err := printStatus(o, "Jenkins X Version", "jx", "version", "--no-version-check")
-		if err != nil {
-			return err
-		}
+	_, table := o.GetPackageVersions(ns, o.HelmTLS)
+
+	// os version
+	osVersion, err := o.GetOsVersion()
+	if err != nil {
+		log.Logger().Warnf("Failed to get OS version: %s", err)
+	} else {
+		table.AddRow("Operating System", util.ColorInfo(osVersion))
 	}
 
-	if o.showOption("status") {
-		err := printStatus(o, "Jenkins X Status", "jx", "status")
-		if err != nil {
-			return err
-		}
-	}
+	table.Render()
 
-	if o.showOption("pvc") {
-		err := printStatus(o, "Kubernetes PVCs", "kubectl", "get", "pvc", "--namespace", ns)
-		if err != nil {
-			return err
+	switch len(o.Args) {
+	//ToDo: This wont be required after the deprecated --show flag is removed
+	case 0:
+		if o.showOption("version") {
+			version := version2.GetVersion()
+			_, err := fmt.Fprintln(o.CommonOptions.Out, util.ColorInfo(version))
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	if o.showOption("pods") {
-		err := printStatus(o, "Kubernetes Pods", "kubectl", "get", "po", "--namespace", ns)
-		if err != nil {
-			return err
+		if o.showOption("status") {
+			err := NewCmdStatus(o.CommonOptions).Execute()
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	if o.showOption("ingresses") {
-		err := printStatus(o, "Kubernetes Ingresses", "kubectl", "get", "ingress", "--namespace", ns)
-		if err != nil {
-			return err
+		if o.showOption("pvc") {
+			err := printStatus(o, "Kubernetes PVCs", "kubectl", "get", "pvc", "--namespace", ns)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	if o.showOption("secrets") {
-		err := printStatus(o, "Kubernetes Secrets", "kubectl", "get", "secrets", "--namespace", ns)
-		if err != nil {
-			return err
+		if o.showOption("pods") {
+			err := printStatus(o, "Kubernetes Pods", "kubectl", "get", "po", "--namespace", ns)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	if o.showOption("configmaps") {
-		err := printStatus(o, "Kubernetes Configmaps", "kubectl", "get", "configmaps", "--namespace", ns)
-		if err != nil {
-			return err
+		if o.showOption("ingresses") {
+			err := printStatus(o, "Kubernetes Ingresses", "kubectl", "get", "ingress", "--namespace", ns)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	if o.showOption("health") {
-		err = health.Kuberhealthy(kubeClient, ns)
-		if err != nil {
-			return err
+		if o.showOption("secrets") {
+			err := printStatus(o, "Kubernetes Secrets", "kubectl", "get", "secrets", "--namespace", ns)
+			if err != nil {
+				return err
+			}
 		}
+
+		if o.showOption("configmaps") {
+			err := printStatus(o, "Kubernetes Configmaps", "kubectl", "get", "configmaps", "--namespace", ns)
+			if err != nil {
+				return err
+			}
+		}
+
+		if o.showOption("health") {
+			err = health.Kuberhealthy(kubeClient, ns)
+			if err != nil {
+				return err
+			}
+		}
+	case 1:
+		if o.showInfo("version") {
+			version := version2.GetVersion()
+			_, err := fmt.Fprintln(o.CommonOptions.Out, util.ColorInfo(version))
+			if err != nil {
+				return err
+			}
+		}
+
+		if o.showInfo("status") {
+			err := NewCmdStatus(o.CommonOptions).Execute()
+			if err != nil {
+				return err
+			}
+		}
+
+		if o.showInfo("pvc") {
+			err := printStatus(o, "Kubernetes PVCs", "kubectl", "get", "pvc", "--namespace", ns)
+			if err != nil {
+				return err
+			}
+		}
+
+		if o.showInfo("pods") {
+			err := printStatus(o, "Kubernetes Pods", "kubectl", "get", "po", "--namespace", ns)
+			if err != nil {
+				return err
+			}
+		}
+
+		if o.showInfo("ingresses") {
+			err := printStatus(o, "Kubernetes Ingresses", "kubectl", "get", "ingress", "--namespace", ns)
+			if err != nil {
+				return err
+			}
+		}
+
+		if o.showInfo("secrets") {
+			err := printStatus(o, "Kubernetes Secrets", "kubectl", "get", "secrets", "--namespace", ns)
+			if err != nil {
+				return err
+			}
+		}
+
+		if o.showInfo("configmaps") {
+			err := printStatus(o, "Kubernetes Configmaps", "kubectl", "get", "configmaps", "--namespace", ns)
+			if err != nil {
+				return err
+			}
+		}
+
+		if o.showInfo("health") {
+			err = health.Kuberhealthy(kubeClient, ns)
+			if err != nil {
+				return err
+			}
+		}
+	//ToDo: This wont be required after the deprecated --show flag is removed
+	default:
+		return errors.New("Only one argument is allowed")
 	}
 
 	log.Logger().Info("\nPlease visit https://jenkins-x.io/faq/issues/ for any known issues.")
@@ -107,7 +232,8 @@ func (o *DiagnoseOptions) Run() error {
 
 // Run the specified command (jx status, kubectl get po, etc) and print its output
 func printStatus(o *DiagnoseOptions, header string, command string, options ...string) error {
-	output, err := o.GetCommandOutput("", command, options...)
+	o.Runner.SetArgs(options)
+	output, err := o.Runner.RunWithoutRetry()
 	if err != nil {
 		log.Logger().Errorf("Unable to get the %s", header)
 		return err
@@ -117,6 +243,7 @@ func printStatus(o *DiagnoseOptions, header string, command string, options ...s
 	return nil
 }
 
+// Deprecated
 func (o *DiagnoseOptions) showOption(e string) bool {
 	for _, a := range o.Show {
 		if a == e {
@@ -124,4 +251,19 @@ func (o *DiagnoseOptions) showOption(e string) bool {
 		}
 	}
 	return false
+}
+
+func (o *DiagnoseOptions) showInfo(e string) bool {
+	for _, a := range o.Args {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+// GetOsVersion returns a human friendly string of the current OS
+// in the case of an error this still returns a valid string for the details that can be found.
+func (o *DiagnoseOptions) GetOsVersion() (string, error) {
+	return system.GetOsVersion()
 }

--- a/pkg/cmd/diagnose_integration_test.go
+++ b/pkg/cmd/diagnose_integration_test.go
@@ -1,0 +1,61 @@
+//// +build integration
+//
+package cmd_test
+
+//
+//import (
+//	"os"
+//	"testing"
+//
+//	"github.com/jenkins-x/jx/v2/pkg/cmd"
+//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+//
+//	"github.com/jenkins-x/jx/v2/pkg/cmd/clients"
+//	"github.com/jenkins-x/jx/v2/pkg/cmd/opts"
+//	"github.com/jenkins-x/jx/v2/pkg/cmd/testhelpers"
+//	"github.com/stretchr/testify/assert"
+//
+//	"github.com/jenkins-x/jx/v2/pkg/log"
+//)
+//
+//const testDiagnoseNamespace = "jx-test"
+//
+//// Test_ExecuteDiagnose tests that jx diagnose works properly
+//func Test_ExecuteDiagnose(t *testing.T) {
+//	// Create home directory
+//	origJXHome, testJXHome, err := testhelpers.CreateTestJxHomeDir()
+//	assert.NoError(t, err, "failed to create a test JX Home directory")
+//	defer func() {
+//		err = testhelpers.CleanupTestJxHomeDir(origJXHome, testJXHome)
+//		if err != nil {
+//			log.Logger().Warnf("unable to remove temporary directory %s: %s", testJXHome, err)
+//		}
+//		log.Logger().Info("Deleted temporary jx home directory")
+//	}()
+//
+//	// Test installing ksync locally
+//	out := &testhelpers.FakeOut{}
+//	commonOpts := opts.NewCommonOptionsWithTerm(clients.NewFactory(), os.Stdin, out, os.Stderr)
+//
+//	// Set batchmode to true for tests
+//	commonOpts.BatchMode = true
+//
+//	// Get the current namespace, we will revert back to this after the tests are over
+//	_, oldNs, _ := commonOpts.KubeClientAndNamespace()
+//
+//	// Create a dev namespace
+//	commonOpts.SetDevNamespace(testDiagnoseNamespace)
+//
+//	command := cmd.NewCmdDiagnose(commonOpts)
+//	err = command.Execute()
+//	assert.NoError(t, err, "could not execute diagnose")
+//
+//	// Revert back to the old namespace
+//	commonOpts.SetCurrentNamespace(oldNs)
+//	client, err := commonOpts.KubeClient()
+//	assert.NoError(t, err, "could not create jx client")
+//
+//	// Delete the namespace created for test purposes
+//	client.CoreV1().Namespaces().Delete(testDiagnoseNamespace, &metav1.DeleteOptions{})
+//	log.Logger().Infof("Deleting test namespace: %s", testDiagnoseNamespace)
+//}


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>


#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
This PR: 
* deprecates --show option, keeps it for backward compatibility
* refactors jx diagnose to this form -> `APPNAME COMMAND ARG --FLAG`
* prints system information all the time (`jx, kubernetes cluster, kubectl, helm, git and os versions`)
* Avoids using os exec to get jx related information 
* adds an example on how to use the command

Need to add some tests before removing WIP.

The command can be used in the following way (for printing diagnostic information about configmaps and pods):
**Deprecated way**
```
jx diagnose --show=pods --show=configmaps 
```
**New way**
Similar to kubectl get pods
```
jx diagnose pods
jx diagnose configmaps
```

#### Special notes for the reviewer(s)
I am not familiar with the deprecation policy for jx commands. I put an arbitrary date of July 1, 2020.

#### Which issue this PR fixes

fixes #7178 