### PR TITLE
fix: check name of devEnv since devEnv never nil

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -486,7 +486,7 @@
       {
         "hashed_secret": "2978f389a32111504f1c3b39df2123be5c453020",
         "is_secret": true,
-        "line_number": 352,
+        "line_number": 359,
         "type": "Secret Keyword"
       }
     ],

--- a/pkg/cmd/add/add_app.go
+++ b/pkg/cmd/add/add_app.go
@@ -121,6 +121,9 @@ func (o *AddAppOptions) addFlags(cmd *cobra.Command, defaultNamespace string) {
 // Run implements this command
 func (o *AddAppOptions) Run() error {
 	o.GitOps, o.DevEnv = o.GetDevEnv()
+	if o.DevEnv == nil {
+		return helper.ErrDevEnvNotFound
+	}
 	if o.Repo == "" {
 		o.Repo = o.DevEnv.Spec.TeamSettings.AppsRepository
 	}

--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -505,7 +505,7 @@ func existingBootClone(dir string) (bool, error) {
 
 func (o *BootOptions) checkIfProvidedRequirementsArePossiblyStale() error {
 	_, devEnv := o.GetDevEnv()
-	if devEnv != nil {
+	if devEnv.Name != "" {
 		log.Logger().Warnf("It seems you're passing a requirements file to cluster which has already been provisioned.")
 		log.Logger().Warnf("We recommend you update the %s file at %s, using the updates provided within your local %s file.",
 			config.RequirementsConfigFileName, devEnv.Spec.Source, o.RequirementsFile)

--- a/pkg/cmd/boot/boot.go
+++ b/pkg/cmd/boot/boot.go
@@ -505,7 +505,7 @@ func existingBootClone(dir string) (bool, error) {
 
 func (o *BootOptions) checkIfProvidedRequirementsArePossiblyStale() error {
 	_, devEnv := o.GetDevEnv()
-	if devEnv.Name != "" {
+	if devEnv != nil {
 		log.Logger().Warnf("It seems you're passing a requirements file to cluster which has already been provisioned.")
 		log.Logger().Warnf("We recommend you update the %s file at %s, using the updates provided within your local %s file.",
 			config.RequirementsConfigFileName, devEnv.Spec.Source, o.RequirementsFile)

--- a/pkg/cmd/deletecmd/delete_app.go
+++ b/pkg/cmd/deletecmd/delete_app.go
@@ -85,6 +85,9 @@ func NewCmdDeleteApp(commonOpts *opts.CommonOptions) *cobra.Command {
 // Run implements this command
 func (o *DeleteAppOptions) Run() error {
 	o.GitOps, o.DevEnv = o.GetDevEnv()
+	if o.DevEnv == nil {
+		return helper.ErrDevEnvNotFound
+	}
 
 	installOptions := apps.InstallOptions{
 		IOFileHandles:       o.GetIOFileHandles(),

--- a/pkg/cmd/get/get_apps.go
+++ b/pkg/cmd/get/get_apps.go
@@ -104,6 +104,9 @@ func NewCmdGetApps(commonOpts *opts.CommonOptions) *cobra.Command {
 // Run implements this command
 func (o *GetAppsOptions) Run() error {
 	o.GitOps, o.DevEnv = o.GetDevEnv()
+	if o.DevEnv == nil {
+		return helper.ErrDevEnvNotFound
+	}
 	kubeClient, err := o.Options.KubeClient()
 	if err != nil {
 		return err

--- a/pkg/cmd/helper/error.go
+++ b/pkg/cmd/helper/error.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -15,7 +16,11 @@ const (
 	defaultErrorExitCode = 1
 )
 
-var fatalErrHandler = Fatal
+var (
+	// ErrDevEnvNotFound is an error representing when a dev environment can't be found.
+	ErrDevEnvNotFound = errors.New("the dev environment was not found")
+	fatalErrHandler   = Fatal
+)
 
 // BehaviorOnFatal allows you to override the default behavior when a fatal
 // error occurs, which is to call os.Exit(code). You can pass 'panic' as a function

--- a/pkg/cmd/opts/environments.go
+++ b/pkg/cmd/opts/environments.go
@@ -25,12 +25,12 @@ func (o *CommonOptions) GetDevEnv() (gitOps bool, devEnv *jenkinsv1.Environment)
 	jxClient, ns, err := o.JXClientAndDevNamespace()
 	if err != nil {
 		log.Logger().Warnf("when attempting to create jx client. %v", err)
-		return false, &jenkinsv1.Environment{}
+		return false, nil
 	} else {
 		devEnv, err := kube.GetDevEnvironment(jxClient, ns)
 		if err != nil {
 			log.Logger().Warnf("when attempting to load team settings. %v", err)
-			return false, &jenkinsv1.Environment{}
+			return false, nil
 		}
 		gitOps := false
 		if devEnv == nil {

--- a/pkg/cmd/step/create/step_create_values.go
+++ b/pkg/cmd/step/create/step_create_values.go
@@ -211,6 +211,9 @@ func (o *StepCreateValuesOptions) CreateValuesFile(secretURLClient secreturl.Cli
 	}
 	gitOpsURL := ""
 	gitOps, devEnv := o.GetDevEnv()
+	if devEnv == nil {
+		return helper.ErrDevEnvNotFound
+	}
 	if gitOps {
 		gitOpsURL = devEnv.Spec.Source.URL
 	}

--- a/pkg/cmd/step/scheduler/step_scheduler_config_apply.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_apply.go
@@ -62,6 +62,9 @@ func NewCmdStepSchedulerConfigApply(commonOpts *opts.CommonOptions) *cobra.Comma
 // Run implements this command
 func (o *StepSchedulerConfigApplyOptions) Run() error {
 	gitOps, devEnv := o.GetDevEnv()
+	if devEnv == nil {
+		return helper.ErrDevEnvNotFound
+	}
 	switch o.Agent {
 	case "prow":
 		jxClient, ns, err := o.JXClientAndDevNamespace()

--- a/pkg/cmd/step/scheduler/step_scheduler_config_migrate.go
+++ b/pkg/cmd/step/scheduler/step_scheduler_config_migrate.go
@@ -77,6 +77,9 @@ func NewCmdStepSchedulerConfigMigrate(commonOpts *opts.CommonOptions) *cobra.Com
 // Run implements this command
 func (o *StepSchedulerConfigMigrateOptions) Run() error {
 	gitOps, devEnv := o.GetDevEnv()
+	if devEnv == nil {
+		return helper.ErrDevEnvNotFound
+	}
 	jxClient, ns, err := o.JXClient()
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/cmd/upgrade/upgrade_addon_prow.go
+++ b/pkg/cmd/upgrade/upgrade_addon_prow.go
@@ -127,8 +127,10 @@ func (o *UpgradeAddonProwOptions) Run() error {
 
 // Upgrade Prow
 func (o *UpgradeAddonProwOptions) Upgrade() error {
-
 	isGitOps, devEnv := o.GetDevEnv()
+	if devEnv == nil {
+		return helper.ErrDevEnvNotFound
+	}
 	if isGitOps {
 		return o.UpgradeViaGitOps(devEnv)
 	}

--- a/pkg/cmd/upgrade/upgrade_apps.go
+++ b/pkg/cmd/upgrade/upgrade_apps.go
@@ -113,6 +113,9 @@ func NewCmdUpgradeApps(commonOpts *opts.CommonOptions) *cobra.Command {
 // Run implements the command
 func (o *UpgradeAppsOptions) Run() error {
 	o.GitOps, o.DevEnv = o.GetDevEnv()
+	if o.DevEnv == nil {
+		return helper.ErrDevEnvNotFound
+	}
 	if o.Repo == "" {
 		o.Repo = o.DevEnv.Spec.TeamSettings.AppsRepository
 	}


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
During boot, new installs were returning that the config was stale. Looking into it, it appears the function checking for this "staleness" assumed the returned environment could be `nil`. However, looking at the function that was called, it would never be `nil`. This PR just changes that check to make sure the returned environment has a name.

Closes #7432 