### PR TITLE
chore: Switch to lighthouse-config for Lighthouse plugins too

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/jenkins-x/draft-repo v0.0.0-20180417100212-2f66cc518135
 	github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314
 	github.com/jenkins-x/jx-logging v0.0.10
-	github.com/jenkins-x/lighthouse-config v0.0.5
+	github.com/jenkins-x/lighthouse-config v0.0.6
 	github.com/jetstack/cert-manager v0.9.1
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -787,6 +787,8 @@ github.com/jenkins-x/lighthouse-config v0.0.4 h1:P581lKt4aU2flsFLajPIGx22Si3ow/4
 github.com/jenkins-x/lighthouse-config v0.0.4/go.mod h1:4ekc+gfCMs4WWKEWhElH2UWOXUMZJkEg9hyM1nPfuys=
 github.com/jenkins-x/lighthouse-config v0.0.5 h1:RyfM6kHs1/8Hc4uRhHd4kvSvRJhbWi3Fm7tlf5JYAFQ=
 github.com/jenkins-x/lighthouse-config v0.0.5/go.mod h1:5ax5UF79SGM+Xc3HrWR/9LsPQBWDxE+TEJMwPAikst8=
+github.com/jenkins-x/lighthouse-config v0.0.6 h1:s73GxzEaqsqn/9w+VnkPKLx4lSs450PMgk4rpCioOm0=
+github.com/jenkins-x/lighthouse-config v0.0.6/go.mod h1:5ax5UF79SGM+Xc3HrWR/9LsPQBWDxE+TEJMwPAikst8=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3 h1:NuRWKUPCEX1wKlXA8ZYSG28qGKd41R7BK11YDQkPwqo=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3/go.mod h1:litPp7VZWDRCl8LvXuqGngy+65kkg/+T23TgFnDmfTk=
 github.com/jenkins-x/test-infra v0.0.0-20200611142252-211a92405c22 h1:aBM49o8gH7ZOp4H+8wr+N6VGC55zd3wV6Wm4lH4l+fY=

