### PR TITLE
feat: attempt to prevent using provided requirements for a provisione…

### DIFF
--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -102,7 +102,7 @@ func NewCmdBoot(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&options.StartStep, "start-step", "s", "", "the step in the pipeline to start from")
 	cmd.Flags().StringVarP(&options.EndStep, "end-step", "e", "", "the step in the pipeline to end at")
 	cmd.Flags().StringVarP(&options.HelmLogLevel, "helm-log", "v", "", "sets the helm logging level from 0 to 9. Passed into the helm CLI via the '-v' argument. Useful to diagnose helm related issues")
-	cmd.Flags().StringVarP(&options.RequirementsFile, "requirements", "r", "", "requirements file which will overwrite the default requirements file")
+	cmd.Flags().StringVarP(&options.RequirementsFile, "requirements", "r", "", "WARNING: this should only be used for the initial boot of a cluster: requirements file which will overwrite the default requirements file")
 	cmd.Flags().BoolVarP(&options.AttemptRestore, "attempt-restore", "a", false, "attempt to boot from an existing dev environment repository")
 	cmd.Flags().BoolVarP(&options.NoUpgradeGit, "no-update-git", "", false, "disables any attempt to update the local git clone if its old")
 

--- a/pkg/cmd/opts/environments.go
+++ b/pkg/cmd/opts/environments.go
@@ -24,12 +24,12 @@ func (o *CommonOptions) GetDevEnv() (gitOps bool, devEnv *jenkinsv1.Environment)
 	// and also access the team settings, so load those
 	jxClient, ns, err := o.JXClientAndDevNamespace()
 	if err != nil {
-		log.Logger().Errorf("Error loading team settings. %v", err)
+		log.Logger().Warnf("when attempting to create jx client. %v", err)
 		return false, &jenkinsv1.Environment{}
 	} else {
 		devEnv, err := kube.GetDevEnvironment(jxClient, ns)
 		if err != nil {
-			log.Logger().Errorf("Error loading team settings. %v", err)
+			log.Logger().Warnf("when attempting to load team settings. %v", err)
 			return false, &jenkinsv1.Environment{}
 		}
 		gitOps := false


### PR DESCRIPTION
…d jenkins-x cluster

The overall goal here is to attempt to prevent the use of the `--requirements` option of `jx boot` on a cluster which is being managed by the environment dev repository for that cluster. It is assumed that the `--requirements` option of the `jx boot` command should only be used for the initial boot.

See https://github.com/jenkins-x/jx/issues/7405 for more details

Updated message on help text for `--requirements` option
```sh
→ ./jx boot --help
Boots up Jenkins X in a Kubernetes cluster using GitOps and a Jenkins X Pipeline

For more documentation see: https://jenkins-x.io/docs/getting-started/setup/boot/

Aliases:
boot, bootstrap
Examples:
  # create a kubernetes cluster via Terraform or via jx
  jx create cluster gke --skip-installation

  # now lets boot up Jenkins X installing/upgrading whatever is needed
  jx boot

  # if we have already booted and just want to apply some environment changes without
  # re-applying ingress and so forth we can start at the environment step:
  jx boot --start-step install-env
Options:
  -a, --attempt-restore=false: attempt to boot from an existing dev environment repository
  -d, --dir='.': the directory to look for the Jenkins X Pipeline, requirements and charts
  -e, --end-step='': the step in the pipeline to end at
      --git-ref='': override the Git ref for the JX Boot source to start from, ignoring the versions stream. Normally specified with git-url as well
  -u, --git-url='': override the Git clone URL for the JX Boot source to start from, ignoring the versions stream. Normally specified with git-ref as well
  -v, --helm-log='': sets the helm logging level from 0 to 9. Passed into the helm CLI via the '-v' argument. Useful to diagnose helm related issues
      --no-update-git=false: disables any attempt to update the local git clone if its old
  -r, --requirements='': WARNING: this should only be used for the initial boot of a cluster: requirements file which will overwrite the default requirements file
  -s, --start-step='': the step in the pipeline to start from
      --versions-ref='master': the bootstrap ref for the versions repo. Once the boot config is cloned, the repo will be then read from the jx-requirements.yml
      --versions-repo='https://github.com/jenkins-x/jenkins-x-versions.git': the bootstrap URL for the versions repo. Once the boot config is cloned, the repo will be then read from the jx-requirements.yml
Usage:
  jx boot [flags] [options]
Use "jx options" for a list of global command-line options (applies to all commands).
```
