### PR TITLE
chore: allow LoadRequirements to be a little less restrictive loading.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2020-05-27T20:16:55Z",
+  "generated_at": "2020-05-27T20:23:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -560,7 +560,7 @@
       {
         "hashed_secret": "beb491c17c5298f5a9848c1d4b34ead07094fceb",
         "is_secret": true,
-        "line_number": 342,
+        "line_number": 370,
         "type": "Secret Keyword"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2020-05-27T20:23:20Z",
+  "generated_at": "2020-05-27T20:32:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -628,7 +628,7 @@
       {
         "hashed_secret": "336636f71f28cba925f25a109aebcf57de39c7cb",
         "is_secret": true,
-        "line_number": 45,
+        "line_number": 47,
         "type": "Secret Keyword"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^pkg/jenkins/test_data/update_center.json.*$|^.secrets.baseline$|^.*test.*$",
     "lines": null
   },
-  "generated_at": "2020-04-03T04:31:46Z",
+  "generated_at": "2020-05-27T20:16:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -458,7 +458,7 @@
       {
         "hashed_secret": "0a5216cef83f3ea3665f6473bfe2c9f6752517e7",
         "is_secret": false,
-        "line_number": 453,
+        "line_number": 456,
         "type": "Secret Keyword"
       }
     ],
@@ -628,7 +628,7 @@
       {
         "hashed_secret": "336636f71f28cba925f25a109aebcf57de39c7cb",
         "is_secret": true,
-        "line_number": 42,
+        "line_number": 45,
         "type": "Secret Keyword"
       }
     ],

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-containerregistry v0.0.0-20190317040536-ebbba8469d06 // indirect
 	github.com/google/go-github v17.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-containerregistry v0.0.0-20190317040536-ebbba8469d06 // indirect
 	github.com/google/go-github v17.0.0+incompatible

--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -153,7 +153,7 @@ func (o *BootOptions) Run() error {
 		o.Dir = cloneDir
 	}
 
-	requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "unable to load %s", config.RequirementsConfigFileName)
 	}
