### PR TITLE
feat(pipelines): add support for Tekton Sidecar containers

### DIFF
--- a/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
+++ b/pkg/tekton/syntax/syntax_helpers_test/test_helpers.go
@@ -160,6 +160,16 @@ func PipelineOptions(ops ...PipelineOptionsOp) PipelineOp {
 	}
 }
 
+// PipelineSidecar adds a sidecar container to the RootOptions for the pipeline
+func PipelineSidecar(sidecar *corev1.Container) PipelineOptionsOp {
+	return func(options *syntax.RootOptions) {
+		if options.Sidecars == nil {
+			options.Sidecars = []*corev1.Container{}
+		}
+		options.Sidecars = append(options.Sidecars, sidecar)
+	}
+}
+
 // PipelineVolume adds a volume to the RootOptions for the pipeline
 func PipelineVolume(volume *corev1.Volume) PipelineOptionsOp {
 	return func(options *syntax.RootOptions) {
@@ -167,6 +177,19 @@ func PipelineVolume(volume *corev1.Volume) PipelineOptionsOp {
 			options.Volumes = []*corev1.Volume{}
 		}
 		options.Volumes = append(options.Volumes, volume)
+	}
+}
+
+// StageSidecar adds a sidecar to the StageOptions for the stage
+func StageSidecar(sidecar *corev1.Container) StageOptionsOp {
+	return func(options *syntax.StageOptions) {
+		if options.RootOptions == nil {
+			options.RootOptions = &syntax.RootOptions{}
+		}
+		if options.Sidecars == nil {
+			options.Sidecars = []*corev1.Container{}
+		}
+		options.Sidecars = append(options.Sidecars, sidecar)
 	}
 }
 

--- a/pkg/tekton/syntax/test_data/sidecars/jenkins-x.yml
+++ b/pkg/tekton/syntax/test_data/sidecars/jenkins-x.yml
@@ -1,0 +1,32 @@
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        options:
+          sidecars:
+            - name: top-level-sidecar
+              image: top-level/sidecar:tag
+        agent:
+          image: some-image
+        stages:
+          - name: A Working Stage
+            options:
+              sidecars:
+                - name: stage-level-sidecar
+                  image: stage-level/sidecar:latest
+                  volumeMounts:
+                    - name: shared-volume
+                      mountPath: /shared
+              volumes:
+                - name: shared-volume
+                  emptyDir: {}
+              containerOptions:
+                volumeMounts:
+                  - name: shared-volume
+                    mountPath: /mnt/shared
+            steps:
+              - command: echo
+                args:
+                  - hello
+                  - world
+                name: A Step With Spaces And Such


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Adding support for [Tekton Sidecars](https://github.com/tektoncd/pipeline/blob/v0.11.3/docs/taskruns.md#sidecars) at the pipeline and/or stage level - in the options:

```
pipelineConfig:
  pipelines:
    release:
      pipeline:
        options:
          sidecars:
            - name: top-level-sidecar
              image: top-level/sidecar:tag
        stages:
          - name: my-stage
            options:
              sidecars:
                - name: stage-level-sidecar
                  image: stage-level/sidecar:latest
```

#### Special notes for the reviewer(s)

- Note that as of Tekton 0.11.3 (current version of Tekton used by jx), sidecars have a few known bugs: https://github.com/tektoncd/pipeline/blob/v0.11.3/docs/taskruns.md#sidecars
- PR to update the docs: https://github.com/jenkins-x/jx-docs/pull/3001

#### Which issue this PR fixes

fixes #7488

