### PR TITLE
fix: eagerly download binary plugins

### DIFF
--- a/pkg/cmd/upgrade/upgrade_cli_test.go
+++ b/pkg/cmd/upgrade/upgrade_cli_test.go
@@ -4,15 +4,23 @@ package upgrade
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/blang/semver"
 	"github.com/jenkins-x/jx-logging/pkg/log"
+	v1 "github.com/jenkins-x/jx/v2/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/v2/pkg/brew"
+	"github.com/jenkins-x/jx/v2/pkg/client/clientset/versioned/fake"
 	"github.com/jenkins-x/jx/v2/pkg/cmd/create/options"
 	"github.com/jenkins-x/jx/v2/pkg/cmd/opts"
+	"github.com/jenkins-x/jx/v2/pkg/extensions"
 	"github.com/jenkins-x/jx/v2/pkg/version"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var sampleBrewInfo = `[  
@@ -200,4 +208,65 @@ func TestVersionCheckWhenCurrentVersionWithPatchIsLessThanReleaseVersion(t *test
 	update, err := opts.ShouldUpdate(jxVersion)
 	assert.NoError(t, err, "should check version without failure")
 	assert.False(t, update, "should not update")
+}
+
+func TestUpgradeBinaryPlugins(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err, "failed to create tmp dir")
+
+	opts := &UpgradeCLIOptions{
+		CreateOptions: options.CreateOptions{
+			CommonOptions: &opts.CommonOptions{},
+		},
+	}
+	dummyPluginURL := "https://raw.githubusercontent.com/jenkins-x/jx/master/hack/gofmt.sh"
+	ns := "jx"
+	pluginName := "jx-my-plugin"
+	pluginVersion := "1.2.3"
+	jxClient := fake.NewSimpleClientset(
+		&v1.Plugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pluginName,
+				Namespace: ns,
+				Labels: map[string]string{
+					extensions.PluginCommandLabel: pluginName,
+				},
+			},
+			Spec: v1.PluginSpec{
+				Name:       pluginName,
+				SubCommand: "my plugin",
+				Group:      "",
+				Binaries: []v1.Binary{
+					{
+						URL:    dummyPluginURL,
+						Goarch: "amd64",
+						Goos:   "Windows",
+					},
+					{
+						URL:    dummyPluginURL,
+						Goarch: "amd64",
+						Goos:   "Darwin",
+					},
+					{
+						URL:    dummyPluginURL,
+						Goarch: "amd64",
+						Goos:   "Linux",
+					},
+				},
+				Description: "my awesome plugin extension",
+				Version:     pluginVersion,
+			},
+		})
+	opts.SetJxClient(jxClient)
+	opts.SetDevNamespace(ns)
+
+	oldJXHome := os.Getenv("JX_HOME")
+	os.Setenv("JX_HOME", tmpDir)
+	defer os.Setenv("JX_HOME", oldJXHome)
+
+	t.Logf("downloading plugins to JX_HOME %s\n", tmpDir)
+
+	err = opts.UpgradeBinaryPlugins()
+	require.NoError(t, err, "should not fail upgrading the binary plugins")
+	assert.FileExists(t, filepath.Join(tmpDir, "plugins", ns, "bin", pluginName+"-"+pluginVersion))
 }


### PR DESCRIPTION
so that running `jx upgrade cli` will eagerly install any binary plugins defined in the current cluster.

This lets you switch clusters and be able to reuse the same binary plugins in other clusters which may not have the Plugin CRDs

fixes #7176

Signed-off-by: James Strachan <james.strachan@gmail.com>