### PR TITLE
fix: add a flag to keep namespaces when uninstalling jx

### DIFF
--- a/pkg/cmd/uninstall/uninstall_test.go
+++ b/pkg/cmd/uninstall/uninstall_test.go
@@ -116,7 +116,7 @@ func TestUninstallOptions_Run_ContextSpecifiedViaCli_FailsWhenContextNamesDoNotM
 	donec := make(chan struct{})
 	go func() {
 		defer close(donec)
-		console.ExpectString("Uninstall JX - this command will remove all JX components and delete all namespaces created by Jenkins X. Do you wish to continue?")
+		console.ExpectString("Uninstall JX - this command will remove all JX components and delete all namespaces (if keep-namespaces is set to false) created by Jenkins X. Do you wish to continue?")
 		console.SendLine("Y")
 		console.ExpectString("This action will permanently delete Jenkins X from the Kubernetes context current-context. Please type in the name of the context to confirm:")
 		console.SendLine("target-context")
@@ -159,7 +159,7 @@ func TestUninstallOptions_Run_ContextSpecifiedViaCli_PassWhenContextNamesMatch(t
 	//noinspection GoUnhandledErrorResult
 	go func() {
 		defer close(donec)
-		console.ExpectString("Uninstall JX - this command will remove all JX components and delete all namespaces created by Jenkins X. Do you wish to continue?")
+		console.ExpectString("Uninstall JX - this command will remove all JX components and delete all namespaces (if keep-namespaces is set to false) created by Jenkins X. Do you wish to continue?")
 		console.SendLine("Y")
 		console.ExpectString("This action will permanently delete Jenkins X from the Kubernetes context correct-context-to-delete. Please type in the name of the context to confirm:")
 		console.SendLine("correct-context-to-delete")


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
Added a flag `keep-namespaces` to uninstall (by default, it deletes all the namespaces). This will ensure that namespaces are not deleted. The namespaces are created in terraform, so I think we should not delete them. However, I dont want to add a breaking change to the jx2 codebase. So this is a way to maintain compatibility.

#### Which issue this PR fixes

fixes #7523