### PR TITLE
feat: let users define a preview namespace when importing / creating quickstarts

### DIFF
--- a/pkg/cmd/importcmd/test_data/application_with_preview/charts/preview/values.yaml
+++ b/pkg/cmd/importcmd/test_data/application_with_preview/charts/preview/values.yaml
@@ -1,0 +1,19 @@
+cleanup:
+  Annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: hook-succeeded
+  Args:
+    - --cleanup
+expose:
+  Annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded
+  config:
+    exposer: Ingress
+    http: true
+    tlsacme: false
+preview:
+  image:
+    pullPolicy: IfNotPresent
+    repository: null
+    tag: null


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
This will allow users define which namespace to use for previews while checking that they can't set a permanent environment's ns as a preview namespace.

This will then modify the `values.yaml` file within the `charts/preview/` folder so it can be read and used by the `jx preview`command within a builder.


#### Which issue this PR fixes

fixes #7302 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
