### PR TITLE
fix: Hardcode DOCKER_REGISTRY_ORG for certain tests

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -113,7 +113,7 @@ pipelineConfig:
                 - --repo
                 - https://github.com/jenkins-x/jenkins-x-builders-ml.git
 
-              - name: update-lighthouse
+              - name: update-lighthouse-jx
                 image: gcr.io/jenkinsxio/builder-go
                 command: jx
                 args:
@@ -128,7 +128,7 @@ pipelineConfig:
                 - --build
                 - "\"make mod\""
                 - --repo
-                - https://github.com/jenkins-x/lighthouse.git
+                - https://github.com/jenkins-x/lighthouse-jx-controller.git
                 # Disable GOPROXY for go module updates to deal with go 1.13 semver resolution issue
                 env:
                 - name: GOPROXY

--- a/pkg/cmd/preview/preview_test.go
+++ b/pkg/cmd/preview/preview_test.go
@@ -17,6 +17,18 @@ import (
 
 func TestGetPreviewValuesConfig(t *testing.T) {
 	t.Parallel()
+
+	// Override the DOCKER_REGISTRY_ORG env var for CI consistency
+	origDRO := os.Getenv("DOCKER_REGISTRY_ORG")
+	os.Setenv("DOCKER_REGISTRY_ORG", "my-org")
+	defer func() {
+		if origDRO != "" {
+			os.Setenv("DOCKER_REGISTRY_ORG", origDRO)
+		} else {
+			os.Unsetenv("DOCKER_REGISTRY_ORG")
+		}
+	}()
+
 	tests := []struct {
 		opts               preview.PreviewOptions
 		env                map[string]string

--- a/pkg/cmd/step/create/step_create_task_test.go
+++ b/pkg/cmd/step/create/step_create_task_test.go
@@ -74,6 +74,17 @@ func TestGenerateTektonCRDs(t *testing.T) {
 	_, err = os.Stat(packsDir)
 	assert.NoError(t, err)
 
+	// Override the DOCKER_REGISTRY_ORG env var for CI consistency
+	origDRO := os.Getenv("DOCKER_REGISTRY_ORG")
+	os.Setenv("DOCKER_REGISTRY_ORG", "abayer")
+	defer func() {
+		if origDRO != "" {
+			os.Setenv("DOCKER_REGISTRY_ORG", origDRO)
+		} else {
+			os.Unsetenv("DOCKER_REGISTRY_ORG")
+		}
+	}()
+
 	rand.Seed(12345)
 
 	resolver := func(importFile *jenkinsfile.ImportFile) (string, error) {

--- a/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
+++ b/pkg/cmd/step/create/test_data/step_create_task/kaniko_entrypoint/tasks.yml
@@ -35,7 +35,7 @@ items:
         value: /workspace/source
       - name: DOCKER_REGISTRY
       - name: DOCKER_REGISTRY_ORG
-        value: jenkins-x
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -84,7 +84,7 @@ items:
         value: /workspace/source
       - name: DOCKER_REGISTRY
       - name: DOCKER_REGISTRY_ORG
-        value: jenkins-x
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -131,7 +131,7 @@ items:
         value: /workspace/source
       - name: DOCKER_REGISTRY
       - name: DOCKER_REGISTRY_ORG
-        value: jenkins-x
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -178,7 +178,7 @@ items:
         value: /workspace/source
       - name: DOCKER_REGISTRY
       - name: DOCKER_REGISTRY_ORG
-        value: jenkins-x
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -227,7 +227,7 @@ items:
         value: /workspace/source
       - name: DOCKER_REGISTRY
       - name: DOCKER_REGISTRY_ORG
-        value: jenkins-x
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -279,7 +279,7 @@ items:
         value: /workspace/source
       - name: DOCKER_REGISTRY
       - name: DOCKER_REGISTRY_ORG
-        value: jenkins-x
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -330,7 +330,7 @@ items:
         value: /workspace/source
       - name: DOCKER_REGISTRY
       - name: DOCKER_REGISTRY_ORG
-        value: jenkins-x
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -381,7 +381,7 @@ items:
         value: /workspace/source
       - name: DOCKER_REGISTRY
       - name: DOCKER_REGISTRY_ORG
-        value: jenkins-x
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND
@@ -430,7 +430,7 @@ items:
         value: /workspace/source
       - name: DOCKER_REGISTRY
       - name: DOCKER_REGISTRY_ORG
-        value: jenkins-x
+        value: abayer
       - name: BUILD_NUMBER
         value: "1"
       - name: PIPELINE_KIND

--- a/pkg/cmd/step/syntax/step_syntax_effective_test.go
+++ b/pkg/cmd/step/syntax/step_syntax_effective_test.go
@@ -59,6 +59,17 @@ func TestCreateCanonicalPipeline(t *testing.T) {
 	_, err = os.Stat(packsDir)
 	assert.NoError(t, err)
 
+	// Override the DOCKER_REGISTRY_ORG env var for CI consistency
+	origDRO := os.Getenv("DOCKER_REGISTRY_ORG")
+	os.Setenv("DOCKER_REGISTRY_ORG", "abayer")
+	defer func() {
+		if origDRO != "" {
+			os.Setenv("DOCKER_REGISTRY_ORG", origDRO)
+		} else {
+			os.Unsetenv("DOCKER_REGISTRY_ORG")
+		}
+	}()
+
 	resolver := func(importFile *jenkinsfile.ImportFile) (string, error) {
 		dirPath := []string{packsDir, "import_dir", importFile.Import}
 		// lets handle cross platform paths in `importFile.File`


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

If `DOCKER_REGISTRY_ORG` is set in the environment the test is being run in, it'll end up overriding what's expected in the test results, so let's override the env var to be safe.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

n/a