### PR TITLE
fix: default the DOCKER_REGISTRY_ORG env var

### DIFF
--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -869,6 +869,12 @@ func (o *StepCreateTaskOptions) modifyEnvVars(container *corev1.Container, globa
 			Value: o.DockerRegistry,
 		})
 	}
+	if kube.GetSliceEnvVar(envVars, "DOCKER_REGISTRY_ORG") == nil && o.DockerRegistryOrg != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "DOCKER_REGISTRY_ORG",
+			Value: o.DockerRegistryOrg,
+		})
+	}
 	if kube.GetSliceEnvVar(envVars, "BUILD_NUMBER") == nil {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "BUILD_NUMBER",
@@ -1284,6 +1290,9 @@ func getVersionFromFile(dir string) (string, error) {
 }
 
 func (o *StepCreateTaskOptions) setBuildVersion(projectConfig *config.ProjectConfig) error {
+	if o.DockerRegistryOrg == "" {
+		o.DockerRegistryOrg = o.GetDockerRegistryOrg(projectConfig, o.GitInfo)
+	}
 	if o.NoReleasePrepare || o.ViewSteps || o.EffectivePipeline || projectConfig.NoReleasePrepare {
 		return nil
 	}

--- a/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/add-env-to-default-in-buildpack/tasks.yml
@@ -36,6 +36,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -83,6 +85,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -144,6 +148,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -210,6 +216,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps-in-jenkins-x-yml/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -155,6 +159,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -223,6 +229,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -314,6 +322,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,6 +391,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -450,6 +462,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -519,6 +533,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -588,6 +604,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/append-and-prepend-stage-steps/tasks.yml
@@ -56,6 +56,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -132,6 +134,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -206,6 +210,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -280,6 +286,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -354,6 +362,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -428,6 +438,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -502,6 +514,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -576,6 +590,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -650,6 +666,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -724,6 +742,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -798,6 +818,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -872,6 +894,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -947,6 +971,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/command-as-multiline-script/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -159,6 +163,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -250,6 +256,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -317,6 +325,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containerOptions-at-top-level-of-buildpack/tasks.yml
@@ -56,6 +56,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -135,6 +137,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -212,6 +216,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -289,6 +295,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -366,6 +374,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -443,6 +453,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -520,6 +532,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -597,6 +611,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -674,6 +690,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -752,6 +770,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -829,6 +849,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/containeroptions-on-pipelineconfig/tasks.yml
@@ -56,6 +56,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -135,6 +137,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -212,6 +216,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -289,6 +295,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -366,6 +374,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -443,6 +453,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -520,6 +532,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -597,6 +611,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -674,6 +690,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -752,6 +770,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/correct-pipeline-stage-is-removed/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -155,6 +159,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -223,6 +229,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -314,6 +322,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,6 +391,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-buildpack/tasks.yml
@@ -32,6 +32,8 @@ items:
       - -c
       env:
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -77,6 +79,8 @@ items:
       - jx
       env:
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -138,6 +142,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -202,6 +208,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/default-in-jenkins-x-yml/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -155,6 +159,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -223,6 +229,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -314,6 +322,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,6 +391,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes-with-labels/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -155,6 +159,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -223,6 +229,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -314,6 +322,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,6 +391,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/distribute-parallel-across-nodes/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -155,6 +159,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -223,6 +229,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -314,6 +322,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,6 +391,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/from_yaml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/from_yaml/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -155,6 +159,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -223,6 +229,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -314,6 +322,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,6 +391,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack/tasks.yml
@@ -50,6 +50,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -116,6 +118,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -180,6 +184,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -244,6 +250,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -308,6 +316,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -374,6 +384,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -440,6 +452,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -505,6 +519,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -569,6 +585,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -634,6 +652,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/js_build_pack_with_yaml/tasks.yml
@@ -53,6 +53,8 @@ items:
         value: jenkins-x-bot
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -117,6 +119,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -181,6 +185,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -245,6 +251,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -309,6 +317,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -375,6 +385,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -440,6 +452,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -504,6 +518,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -569,6 +585,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
@@ -34,6 +34,8 @@ items:
       - name: BASE_WORKSPACE
         value: /workspace/source
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: jenkins-x
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -81,6 +83,8 @@ items:
       - name: BASE_WORKSPACE
         value: /workspace/source
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: jenkins-x
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -126,6 +130,8 @@ items:
       - name: BASE_WORKSPACE
         value: /workspace/source
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: jenkins-x
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -171,6 +177,8 @@ items:
       - name: BASE_WORKSPACE
         value: /workspace/source
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: jenkins-x
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -218,6 +226,8 @@ items:
       - name: BASE_WORKSPACE
         value: /workspace/source
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: jenkins-x
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -268,6 +278,8 @@ items:
       - name: BASE_WORKSPACE
         value: /workspace/source
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: jenkins-x
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -317,6 +329,8 @@ items:
       - name: BASE_WORKSPACE
         value: /workspace/source
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: jenkins-x
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -366,6 +380,8 @@ items:
       - name: BASE_WORKSPACE
         value: /workspace/source
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: jenkins-x
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -413,6 +429,8 @@ items:
       - name: BASE_WORKSPACE
         value: /workspace/source
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: jenkins-x
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/loop-in-buildpack-syntax/tasks.yml
@@ -56,6 +56,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -132,6 +134,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -206,6 +210,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -282,6 +288,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -360,6 +368,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -438,6 +448,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -514,6 +526,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -592,6 +606,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -670,6 +686,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -744,6 +762,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -818,6 +838,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -892,6 +914,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -966,6 +990,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -1040,6 +1066,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -1114,6 +1142,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -1189,6 +1219,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/maven_build_pack/tasks.yml
@@ -56,6 +56,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -132,6 +134,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -206,6 +210,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -280,6 +286,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -354,6 +362,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -428,6 +438,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -502,6 +514,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -576,6 +590,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -650,6 +666,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -725,6 +743,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -799,6 +819,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-agent-container-with-build-pack/tasks.yml
@@ -50,6 +50,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -116,6 +118,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -180,6 +184,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -244,6 +250,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-buildpack/tasks.yml
@@ -36,6 +36,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -83,6 +85,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -144,6 +148,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -210,6 +216,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-default-in-jenkins-x-yml/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -155,6 +159,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -223,6 +229,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -314,6 +322,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,6 +391,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/override-pod-template-env-var-extending-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-pod-template-env-var-extending-build-pack/tasks.yml
@@ -54,6 +54,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -128,6 +130,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -200,6 +204,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -272,6 +278,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -344,6 +352,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -416,6 +426,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -488,6 +500,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -560,6 +574,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -632,6 +648,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -705,6 +723,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -777,6 +797,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/override-pod-template-env-var/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-pod-template-env-var/tasks.yml
@@ -54,6 +54,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -128,6 +130,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -200,6 +204,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -272,6 +278,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -344,6 +352,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -416,6 +426,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -488,6 +500,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -560,6 +574,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -632,6 +648,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -705,6 +723,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -777,6 +797,8 @@ items:
         value: /workspace/xdg_config
       - name: _JAVA_OPTIONS
         value: something else
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override-steps/tasks.yml
@@ -56,6 +56,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -132,6 +134,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -206,6 +210,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -280,6 +286,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -354,6 +362,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -425,6 +435,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -499,6 +511,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -573,6 +587,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -647,6 +663,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -721,6 +739,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -796,6 +816,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/override_block_step/tasks.yml
@@ -50,6 +50,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -116,6 +118,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -180,6 +184,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -244,6 +250,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -308,6 +316,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -372,6 +382,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -436,6 +448,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -500,6 +514,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -564,6 +580,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/per_step_container_build_pack/tasks.yml
@@ -50,6 +50,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -116,6 +118,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -180,6 +184,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -244,6 +250,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -308,6 +316,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -372,6 +382,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -436,6 +448,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -500,6 +514,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -564,6 +580,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -629,6 +647,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/pipeline-timeout/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -155,6 +159,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -223,6 +229,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -314,6 +322,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,6 +391,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage-from-jenkins-x-yml/tasks.yml
@@ -36,6 +36,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -86,6 +88,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -150,6 +154,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -218,6 +224,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/remove-stage/tasks.yml
@@ -56,6 +56,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -132,6 +134,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -206,6 +210,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -280,6 +286,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -354,6 +362,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -429,6 +439,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps-in-jenkins-x-yml/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -155,6 +159,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -223,6 +229,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -314,6 +322,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,6 +391,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -450,6 +462,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/replace-stage-steps/tasks.yml
@@ -56,6 +56,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -132,6 +134,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -206,6 +210,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -280,6 +286,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -354,6 +362,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -428,6 +438,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -502,6 +514,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -577,6 +591,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/secret-in-pipelineconfig-env/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/secret-in-pipelineconfig-env/tasks.yml
@@ -46,6 +46,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -101,6 +103,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -170,6 +174,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -243,6 +249,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -339,6 +347,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -411,6 +421,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/set-agent-container-with-agentless-build-pack/tasks.yml
@@ -50,6 +50,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -116,6 +118,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -180,6 +184,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -244,6 +250,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/tolerations/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/tolerations/tasks.yml
@@ -41,6 +41,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -91,6 +93,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -155,6 +159,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -223,6 +229,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -314,6 +322,8 @@ items:
       - name: GIT_AUTHOR_NAME
         value: somebodyelse
       - name: DOCKER_REGISTRY
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,6 +391,8 @@ items:
         value: kube-system
       - name: XDG_CONFIG_HOME
         value: /workspace/xdg_config
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/volume-in-overrides/tasks.yml
@@ -56,6 +56,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -134,6 +136,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -210,6 +214,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -286,6 +292,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -362,6 +370,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -439,6 +449,8 @@ items:
         value: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
           -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
+      - name: DOCKER_REGISTRY_ORG
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND


### PR DESCRIPTION
so that pipelines can use an env var to refer to the docker registry org so that we can avoid the search/replace of skaffold -> kaniko in build packs

Signed-off-by: James Strachan <james.strachan@gmail.com>