### PR TITLE
fix: Use $() instead of ${} for pipeline parameters

### DIFF
--- a/jenkins-x-bdd.yml
+++ b/jenkins-x-bdd.yml
@@ -64,7 +64,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-jx
-                  - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-jx:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -75,7 +75,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-nodejs
-                  - --destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-nodejs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -86,7 +86,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-maven
-                  - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-maven:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -97,7 +97,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-go
-                  - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -108,7 +108,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-go-nodejs
-                  - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-jx:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -158,11 +158,11 @@ pipelineConfig:
 
             steps:
               - name: e2e-tests
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: ./jx/bdd/static/ci.sh
 
               - name: stash-xml-report
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: jx
                 args:
                   - step
@@ -192,11 +192,11 @@ pipelineConfig:
                   - "Static_BDD_Tests"
 
               - name: clear-kubeconfig
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: rm ~/.kube/config
 
               - name: stash-html-report
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: jx
                 args:
                   - step

--- a/jenkins-x-boot-lh-ghe.yml
+++ b/jenkins-x-boot-lh-ghe.yml
@@ -63,7 +63,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-jx
-                  - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-jx:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -74,7 +74,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-nodejs
-                  - --destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-nodejs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -85,7 +85,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-maven
-                  - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-maven:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -96,7 +96,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-go
-                  - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -107,7 +107,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-go-nodejs
-                  - --destination=gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-go-nodejs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -156,7 +156,7 @@ pipelineConfig:
                     key: password
             steps:
               - name: boot-lh-ghe-e2e-tests
-                image: gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go-nodejs:$(inputs.params.version)
                 command: ./jx/bdd/boot-lh-ghe/ci.sh
 
               - name: generate-report
@@ -178,11 +178,11 @@ pipelineConfig:
                   - "BDD_Boot_LH_GHE_Tests"
 
               - name: clear-kubeconfig
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: rm ~/.kube/config
 
               - name: stash_html_report
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: jx
                 args:
                   - step

--- a/jenkins-x-boot-vault.yml
+++ b/jenkins-x-boot-vault.yml
@@ -63,7 +63,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-jx
-                  - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-jx:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -74,7 +74,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-nodejs
-                  - --destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-nodejs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -85,7 +85,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-maven
-                  - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-maven:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -96,7 +96,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-go
-                  - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -107,7 +107,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-go-nodejs
-                  - --destination=gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-go-nodejs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -156,7 +156,7 @@ pipelineConfig:
                     key: password
             steps:
               - name: boot-vault-e2e-tests
-                image: gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go-nodejs:$(inputs.params.version)
                 command: ./jx/bdd/boot-vault/ci.sh
 
               - name: generate-report
@@ -178,11 +178,11 @@ pipelineConfig:
                   - "BDD_Boot_Vault_Tests"
 
               - name: clear-kubeconfig
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: rm ~/.kube/config
 
               - name: stash_html_report
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: jx
                 args:
                   - step

--- a/jenkins-x-images.yml
+++ b/jenkins-x-images.yml
@@ -56,25 +56,25 @@ pipelineConfig:
 
               - name: build-and-push-image
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:$(inputs.params.version)','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-nodejs
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-nodejs','--destination=gcr.io/jenkinsxio/builder-nodejs:$(inputs.params.version)','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-maven
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-maven','--destination=gcr.io/jenkinsxio/builder-maven:$(inputs.params.version)','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-go
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go','--destination=gcr.io/jenkinsxio/builder-go:$(inputs.params.version)','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-go-maven
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go-maven','--destination=gcr.io/jenkinsxio/builder-go-maven:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-go-maven','--destination=gcr.io/jenkinsxio/builder-go-maven:$(inputs.params.version)','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 
               - name: build-and-push-ml
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile.builder-ml','--destination=gcr.io/jenkinsxio/builder-machine-learning:${inputs.params.version}','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
+                args: ['--dockerfile=/workspace/source/Dockerfile.builder-ml','--destination=gcr.io/jenkinsxio/builder-machine-learning:$(inputs.params.version)','--context=/workspace/source','--cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/','--cache=true','--cache-dir=/workspace','--skip-tls-verify-registry=jenkins-x-docker-registry.jx.svc.cluster.local:5000']
 

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -63,7 +63,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-jx
-                  - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-jx:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -74,7 +74,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-nodejs
-                  - --destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-nodejs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -85,7 +85,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-maven
-                  - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-maven:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -96,7 +96,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-go
-                  - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -107,7 +107,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-go-nodejs
-                  - --destination=gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-go-nodejs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -157,7 +157,7 @@ pipelineConfig:
 
             steps:
               - name: tekton-e2e-tests
-                image: gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go-nodejs:$(inputs.params.version)
                 command: ./jx/bdd/tekton/ci.sh
 
               - name: generate-report
@@ -179,11 +179,11 @@ pipelineConfig:
                   - "BDD_Tekton_Tests"
 
               - name: clear-kubeconfig
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: rm ~/.kube/config
 
               - name: stash-xml-report
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: jx
                 args:
                   - step
@@ -195,7 +195,7 @@ pipelineConfig:
                   - --bucket-url gs://jx-prod-logs
 
               - name: stash-html-report
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: jx
                 args:
                   - step

--- a/jenkins-x-tf-boot.yml
+++ b/jenkins-x-tf-boot.yml
@@ -63,7 +63,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-jx
-                  - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-jx:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -74,7 +74,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-nodejs
-                  - --destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-nodejs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -85,7 +85,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-maven
-                  - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-maven:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -96,7 +96,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-go
-                  - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -107,7 +107,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-go-nodejs
-                  - --destination=gcr.io/jenkinsxio/builder-go-nodejs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-go-nodejs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -118,7 +118,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.builder-terraform
-                  - --destination=gcr.io/jenkinsxio/builder-terraform:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/builder-terraform:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-repo=jenkins-x-docker-registry.jx.svc.cluster.local:5000/
                   - --cache=true
@@ -167,7 +167,7 @@ pipelineConfig:
                     key: password
             steps:
               - name: e2e-tests
-                image: gcr.io/jenkinsxio/builder-terraform:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-terraform:$(inputs.params.version)
                 command: ./jx/bdd/tf-boot/ci.sh
 
               - name: generate-report
@@ -189,7 +189,7 @@ pipelineConfig:
                   - "BDD_Terraform_Boot_Tests"
 
               - name: stash_html_report
-                image: gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                image: gcr.io/jenkinsxio/builder-go:$(inputs.params.version)
                 command: jx
                 args:
                   - step

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -86,7 +86,7 @@ pipelineConfig:
               - name: build-and-push-image
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
-                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:${inputs.params.version}','--destination=gcr.io/jenkinsxio/jx:latest','--context=/workspace/source','--cache-dir=/workspace']
+                args: ['--dockerfile=/workspace/source/Dockerfile','--destination=gcr.io/jenkinsxio/jx:$(inputs.params.version)','--destination=gcr.io/jenkinsxio/jx:latest','--context=/workspace/source','--cache-dir=/workspace']
 
               - name: release-charts
                 image: gcr.io/jenkinsxio/builder-go


### PR DESCRIPTION
Because Tekton 0.11 only supports $(). We work around this behind the scenes in steps, but not in image tags, so might as well just update it across the board to be safe.
