### PR TITLE
fix(pencil): Fixed up local unit test failures for empty commits for …

### DIFF
--- a/pkg/gits/errors.go
+++ b/pkg/gits/errors.go
@@ -15,6 +15,19 @@ func IsEmptyCommitError(err error) bool {
 Otherwise, please use 'git reset'`)
 }
 
+// IsEmptyCherryPickCommitError checks if the error during git cherry-pick is caused by the commit being empty at the end of the cherry-pick
+func IsEmptyCherryPickCommitError(err error) bool {
+	if err != nil {
+		s := err.Error()
+		return strings.Contains(s, `If you wish to commit it anyway, use:
+
+    git commit --allow-empty
+
+Otherwise, please use 'git cherry-pick --skip'`)
+	}
+	return false
+}
+
 // IsRepositoryNotExportedError checks if the clone error happens because the repository is not exported
 func IsRepositoryNotExportedError(err error) bool {
 	if err == nil {

--- a/pkg/gits/helpers.go
+++ b/pkg/gits/helpers.go
@@ -680,7 +680,7 @@ func ForkAndPullRepo(gitURL string, dir string, baseRef string, branchName strin
 	for _, c := range toCherryPick {
 		err = gitter.CherryPick(dir, c.SHA)
 		if err != nil {
-			if IsEmptyCommitError(err) {
+			if IsEmptyCherryPickCommitError(err) {
 				log.Logger().Debugf("  Ignoring %s as is empty", c.OneLine())
 				err = gitter.Reset(dir, "", true)
 				if err != nil {

--- a/pkg/gits/helpers_test.go
+++ b/pkg/gits/helpers_test.go
@@ -380,7 +380,7 @@ func TestNewForkAndNewDir(t *testing.T) {
 		},
 	})
 }
-func TestNoFormAndExistingDir(t *testing.T) {
+func TestNoForkAndExistingDir(t *testing.T) {
 
 	runForkAndPullTestCase(t, forkAndPullTest{
 		name: "noForkAndExistingDir",


### PR DESCRIPTION
…git cherry picks vs git rebases producing different error message text


#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description

Unit test fails locally because error message produced  from a cherry picked empty commit is different  from the rebase variant. Modifying tests and underlying implementation to detect this.

#### Special notes for the reviewer(s)

Unsure why this doesn't appear to reflect in a successful unit  pipeline run, but this certainly has been failing locally for a while (if I step back in git history locally). Perhaps something to do with my local git version? But having checked the git c source code latest master branch there are definitely differences in these git error messages. Are we locked in to a specific git version for jx?
