### PR TITLE
fix: kaniko env vars

### DIFF
--- a/pkg/cmd/step/create/step_create_task.go
+++ b/pkg/cmd/step/create/step_create_task.go
@@ -1020,7 +1020,7 @@ func (o *StepCreateTaskOptions) modifyEnvVars(container *corev1.Container, globa
 		}
 	}
 
-	if isKanikoExecutorStep(container) && !o.NoKaniko {
+	if isKanikoExecutorStep(container) && !o.NoKaniko && kube.GetSliceEnvVar(envVars, "NO_GOOGLE_APPLICATION_CREDENTIALS") == nil {
 		if kube.GetSliceEnvVar(envVars, "GOOGLE_APPLICATION_CREDENTIALS") == nil {
 			envVars = append(envVars, corev1.EnvVar{
 				Name:  "GOOGLE_APPLICATION_CREDENTIALS",


### PR DESCRIPTION
allow a build pack to opt out of using the google kaniko secret for when folks use workload identity

Signed-off-by: James Strachan <james.strachan@gmail.com>