### PR TITLE
fix: add missing btree dependency to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-containerregistry v0.0.0-20190317040536-ebbba8469d06 // indirect
 	github.com/google/go-github v17.0.0+incompatible


### PR DESCRIPTION
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description
The `btree` dependency was accidently removed from go.mod. It was introduced in [this PR](https://github.com/jenkins-x/jx/pull/7249) , in an earlier commit d6e753e7e8ef66d and removed accidentally in a later commit b30ef8c30bc6f88369.
