### PR TITLE
fix: add missing v1 to api directory

### DIFF
--- a/Makefile.codegen
+++ b/Makefile.codegen
@@ -66,7 +66,7 @@ generate-refdocs: generate-api-refdocs generate-config-refdocs
 generate-api-refdocs: install-refdocs
 	${GOPATH}/bin/gen-crd-api-reference-docs -config "docs/refdocs/config.json" \
 	-template-dir docs/refdocs/templates \
-    -api-dir "./pkg/apis/jenkins.io" \
+    -api-dir "./pkg/apis/jenkins.io/v1" \
     -out-file docs/apidocs.md
 
 generate-config-refdocs:

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -11,7 +11,9 @@ echo "Running validation scripts..."
 scripts=(
     "make verify-generation-complete"
     "make generate-docs"
+    "make generate-refdocs"
 )
+
 fail=0
 for s in "${scripts[@]}"; do
     echo "RUN ${s}"


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>


#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
`generate-api-refdocs` was throwing an error because the wrong api-directory location was passed to it. This PR fixes that.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #7350 
