### PR TITLE
[wip] chore: allow GetRequirementsConfigFromTeamSettings to be less restrictive validating settings

### DIFF
--- a/pkg/cloud/factory/factory.go
+++ b/pkg/cloud/factory/factory.go
@@ -40,7 +40,7 @@ func NewBucketProviderFromTeamSettingsConfiguration(factory clients.Factory) (bu
 	if err != nil {
 		return nil, errors.Wrap(err, "error obtaining the dev environment teamSettings to select the correct bucket provider")
 	}
-	requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings, config.DefaultFailOnValidationError)
 	if err != nil || requirements == nil {
 		return nil, errorutil.CombineErrors(err, errors.New("error obtaining the requirements file to decide bucket provider"))
 	}

--- a/pkg/cmd/clients/factory.go
+++ b/pkg/cmd/clients/factory.go
@@ -628,7 +628,7 @@ func (f *factory) useVaultIngress(devNamespace string) (bool, error) {
 	if err != nil {
 		return false, errors.Wrapf(err, "getting team settings from namespace %s", devNamespace)
 	}
-	reqsFromTeamSettings, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	reqsFromTeamSettings, err := config.GetRequirementsConfigFromTeamSettings(teamSettings, config.DefaultFailOnValidationError)
 	if err == nil && reqsFromTeamSettings != nil && reqsFromTeamSettings.Vault.DisableURLDiscovery {
 		log.Logger().Debugf("Using vault ingress because the requirements.Vault.DisableURLDiscovery is set in team settings")
 		return true, nil

--- a/pkg/cmd/opts/git.go
+++ b/pkg/cmd/opts/git.go
@@ -320,7 +320,7 @@ func (o *CommonOptions) IsGitHubAppMode() (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "error loading TeamSettings to determine if in GitHub app mode")
 	}
-	requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings, false)
 	if err != nil {
 		return false, errors.Wrap(err, "error getting Requirements from TeamSettings to determine if in GitHub app mode")
 	}

--- a/pkg/cmd/opts/helm.go
+++ b/pkg/cmd/opts/helm.go
@@ -796,7 +796,7 @@ func (o *CommonOptions) ReleaseChartRepositoryURL() string {
 		if err != nil {
 			log.Logger().Warnf("failed to get the team settings: %s", err.Error())
 		} else {
-			requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+			requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings, config.DefaultFailOnValidationError)
 			if err != nil {
 				log.Logger().Warnf("failed to get the requirements from team settings: %s", err.Error())
 			} else if requirements != nil {

--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -979,7 +979,7 @@ func (o *PreviewOptions) getContainerRegistry(projectConfig *config.ProjectConfi
 	if err != nil {
 		return "", errors.Wrap(err, "could not load team")
 	}
-	requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings, config.DefaultFailOnValidationError)
 	if err != nil {
 		return "", errors.Wrap(err, "could not get requirements from team setting")
 	}

--- a/pkg/cmd/step/helm/step_helm_apply.go
+++ b/pkg/cmd/step/helm/step_helm_apply.go
@@ -417,7 +417,7 @@ func (o *StepHelmApplyOptions) getRequirements() (*config.RequirementsConfig, st
 		return nil, "", errors.Wrap(err, "getting the team setting from the cluster")
 	}
 
-	requirements, err = config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	requirements, err = config.GetRequirementsConfigFromTeamSettings(teamSettings, config.DefaultFailOnValidationError)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "getting the requirements from team settings")
 	}

