### PR TITLE
WIP: feat(import): skip draft if jenkins-x.yml exists.

### DIFF
--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -383,11 +383,21 @@ func (options *ImportOptions) Run() error {
 	options.AppName = naming.ToValidName(strings.ToLower(options.AppName))
 
 	if !options.DisableDraft {
+		// Disable draft if jenkins-x.yaml is already present
+		jenkinsxFile := filepath.Join(options.Dir, "jenkins-x.yml")
+		_, err = os.Stat(jenkinsxFile)
+		if err == nil {
+			options.DisableDraft = true
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	if !options.DisableDraft {
 		err = options.DraftCreate()
 		if err != nil {
 			return err
 		}
-
 	}
 	err = options.fixDockerIgnoreFile()
 	if err != nil {


### PR DESCRIPTION
Allows to reimport projects that have previously been imported/created using Jenkins X (without explicitly specifying `--no-draft`).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.

#### Description

During repo import skip enhancing the repo with draft (buildpack) when a `jenkins-x.yml` is already present.
Previously importing a project that has been created with Jenkins X failed when `--no-draft` not set because draft attempts to manipulate the project but fails when the files it wants to write are already present.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

corresponding JXUI issue linked below