### PR TITLE
refactor: improve build log stream

### DIFF
--- a/pkg/cloud/amazon/storage/bucket_provider_test.go
+++ b/pkg/cloud/amazon/storage/bucket_provider_test.go
@@ -3,6 +3,7 @@
 package storage
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -181,13 +182,17 @@ func TestAmazonBucketProvider_DownloadFileFromBucket(t *testing.T) {
 		},
 		downloader: mockedDownloader{},
 	}
-	scanner, err := p.DownloadFileFromBucket("s3://bucket/key")
+	reader, err := p.DownloadFileFromBucket("s3://bucket/key")
 	assert.NoError(t, err)
 
+	scanner := bufio.NewScanner(reader)
+	scanner.Split(bufio.ScanLines)
 	var bucketContent string
 	for scanner.Scan() {
 		bucketContent += fmt.Sprintln(scanner.Text())
 	}
 
 	assert.Equal(t, expectedBucketContents, bucketContent, "the returned contents should be match")
+	err = reader.Close()
+	assert.NoError(t, err, "reader.Close()")
 }

--- a/pkg/cloud/buckets/buckets.go
+++ b/pkg/cloud/buckets/buckets.go
@@ -3,7 +3,7 @@ package buckets
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -47,7 +47,7 @@ func KubeProviderToBucketScheme(provider string) string {
 
 // ReadURL reads the given URL from either a http/https endpoint or a bucket URL path.
 // if specified the httpFn is a function which can append the user/password or token and/or add a header with the token if using a git provider
-func ReadURL(urlText string, timeout time.Duration, httpFn func(urlString string) (string, func(*http.Request), error)) ([]byte, error) {
+func ReadURL(urlText string, timeout time.Duration, httpFn func(urlString string) (string, func(*http.Request), error)) (io.ReadCloser, error) {
 	u, err := url.Parse(urlText)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse URL %s", urlText)
@@ -68,7 +68,7 @@ func ReadURL(urlText string, timeout time.Duration, httpFn func(urlString string
 }
 
 // ReadHTTPURL reads the HTTP based URL, modifying the headers as needed, and returns the data or returning an error if a 2xx status is not returned
-func ReadHTTPURL(u string, headerFunc func(*http.Request), timeout time.Duration) ([]byte, error) {
+func ReadHTTPURL(u string, headerFunc func(*http.Request), timeout time.Duration) (io.ReadCloser, error) {
 	httpClient := util.GetClientWithTimeout(timeout)
 
 	req, err := http.NewRequest("GET", u, nil)
@@ -81,22 +81,18 @@ func ReadHTTPURL(u string, headerFunc func(*http.Request), timeout time.Duration
 		return nil, errors.Wrapf(err, "failed to invoke GET on %s", u)
 	}
 	stream := resp.Body
-	defer stream.Close()
 
-	data, err := ioutil.ReadAll(stream)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to GET data from %s", u)
-	}
 	if resp.StatusCode >= 400 {
-		return data, fmt.Errorf("status %s when performing GET on %s", resp.Status, u)
+		_ = stream.Close()
+		return nil, fmt.Errorf("status %s when performing GET on %s", resp.Status, u)
 	}
-	return data, err
+	return stream, nil
 }
 
 // ReadBucketURL reads the content of a bucket URL of the for 's3://bucketName/foo/bar/whatnot.txt?param=123'
 // where any of the query arguments are applied to the underlying Bucket URL and the path is extracted and resolved
 // within the bucket
-func ReadBucketURL(u *url.URL, timeout time.Duration) ([]byte, error) {
+func ReadBucketURL(u *url.URL, timeout time.Duration) (io.ReadCloser, error) {
 	bucketURL, key := SplitBucketURL(u)
 
 	ctx, _ := context.WithTimeout(context.Background(), timeout)
@@ -104,7 +100,7 @@ func ReadBucketURL(u *url.URL, timeout time.Duration) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open bucket %s", bucketURL)
 	}
-	data, err := bucket.ReadAll(ctx, key)
+	data, err := bucket.NewReader(ctx, key, nil)
 	if err != nil {
 		return data, errors.Wrapf(err, "failed to read key %s in bucket %s", key, bucketURL)
 	}
@@ -113,24 +109,31 @@ func ReadBucketURL(u *url.URL, timeout time.Duration) ([]byte, error) {
 
 // WriteBucketURL writes the data to a bucket URL of the for 's3://bucketName/foo/bar/whatnot.txt?param=123'
 // with the given timeout
-func WriteBucketURL(u *url.URL, data []byte, timeout time.Duration) error {
+func WriteBucketURL(u *url.URL, data io.Reader, timeout time.Duration) error {
 	bucketURL, key := SplitBucketURL(u)
 	return WriteBucket(bucketURL, key, data, timeout)
 }
 
 // WriteBucket writes the data to a bucket URL and key of the for 's3://bucketName' and key 'foo/bar/whatnot.txt'
 // with the given timeout
-func WriteBucket(bucketURL string, key string, data []byte, timeout time.Duration) error {
+func WriteBucket(bucketURL string, key string, data io.Reader, timeout time.Duration) (err error) {
 	ctx, _ := context.WithTimeout(context.Background(), timeout)
 	bucket, err := blob.Open(ctx, bucketURL)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open bucket %s", bucketURL)
 	}
-	err = bucket.WriteAll(ctx, key, data, nil)
+	w, err := bucket.NewWriter(ctx, key, nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to write key %s in bucket %s", key, bucketURL)
+		return errors.Wrapf(err, "failed to create key %s in bucket %s", key, bucketURL)
 	}
-	return nil
+	defer func() {
+		if e := w.Close(); e != nil && err == nil {
+			err = e
+		}
+		err = errors.Wrapf(err, "failed to write key %s in bucket %s", key, bucketURL)
+	}()
+	_, err = io.Copy(w, data)
+	return
 }
 
 // SplitBucketURL splits the full bucket URL into the URL to open the bucket and the file name to refer to

--- a/pkg/cloud/buckets/default_provider.go
+++ b/pkg/cloud/buckets/default_provider.go
@@ -1,7 +1,6 @@
 package buckets
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -38,7 +37,7 @@ func (LegacyBucketProvider) EnsureBucketIsCreated(bucketURL string) error {
 }
 
 // DownloadFileFromBucket is not supported for LegacyBucketProvider
-func (LegacyBucketProvider) DownloadFileFromBucket(bucketURL string) (*bufio.Scanner, error) {
+func (LegacyBucketProvider) DownloadFileFromBucket(bucketURL string) (io.ReadCloser, error) {
 	return nil, fmt.Errorf("DownloadFileFromBucket not implemented for LegacyBucketProvider")
 }
 

--- a/pkg/cloud/buckets/interface.go
+++ b/pkg/cloud/buckets/interface.go
@@ -1,7 +1,6 @@
 package buckets
 
 import (
-	"bufio"
 	"io"
 )
 
@@ -12,5 +11,5 @@ type Provider interface {
 	CreateNewBucketForCluster(clusterName string, bucketKind string) (string, error)
 	EnsureBucketIsCreated(bucketURL string) error
 	UploadFileToBucket(r io.Reader, outputName string, bucketURL string) (string, error)
-	DownloadFileFromBucket(bucketURL string) (*bufio.Scanner, error)
+	DownloadFileFromBucket(bucketURL string) (io.ReadCloser, error)
 }

--- a/pkg/cloud/buckets/mocks/buckets_interface.go
+++ b/pkg/cloud/buckets/mocks/buckets_interface.go
@@ -4,7 +4,6 @@
 package buckets_test
 
 import (
-	bufio "bufio"
 	io "io"
 	"reflect"
 	"time"
@@ -46,17 +45,17 @@ func (mock *MockProvider) CreateNewBucketForCluster(_param0 string, _param1 stri
 	return ret0, ret1
 }
 
-func (mock *MockProvider) DownloadFileFromBucket(_param0 string) (*bufio.Scanner, error) {
+func (mock *MockProvider) DownloadFileFromBucket(_param0 string) (io.ReadCloser, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockProvider().")
 	}
 	params := []pegomock.Param{_param0}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("DownloadFileFromBucket", params, []reflect.Type{reflect.TypeOf((**bufio.Scanner)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 *bufio.Scanner
+	result := pegomock.GetGenericMockFrom(mock).Invoke("DownloadFileFromBucket", params, []reflect.Type{reflect.TypeOf((*io.ReadCloser)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 io.ReadCloser
 	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(*bufio.Scanner)
+			ret0 = result[0].(io.ReadCloser)
 		}
 		if result[1] != nil {
 			ret1 = result[1].(error)

--- a/pkg/cloud/gke/gcloud.go
+++ b/pkg/cloud/gke/gcloud.go
@@ -4,12 +4,12 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-
 	"time"
 
 	osUser "os/user"
@@ -555,7 +555,7 @@ func (g *GCloud) DeleteAllObjectsInBucket(bucketName string) error {
 
 // StreamTransferFileFromBucket will perform a stream transfer from the GCS bucket to stdout and return a scanner
 // with the piped result
-func StreamTransferFileFromBucket(fullBucketURL string) (*bufio.Scanner, error) {
+func StreamTransferFileFromBucket(fullBucketURL string) (io.ReadCloser, error) {
 	bucketAccessible, err := isBucketAccessible(fullBucketURL)
 	if !bucketAccessible || err != nil {
 		return nil, errors.Wrap(err, "can't access bucket")
@@ -571,9 +571,7 @@ func StreamTransferFileFromBucket(fullBucketURL string) (*bufio.Scanner, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "error streaming the logs from bucket")
 	}
-	scanner := bufio.NewScanner(stdout)
-	scanner.Split(bufio.ScanLines)
-	return scanner, nil
+	return stdout, nil
 }
 
 func isBucketAccessible(bucketURL string) (bool, error) {

--- a/pkg/cloud/gke/storage/bucket_provider.go
+++ b/pkg/cloud/gke/storage/bucket_provider.go
@@ -1,10 +1,8 @@
 package storage
 
 import (
-	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strings"
 	"time"
@@ -80,18 +78,13 @@ func (b *GKEBucketProvider) EnsureBucketIsCreated(bucketURL string) error {
 
 // UploadFileToBucket uploads a file to the provided GCS bucket with the provided outputName
 func (b *GKEBucketProvider) UploadFileToBucket(reader io.Reader, key string, bucketURL string) (string, error) {
-	data, err := ioutil.ReadAll(reader)
-	if err != nil {
-		return "", err
-	}
-
-	log.Logger().Debugf("Uploading %d bytes to bucket %s with key %s", len(data), bucketURL, key)
-	err = buckets.WriteBucket(bucketURL, key, data, defaultBucketWriteTimeout)
+	log.Logger().Debugf("Uploading to bucket %s with key %s", bucketURL, key)
+	err := buckets.WriteBucket(bucketURL, key, reader, defaultBucketWriteTimeout)
 	return bucketURL + "/" + key, err
 }
 
 // DownloadFileFromBucket downloads a file from GCS from the given bucketURL and server its contents with a bufio.Scanner
-func (b *GKEBucketProvider) DownloadFileFromBucket(bucketURL string) (*bufio.Scanner, error) {
+func (b *GKEBucketProvider) DownloadFileFromBucket(bucketURL string) (io.ReadCloser, error) {
 	return gke.StreamTransferFileFromBucket(bucketURL)
 }
 

--- a/pkg/cmd/step/step_unstash.go
+++ b/pkg/cmd/step/step_unstash.go
@@ -106,7 +106,12 @@ func Unstash(u string, outDir string, timeout time.Duration, authSvc auth.Config
 		}
 	}
 
-	data, err := buckets.ReadURL(u, timeout, CreateBucketHTTPFn(authSvc))
+	reader, err := buckets.ReadURL(u, timeout, CreateBucketHTTPFn(authSvc))
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	data, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/bucket_collector_test.go
+++ b/pkg/collector/bucket_collector_test.go
@@ -30,7 +30,7 @@ func TestBucketCollector_CollectData(t *testing.T) {
 		provider:  mp,
 	}
 
-	finalURL, err := collector.CollectData(contents, outputName)
+	finalURL, err := collector.CollectData(bytes.NewReader(contents), outputName)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%s/%s", collector.bucketURL, outputName), finalURL)
 }

--- a/pkg/collector/interface.go
+++ b/pkg/collector/interface.go
@@ -1,5 +1,9 @@
 package collector
 
+import (
+	"io"
+)
+
 // Collector an interface to collect data for storage in git or cloud storage etc
 type Collector interface {
 
@@ -9,5 +13,5 @@ type Collector interface {
 
 	// CollectData collects the data storing it at the given output path and returning the URL
 	// to access it
-	CollectData(data []byte, outputPath string) (string, error)
+	CollectData(data io.Reader, outputPath string) (string, error)
 }

--- a/pkg/logs/tekton_logging_test.go
+++ b/pkg/logs/tekton_logging_test.go
@@ -15,25 +15,20 @@ import (
 	v1 "github.com/jenkins-x/jx-api/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx-api/pkg/client/clientset/versioned"
 	jxfake "github.com/jenkins-x/jx-api/pkg/client/clientset/versioned/fake"
-	"github.com/jenkins-x/jx-logging/pkg/log"
 	"github.com/jenkins-x/jx/v2/pkg/cmd/clients/fake"
 	"github.com/jenkins-x/jx/v2/pkg/cmd/opts"
 	"github.com/jenkins-x/jx/v2/pkg/cmd/testhelpers"
 	"github.com/jenkins-x/jx/v2/pkg/kube"
 	"github.com/jenkins-x/jx/v2/pkg/tekton/tekton_helpers_test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	tektonMocks "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kubeMocks "k8s.io/client-go/kubernetes/fake"
 )
-
-type TestWriter struct {
-	StreamLinesLogged []string
-	SingleLinesLogged []string
-}
 
 const (
 	LogsHeadersMultiplier = 2
@@ -46,11 +41,6 @@ func TestGetTektonPipelinesWithActivePipelineActivityNoData(t *testing.T) {
 		JXClient:     jxClient,
 		TektonClient: tektonClient,
 		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
 	}
 	names, paNames, err := tl.GetTektonPipelinesWithActivePipelineActivity([]string{})
 
@@ -67,14 +57,10 @@ func TestGetTektonPipelinesWithActivePipelineActivitySingleBuild(t *testing.T) {
 	tektonClient := tektonMocks.NewSimpleClientset(pipelineRuns)
 
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	_ = assertAndCreatePA1(t, jxClient, ns)
@@ -95,14 +81,10 @@ func TestGetTektonPipelinesWithActivePipelineActivityOnlyWaitingStep(t *testing.
 	pipelineRuns := tekton_helpers_test.AssertLoadPipelineRuns(t, testCaseDir)
 	tektonClient := tektonMocks.NewSimpleClientset(pipelineRuns)
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	_ = assertAndCreatePA1(t, jxClient, ns)
@@ -122,14 +104,10 @@ func TestGetTektonPipelinesWithActivePipelineActivityInvalidName(t *testing.T) {
 	pipelineRuns := tekton_helpers_test.AssertLoadPipelineRuns(t, testCaseDir)
 	tektonClient := tektonMocks.NewSimpleClientset(pipelineRuns)
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	activity := tekton_helpers_test.AssertLoadSinglePipelineActivity(t, testCaseDir)
@@ -150,22 +128,28 @@ func TestGetTektonPipelinesWithActivePipelineActivityInvalidName(t *testing.T) {
 func TestGetRunningBuildLogsNoBuildPods(t *testing.T) {
 	jxClient, tektonClient, kubeClient, _, ns := getFakeClientsAndNs(t)
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		KubeClient:   kubeClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		KubeClient:        kubeClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	pa := assertAndCreatePA1(t, jxClient, ns)
 
-	err := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	ch := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	lines := readLogChannel(ch)
+	err := tl.Err()
 	assert.Error(t, err)
+	assert.Empty(t, lines, "logged lines")
 	assert.Equal(t, "the build pods for this build have been garbage collected and the log was not found in the long term storage bucket", err.Error())
+}
+
+func readLogChannel(ch <-chan LogLine) (l []string) {
+	for line := range ch {
+		l = append(l, line.Line)
+	}
+	return
 }
 
 func TestGetRunningBuildLogsWithPipelineRunButNoBuildPods(t *testing.T) {
@@ -178,20 +162,18 @@ func TestGetRunningBuildLogsWithPipelineRunButNoBuildPods(t *testing.T) {
 	jxClient := jxfake.NewSimpleClientset(structures)
 
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		Namespace:    ns,
-		KubeClient:   kubeClient,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		Namespace:         ns,
+		KubeClient:        kubeClient,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	pa := assertAndCreatePA1(t, jxClient, ns)
 
-	err := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	ch := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	readLogChannel(ch)
+	err := tl.Err()
 	assert.Error(t, err)
 	assert.Equal(t, "the build pods for this build have been garbage collected and the log was not found in the long term storage bucket", err.Error())
 }
@@ -204,20 +186,18 @@ func TestGetRunningBuildLogsNoMatchingBuildPods(t *testing.T) {
 	kubeClient := kubeMocks.NewSimpleClientset(podsList)
 
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		KubeClient:   kubeClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		KubeClient:        kubeClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	pa := assertAndCreatePA1(t, jxClient, ns)
 
-	err := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	ch := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	readLogChannel(ch)
+	err := tl.Err()
 	assert.Error(t, err)
 	assert.Equal(t, "the build pods for this build have been garbage collected and the log was not found in the long term storage bucket", err.Error())
 }
@@ -235,26 +215,23 @@ func TestGetRunningBuildLogsWithMatchingBuildPods(t *testing.T) {
 	jxClient := jxfake.NewSimpleClientset(structures)
 
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		KubeClient:   kubeClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		KubeClient:        kubeClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	pa := assertAndCreatePA1(t, jxClient, ns)
 
-	err := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	ch := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	lines := readLogChannel(ch)
 
 	buildContainers, _, _ := kube.GetContainersWithStatusAndIsInit(&podsList.Items[1])
 	containersNumber := len(buildContainers) * LogsHeadersMultiplier
 
-	assert.NoError(t, err)
-	assert.Equal(t, containersNumber, len(tl.LogWriter.(*TestWriter).StreamLinesLogged))
+	assert.NoError(t, tl.Err())
+	assert.Equal(t, containersNumber, len(lines))
 }
 
 func TestGetRunningBuildLogsWithMatchingBuildPodsWithFailedContainerInTheMiddle(t *testing.T) {
@@ -270,26 +247,23 @@ func TestGetRunningBuildLogsWithMatchingBuildPodsWithFailedContainerInTheMiddle(
 	jxClient := jxfake.NewSimpleClientset(structures)
 
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		KubeClient:   kubeClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		KubeClient:        kubeClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	pa := assertAndCreatePA1(t, jxClient, ns)
 
-	err := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	ch := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	lines := readLogChannel(ch)
 
 	stepsExecutedBeforeFailure := 4
 	containersNumber := stepsExecutedBeforeFailure*LogsHeadersMultiplier + FailureLineAddition
 
-	assert.NoError(t, err)
-	assert.Equal(t, containersNumber, len(tl.LogWriter.(*TestWriter).StreamLinesLogged), "should stop logging after a step has failed")
+	assert.NoError(t, tl.Err())
+	assert.Equal(t, containersNumber, len(lines), "should stop logging after a step has failed")
 }
 
 func TestGetRunningBuildLogsWithMatchingBuildPodsWithFailedMetapipeline(t *testing.T) {
@@ -305,29 +279,25 @@ func TestGetRunningBuildLogsWithMatchingBuildPodsWithFailedMetapipeline(t *testi
 	jxClient := jxfake.NewSimpleClientset(structures)
 
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		KubeClient:   kubeClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		KubeClient:        kubeClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	pa := assertAndCreatePA1(t, jxClient, ns)
 
-	err := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	ch := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	lines := readLogChannel(ch)
 
 	stepsExecutedBeforeFailure := 6
 	containersNumber := stepsExecutedBeforeFailure*LogsHeadersMultiplier + FailureLineAddition
 
-	assert.NoError(t, err)
-	assert.Equal(t, containersNumber, len(tl.LogWriter.(*TestWriter).StreamLinesLogged), "should stop logging after a step has failed")
-	firstLine := tl.LogWriter.(*TestWriter).StreamLinesLogged[0]
+	assert.NoError(t, tl.Err())
+	require.Equal(t, containersNumber, len(lines), "should stop logging after a step has failed")
 	assert.Regexp(t, "Showing logs for build (?s).* stage app-extension and container (?s).*$",
-		stripansi.Strip(firstLine), "Metapipeline failed so 'app-extension' should be the first stage logged")
+		stripansi.Strip(lines[0]), "Metapipeline failed so 'app-extension' should be the first stage logged")
 }
 
 func TestGetRunningBuildLogsForLegacyPipelineRunWithMatchingBuildPods(t *testing.T) {
@@ -343,43 +313,36 @@ func TestGetRunningBuildLogsForLegacyPipelineRunWithMatchingBuildPods(t *testing
 	jxClient := jxfake.NewSimpleClientset(structures)
 
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		KubeClient:   kubeClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		KubeClient:        kubeClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	pa := assertAndCreatePA1(t, jxClient, ns)
 
-	err := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	ch := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", false)
+	lines := readLogChannel(ch)
 
 	buildContainers, _, _ := kube.GetContainersWithStatusAndIsInit(&podsList.Items[1])
 	containersNumber := len(buildContainers) * LogsHeadersMultiplier
 
-	assert.NoError(t, err)
-	assert.Equal(t, containersNumber, len(tl.LogWriter.(*TestWriter).StreamLinesLogged))
-	firstLine := tl.LogWriter.(*TestWriter).StreamLinesLogged[0]
+	assert.NoError(t, tl.Err())
+	require.Equal(t, containersNumber, len(lines))
 	assert.Regexp(t, "Showing logs for build (?s).* stage from-fakebranch and container (?s).*$",
-		stripansi.Strip(firstLine), "the metapipeline completed successfully so 'from-fakebranch' should be the first stage logged")
+		stripansi.Strip(lines[0]), "the metapipeline completed successfully so 'from-fakebranch' should be the first stage logged")
 }
 
 func TestStreamPipelinePersistentLogsNotInBucket(t *testing.T) {
 	_, _, _, commonOptions, _ := getFakeClientsAndNs(t)
 	commonOptions.SkipAuthSecretsMerge = true
-
-	lch := make(chan LogLine)
-	writer := &TestWriter{
-		StreamLinesLogged: make([]string, 0),
-		SingleLinesLogged: make([]string, 0),
-	}
+	jxClient, ns, err := commonOptions.JXClient()
+	require.NoError(t, err)
 	tl := TektonLogger{
-		LogWriter:   writer,
-		logsChannel: lch,
+		JXClient:          jxClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	exampleLogLine := "This is an example log line"
@@ -390,35 +353,33 @@ func TestStreamPipelinePersistentLogsNotInBucket(t *testing.T) {
 		assert.NoError(t, err)
 	}))
 
-	jxClient, ns, err := commonOptions.JXClient()
-	assert.NoError(t, err)
 	authSvc, err := commonOptions.GitAuthConfigService()
 	assert.NoError(t, err)
-	err = tl.StreamPipelinePersistentLogs(server.URL, jxClient, ns, authSvc)
-	assert.NoError(t, err)
-
-	assert.Contains(t, tl.LogWriter.(*TestWriter).StreamLinesLogged[0], "This is an example log line")
+	ch := tl.StreamPipelinePersistentLogs(server.URL, authSvc)
+	lines := readLogChannel(ch)
+	assert.NoError(t, tl.Err())
+	require.Equal(t, 1, len(lines), "len(logLines)")
+	assert.Contains(t, lines[0], exampleLogLine)
 }
 
 func TestStreamPipelinePersistentLogsInUnsupportedBucketProvider(t *testing.T) {
 	_, _, _, commonOptions, _ := getFakeClientsAndNs(t)
 	commonOptions.SkipAuthSecretsMerge = true
-	lch := make(chan LogLine)
+	jxClient, ns, err := commonOptions.JXClient()
+	require.NoError(t, err)
 	tl := TektonLogger{
-		logsChannel: lch,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
+		JXClient:          jxClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
-	jxClient, ns, err := commonOptions.JXClient()
-	assert.NoError(t, err)
 	authSvc, err := commonOptions.GitAuthConfigService()
 	assert.NoError(t, err)
-	err = tl.StreamPipelinePersistentLogs("azblob://nonSupportedBucket", jxClient, ns, authSvc)
+	ch := tl.StreamPipelinePersistentLogs("azblob://nonSupportedBucket", authSvc)
+	lines := readLogChannel(ch)
+	err = tl.Err()
 	assert.NoError(t, err)
-	assert.Contains(t, tl.LogWriter.(*TestWriter).StreamLinesLogged[0], "The provided logsURL scheme is not supported: azblob")
+	assert.Contains(t, lines[0], "The provided logsURL scheme is not supported: azblob")
 }
 
 func TestGetRunningBuildLogsWithMultipleStages(t *testing.T) {
@@ -434,19 +395,15 @@ func TestGetRunningBuildLogsWithMultipleStages(t *testing.T) {
 	jxClient := jxfake.NewSimpleClientset(structures)
 
 	tl := TektonLogger{
-		KubeClient:   kubeClient,
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		KubeClient:        kubeClient,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	pa := &v1.PipelineActivity{
-		ObjectMeta: v12.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "abayer-js-test-repo-master-1",
 			Namespace: ns,
 			Labels: map[string]string{
@@ -464,17 +421,17 @@ func TestGetRunningBuildLogsWithMultipleStages(t *testing.T) {
 		},
 	}
 
-	err := tl.GetRunningBuildLogs(pa, "abayer/js-test-repo/master/1", false)
-	assert.NoError(t, err)
+	ch := tl.GetRunningBuildLogs(pa, "abayer/js-test-repo/master/1", false)
+	lines := readLogChannel(ch)
+	assert.NoError(t, tl.Err())
 
 	containers1, _, _ := kube.GetContainersWithStatusAndIsInit(&podsList.Items[0])
 	containers2, _, _ := kube.GetContainersWithStatusAndIsInit(&podsList.Items[1])
 	containersNumber := (len(containers1) + len(containers2)) * LogsHeadersMultiplier
 
-	assert.Equal(t, containersNumber, len(tl.LogWriter.(*TestWriter).StreamLinesLogged))
-	firstLine := tl.LogWriter.(*TestWriter).StreamLinesLogged[0]
+	require.Equal(t, containersNumber, len(lines))
 	assert.Regexp(t, "Showing logs for build (?s).* stage build and container (?s).*$",
-		stripansi.Strip(firstLine), "'build' should be the first stage logged")
+		stripansi.Strip(lines[0]), "'build' should be the first stage logged")
 }
 
 func TestGetRunningBuildLogsWithMultipleStagesWithFailureInFirstStage(t *testing.T) {
@@ -490,27 +447,23 @@ func TestGetRunningBuildLogsWithMultipleStagesWithFailureInFirstStage(t *testing
 	jxClient := jxfake.NewSimpleClientset(structures, pa)
 
 	tl := TektonLogger{
-		KubeClient:   kubeClient,
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		KubeClient:        kubeClient,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
-	err := tl.GetRunningBuildLogs(pa, "cb-kubecd/bdd-spring-1568135191/master/1", false)
-	assert.NoError(t, err)
+	ch := tl.GetRunningBuildLogs(pa, "cb-kubecd/bdd-spring-1568135191/master/1", false)
+	lines := readLogChannel(ch)
+	assert.NoError(t, tl.Err())
 
 	containers1, _, _ := kube.GetContainersWithStatusAndIsInit(&podsList.Items[1])
 	containersNumber := len(containers1)*LogsHeadersMultiplier + 1 // One additional line for the failure
 
-	assert.Equal(t, containersNumber, len(tl.LogWriter.(*TestWriter).StreamLinesLogged))
-	firstLine := tl.LogWriter.(*TestWriter).StreamLinesLogged[0]
+	require.Equal(t, containersNumber, len(lines))
 	assert.Regexp(t, "Showing logs for build (?s).* stage from-build-pack and container (?s).*$",
-		stripansi.Strip(firstLine), "'from-build-pack' should be the first stage logged")
+		stripansi.Strip(lines[0]), "'from-build-pack' should be the first stage logged")
 }
 
 func TestGetRunningBuildLogsWithMultipleStagesFailureActivityDoneRunNotDone(t *testing.T) {
@@ -526,27 +479,23 @@ func TestGetRunningBuildLogsWithMultipleStagesFailureActivityDoneRunNotDone(t *t
 	jxClient := jxfake.NewSimpleClientset(structures, pa)
 
 	tl := TektonLogger{
-		KubeClient:   kubeClient,
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		KubeClient:        kubeClient,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
-	err := tl.GetRunningBuildLogs(pa, "cb-kubecd/bdd-spring-1568135191/master/1", false)
-	assert.NoError(t, err)
+	ch := tl.GetRunningBuildLogs(pa, "cb-kubecd/bdd-spring-1568135191/master/1", false)
+	lines := readLogChannel(ch)
+	assert.NoError(t, tl.Err())
 
 	containers1, _, _ := kube.GetContainersWithStatusAndIsInit(&podsList.Items[1])
 	containersNumber := len(containers1)*LogsHeadersMultiplier + 1 // One additional line for the failure
 
-	assert.Equal(t, containersNumber, len(tl.LogWriter.(*TestWriter).StreamLinesLogged))
-	firstLine := tl.LogWriter.(*TestWriter).StreamLinesLogged[0]
+	require.Equal(t, containersNumber, len(lines))
 	assert.Regexp(t, "Showing logs for build (?s).* stage from-build-pack and container (?s).*$",
-		stripansi.Strip(firstLine), "'from-build-pack' should be the first stage logged")
+		stripansi.Strip(lines[0]), "'from-build-pack' should be the first stage logged")
 }
 
 func TestGetRunningBuildLogsMetapipelineAndPendingGenerated(t *testing.T) {
@@ -561,29 +510,25 @@ func TestGetRunningBuildLogsMetapipelineAndPendingGenerated(t *testing.T) {
 	jxClient := jxfake.NewSimpleClientset(structures)
 
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		KubeClient:   kubeClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		KubeClient:        kubeClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	pa := assertAndCreatePA1(t, jxClient, ns)
 
-	err := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", true)
-	assert.NoError(t, err)
+	ch := tl.GetRunningBuildLogs(pa, "fakeowner/fakerepo/fakebranch/1", true)
+	lines := readLogChannel(ch)
+	assert.NoError(t, tl.Err())
 
 	metapipelineContainers, _, _ := kube.GetContainersWithStatusAndIsInit(&podsList.Items[0])
 	containersNumber := len(metapipelineContainers) * LogsHeadersMultiplier
 
-	assert.Equal(t, containersNumber, len(tl.LogWriter.(*TestWriter).StreamLinesLogged))
-	firstLine := tl.LogWriter.(*TestWriter).StreamLinesLogged[0]
+	assert.Equal(t, containersNumber, len(lines))
 	assert.Regexp(t, "Showing logs for build (?s).* stage app-extension and container (?s).*$",
-		stripansi.Strip(firstLine), "'app-extension' should be the first stage logged")
+		stripansi.Strip(lines[0]), "'app-extension' should be the first stage logged")
 }
 
 func TestGetTektonPipelinesWithFailedAndRetriedPipeline(t *testing.T) {
@@ -594,20 +539,16 @@ func TestGetTektonPipelinesWithFailedAndRetriedPipeline(t *testing.T) {
 	tektonClient := tektonMocks.NewSimpleClientset(pipelineRuns)
 
 	tl := TektonLogger{
-		JXClient:     jxClient,
-		TektonClient: tektonClient,
-		Namespace:    ns,
-		LogWriter: &TestWriter{
-			StreamLinesLogged: make([]string, 0),
-			SingleLinesLogged: make([]string, 0),
-		},
-		LogsRetrieverFunc: LogsProvider,
+		JXClient:          jxClient,
+		TektonClient:      tektonClient,
+		Namespace:         ns,
+		LogsRetrieverFunc: fakeLogsRetriever,
 	}
 
 	_ = assertAndCreatePA1(t, jxClient, ns)
 
 	_, err := jxClient.JenkinsV1().PipelineActivities(ns).Create(&v1.PipelineActivity{
-		ObjectMeta: v12.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "PA2",
 			Namespace: ns,
 			Labels: map[string]string{
@@ -654,38 +595,9 @@ func getFakeClientsAndNs(t *testing.T) (versioned.Interface, tektonclient.Interf
 	return jxClient, tektonClient, kubeClient, commonOpts, ns
 }
 
-func (w *TestWriter) WriteLog(logLine LogLine, lch chan<- LogLine) error {
-	w.SingleLinesLogged = append(w.SingleLinesLogged, logLine.Line)
-	lch <- logLine
-	return nil
-}
-
-func (w *TestWriter) StreamLog(lch <-chan LogLine, ech <-chan error) error {
-	for {
-		select {
-		case l, ok := <-lch:
-			if !ok {
-				return nil
-			}
-			w.StreamLinesLogged = append(w.StreamLinesLogged, l.Line)
-			log.Logger().Info(l.Line)
-		}
-	}
-}
-
-func (w TestWriter) BytesLimit() int {
-	return 0
-}
-
-func LogsProvider(pod *corev1.Pod, container *corev1.Container) (io.Reader, func(), error) {
-	return bytes.NewReader([]byte(fmt.Sprintf("Writing pod log for pod %s and container %s", pod.Name, container.Name))), func() {
-		//nothing to clean
-	}, nil
-}
-
 func assertAndCreatePA1(t *testing.T, jxClient versioned.Interface, ns string) *v1.PipelineActivity {
 	pa, err := jxClient.JenkinsV1().PipelineActivities(ns).Create(&v1.PipelineActivity{
-		ObjectMeta: v12.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "PA1",
 			Namespace: ns,
 			Labels: map[string]string{
@@ -707,3 +619,14 @@ func assertAndCreatePA1(t *testing.T, jxClient versioned.Interface, ns string) *
 
 	return pa
 }
+
+func fakeLogsRetriever(pod *corev1.Pod, container *corev1.Container, limitBytes int64, c kubernetes.Interface) (io.ReadCloser, error) {
+	mockLog := []byte(fmt.Sprintf("Writing pod log for pod %s and container %s", pod.Name, container.Name))
+	return &fakeReadCloser{bytes.NewReader(mockLog)}, nil
+}
+
+type fakeReadCloser struct {
+	io.Reader
+}
+
+func (r *fakeReadCloser) Close() error { return nil }


### PR DESCRIPTION
Improvements:
* let build log methods return channel to let the caller
  handle streamed log lines within its own goroutine.
* stream build log to long-term storage.
* change storage provider interface to stream data.

Closes #7422

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
improve build log stream

#### Special notes for the reviewer(s)

#### Which issue this PR fixes
fixes #7422