### PR TITLE
fix: fix changelog errors

### DIFF
--- a/pkg/cmd/step/step_changelog.go
+++ b/pkg/cmd/step/step_changelog.go
@@ -727,9 +727,8 @@ func (o *StepChangelogOptions) addIssuesAndPullRequests(spec *v1.ReleaseSpec, co
 				} else {
 					u, err := resolver.Resolve(issue.User)
 					if err != nil {
-						return err
-					}
-					if u != nil {
+						log.Logger().Warnf("Failed to resolve user %v for issue %s repository %s", issue.User, result, tracker.HomeURL())
+					} else if u != nil {
 						user = u.Spec
 					}
 				}
@@ -740,9 +739,8 @@ func (o *StepChangelogOptions) addIssuesAndPullRequests(spec *v1.ReleaseSpec, co
 				} else {
 					u, err := resolver.Resolve(issue.User)
 					if err != nil {
-						return err
-					}
-					if u != nil {
+						log.Logger().Warnf("Failed to resolve closedBy user %v for issue %s repository %s", issue.User, result, tracker.HomeURL())
+					} else if u != nil {
 						closedBy = u.Spec
 					}
 				}
@@ -753,7 +751,7 @@ func (o *StepChangelogOptions) addIssuesAndPullRequests(spec *v1.ReleaseSpec, co
 				} else {
 					u, err := resolver.GitUserSliceAsUserDetailsSlice(issue.Assignees)
 					if err != nil {
-						return err
+						log.Logger().Warnf("Failed to resolve Assignees %v for issue %s repository %s", issue.Assignees, result, tracker.HomeURL())
 					}
 					assignees = u
 				}

--- a/pkg/users/git.go
+++ b/pkg/users/git.go
@@ -87,14 +87,18 @@ func (r *GitUserResolver) Resolve(user *gits.GitUser) (*jenkinsv1.User, error) {
 			}
 		}
 		new := r.GitUserToUser(gitUser)
-		id = naming.ToValidName(gitUser.Login)
+		login := gitUser.Login
+		if login == "" {
+			login = gitUser.Name
+		}
+		id = naming.ToValidName(login)
 		// Check if the user id is available, if not append "-<n>" where <n> is some integer
 		for i := 0; true; i++ {
 			_, err := r.JXClient.JenkinsV1().Users(r.Namespace).Get(id, v1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
 				break
 			}
-			id = fmt.Sprintf("%s-%d", gitUser.Login, i)
+			id = fmt.Sprintf("%s-%d", login, i)
 		}
 		new.Name = naming.ToValidName(id)
 		return id, possibles, new, nil


### PR DESCRIPTION
see https://github.com/jenkins-x/jx/issues/6879

lets try do a better job of defaulting the user login name if there's no login but there is a name + lets treat resolve errors as warnings; as not having the user in a CRD isn't the end of the world; we still want the commits in the release notes + to not fail generating the changelog

Signed-off-by: James Strachan <james.strachan@gmail.com>