### PR TITLE
fix: update the docs to point to correct URL

### DIFF
--- a/pkg/cmd/edit/edit_buildpack.go
+++ b/pkg/cmd/edit/edit_buildpack.go
@@ -90,7 +90,7 @@ func (o *EditBuildPackOptions) Run() error {
 	}
 
 	if isBoot {
-		log.Logger().Warnf("This functionality is not supported in boot based clusters, please checkout https://jenkins-x.io/commands/jx_edit_buildpack/ for how to specify custom buildpacks for boot clusters.")
+		log.Logger().Warnf("This functionality is not supported in boot based clusters, please checkout https://jenkins-x.io/docs/create-project/build-packs/ for how to specify custom buildpacks for boot clusters.")
 		return nil
 	}
 


### PR DESCRIPTION
#### Description
Follows on for this [PR](https://github.com/jenkins-x/jx/pull/7311) and sets the docs link to correctly URL.
