### PR TITLE
fix: avoid nil pointer exception when creating sr

### DIFF
--- a/pkg/cmd/create/create_env.go
+++ b/pkg/cmd/create/create_env.go
@@ -320,7 +320,13 @@ func (o *CreateEnvOptions) RegisterEnvironment(env *v1.Environment, gitProvider 
 				return err
 			}
 			sr, err := kube.GetOrCreateSourceRepository(jxClient, devNs, gitInfo.Name, gitInfo.Organisation, gitInfo.HostURLWithoutUser())
-			log.Logger().Debugf("have SourceRepository: %s\n", sr.Name)
+			if err != nil {
+				return errors.Wrap(err, "getting or creating source repository")
+			} else if sr == nil {
+				log.Logger().Warnf("unexpected returned nil value for sr in GetOrCreateSourceRepository")
+			} else {
+				log.Logger().Debugf("have SourceRepository: %s\n", sr.Name)
+			}
 
 			err = o.GenerateProwConfig(devNs, devEnv)
 			if err != nil {


### PR DESCRIPTION
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

When registering an environment (in `RegisterEnvironment` function in `create_env.go`), eventually a call to `kube.GetOrCreateSourceRepository` is made, which is expected to return the `sr` (but it might eventually fail). Immediately after this call, there was a line that tried to log the SourceRepository's name. However, if an error was produced and/or the `sr` value was nil, attempting to access fields was causing a nil pointer exception, as in the example included in the reported issue.

With this change, some new validations are introduced to make sure that the nil pointer exception doesn't occur and that an error or a log entry is produced instead.

#### Which issue this PR fixes
fixes #7349