### PR TITLE
fix: Fix build log retrieval for BitBucket Server and GitLab

### DIFF
--- a/pkg/cmd/step/step_unstash_test.go
+++ b/pkg/cmd/step/step_unstash_test.go
@@ -1,0 +1,90 @@
+// +build unit
+
+package step_test
+
+import (
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/jenkins-x/jx/v2/pkg/auth"
+	"github.com/jenkins-x/jx/v2/pkg/cmd/step"
+	"github.com/jenkins-x/jx/v2/pkg/kube"
+	"github.com/jenkins-x/jx/v2/pkg/secreturl/fakevault"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/yaml"
+)
+
+const secretName = kube.SecretJenkinsPipelineGitCredentials + "github-ghe"
+
+func TestGetTokenForGitURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		gitURL        string
+		expectedToken string
+	}{
+		{
+			name:          "bitbucketserver",
+			gitURL:        "https://bitbucket.example.com/scm/some-org/some-proj.git",
+			expectedToken: "test:test",
+		},
+		{
+			name:          "github",
+			gitURL:        "https://raw.githubusercontent.com/jenkins-x/environment-tekton-weasel-dev/master/OWNERS",
+			expectedToken: "test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := "jx"
+
+			authFile := path.Join("test_data", "step_unstash", tc.name+".yaml")
+			data, err := ioutil.ReadFile(authFile)
+			require.NoError(t, err)
+
+			var expectedAuthConfig auth.AuthConfig
+			err = yaml.Unmarshal(data, &expectedAuthConfig)
+			require.NoError(t, err)
+
+			namespace := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			}
+			config := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jx-auth",
+					Namespace: ns,
+					Labels: map[string]string{
+						"jenkins.io/config-type": "auth",
+					},
+				},
+				Data: map[string]string{
+					secretName: string(data),
+				},
+			}
+			kubeClient := fake.NewSimpleClientset(namespace, config)
+			configMapInterface := kubeClient.CoreV1().ConfigMaps(ns)
+
+			vaultClient := fakevault.NewFakeClient()
+			_, err = vaultClient.Write("test-cluster/pipelineUser", map[string]interface{}{"token": "test"})
+			require.NoError(t, err)
+			expectedAuthConfig.Servers[0].Users[0].ApiToken = "test"
+
+			authCfgSvc := auth.NewConfigmapVaultAuthConfigService(secretName, configMapInterface, vaultClient)
+			_, err = authCfgSvc.LoadConfig()
+			assert.NoError(t, err)
+
+			gitToken, err := step.GetTokenForGitURL(authCfgSvc, tc.gitURL)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedToken, gitToken)
+		})
+	}
+}

