### PR TITLE
fix: Docker auth use prompted secret

### DIFF
--- a/pkg/cmd/create/create_docker_auth.go
+++ b/pkg/cmd/create/create_docker_auth.go
@@ -124,7 +124,7 @@ func (o *CreateDockerAuthOptions) Run() error {
 	foundAuth := false
 	for k, v := range dockerConfig.Auths {
 		if util.StringMatchesPattern(k, o.Host) {
-			v.Auth = b64.StdEncoding.EncodeToString([]byte(o.User + ":" + o.Secret))
+			v.Auth = b64.StdEncoding.EncodeToString([]byte(o.User + ":" + secret))
 			v.Email = email
 			foundAuth = true
 			break
@@ -132,7 +132,7 @@ func (o *CreateDockerAuthOptions) Run() error {
 	}
 	if foundAuth != true {
 		newConfigData := &Auth{}
-		newConfigData.Auth = b64.StdEncoding.EncodeToString([]byte(o.User + ":" + o.Secret))
+		newConfigData.Auth = b64.StdEncoding.EncodeToString([]byte(o.User + ":" + secret))
 		newConfigData.Email = email
 		if dockerConfig.Auths == nil {
 			dockerConfig.Auths = map[string]*Auth{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

If you specify a secret on the command line, it will be used.
If you don't, it prompts a value but it was not used.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #7286 
Related to #7203 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
