### PR TITLE
fix: Don't use pr:from_ref_updated webhook on older BitBucket Servers

### DIFF
--- a/pkg/gits/bitbucket_server_test.go
+++ b/pkg/gits/bitbucket_server_test.go
@@ -87,6 +87,9 @@ var bitbucketServerRouter = util.Router{
 	"/rest/api/1.0/projects/test-org/repos/repo/permissions/users": util.MethodMap{
 		"PUT": "user.json",
 	},
+	"/rest/api/1.0/application-properties": util.MethodMap{
+		"GET": "app-props.json",
+	},
 }
 
 func (suite *BitbucketServerProviderTestSuite) SetupSuite() {

--- a/pkg/gits/test_data/bitbucket_server/app-props.json
+++ b/pkg/gits/test_data/bitbucket_server/app-props.json
@@ -1,0 +1,6 @@
+{
+  "version": "2.1.0",
+  "buildNumber": "20130123103656677",
+  "buildDate": "1358897885952000",
+  "displayName": "Example.com Bitbucket"
+}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

`pr:from_ref_updated` was added in BitBucket Server 7.0.0. Without it, we're never notified when a new commit is pushed to an existing PR, so it's obviously something we really want enabled, but it doesn't exist prior to 7.0.0. If we try to enable it on older versions, the whole API call will fail. So let's only enable it if the target server is new enough.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #7204
