### PR TITLE
fix: Increase max age of PipelineRuns for GCing

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -126,7 +126,7 @@ pipelineConfig:
                 - --version
                 - $VERSION
                 - --build
-                - "make mod"
+                - "\"make mod\""
                 - --repo
                 - https://github.com/jenkins-x/lighthouse.git
                 # Disable GOPROXY for go module updates to deal with go 1.13 semver resolution issue
@@ -147,7 +147,7 @@ pipelineConfig:
                 - --version
                 - $VERSION
                 - --build
-                - "make build"
+                - "\"make build\""
                 - --repo
                 - https://github.com/cloudbees/jxui-backend.git
                 # Disable GOPROXY for go module updates to deal with go 1.13 semver resolution issue

--- a/pkg/cmd/gc/gc_activities.go
+++ b/pkg/cmd/gc/gc_activities.go
@@ -105,7 +105,7 @@ func NewCmdGCActivities(commonOpts *opts.CommonOptions) *cobra.Command {
 	cmd.Flags().IntVarP(&options.PullRequestHistoryLimit, "pr-history-limit", "", 2, "Minimum number of PipelineActivities to keep around per repository Pull Request")
 	cmd.Flags().DurationVarP(&options.PullRequestAgeLimit, "pull-request-age", "p", time.Hour*48, "Maximum age to keep PipelineActivities for Pull Requests")
 	cmd.Flags().DurationVarP(&options.ReleaseAgeLimit, "release-age", "r", time.Hour*24*30, "Maximum age to keep PipelineActivities for Releases")
-	cmd.Flags().DurationVarP(&options.PipelineRunAgeLimit, "pipelinerun-age", "", time.Hour*2, "Maximum age to keep completed PipelineRuns for all pipelines")
+	cmd.Flags().DurationVarP(&options.PipelineRunAgeLimit, "pipelinerun-age", "", time.Hour*12, "Maximum age to keep completed PipelineRuns for all pipelines")
 	cmd.Flags().DurationVarP(&options.ProwJobAgeLimit, "prowjob-age", "", time.Hour*24*7, "Maximum age to keep completed ProwJobs for all pipelines")
 	return cmd
 }
@@ -258,7 +258,7 @@ func (o *GCActivitiesOptions) gcPipelineRuns(ns string) error {
 	for _, pr := range runList.Items {
 		pipelineRun := pr
 		completionTime := pipelineRun.Status.CompletionTime
-		if completionTime != nil && completionTime.Add(o.PipelineRunAgeLimit).Before(now) {
+		if pipelineRun.IsDone() && completionTime != nil && completionTime.Add(o.PipelineRunAgeLimit).Before(now) {
 			err = o.deletePipelineRun(pipelineRunInterface, &pipelineRun)
 			if err != nil {
 				return err


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

In practice, this results in builds that take longer than the max age sometimes (though not always) failing to get their status actually recorded properly. So let's increase that age, and also add a check to make sure the `PipelineRun` is in a terminal state before we even consider deleting it.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #7444 
