### PR TITLE
docs: fix broken link for create cluster demo

### DIFF
--- a/pkg/cmd/create/create_cluster.go
+++ b/pkg/cmd/create/create_cluster.go
@@ -56,7 +56,7 @@ var (
 	CreateClusterLong = templates.LongDesc(`
 		This command creates a new Kubernetes cluster, installing required local dependencies and provisions the Jenkins X platform
 
-		You can see a demo of this command here: [https://jenkins-x.io/demos/create_cluster/](https://jenkins-x.io/demos/create_cluster/)
+		You can see a demo of this command here: [https://jenkins-x.io/demos/create_cluster/](https://jenkins-x.io/docs/resources/demos-talks-posts/create_cluster/)
 
 		%s
 


### PR DESCRIPTION
#### Submitter checklist 

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Updating broken link in `jx create cluster` command description. Changing link to [new link](https://jenkins-x.io/docs/resources/demos-talks-posts/create_cluster/) for create cluster demo. It might also be a better approach to completely remove the link to prevent this from happening in the future if the website changes.

#### Special notes for the reviewer(s)

None

#### Which issue this PR fixes

N/A
