### PR TITLE
fix: support ingress.ignoreLoadBalancer flag

### DIFF
--- a/pkg/cmd/step/verify/step_verify_ingress.go
+++ b/pkg/cmd/step/verify/step_verify_ingress.go
@@ -199,6 +199,10 @@ func (o *StepVerifyIngressOptions) Run() error {
 }
 
 func (o *StepVerifyIngressOptions) discoverIngressDomain(requirements *config.RequirementsConfig, requirementsFileName string) error {
+	if requirements.Ingress.IgnoreLoadBalancer {
+		log.Logger().Infof("ignoring the load balancer to detect a public ingress domain")
+		return nil
+	}
 	client, err := o.KubeClient()
 	var domain string
 	if err != nil {


### PR DESCRIPTION
so that we can disable waiting for the load balancer IP

Signed-off-by: James Strachan <james.strachan@gmail.com>