### PR TITLE
fix: broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ JX is a command line tool for installing and using [Jenkins X](https://jenkins-x
 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3237/badge)](https://bestpractices.coreinfrastructure.org/projects/3237)
 [![GoDoc](https://godoc.org/github.com/jenkins-x/jx?status.svg)](https://godoc.org/github.com/jenkins-x/jx)
-[![Docs](https://readthedocs.org/projects/docs/badge/?version=latest)](https://jenkins-x.io/documentation/)
+[![Docs](https://readthedocs.org/projects/docs/badge/?version=latest)](https://jenkins-x.io/docs/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/jenkinsxio/jx.svg)](https://hub.docker.com/r/jenkinsxio/jx/tags)
 [![Downloads](https://img.shields.io/github/downloads/jenkins-x/jx/total.svg)](https://github.com/jenkins-x/jx/releases)
 [![GoReport](https://goreportcard.com/badge/github.com/jenkins-x/jx)](https://goreportcard.com/report/github.com/jenkins-x/jx)


### PR DESCRIPTION
#### Which issue this PR fixes

https://jenkins-x.io/documentation/ 404