--- a/pkg/cmd/step/step_unstash_test.go
+++ b/pkg/cmd/step/step_unstash_test.go
@@ -29,25 +29,30 @@ func TestCreateBucketHTTPFn(t *testing.T) {
 	testCases := []struct {
 		name                string
 		gitURL              string
-		expectedToken       string
+		expectedTokenPrefix string
 		expectedHeader      string
 		expectedHeaderValue string
 	}{
 		{
-			name:          "bitbucketserver",
-			gitURL:        "bitbucket.example.com/scm/some-org/some-proj.git",
-			expectedToken: "test:test",
+			name:                "bitbucketserver",
+			gitURL:              "bitbucket.example.com/scm/some-org/some-proj.git",
+			expectedTokenPrefix: "test:test",
 		},
 		{
-			name:          "github",
-			gitURL:        "raw.githubusercontent.com/jenkins-x/environment-tekton-weasel-dev/master/OWNERS",
-			expectedToken: "test",
+			name:                "github",
+			gitURL:              "raw.githubusercontent.com/jenkins-x/environment-tekton-weasel-dev/master/OWNERS",
+			expectedTokenPrefix: "test",
 		},
 		{
 			name:                "gitlab",
 			gitURL:              "gitlab.com/api/v4/projects/jxbdd%2Fenvironment-pr-751-6-lh-bdd-gl-dev/repository/files/jenkins-x%2Flogs%2Fjxbdd%2Fenvironment-pr-751-6-lh-bdd-gl-dev%2FPR-1%2F1.log/raw?ref=gh-pages",
 			expectedHeader:      "PRIVATE-TOKEN",
 			expectedHeaderValue: "test",
+		},
+		{
+			name:                "ghe",
+			gitURL:              "github.something.com/raw/foo/bar/branch/blah.log",
+			expectedTokenPrefix: "test",
 		},
 	}
 
@@ -100,8 +105,8 @@ func TestCreateBucketHTTPFn(t *testing.T) {
 			bucketURL, headerFn, err := httpFn("https://" + tc.gitURL)
 
 			assert.NoError(t, err)
-			expectedURL := fmt.Sprintf("https://%s@%s", tc.expectedToken, tc.gitURL)
-			if tc.expectedToken == "" {
+			expectedURL := fmt.Sprintf("https://%s@%s", tc.expectedTokenPrefix, tc.gitURL)
+			if tc.expectedTokenPrefix == "" {
 				expectedURL = fmt.Sprintf("https://%s", tc.gitURL)
 			}
 			assert.Equal(t, expectedURL, bucketURL)

--- a/pkg/cmd/step/test_data/step_unstash/bitbucketserver.yaml
+++ b/pkg/cmd/step/test_data/step_unstash/bitbucketserver.yaml
@@ -1,0 +1,13 @@
+currentserver: test
+defaultusername: "test"
+pipelineserver: "test"
+pipelineusername: "test"
+servers:
+- currentuser: "test"
+  kind: bitbucketserver
+  name: bs
+  url: https://bitbucket.example.com
+  users:
+  - apitoken: "vault:test-cluster/pipelineUser:token"
+    bearertoken: ""
+    username: "test"

--- a/pkg/cmd/step/test_data/step_unstash/ghe.yaml
+++ b/pkg/cmd/step/test_data/step_unstash/ghe.yaml
@@ -1,0 +1,13 @@
+currentserver: test
+defaultusername: "test"
+pipelineserver: "test"
+pipelineusername: "test"
+servers:
+- currentuser: "test"
+  kind: github
+  name: ghe
+  url: https://github.something.com
+  users:
+  - apitoken: "vault:test-cluster/pipelineUser:token"
+    bearertoken: ""
+    username: "test"

--- a/pkg/cmd/step/test_data/step_unstash/github.yaml
+++ b/pkg/cmd/step/test_data/step_unstash/github.yaml
@@ -1,0 +1,13 @@
+currentserver: test
+defaultusername: "test"
+pipelineserver: "test"
+pipelineusername: "test"
+servers:
+- currentuser: "test"
+  kind: github
+  name: github
+  url: https://github.com
+  users:
+  - apitoken: "vault:test-cluster/pipelineUser:token"
+    bearertoken: ""
+    username: "test"

--- a/pkg/cmd/step/test_data/step_unstash/gitlab.yaml
+++ b/pkg/cmd/step/test_data/step_unstash/gitlab.yaml
@@ -1,0 +1,13 @@
+currentserver: test
+defaultusername: "test"
+pipelineserver: "test"
+pipelineusername: "test"
+servers:
+- currentuser: "test"
+  kind: gitlab
+  name: gl
+  url: https://gitlab.com
+  users:
+  - apitoken: "vault:test-cluster/pipelineUser:token"
+    bearertoken: ""
+    username: "test"

--- a/pkg/collector/git_collector.go
+++ b/pkg/collector/git_collector.go
@@ -162,8 +162,8 @@ func (c *GitCollector) CollectData(data []byte, outputPath string) (string, erro
 }
 
 func (c *GitCollector) generateURL(storageOrg string, storageRepoName string, rPath string) (url string) {
-	if !c.gitInfo.IsGitHub() && gits.SaasGitKind(c.gitInfo.Host) == gits.KindGitHub {
-		url = fmt.Sprintf("https://raw.%s/%s/%s/%s/%s", c.gitInfo.Host, storageOrg, storageRepoName, c.gitBranch, rPath)
+	if !c.gitInfo.IsGitHub() && c.gitKind == gits.KindGitHub {
+		url = fmt.Sprintf("https://%s/raw/%s/%s/%s/%s", c.gitInfo.Host, storageOrg, storageRepoName, c.gitBranch, rPath)
 	} else {
 		switch c.gitKind {
 		case gits.KindGitlab:

--- a/pkg/collector/git_collector.go
+++ b/pkg/collector/git_collector.go
@@ -167,7 +167,11 @@ func (c *GitCollector) generateURL(storageOrg string, storageRepoName string, rP
 	} else {
 		switch c.gitKind {
 		case gits.KindGitlab:
-			url = fmt.Sprintf("https://%s/%s/%s/-/raw/%s/%s", c.gitInfo.Host, storageOrg, storageRepoName, c.gitBranch, rPath)
+			url = fmt.Sprintf("https://%s/api/v4/projects/%s/repository/files/%s/raw?ref=%s",
+				c.gitInfo.Host,
+				neturl.PathEscape(fmt.Sprintf("%s/%s", storageOrg, storageRepoName)),
+				neturl.PathEscape(rPath),
+				neturl.QueryEscape(c.gitBranch))
 		case gits.KindBitBucketServer:
 			url = fmt.Sprintf("https://%s/projects/%s/repos/%s/raw/%s?at=%s", c.gitInfo.Host, storageOrg, storageRepoName, rPath, neturl.QueryEscape(fmt.Sprintf("refs/heads/%s", c.gitBranch)))
 		default:


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

GitHub allows fetching raw file content with a url like `https://TOKEN@...`, but BitBucket Server requires `https://USER:TOKEN@...`. We need to fetch GitLab raw files via the REST API, regrettably. See https://gitlab.com/gitlab-org/gitlab/-/issues/36191 for more details. So let's change the generated logs URL to the REST API url, and change the unstashing behavior to support the idea of adding a header, not just manipulating the URL.

And finally, the logic for determining whether the provider is github.com or GitHub Enterprise here wasn't working right, so let's tweak that.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #7216 
fixes #7217 
fixes #7219 