### PR TITLE
feat: remove the CRD creation from the changelog step and allow the creation of the controller's role and rolebindings on other namespaces

### DIFF
--- a/charts/jx/templates/role.yaml
+++ b/charts/jx/templates/role.yaml
@@ -7,4 +7,20 @@ metadata:
 rules:
 {{ toYaml .Values.role.rules | indent 0 }}
 {{- end }}
+
+{{- if .Values.role.additionalNamespaces }}
+{{- $ctx := . -}}
+{{- range .Values.role.additionalNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "jx.name" $ctx }}
+  namespace: {{ . }}
+{{ if $.Values.role.rules -}}
+rules:
+{{ toYaml $.Values.role.rules | indent 0 }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/jx/templates/rolebinding.yaml
+++ b/charts/jx/templates/rolebinding.yaml
@@ -17,5 +17,30 @@ subjects:
   name: {{ template "jx.fullname" . }}
 {{- end }}
   namespace: {{ .Release.Namespace }}
+
+{{- if .Values.role.additionalNamespaces }}
+{{- $ctx := . -}}
+{{- range .Values.role.additionalNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "jx.name" $ctx }}
+  namespace: {{ . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "jx.name" $ctx }}
+subjects:
+  - kind: ServiceAccount
+{{- if $.Values.serviceaccount.customName }}
+    name: {{ $.Values.serviceaccount.customName }}
+{{- else }}
+    name: {{ template "jx.fullname" $ctx }}
+{{- end }}
+    namespace: {{ $.Release.Namespace }}
 {{- end }}
 {{- end }}
+{{- end }}
+{{- end }}
+

--- a/pkg/cmd/step/step_changelog.go
+++ b/pkg/cmd/step/step_changelog.go
@@ -205,28 +205,8 @@ func (o *StepChangelogOptions) Run() error {
 		o.BatchMode = true
 	}
 
-	apisClient, err := o.ApiExtensionsClient()
-	if err != nil {
-		return err
-	}
-	err = kube.RegisterPipelineActivityCRD(apisClient)
-	if err != nil {
-		return err
-	}
-	err = kube.RegisterGitServiceCRD(apisClient)
-	if err != nil {
-		return err
-	}
-	err = kube.RegisterReleaseCRD(apisClient)
-	if err != nil {
-		return err
-	}
-	err = o.RegisterUserCRD()
-	if err != nil {
-		return err
-	}
-
 	dir := o.Dir
+	var err error
 	if dir == "" {
 		dir, err = os.Getwd()
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
We should not register any CRDs on any controller as they are being registered and updated by Boot. This makes the steps / controllers to fail on a cluster without cluster-wide permissions.

Also, allow the creation of `roles` and `rolebindings` for the `jx` Helm chart on different namespaces when configured.

#### Which issue this PR fixes

fixes #7209 
fixes #7210 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
