### PR TITLE
fix: Bring back config refdocs generation

### DIFF
--- a/Makefile.codegen
+++ b/Makefile.codegen
@@ -49,6 +49,14 @@ generate-docs: build-codegen ## Generate the docs
 install-refdocs:
 	$(GO) get github.com/jenkins-x/gen-crd-api-reference-docs
 
+generate-refdocs: generate-config-refdocs
+
+generate-config-refdocs:
+	${GOPATH}/bin/gen-crd-api-reference-docs -config "docs/configdocs/config.json" \
+	-template-dir docs/configdocs/templates \
+    -api-dir "./pkg/config" \
+    -out-file docs/config.md
+
 stash:
 	# Making sure repo has no outstanding changes
 	git stash


### PR DESCRIPTION
This got moved to jx-api, but won't actually _work_ there, so we need to bring it back into jx.git or the docs site will never get automatically updated.
