### PR TITLE
fix: update eksctl binary to the latest stable version

### DIFF
--- a/pkg/packages/packages.go
+++ b/pkg/packages/packages.go
@@ -23,7 +23,7 @@ const IBMCloudVersion = "0.10.1"
 const IamAuthenticatorAwsVersion = "1.12.7"
 
 // EksCtlVersion binary version to use
-const EksCtlVersion = "0.11.1"
+const EksCtlVersion = "0.25.0"
 
 // KubectlVersion binary version to use
 const KubectlVersion = "1.16.5"


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>


#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
This is required to support newer regions like cn-north-1 (we could have used anything greater than 0.15.0 to support that region, but subsequent versions add support for other regions as well as newer K8s versions)

#### Which issue this PR fixes

fixes #7528