### PR TITLE
fix: Lock eksctl version to 0.11.1

### DIFF
--- a/pkg/cloud/amazon/cli.go
+++ b/pkg/cloud/amazon/cli.go
@@ -36,5 +36,5 @@ func InstallEksCtlWithVersion(version string, skipPathScan bool) error {
 
 // InstallEksCtl installs eks cli
 func InstallEksCtl(skipPathScan bool) error {
-	return InstallEksCtlWithVersion("", skipPathScan)
+	return InstallEksCtlWithVersion(packages.EksCtlVersion, skipPathScan)
 }

--- a/pkg/ksync/cli.go
+++ b/pkg/ksync/cli.go
@@ -79,10 +79,7 @@ func install(latestVersion, binDir, fileName string) error {
 func (kcli *CLI) Version() (string, error) {
 	args := []string{"version"}
 	kcli.Runner.SetArgs(args)
-	out, err := kcli.Runner.RunWithoutRetry()
-	if err != nil {
-		return "", err
-	}
+	out, _ := kcli.Runner.RunWithoutRetry()
 	return out, nil
 }
 

--- a/pkg/packages/packages.go
+++ b/pkg/packages/packages.go
@@ -22,6 +22,9 @@ const IBMCloudVersion = "0.10.1"
 // IamAuthenticatorAwsVersion authenticator binary version to use
 const IamAuthenticatorAwsVersion = "1.12.7"
 
+// EksCtlVersion binary version to use
+const EksCtlVersion = "0.11.1"
+
 // KubectlVersion binary version to use
 const KubectlVersion = "1.13.2"
 


### PR DESCRIPTION
This PR fixes the eksctl version to 0.11.1 to keep it inline with other binaries that we install. The fix prevents `jx create cluster` from creating a 1.16 k8s cluster if the incorrect binary version is used.

fixes #7235

Also fixes a warning during ksync version checking.

Signed-off-by: David Conde 