### PR TITLE
fix: make sure Vault config struct is not created too early in CreateSystemVaultClient

### DIFF
--- a/pkg/cmd/clients/factory.go
+++ b/pkg/cmd/clients/factory.go
@@ -466,12 +466,11 @@ func (f *factory) CreateSystemVaultClient(namespace string) (vault.Client, error
 		return nil, errors.Errorf("unable to create Vault client for secret location kind '%s'", installValues[secrets.SecretsLocationKey])
 	}
 
-	vaultConfig, err := vault.FromMap(installValues, namespace)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing Vault configuration from ConfigMap %s in namespace %s", kube.ConfigMapNameJXInstallConfig, namespace)
-	}
-
-	if vaultConfig.IsExternal() {
+	if installValues[vault.URL] != "" {
+		vaultConfig, err := vault.FromMap(installValues, namespace)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing Vault configuration from ConfigMap %s in namespace %s", kube.ConfigMapNameJXInstallConfig, namespace)
+		}
 		return f.CreateExternalVaultClient(vaultConfig, kubeClient)
 	}
 

--- a/pkg/kube/vault/vault_factory.go
+++ b/pkg/kube/vault/vault_factory.go
@@ -125,7 +125,6 @@ func (v *VaultClientFactory) NewVaultClient(name string, namespace string, useIn
 		return nil, err
 	}
 
-	// TODO: issue:7090
 	vaultConfig := vault.Vault{
 		Name:                   name,
 		ServiceAccountName:     serviceAccountName,


### PR DESCRIPTION
- the reason the Vault struct was created early was to call v.isExternal. As a side effect
  it would fail in cases where CreateSystemVaultClient is called with a newer version of jx
  with a Jenkins X install which has not been upgraded.
  Technically the creation of the Vault struct can be deferred until the service account name
  is determined in the old way further down in the call stack of CreateInternalVaultClient

fixes #7291

