### PR TITLE
fix: jx step tag can edit the wrong chart file

### DIFF
--- a/pkg/cmd/step/step_tag_test.go
+++ b/pkg/cmd/step/step_tag_test.go
@@ -131,3 +131,39 @@ func TestDefaultChartValueRepositoryValidName(t *testing.T) {
 
 	assert.Equal(t, expectedImageName, o.defaultChartValueRepository())
 }
+
+func TestFindChartsDir(t *testing.T) {
+	testData := path.Join("test_data", "step_tag_find_chart")
+	dir, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(dir)
+	assert.NoError(t, os.Chdir(testData))
+
+	if val, ok := os.LookupEnv("APP_NAME"); ok {
+		assert.NoError(t, os.Unsetenv("APP_NAME"))
+		defer os.Setenv("APP_NAME", val)
+	} else {
+		defer os.Unsetenv("APP_NAME")
+	}
+	if val, ok := os.LookupEnv("REPO_NAME"); ok {
+		assert.NoError(t, os.Unsetenv("REPO_NAME"))
+		defer os.Setenv("REPO_NAME", val)
+	} else {
+		defer os.Unsetenv("REPO_NAME")
+	}
+
+	chartsDir := filepath.Join("charts", "my-project") + "/"
+	o := StepTagOptions{}
+
+	assert.NoError(t, os.Setenv("APP_NAME", "My.Project"))
+	val, err := o.findChartsDir()
+	assert.NoError(t, err)
+	assert.Equal(t, chartsDir, val)
+	assert.NoError(t, os.Unsetenv("APP_NAME"))
+
+	assert.NoError(t, os.Setenv("REPO_NAME", "my-project"))
+	val, err = o.findChartsDir()
+	assert.NoError(t, err)
+	assert.Equal(t, chartsDir, val)
+	assert.NoError(t, os.Unsetenv("REPO_NAME"))
+}

--- a/pkg/cmd/step/test_data/step_tag_find_chart/aaa/my-project/Chart.yaml
+++ b/pkg/cmd/step/test_data/step_tag_find_chart/aaa/my-project/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: my-project
+version: 0.1.0-SNAPSHOT
+appVersion: 0.1.0-SNAPSHOT

--- a/pkg/cmd/step/test_data/step_tag_find_chart/charts/aaa/Chart.yaml
+++ b/pkg/cmd/step/test_data/step_tag_find_chart/charts/aaa/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: my-project
+version: 0.1.0-SNAPSHOT
+appVersion: 0.1.0-SNAPSHOT

--- a/pkg/cmd/step/test_data/step_tag_find_chart/charts/my-project/Chart.yaml
+++ b/pkg/cmd/step/test_data/step_tag_find_chart/charts/my-project/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: my-project
+version: 0.1.0-SNAPSHOT
+appVersion: 0.1.0-SNAPSHOT


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Priori to this commit, `jx step tag` would edit the first `*/*/Chart.yaml` file found. This commit gives priority to the more likely `charts/<appName>/Chart.yaml` file.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #7417

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
