### PR TITLE
fix: Set HELM_HOME to /tekton/home/.helm

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -24,7 +24,7 @@ pipelineConfig:
               - name: BASE_WORKSPACE
                 value: /workspace/source
               - name: HELM_HOME
-                value: /builder/home/.helm
+                value: /tekton/home/.helm
               - name: GOPATH
                 value: /workspace/go
               - name: GOPROXY


### PR DESCRIPTION
`/builder/home` is now `/tekton/home` since we've upgraded to Tekton 0.11.3, so the old path is breaking release builds.