@@ -497,14 +497,14 @@ func existingBootClone(dir string) (bool, error) {
 }
 
 func (o *BootOptions) overrideRequirements(defaultBootConfigURL string) error {
-	requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "loading requirements from dir %q", o.Dir)
 	}
 
 	// overwrite the default requirements with provided requirements
 	if o.RequirementsFile != "" {
-		providedRequirements, err := config.LoadRequirementsConfigFile(o.RequirementsFile)
+		providedRequirements, err := config.LoadRequirementsConfigFile(o.RequirementsFile, config.DefaultFailOnValidationError)
 		if err != nil {
 			return errors.Wrapf(err, "loading requirements from file %q", o.RequirementsFile)
 		}

--- a/pkg/cmd/boot/boot_test.go
+++ b/pkg/cmd/boot/boot_test.go
@@ -53,7 +53,7 @@ func TestDetermineGitRef_DefaultGitUrl(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(dir)
 	}()
-	requirements, _, err := config.LoadRequirementsConfig(dir)
+	requirements, _, err := config.LoadRequirementsConfig(dir, config.DefaultFailOnValidationError)
 	require.NoError(t, err, "unable to load tmp jx-requirements")
 	resolver := &versionstream.VersionResolver{
 		VersionsDir: filepath.Join("test_data", "jenkins-x-versions"),
@@ -79,7 +79,7 @@ func TestDetermineGitRef_GitURLNotInVersionStream(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(dir)
 	}()
-	requirements, _, err := config.LoadRequirementsConfig(dir)
+	requirements, _, err := config.LoadRequirementsConfig(dir, config.DefaultFailOnValidationError)
 	require.NoError(t, err, "unable to load tmp jx-requirements")
 	resolver := &versionstream.VersionResolver{
 		VersionsDir: filepath.Join("test_data", "jenkins-x-versions"),

--- a/pkg/cmd/clients/factory.go
+++ b/pkg/cmd/clients/factory.go
@@ -568,7 +568,7 @@ func (f *factory) useVaultInsecureSSL(namespace string) (bool, error) {
 }
 
 func (f *factory) useVaultIngress(devNamespace string) (bool, error) {
-	requirements, _, err := config.LoadRequirementsConfig("")
+	requirements, _, err := config.LoadRequirementsConfig("", config.DefaultFailOnValidationError)
 	if err == nil && requirements != nil && requirements.Vault.DisableURLDiscovery {
 		log.Logger().Debugf("Using vault ingress because the Vault.DisableURLDiscovery is set in requirements file")
 		return true, nil

--- a/pkg/cmd/edit/requirements/requirements.go
+++ b/pkg/cmd/edit/requirements/requirements.go
@@ -138,7 +138,7 @@ func NewCmdEditRequirements(commonOpts *opts.CommonOptions) *cobra.Command {
 
 // Run runs the command
 func (o *RequirementsOptions) Run() error {
-	requirements, fileName, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, fileName, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/edit/requirements/requirements_test.go
+++ b/pkg/cmd/edit/requirements/requirements_test.go
@@ -128,7 +128,7 @@ func TestCmdEditRequirements(t *testing.T) {
 		file := localReqFile
 		require.FileExists(t, file, "should have generated the requirements file")
 
-		req, _, err := config.LoadRequirementsConfig(dir)
+		req, _, err := config.LoadRequirementsConfig(dir, config.DefaultFailOnValidationError)
 		require.NoError(t, err, "failed to load requirements from dir %s", dir)
 
 		if tt.callback != nil {

--- a/pkg/cmd/opts/common.go
+++ b/pkg/cmd/opts/common.go
@@ -550,7 +550,7 @@ func (o *CommonOptions) Helm() helm.Helmer {
 
 			// check helmfile featureflag but default to existing behaviour if there's any issues
 			var helmer helm.Helmer
-			r, _, err := config.LoadRequirementsConfig("")
+			r, _, err := config.LoadRequirementsConfig("", config.DefaultFailOnValidationError)
 			if err != nil {
 				r = config.NewRequirementsConfig()
 			}

--- a/pkg/cmd/step/bdd/step_bdd.go
+++ b/pkg/cmd/step/bdd/step_bdd.go
@@ -763,7 +763,7 @@ func (o *StepBDDOptions) createCluster(cluster *CreateCluster) error {
 }
 
 func (o *StepBDDOptions) getTestSpecificRequirementsIfExists(cluster *CreateCluster) (*config.RequirementsConfig, error) {
-	requirements, requirementsFile, _ := config.LoadRequirementsConfig(o.Flags.Dir)
+	requirements, requirementsFile, _ := config.LoadRequirementsConfig(o.Flags.Dir, config.DefaultFailOnValidationError)
 	if requirements == nil {
 		return nil, nil
 	}

--- a/pkg/cmd/step/boot/step_boot_vault.go
+++ b/pkg/cmd/step/boot/step_boot_vault.go
@@ -82,7 +82,7 @@ func (o *StepBootVaultOptions) Run() error {
 		return err
 	}
 
-	requirements, _, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/step/create/step_create_templated_config.go
+++ b/pkg/cmd/step/create/step_create_templated_config.go
@@ -106,7 +106,7 @@ func (o *StepCreateTemplatedConfigOptions) Run() error {
 	if err := o.checkFlags(); err != nil {
 		return err
 	}
-	requirements, _, err := config.LoadRequirementsConfig(o.RequirementsDir)
+	requirements, _, err := config.LoadRequirementsConfig(o.RequirementsDir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "loading requirements file form dir %q", o.RequirementsDir)
 	}

--- a/pkg/cmd/step/create/step_create_values.go
+++ b/pkg/cmd/step/create/step_create_values.go
@@ -129,7 +129,7 @@ func (o *StepCreateValuesOptions) Run() error {
 		}
 	}
 	// lets default to the install requirements setting
-	requirements, fileName, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, fileName, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/step/expose/step_expose.go
+++ b/pkg/cmd/step/expose/step_expose.go
@@ -104,7 +104,7 @@ func (o *StepExposeOptions) Run() error {
 		return err
 	}
 
-	requirements, _, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load requirements YAML")
 	}

--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -402,7 +402,7 @@ func (o *StepHelmApplyOptions) Run() error {
 // getRequirements tries to load the requirements either from the team settings or local requirements file
 func (o *StepHelmApplyOptions) getRequirements() (*config.RequirementsConfig, string, error) {
 	// Try to load first the requirements from current directory
-	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err == nil {
 		return requirements, requirementsFileName, nil
 	}

--- a/pkg/cmd/step/helm/step_helm_build.go
+++ b/pkg/cmd/step/helm/step_helm_build.go
@@ -91,7 +91,7 @@ func (o *StepHelmBuildOptions) Run() error {
 	}
 
 	if o.Boot {
-		requirements, requirementsFileName, err := config.LoadRequirementsConfig(dir)
+		requirements, requirementsFileName, err := config.LoadRequirementsConfig(dir, config.DefaultFailOnValidationError)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/step/step_override_requirements.go
+++ b/pkg/cmd/step/step_override_requirements.go
@@ -41,7 +41,7 @@ func NewCmdStepOverrideRequirements(commonOpts *opts.CommonOptions) *cobra.Comma
 
 // Run implements this command
 func (o *StepOverrideRequirementsOptions) Run() error {
-	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -72,7 +72,7 @@ func (o *StepVerifyEnvironmentsOptions) Run() error {
 		return err
 	}
 
-	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/step/verify/step_verify_ingress.go
+++ b/pkg/cmd/step/verify/step_verify_ingress.go
@@ -111,7 +111,7 @@ func (o *StepVerifyIngressOptions) Run() error {
 			return fmt.Errorf("no default namespace found")
 		}
 	}
-	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load Jenkins X requirements")
 	}

--- a/pkg/cmd/step/verify/step_verify_ingress_test.go
+++ b/pkg/cmd/step/verify/step_verify_ingress_test.go
@@ -114,14 +114,14 @@ func TestExternalDNSDisabledDomainNotOwned(t *testing.T) {
 	err = requirements.SaveConfig(file)
 	assert.NoError(t, err, "failed to save file %s", file)
 
-	requirements, fileName, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, fileName, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	assert.NoError(t, err, "failed to load requirements file in dir %s", o.Dir)
 	assert.FileExists(t, fileName)
 
 	err = o.Run()
 	assert.NoError(t, err, "failed to run step in dir %s", o.Dir)
 
-	requirements, fileName, err = config.LoadRequirementsConfig(o.Dir)
+	requirements, fileName, err = config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	assert.NoError(t, err, "failed to load requirements file in dir %s", o.Dir)
 	assert.FileExists(t, fileName)
 
@@ -155,14 +155,14 @@ func TestExternalDNSDisabledNotGKE(t *testing.T) {
 	err = requirements.SaveConfig(file)
 	assert.NoError(t, err, "failed to save file %s", file)
 
-	requirements, fileName, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, fileName, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	assert.NoError(t, err, "failed to load requirements file in dir %s", o.Dir)
 	assert.FileExists(t, fileName)
 
 	err = o.Run()
 	assert.NoError(t, err, "failed to run step in dir %s", o.Dir)
 
-	requirements, fileName, err = config.LoadRequirementsConfig(o.Dir)
+	requirements, fileName, err = config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	assert.NoError(t, err, "failed to load requirements file in dir %s", o.Dir)
 	assert.FileExists(t, fileName)
 

--- a/pkg/cmd/step/verify/step_verify_install.go
+++ b/pkg/cmd/step/verify/step_verify_install.go
@@ -82,7 +82,7 @@ func (o *StepVerifyInstallOptions) Run() error {
 		return err
 	}
 
-	requirements, _, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/step/verify/step_verify_packages.go
+++ b/pkg/cmd/step/verify/step_verify_packages.go
@@ -86,7 +86,7 @@ func (o *StepVerifyPackagesOptions) Run() error {
 		verifyMap[k] = packages[k]
 	}
 
-	requirements, _, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load boot requirements")
 	}

--- a/pkg/cmd/step/verify/step_verify_preinstall.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall.go
@@ -94,7 +94,7 @@ func NewCmdStepVerifyPreInstall(commonOpts *opts.CommonOptions) *cobra.Command {
 // Run implements this command
 func (o *StepVerifyPreInstallOptions) Run() error {
 	info := util.ColorInfo
-	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, requirementsFileName, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/step/verify/step_verify_preinstall_integration_test.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall_integration_test.go
@@ -167,7 +167,7 @@ func TestStepVerifyPreInstallRequirements(t *testing.T) {
 		assert.NoError(t, err)
 		defer resetNamespace(t, origNamespace)
 
-		requirements, requirementsFileName, err := config.LoadRequirementsConfig(testDir)
+		requirements, requirementsFileName, err := config.LoadRequirementsConfig(testDir, config.DefaultFailOnValidationError)
 		assert.NoError(t, err, "for test %s", dir)
 
 		err = options.ValidateRequirements(requirements, requirementsFileName)
@@ -230,7 +230,7 @@ func TestStepVerifyPreInstallSetClusterRequirementsViaEnvars(t *testing.T) {
 	err = requirements.SaveConfig(file)
 	assert.NoError(t, err, "failed to save file %s", file)
 
-	requirements, fileName, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, fileName, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	assert.NoError(t, err, "failed to load requirements file in dir %s", o.Dir)
 	assert.FileExists(t, fileName)
 

--- a/pkg/cmd/step/verify/step_verify_preinstall_test.go
+++ b/pkg/cmd/step/verify/step_verify_preinstall_test.go
@@ -157,7 +157,7 @@ func TestGatherRequirements_PreserveEnvironmentGitOwnerCase(t *testing.T) {
 	_, err = testOptions.gatherRequirements(testConfig, requirementsFileName)
 	assert.NoError(t, err)
 
-	requirementsWithDefaults, err := config.LoadRequirementsConfigFile(requirementsFileName)
+	requirementsWithDefaults, err := config.LoadRequirementsConfigFile(requirementsFileName, config.DefaultFailOnValidationError)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "jx", requirementsWithDefaults.Cluster.Namespace)
@@ -201,7 +201,7 @@ func TestGatherRequirements_DevEnvApprovers(t *testing.T) {
 	_, err = testOptions.gatherRequirements(testConfig, requirementsFileName)
 	assert.NoError(t, err)
 
-	requirementsWithDefaults, err := config.LoadRequirementsConfigFile(requirementsFileName)
+	requirementsWithDefaults, err := config.LoadRequirementsConfigFile(requirementsFileName, config.DefaultFailOnValidationError)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "jx", requirementsWithDefaults.Cluster.Namespace)
@@ -260,7 +260,7 @@ func TestGatherRequirements_SetsDefaults(t *testing.T) {
 	_, err = testOptions.gatherRequirements(testConfig, requirementsFileName)
 	assert.NoError(t, err)
 
-	requirementsWithDefaults, err := config.LoadRequirementsConfigFile(requirementsFileName)
+	requirementsWithDefaults, err := config.LoadRequirementsConfigFile(requirementsFileName, config.DefaultFailOnValidationError)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "jx", requirementsWithDefaults.Cluster.Namespace)

--- a/pkg/cmd/step/verify/step_verify_requirements.go
+++ b/pkg/cmd/step/verify/step_verify_requirements.go
@@ -82,7 +82,7 @@ func (o *StepVerifyRequirementsOptions) Run() error {
 			return err
 		}
 	}
-	requirements, _, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load boot requirements")
 	}

--- a/pkg/cmd/step/verify/step_verify_values.go
+++ b/pkg/cmd/step/verify/step_verify_values.go
@@ -114,7 +114,7 @@ func (o *StepVerifyValuesOptions) Run() error {
 		return err
 	}
 
-	requirements, reqFile, err := config.LoadRequirementsConfig(o.RequirementsDir)
+	requirements, reqFile, err := config.LoadRequirementsConfig(o.RequirementsDir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "loading requirements from %q", o.RequirementsDir)
 	}

--- a/pkg/cmd/upgrade/upgrade_boot.go
+++ b/pkg/cmd/upgrade/upgrade_boot.go
@@ -95,7 +95,7 @@ func (o *UpgradeBootOptions) Run() error {
 		}
 	}
 
-	requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load requirements config %s", requirementsFile)
 	}
@@ -143,7 +143,7 @@ func (o *UpgradeBootOptions) Run() error {
 	}
 
 	// load modified requirements so we can merge with the base ones
-	modifiedRequirements, modifiedRequirementsFile, err := config.LoadRequirementsConfig(o.Dir)
+	modifiedRequirements, modifiedRequirementsFile, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load requirements config %s", modifiedRequirementsFile)
 	}
@@ -192,7 +192,7 @@ func (o UpgradeBootOptions) determineBootConfigURL(versionStreamURL string) (str
 	}
 
 	if bootConfigURL == "" {
-		requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir)
+		requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to load requirements config %s", requirementsFile)
 		}
@@ -259,7 +259,7 @@ func (o *UpgradeBootOptions) checkoutNewBranch() (string, error) {
 }
 
 func (o *UpgradeBootOptions) updateVersionStreamRef(upgradeRef string) error {
-	requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir)
+	requirements, requirementsFile, err := config.LoadRequirementsConfig(o.Dir, config.DefaultFailOnValidationError)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load requirements file %s", requirementsFile)
 	}

--- a/pkg/cmd/upgrade/upgrade_boot_test.go
+++ b/pkg/cmd/upgrade/upgrade_boot_test.go
@@ -116,7 +116,7 @@ func TestDetermineBootConfigURL(t *testing.T) {
 	o := TestUpgradeBootOptions{}
 	o.setup(defaultBootRequirements, "", "", "")
 
-	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir, config.DefaultFailOnValidationError)
 	require.NoError(t, err, "could not get requirements file")
 	vs := &requirements.VersionStream
 
@@ -131,7 +131,7 @@ func TestRequirementsVersionStream(t *testing.T) {
 	o := TestUpgradeBootOptions{}
 	o.setup(defaultBootRequirements, "", "", "")
 
-	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir, config.DefaultFailOnValidationError)
 	require.NoError(t, err, "could not get requirements file")
 	vs := &requirements.VersionStream
 
@@ -156,7 +156,7 @@ func TestUpdateVersionStreamRef(t *testing.T) {
 	err := o.updateVersionStreamRef("22222222")
 	require.NoError(t, err, "could not update version stream ref")
 
-	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir, config.DefaultFailOnValidationError)
 	require.NoError(t, err, "could not get requirements file")
 	vs := &requirements.VersionStream
 	assert.Equal(t, "22222222", vs.Ref, "UpdateVersionStreamRef Ref")
@@ -241,7 +241,7 @@ func TestDetermineBootConfigURLAlternative(t *testing.T) {
 	o := TestUpgradeBootOptions{}
 	o.setup(alternativeBootRequirements, "", "", "")
 
-	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir, config.DefaultFailOnValidationError)
 	require.NoError(t, err, "could not get requirements file")
 	vs := &requirements.VersionStream
 
@@ -256,7 +256,7 @@ func TestRequirementsVersionStreamAlternative(t *testing.T) {
 	o := TestUpgradeBootOptions{}
 	o.setup(alternativeBootRequirements, "", "", "")
 
-	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir, config.DefaultFailOnValidationError)
 	require.NoError(t, err, "could not get requirements file")
 	vs := &requirements.VersionStream
 
@@ -281,7 +281,7 @@ func TestUpdateVersionStreamRefAlternative(t *testing.T) {
 	err := o.updateVersionStreamRef("22222222")
 	require.NoError(t, err, "could not update version stream ref")
 
-	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir)
+	requirements, _, err := config.LoadRequirementsConfig(o.UpgradeBootOptions.Dir, config.DefaultFailOnValidationError)
 	require.NoError(t, err, "could not get requirements file")
 	vs := &requirements.VersionStream
 

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -30,7 +30,9 @@ var (
 		".beesdns.com",
 	}
 )
+
 const (
+	// DefaultFailOnValidationError by default fail if validation fails when reading jx-requirements
 	DefaultFailOnValidationError = true
 )
 
@@ -582,10 +584,10 @@ func LoadRequirementsConfigFile(fileName string, failOnValidationErrors bool) (*
 	}
 
 	if len(validationErrors) > 0 {
+		log.Logger().Warnf("validation failures in YAML file %s: %s", fileName, strings.Join(validationErrors, ", "))
+
 		if failOnValidationErrors {
 			return nil, fmt.Errorf("validation failures in YAML file %s:\n%s", fileName, strings.Join(validationErrors, "\n"))
-		} else {
-			log.Logger().Warnf("validation failures in YAML file %s: %s", fileName, strings.Join(validationErrors, ", "))
 		}
 	}
 

--- a/pkg/config/install_requirements_test.go
+++ b/pkg/config/install_requirements_test.go
@@ -47,7 +47,7 @@ func TestRequirementsConfigMarshalExistingFile(t *testing.T) {
 	err = requirements.SaveConfig(file)
 	assert.NoError(t, err, "failed to save file %s", file)
 
-	requirements, fileName, err := config.LoadRequirementsConfig(dir)
+	requirements, fileName, err := config.LoadRequirementsConfig(dir, config.DefaultFailOnValidationError)
 	assert.NoError(t, err, "failed to load requirements file in dir %s", dir)
 	assert.FileExists(t, fileName)
 
@@ -58,7 +58,7 @@ func TestRequirementsConfigMarshalExistingFile(t *testing.T) {
 
 	// lets check we can load the file from a sub dir
 	subDir := filepath.Join(dir, "subdir")
-	requirements, fileName, err = config.LoadRequirementsConfig(subDir)
+	requirements, fileName, err = config.LoadRequirementsConfig(subDir, config.DefaultFailOnValidationError)
 	assert.NoError(t, err, "failed to load requirements file in subDir: %s", subDir)
 	assert.FileExists(t, fileName)
 
@@ -71,7 +71,7 @@ func TestRequirementsConfigMarshalExistingFile(t *testing.T) {
 func TestOverrideRequirementsFromEnvironment(t *testing.T) {
 	t.Parallel()
 
-	requirements, fileName, err := config.LoadRequirementsConfig(testDataDir)
+	requirements, fileName, err := config.LoadRequirementsConfig(testDataDir, config.DefaultFailOnValidationError)
 	assert.NoError(t, err, "failed to load requirements file in dir %s", testDataDir)
 	assert.FileExists(t, fileName)
 
@@ -87,7 +87,7 @@ func TestOverrideRequirementsFromEnvironment(t *testing.T) {
 
 	err = requirements.SaveConfig(filepath.Join(tempDir, config.RequirementsConfigFileName))
 	assert.NoError(t, err, "failed to save requirements file in dir %s", tempDir)
-	overrideRequirements, fileName, err := config.LoadRequirementsConfig(tempDir)
+	overrideRequirements, fileName, err := config.LoadRequirementsConfig(tempDir, config.DefaultFailOnValidationError)
 	assert.NoError(t, err, "failed to load requirements file in dir %s", testDataDir)
 	assert.FileExists(t, fileName)
 
@@ -109,7 +109,7 @@ func TestRequirementsConfigMarshalExistingFileKanikoFalse(t *testing.T) {
 	assert.NoError(t, err, "failed to save file %s", file)
 	t.Logf("saved file %s", file)
 
-	requirements, fileName, err := config.LoadRequirementsConfig(dir)
+	requirements, fileName, err := config.LoadRequirementsConfig(dir, config.DefaultFailOnValidationError)
 	assert.NoError(t, err, "failed to load requirements file in dir %s", dir)
 	assert.FileExists(t, fileName)
 
@@ -122,7 +122,7 @@ func TestRequirementsConfigMarshalInEmptyDir(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "test-requirements-config-empty-")
 
-	requirements, fileName, err := config.LoadRequirementsConfig(dir)
+	requirements, fileName, err := config.LoadRequirementsConfig(dir, config.DefaultFailOnValidationError)
 	assert.Error(t, err)
 	assert.Empty(t, fileName)
 	assert.Nil(t, requirements)
@@ -422,7 +422,7 @@ func Test_LoadRequirementsConfig(t *testing.T) {
 				require.NoError(t, err, "unable to write requirements file %s", expectedRequirementsFile)
 			}
 
-			requirements, requirementsFile, err := config.LoadRequirementsConfig(testPath)
+			requirements, requirementsFile, err := config.LoadRequirementsConfig(testPath, config.DefaultFailOnValidationError)
 			if testCase.createRequirements {
 				require.NoError(t, err)
 				assert.Equal(t, expectedRequirementsFile, requirementsFile)
@@ -442,7 +442,7 @@ func TestLoadRequirementsConfig_load_invalid_yaml(t *testing.T) {
 	absolute, err := filepath.Abs(testDir)
 	assert.NoError(t, err, "could not find absolute path of dir %s", testDataDir)
 
-	_, _, err = config.LoadRequirementsConfig(testDir)
+	_, _, err = config.LoadRequirementsConfig(testDir, config.DefaultFailOnValidationError)
 	requirementsConfigPath := path.Join(absolute, config.RequirementsConfigFileName)
 	assert.EqualError(t, err, fmt.Sprintf("validation failures in YAML file %s:\nenvironments.0: Additional property namespace is not allowed", requirementsConfigPath))
 }

--- a/pkg/surveyutils/schema_template_test.go
+++ b/pkg/surveyutils/schema_template_test.go
@@ -57,7 +57,7 @@ func TestTemplateSchemaFile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.DirExists(t, testData)
 
-		requirements, requirementsFile, err := config.LoadRequirementsConfig(testData)
+		requirements, requirementsFile, err := config.LoadRequirementsConfig(testData, config.DefaultFailOnValidationError)
 		require.NoError(t, err, "failed to load requirements in dir %s", testData)
 
 		requirements.Cluster.GitKind = tc.GitKind


### PR DESCRIPTION
This is useful downstream where we use this function to load requirements
from the file system and we're not guarrenteed to have exactly the same
version of JX.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->