### PR TITLE
fix(import): Fix application reimport

### DIFF
--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/Dockerfile
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+EXPOSE 8080
+ENTRYPOINT ["/jx-quickstartxy"]
+COPY ./bin/ /

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/Makefile
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/Makefile
@@ -1,0 +1,69 @@
+SHELL := /bin/bash
+GO := GO15VENDOREXPERIMENT=1 go
+NAME := jx-quickstartxy
+OS := $(shell uname)
+MAIN_GO := main.go
+ROOT_PACKAGE := $(GIT_PROVIDER)/$(ORG)/$(NAME)
+GO_VERSION := $(shell $(GO) version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/')
+PACKAGE_DIRS := $(shell $(GO) list ./... | grep -v /vendor/)
+PKGS := $(shell go list ./... | grep -v /vendor | grep -v generated)
+PKGS := $(subst  :,_,$(PKGS))
+BUILDFLAGS := ''
+CGO_ENABLED = 0
+VENDOR_DIR=vendor
+
+all: build
+
+check: fmt build test
+
+.PHONY: build
+build:
+	CGO_ENABLED=$(CGO_ENABLED) $(GO) build -ldflags $(BUILDFLAGS) -o bin/$(NAME) $(MAIN_GO)
+
+test: 
+	CGO_ENABLED=$(CGO_ENABLED) $(GO) test $(PACKAGE_DIRS) -test.v
+
+full: $(PKGS)
+
+install:
+	GOBIN=${GOPATH}/bin $(GO) install -ldflags $(BUILDFLAGS) $(MAIN_GO)
+
+fmt:
+	@FORMATTED=`$(GO) fmt $(PACKAGE_DIRS)`
+	@([[ ! -z "$(FORMATTED)" ]] && printf "Fixed unformatted files:\n$(FORMATTED)") || true
+
+clean:
+	rm -rf build release
+
+linux:
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=amd64 $(GO) build -ldflags $(BUILDFLAGS) -o bin/$(NAME) $(MAIN_GO)
+
+.PHONY: release clean
+
+FGT := $(GOPATH)/bin/fgt
+$(FGT):
+	go get github.com/GeertJohan/fgt
+
+GOLINT := $(GOPATH)/bin/golint
+$(GOLINT):
+	go get github.com/golang/lint/golint
+
+$(PKGS): $(GOLINT) $(FGT)
+	@echo "LINTING"
+	@$(FGT) $(GOLINT) $(GOPATH)/src/$@/*.go
+	@echo "VETTING"
+	@go vet -v $@
+	@echo "TESTING"
+	@go test -v $@
+
+.PHONY: lint
+lint: vendor | $(PKGS) $(GOLINT) # ❷
+	@cd $(BASE) && ret=0 && for pkg in $(PKGS); do \
+	    test -z "$$($(GOLINT) $$pkg | tee /dev/stderr)" || ret=1 ; \
+	done ; exit $$ret
+
+watch:
+	reflex -r "\.go$" -R "vendor.*" make skaffold-run
+
+skaffold-run: build
+	skaffold run -p dev

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/OWNERS
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- mgoltzsche
+reviewers:
+- mgoltzsche

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/OWNERS_ALIASES
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/OWNERS_ALIASES
@@ -1,0 +1,6 @@
+aliases:
+- mgoltzsche
+best-approvers:
+- mgoltzsche
+best-reviewers:
+- mgoltzsche

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/README.md
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/README.md
@@ -1,0 +1,1 @@
+# golang-http           

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/.helmignore
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/Chart.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/d273e09/images/go.png
+name: jx-quickstartxy
+version: 0.1.0-SNAPSHOT

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/Makefile
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/Makefile
@@ -1,0 +1,48 @@
+CHART_REPO := http://jenkins-x-chartmuseum:8080
+CURRENT=$(pwd)
+NAME := jx-quickstartxy
+OS := $(shell uname)
+VERSION := $(shell cat ../../VERSION)
+
+build: clean
+	rm -rf requirements.lock
+	helm dependency build
+	helm lint
+
+install: clean build
+	helm install . --name ${NAME}
+
+upgrade: clean build
+	helm upgrade ${NAME} .
+
+delete:
+	helm delete --purge ${NAME}
+
+clean:
+	rm -rf charts
+	rm -rf ${NAME}*.tgz
+
+release: clean
+	helm dependency build
+	helm lint
+	helm init --client-only
+	helm package .
+	curl --fail -u $(CHARTMUSEUM_CREDS_USR):$(CHARTMUSEUM_CREDS_PSW) --data-binary "@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz" $(CHART_REPO)/api/charts
+	rm -rf ${NAME}*.tgz%
+
+tag:
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(VERSION)/" Chart.yaml
+	sed -i "" -e "s/tag:.*/tag: $(VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(VERSION)/" Chart.yaml
+	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/apps-dev-229310\/$(NAME)|" values.yaml
+	sed -i -e "s/tag:.*/tag: $(VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to tag with"
+	exit -1
+endif
+	git add --all
+	git commit -m "release $(VERSION)" --allow-empty # if first release then no verion update is performed
+	git tag -fa v$(VERSION) -m "Release version $(VERSION)"
+	git push origin v$(VERSION)

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/README.md
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/README.md
@@ -1,0 +1,1 @@
+# golang application

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/NOTES.txt
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/NOTES.txt
@@ -1,0 +1,4 @@
+
+Get the application URL by running these commands:
+
+kubectl get ingress {{ template "fullname" . }}

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/_helpers.tpl
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/canary.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/canary.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.canary.enabled }}
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  provider: istio
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "fullname" . }}
+  progressDeadlineSeconds: {{ .Values.canary.progressDeadlineSeconds }}
+  {{- if .Values.hpa.enabled }}
+  autoscalerRef:
+    apiVersion: autoscaling/v2beta1
+    kind: HorizontalPodAutoscaler
+    name: {{ template "fullname" . }}
+  {{- end }}
+  service:
+    port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    gateways:
+    - {{ template "fullname" . }}
+    hosts:
+    - {{ .Values.canary.host }}
+  analysis:
+    interval: {{ .Values.canary.canaryAnalysis.interval }}
+    threshold: {{ .Values.canary.canaryAnalysis.threshold }}
+    maxWeight: {{ .Values.canary.canaryAnalysis.maxWeight }}
+    stepWeight: {{ .Values.canary.canaryAnalysis.stepWeight }}
+    metrics:
+    - name: request-success-rate
+      threshold: {{ .Values.canary.canaryAnalysis.metrics.requestSuccessRate.threshold }}
+      interval: {{ .Values.canary.canaryAnalysis.metrics.requestSuccessRate.interval }}
+    - name: latency
+      templateRef:
+        name: latency
+      thresholdRange:
+        max: {{ .Values.canary.canaryAnalysis.metrics.requestDuration.threshold }}
+      interval: {{ .Values.canary.canaryAnalysis.metrics.requestDuration.interval }}
+
+---
+
+apiVersion: flagger.app/v1beta1
+kind: MetricTemplate
+metadata:
+  name: latency
+spec:
+  provider:
+    type: prometheus
+    address: http://prometheus.istio-system:9090
+  query: |
+    histogram_quantile(
+        0.99,
+        sum(
+            rate(
+                istio_request_duration_milliseconds_bucket{
+                    reporter="destination",
+                    destination_workload_namespace="{{ "{{" }} namespace {{ "}}" }}",
+                    destination_workload=~"{{ "{{" }} target {{ "}}" }}"
+                }[{{ "{{" }} interval {{ "}}" }}]
+            )
+        ) by (le)
+    )
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: {{ template "fullname" . }}
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: {{ .Values.service.externalPort }}
+      name: http
+      protocol: HTTP
+    hosts:
+    - {{ .Values.canary.host }}
+{{- end }}

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/deployment.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/deployment.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.knativeDeploy }}
+{{- else }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+{{- if .Values.hpa.enabled }}
+{{- else }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  template:
+    metadata:
+      labels:
+        draft: {{ default "draft-app" .Values.draft }}
+        app: {{ template "fullname" . }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+{{- range $pkey, $pval := .Values.env }}
+        - name: {{ $pkey }}
+          value: {{ quote $pval }}
+{{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.probePath }}
+            port: {{ .Values.service.internalPort }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.probePath }}
+            port: {{ .Values.service.internalPort }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+{{- end }}

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/hpa.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/hpa.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.hpa.cpuTargetAverageUtilization }}
+  - type: Resource
+    resource:
+      name: memory
+      targetAverageUtilization: {{ .Values.hpa.memoryTargetAverageUtilization }}
+{{- end }}

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/ingress.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+apiVersion: {{ .Values.jxRequirements.ingress.apiVersion }}
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+{{- if .Values.ingress.annotations }}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.jxRequirements.ingress.annotations }}
+{{ toYaml .Values.jxRequirements.ingress.annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+spec:
+  rules:
+  - host: {{ .Values.service.name }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Values.service.name }}
+          servicePort: 80
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.service.name }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- if .Values.jxRequirements.ingress.tls.production }}
+    secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"
+{{- else }}
+    secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/ksvc.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/ksvc.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.knativeDeploy }}
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            env:
+{{- range $pkey, $pval := .Values.env }}
+            - name: {{ $pkey }}
+              value: {{ quote $pval }}
+{{- end }}
+            livenessProbe:
+              httpGet:
+                path: {{ .Values.probePath }}
+              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+              successThreshold: {{ .Values.livenessProbe.successThreshold }}
+              timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            readinessProbe:
+              failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+              httpGet:
+                path: {{ .Values.probePath }}
+              periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+              successThreshold: {{ .Values.readinessProbe.successThreshold }}
+              timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            resources:
+{{ toYaml .Values.resources | indent 14 }}
+{{- end }}

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/service.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/templates/service.yaml
@@ -1,0 +1,26 @@
+{{- if or .Values.knativeDeploy .Values.canary.enabled }}
+{{- else }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: http
+  selector:
+    app: {{ template "fullname" . }}
+{{- end }}

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/values.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/jx-quickstartxy/values.yaml
@@ -1,0 +1,95 @@
+# Default values for Go projects.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: draft
+  tag: dev
+  pullPolicy: IfNotPresent
+
+# define environment variables here as a map of key: value
+env:
+
+# enable this flag to use knative serve to deploy the app
+knativeDeploy: false
+
+# HorizontalPodAutoscaler
+hpa:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 6
+  cpuTargetAverageUtilization: 80
+  memoryTargetAverageUtilization: 80
+
+# Canary deployments
+# If enabled, Istio v1.5+ and Flagger need to be installed in the cluster
+canary:
+  enabled: false
+  progressDeadlineSeconds: 60
+  canaryAnalysis:
+    interval: "1m"
+    threshold: 5
+    maxWeight: 60
+    stepWeight: 20
+    # WARNING: Canary deployments will fail and rollback if there is no traffic that will generate the below specified metrics.
+    metrics:
+      requestSuccessRate:
+        threshold: 99
+        interval: "1m"
+      requestDuration:
+        threshold: 1000
+        interval: "1m"
+  # The host is using Istio Gateway and is currently not auto-generated
+  # Please overwrite the `canary.host` in `values.yaml` in each environment repository (e.g., staging, production)
+  host: acme.com
+
+service:
+  name: jx-quickstartxy
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8080
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx"
+resources:
+  limits:
+    cpu: 100m
+    memory: 256Mi
+  requests:
+    cpu: 80m
+    memory: 128Mi
+probePath: /
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+readinessProbe:
+  failureThreshold: 1
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+
+
+# custom ingress annotations on this service
+ingress:
+  annotations:
+#      kubernetes.io/ingress.class: nginx
+
+# values we use from the `jx-requirements.yml` file if we are using helmfile and helm 3
+jxRequirements:
+  ingress:
+    domain: ""
+    externalDNS: false
+    namespaceSubDomain: -jx.
+    tls:
+      email: ""
+      enabled: false
+      production: false
+
+    # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
+    apiVersion: "extensions/v1beta1"
+
+    # shared ingress annotations on all services
+    annotations:
+    #  kubernetes.io/ingress.class: nginx

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/preview/Chart.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/preview/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/images/go.png
+name: preview
+version: 0.1.0-SNAPSHOT

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/preview/Makefile
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/preview/Makefile
@@ -1,0 +1,18 @@
+OS := $(shell uname)
+
+preview:
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
+	sed -i "" -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
+	sed -i "" -e "s/tag:.*/tag: $(PREVIEW_VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
+	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
+	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/apps-dev-229310\/jx-quickstartxy|" values.yaml
+	sed -i -e "s/tag:.*/tag: $(PREVIEW_VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+	echo "  version: $(PREVIEW_VERSION)" >> requirements.yaml
+	jx step helm build

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/preview/requirements.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/preview/requirements.yaml
@@ -1,0 +1,16 @@
+# !! File must end with empty line !!
+dependencies:
+- alias: expose
+  name: exposecontroller
+  repository: http://chartmuseum.jenkins-x.io
+  version: 2.3.92
+- alias: cleanup
+  name: exposecontroller
+  repository: http://chartmuseum.jenkins-x.io
+  version: 2.3.92
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
+- alias: preview
+  name: jx-quickstartxy
+  repository: file://../jx-quickstartxy

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/preview/values.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/charts/preview/values.yaml
@@ -1,0 +1,22 @@
+
+expose:
+  Annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded
+  config:
+    exposer: Ingress
+    http: true
+    tlsacme: false
+
+cleanup:
+  Args:
+    - --cleanup
+  Annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: hook-succeeded
+
+preview:
+  image:
+    repository:
+    tag:
+    pullPolicy: IfNotPresent

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/curlloop.sh
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/curlloop.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export APP="$1"
+echo "curling URL $APP in a loop..."
+
+while true
+do 
+    curl $APP 
+    sleep 2
+done

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/jenkins-x.yml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/jenkins-x.yml
@@ -1,0 +1,69 @@
+pipelineConfig:
+  agent:
+    image: go
+    label: jenkins-go
+  pipelines:
+    pullRequest:
+      pipeline:
+        agent:
+          image: go
+        stages:
+        - name: run-make
+          steps:
+          - command: make linux
+            name: build-make-linux
+        - name: everything-else
+          steps:
+          - args:
+            - --cache=true
+            - --cache-dir=/workspace
+            - --context=/workspace/source
+            - --dockerfile=/workspace/source/Dockerfile
+            - --destination=gcr.io/apps-dev-229310/jx-quickstartxy:${inputs.params.version}
+            - --cache-repo=gcr.io/apps-dev-229310/cache
+            command: /kaniko/executor
+            dir: /workspace/source
+            image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+            name: build-container-build
+          - command: jx step post build --image gcr.io/apps-dev-229310/jx-quickstartxy:$PREVIEW_VERSION
+            name: postbuild-post-build
+          - command: make preview
+            dir: /workspace/source/charts/preview
+            name: promote-make-preview
+          - command: jx preview --app $APP_NAME --dir ../..
+            dir: /workspace/source/charts/preview
+            name: promote-jx-preview
+    release:
+      pipeline:
+        agent:
+          image: go
+        stages:
+        - name: run-make
+          steps:
+          - command: jx step git credentials
+            name: setup-jx-git-credentials
+          - command: make build
+            name: build-make-build
+        - name: everything-else
+          steps:
+          - args:
+            - --cache=true
+            - --cache-dir=/workspace
+            - --context=/workspace/source
+            - --dockerfile=/workspace/source/Dockerfile
+            - --destination=gcr.io/apps-dev-229310/jx-quickstartxy:${inputs.params.version}
+            - --cache-repo=gcr.io/apps-dev-229310/cache
+            command: /kaniko/executor
+            dir: /workspace/source
+            image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+            name: build-container-build
+          - command: jx step post build --image gcr.io/apps-dev-229310/jx-quickstartxy:${VERSION}
+            name: build-post-build
+          - command: jx step changelog --version v${VERSION}
+            name: promote-changelog
+          - command: jx step helm release
+            dir: /workspace/source/charts/jx-quickstartxy
+            name: promote-helm-release
+          - command: jx promote -b --all-auto --timeout 1h --version ${VERSION}
+            dir: /workspace/source/charts/jx-quickstartxy
+            name: promote-jx-promote

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/main.go
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	title := "Jenkins X golang http example"
+
+	from := ""
+	if r.URL != nil {
+		from = r.URL.String()
+	}
+	if from != "/favicon.ico" {
+		log.Printf("title: %s\n", title)
+	}
+
+	fmt.Fprintf(w, "Hello from:  "+title+"\n")
+}
+
+func main() {
+	http.HandleFunc("/", handler)
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/skaffold.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/skaffold.yaml
@@ -1,0 +1,28 @@
+apiVersion: skaffold/v1beta2
+kind: Config
+build:
+  artifacts:
+  - image: apps-dev-229310/jx-quickstartxy
+    context: .
+    docker: {}
+  tagPolicy:
+    envTemplate:
+      template: '{{.DOCKER_REGISTRY}}/{{.IMAGE_NAME}}:{{.VERSION}}'
+  local: {}
+deploy:
+  kubectl: {}
+profiles:
+- name: dev
+  build:
+    tagPolicy:
+      envTemplate:
+        template: '{{.DOCKER_REGISTRY}}/{{.IMAGE_NAME}}:{{.DIGEST_HEX}}'
+    local: {}
+  deploy:
+    helm:
+      releases:
+      - name: jx-quickstartxy
+        chartPath: charts/jx-quickstartxy
+        setValueTemplates:
+          image.repository: '{{.DOCKER_REGISTRY}}/{{.IMAGE_NAME}}'
+          image.tag: '{{.DIGEST_HEX}}'

--- a/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/watch.sh
+++ b/pkg/cmd/importcmd/test_data/import_projects/jenkins-x-go/watch.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+make skaffold-run
+reflex -r "\.go$" -R "vendor.*" make skaffold-run

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -121,11 +121,11 @@ func CreateUniqueDirectory(dir string, name string, maximumAttempts int) (string
 func RenameDir(src string, dst string, force bool) (err error) {
 	err = CopyDir(src, dst, force)
 	if err != nil {
-		return fmt.Errorf("failed to copy source dir %s to %s: %s", src, dst, err)
+		return errors.Wrapf(err, "failed to copy source dir %s to %s", src, dst)
 	}
 	err = os.RemoveAll(src)
 	if err != nil {
-		return fmt.Errorf("failed to cleanup source dir %s: %s", src, err)
+		return errors.Wrapf(err, "failed to cleanup source dir %s", src)
 	}
 	return nil
 }
@@ -178,7 +178,7 @@ func CopyDir(src string, dst string, force bool) (err error) {
 		if force {
 			os.RemoveAll(dst)
 		} else {
-			return fmt.Errorf("destination already exists")
+			return os.ErrExist
 		}
 	}
 


### PR DESCRIPTION
Allows to reimport projects that have previously been
imported/created using Jenkins X by ignoring an already
existing chart directory.

Closes #7325

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
Skip copying chart dir from buildpack when the destination dir already exist and contains a `Chart.yaml`.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #7325