--- a/pkg/cmd/step/scheduler/step_scheduler_config_apply_test.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_apply_test.go
@@ -20,11 +20,11 @@ import (
 	"github.com/jenkins-x/jx/v2/pkg/kube"
 	resources_test "github.com/jenkins-x/jx/v2/pkg/kube/resources/mocks"
 	"github.com/jenkins-x/jx/v2/pkg/prow"
+	"github.com/jenkins-x/lighthouse-config/pkg/plugins"
 	uuid "github.com/satori/go.uuid"
 	v12 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/test-infra/prow/plugins"
 
 	cmd_test "github.com/jenkins-x/jx/v2/pkg/cmd/clients/mocks"
 	"github.com/jenkins-x/jx/v2/pkg/gits"
@@ -214,7 +214,7 @@ func verifyProwConfigMap(err error, kubeClient kubernetes.Interface, devEnv *v1.
 	assert.NotNil(t, pluginsConfigMap.Data)
 	expectedPluginConfig, err := testOptions.loadExpectedConfig(testOptions.TestType, "plugins.yaml", testOptions.DevEnvRepo.Owner, testOptions.DevRepoName)
 	assert.NoError(t, err)
-	assert.Equal(t, pluginsConfigMap.Data["plugins.yaml"], expectedPluginConfig)
+	assert.Equal(t, expectedPluginConfig, pluginsConfigMap.Data["plugins.yaml"])
 }
 
 // AppTestOptions contains all useful data from the test environment initialized by `prepareInitialPromotionEnv`

--- a/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/gitops_all/plugins.yaml
+++ b/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/gitops_all/plugins.yaml
@@ -2,13 +2,11 @@ blunderbuss: {}
 cat: {}
 cherry_pick_unapproved: {}
 config_updater:
-  gzip: false
   maps:
     env/prow/config.yaml:
       name: config
     env/prow/plugins.yaml:
       name: plugins
-golint: {}
 heart: {}
 label:
   additional_labels: null
@@ -16,7 +14,6 @@ owners: {}
 plugins:
   @@DEV_ENV_ORG@@/environment-@@DEV_ENV_ORG@@-@@DEV_ENV_REPO@@-dev:
   - config-updater
-project_config: {}
 requiresig: {}
 sigmention: {}
 size:

--- a/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/gitops_default_scheduler/plugins.yaml
+++ b/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/gitops_default_scheduler/plugins.yaml
@@ -2,13 +2,11 @@ blunderbuss: {}
 cat: {}
 cherry_pick_unapproved: {}
 config_updater:
-  gzip: false
   maps:
     env/prow/config.yaml:
       name: config
     env/prow/plugins.yaml:
       name: plugins
-golint: {}
 heart: {}
 label:
   additional_labels: null
@@ -16,7 +14,6 @@ owners: {}
 plugins:
   @@DEV_ENV_ORG@@/environment-@@DEV_ENV_ORG@@-@@DEV_ENV_REPO@@-dev:
   - config-updater
-project_config: {}
 requiresig: {}
 sigmention: {}
 size:

--- a/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/gitops_repo_scheduler/plugins.yaml
+++ b/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/gitops_repo_scheduler/plugins.yaml
@@ -2,13 +2,11 @@ blunderbuss: {}
 cat: {}
 cherry_pick_unapproved: {}
 config_updater:
-  gzip: false
   maps:
     env/prow/config.yaml:
       name: config
     env/prow/plugins.yaml:
       name: plugins
-golint: {}
 heart: {}
 label:
   additional_labels: null
@@ -16,7 +14,6 @@ owners: {}
 plugins:
   @@DEV_ENV_ORG@@/environment-@@DEV_ENV_ORG@@-@@DEV_ENV_REPO@@-dev:
   - config-updater
-project_config: {}
 requiresig: {}
 sigmention: {}
 size:

--- a/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/gitops_repogroup_scheduler/plugins.yaml
+++ b/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/gitops_repogroup_scheduler/plugins.yaml
@@ -2,13 +2,11 @@ blunderbuss: {}
 cat: {}
 cherry_pick_unapproved: {}
 config_updater:
-  gzip: false
   maps:
     env/prow/config.yaml:
       name: config
     env/prow/plugins.yaml:
       name: plugins
-golint: {}
 heart: {}
 label:
   additional_labels: null
@@ -16,7 +14,6 @@ owners: {}
 plugins:
   @@DEV_ENV_ORG@@/environment-@@DEV_ENV_ORG@@-@@DEV_ENV_REPO@@-dev:
   - config-updater
-project_config: {}
 requiresig: {}
 sigmention: {}
 size:

--- a/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/nongitops_all/plugins.yaml
+++ b/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/nongitops_all/plugins.yaml
@@ -1,14 +1,11 @@
 blunderbuss: {}
 cat: {}
 cherry_pick_unapproved: {}
-config_updater:
-  gzip: false
-golint: {}
+config_updater: {}
 heart: {}
 label:
   additional_labels: null
 owners: {}
-project_config: {}
 requiresig: {}
 sigmention: {}
 size:

--- a/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/nongitops_default_scheduler/plugins.yaml
+++ b/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/nongitops_default_scheduler/plugins.yaml
@@ -1,14 +1,11 @@
 blunderbuss: {}
 cat: {}
 cherry_pick_unapproved: {}
-config_updater:
-  gzip: false
-golint: {}
+config_updater: {}
 heart: {}
 label:
   additional_labels: null
 owners: {}
-project_config: {}
 requiresig: {}
 sigmention: {}
 size:

--- a/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/nongitops_repo_scheduler/plugins.yaml
+++ b/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/nongitops_repo_scheduler/plugins.yaml
@@ -1,14 +1,11 @@
 blunderbuss: {}
 cat: {}
 cherry_pick_unapproved: {}
-config_updater:
-  gzip: false
-golint: {}
+config_updater: {}
 heart: {}
 label:
   additional_labels: null
 owners: {}
-project_config: {}
 requiresig: {}
 sigmention: {}
 size:

--- a/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/nongitops_repogroup_scheduler/plugins.yaml
+++ b/pkg/cmd/step/scheduler/test_data/step_scheduler_config_apply/nongitops_repogroup_scheduler/plugins.yaml
@@ -1,14 +1,11 @@
 blunderbuss: {}
 cat: {}
 cherry_pick_unapproved: {}
-config_updater:
-  gzip: false
-golint: {}
+config_updater: {}
 heart: {}
 label:
   additional_labels: null
 owners: {}
-project_config: {}
 requiresig: {}
 sigmention: {}
 size:

--- a/pkg/pipelinescheduler/config_builder.go
+++ b/pkg/pipelinescheduler/config_builder.go
@@ -7,9 +7,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	jenkinsv1 "github.com/jenkins-x/jx/v2/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/lighthouse-config/pkg/config"
+	"github.com/jenkins-x/lighthouse-config/pkg/plugins"
 	"github.com/pkg/errors"
 	"github.com/rollout/rox-go/core/utils"
-	"k8s.io/test-infra/prow/plugins"
 )
 
 // BuildProwConfig takes a list of schedulers and creates a Prow Config from it