--- a/pkg/cmd/step/verify/step_verify_environments.go
+++ b/pkg/cmd/step/verify/step_verify_environments.go
@@ -99,7 +99,7 @@ func (o *StepVerifyEnvironmentsOptions) Run() error {
 	} else {
 		devEnv := envMap[kube.LabelValueDevEnvironment]
 		if devEnv != nil {
-			requirements, err = config.GetRequirementsConfigFromTeamSettings(&devEnv.Spec.TeamSettings)
+			requirements, err = config.GetRequirementsConfigFromTeamSettings(&devEnv.Spec.TeamSettings, config.DefaultFailOnValidationError)
 			if err != nil {
 				return errors.Wrap(err, "failed to load requirements from team settings")
 			}

--- a/pkg/cmd/step/verify/step_verify_environments_test.go
+++ b/pkg/cmd/step/verify/step_verify_environments_test.go
@@ -61,7 +61,7 @@ func TestStepVerifyEnvironmentsOptions_StoreRequirementsInTeamSettings(t *testin
 	requirementsCm := teamSettings.BootRequirements
 	assert.NotEqual(t, "", requirementsCm, "the BootRequirements field should be present and not empty")
 
-	mapRequirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	mapRequirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings, config.DefaultFailOnValidationError)
 	assert.NoError(t, err)
 
 	assert.Equal(t, requirements, mapRequirements)
@@ -114,7 +114,7 @@ func TestStepVerifyEnvironmentsOptions_StoreRequirementsConfigMapWithModificatio
 	requirementsCm := teamSettings.BootRequirements
 	assert.NotEqual(t, "", requirementsCm, "the BootRequirements field should be present and not empty")
 
-	mapRequirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	mapRequirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings, config.DefaultFailOnValidationError)
 	assert.NoError(t, err)
 
 	assert.Equal(t, requirements.Storage.Logs, mapRequirements.Storage.Logs, "the change done before calling"+

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -626,7 +626,7 @@ func LoadRequirementsConfigFile(fileName string, failOnValidationErrors bool) (*
 }
 
 // GetRequirementsConfigFromTeamSettings reads the BootRequirements string from TeamSettings and unmarshals it
-func GetRequirementsConfigFromTeamSettings(settings *v1.TeamSettings) (*RequirementsConfig, error) {
+func GetRequirementsConfigFromTeamSettings(settings *v1.TeamSettings, failOnValidationErrors bool) (*RequirementsConfig, error) {
 	if settings == nil {
 		return nil, nil
 	}
@@ -643,7 +643,11 @@ func GetRequirementsConfigFromTeamSettings(settings *v1.TeamSettings) (*Requirem
 		return config, fmt.Errorf("failed to validate requirements from team settings due to %s", err)
 	}
 	if len(validationErrors) > 0 {
-		return config, fmt.Errorf("validation failures in requirements from team settings:\n%s", strings.Join(validationErrors, "\n"))
+		log.Logger().Warnf("validation failures in requirements from team settings:\n%s", strings.Join(validationErrors, "\n"))
+
+		if failOnValidationErrors {
+			return config, fmt.Errorf("validation failures in requirements from team settings:\n%s", strings.Join(validationErrors, "\n"))
+		}
 	}
 	err = yaml.Unmarshal(data, config)
 	if err != nil {

--- a/pkg/github/github_app.go
+++ b/pkg/github/github_app.go
@@ -103,7 +103,7 @@ func (gh *GithubApp) getRequirementConfig() (*config.RequirementsConfig, error) 
 		return nil, err
 	}
 
-	requirementConfig, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	requirementConfig, err := config.GetRequirementsConfigFromTeamSettings(teamSettings, config.DefaultFailOnValidationError)
 	if err != nil {
 		log.Logger().Errorf("error getting requirement config from team settings %v", err)
 		return nil, err

--- a/pkg/logs/tekton_logging.go
+++ b/pkg/logs/tekton_logging.go
@@ -594,7 +594,7 @@ func NewBucketProviderFromTeamSettingsConfiguration(jxClient versioned.Interface
 	if err != nil {
 		return nil, errors.Wrap(err, "error obtaining the dev environment teamSettings to select the correct bucket provider")
 	}
-	requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings)
+	requirements, err := config.GetRequirementsConfigFromTeamSettings(teamSettings, config.DefaultFailOnValidationError)
 	if err != nil || requirements == nil {
 		return nil, errorutil.CombineErrors(err, errors.New("error obtaining the requirements file to decide bucket provider"))
 	}


### PR DESCRIPTION
#### Submitter checklist

- [*] Change is code complete and matches issue description.
- [*] Change is covered by existing or new tests.

#### Description
This is useful downstream where we use this function to load requirements
from the file system and we're not guarrenteed to have exactly the same
version of JX.

fixes https://github.com/jenkins-x/jx/issues/7288