--- a/pkg/pipelinescheduler/generator.go
+++ b/pkg/pipelinescheduler/generator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jenkins-x/jx/v2/pkg/gits"
 	"github.com/jenkins-x/jx/v2/pkg/helm"
 	"github.com/jenkins-x/lighthouse-config/pkg/config"
+	"github.com/jenkins-x/lighthouse-config/pkg/plugins"
 	uuid "github.com/satori/go.uuid"
 	v1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,7 +34,6 @@ import (
 	"github.com/jenkins-x/jx/v2/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/test-infra/prow/plugins"
 )
 
 // GenerateProw will generate the prow config for the namespace

--- a/pkg/pipelinescheduler/scheduler_builder.go
+++ b/pkg/pipelinescheduler/scheduler_builder.go
@@ -9,8 +9,7 @@ import (
 	"github.com/jenkins-x/jx/v2/pkg/gits"
 	"github.com/jenkins-x/jx/v2/pkg/util"
 	"github.com/jenkins-x/lighthouse-config/pkg/config"
-
-	"k8s.io/test-infra/prow/plugins"
+	"github.com/jenkins-x/lighthouse-config/pkg/plugins"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/pipelinescheduler/testhelpers/helpers.go
+++ b/pkg/pipelinescheduler/testhelpers/helpers.go
@@ -13,8 +13,7 @@ import (
 
 	"github.com/jenkins-x/jx/v2/pkg/pipelinescheduler"
 	"github.com/jenkins-x/lighthouse-config/pkg/config"
-
-	"k8s.io/test-infra/prow/plugins"
+	"github.com/jenkins-x/lighthouse-config/pkg/plugins"
 
 	"github.com/stretchr/testify/assert"
 

--- a/pkg/prow/prow.go
+++ b/pkg/prow/prow.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jenkins-x/jx/v2/pkg/kube"
 	"github.com/jenkins-x/jx/v2/pkg/util"
 	"github.com/jenkins-x/lighthouse-config/pkg/config"
+	"github.com/jenkins-x/lighthouse-config/pkg/plugins"
 
 	"github.com/pkg/errors"
 
@@ -19,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	"k8s.io/test-infra/prow/plugins"
 )
 
 const (

--- a/pkg/prow/prow_test.go
+++ b/pkg/prow/prow_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jenkins-x/jx/v2/pkg/prow"
 	prowconfig "github.com/jenkins-x/jx/v2/pkg/prow/config"
 	"github.com/jenkins-x/lighthouse-config/pkg/config"
+	"github.com/jenkins-x/lighthouse-config/pkg/plugins"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
@@ -17,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
-	"k8s.io/test-infra/prow/plugins"
 )
 
 type TestOptions struct {


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Followup to earlier when we did this for the config package, but now for the plugins package. Now the only `k8s.io/test-infra/prow` dependencies left are relating to `ProwJobs`, so once we eventually officially remove Prow, we can get rid of those too.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a