### PR TITLE
fix: step next-version and helm 3

### DIFF
--- a/pkg/cmd/step/step_next_version.go
+++ b/pkg/cmd/step/step_next_version.go
@@ -391,9 +391,11 @@ func (o *StepNextVersionOptions) SetVersion() error {
 
 	lines := strings.Split(string(b), "\n")
 
+	replaced := false
 	for i, line := range lines {
-		if strings.Contains(line, matchField) {
+		if !replaced && strings.Contains(line, matchField) {
 			lines[i] = regex.ReplaceAllString(line, o.NewVersion)
+			replaced = true
 		} else {
 			lines[i] = line
 		}

--- a/pkg/cmd/step/test_data/next_version/helm3/Chart.yaml
+++ b/pkg/cmd/step/test_data/next_version/helm3/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: test
+home: https://github.com/rawlingsj/test
+version: 0.0.1-SNAPSHOT
+description: test
+maintainers:
+  - name: fabric8 Team
+    email: fabric8@googlegroups.com
+dependencies:
+- name: some-chart
+  version: 2.0.0
+  repository: https://repo.example.com/

--- a/pkg/cmd/step/test_data/next_version/helm3/expected_Chart.yaml
+++ b/pkg/cmd/step/test_data/next_version/helm3/expected_Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: test
+home: https://github.com/rawlingsj/test
+version: 1.2.3
+description: test
+maintainers:
+  - name: fabric8 Team
+    email: fabric8@googlegroups.com
+dependencies:
+- name: some-chart
+  version: 2.0.0
+  repository: https://repo.example.com/


### PR DESCRIPTION
#### Description

This makes the `jx step next-version` command compatible with Helm 3 when it reads/writes `Chart.yaml` files.

#### Special notes for the reviewer(s)

When the `jx step next-version` command reads the version from a Chart.yaml file, it looks for the `version` string, reads the value and stops there.
But when it writes a version in a Chart.yaml file, it replaces all the values following the `version` string.
This was not an issue with Helm 2, because there used to be a single `version` field in the Chart.yaml file.
But in Helm 3, the dependencies have been moved inside the Chart.yaml file, which means that each dependency now has a `version` field.
As a result, when the `jx step next-version` updates a version, it replaces all versions (including the dependencies) with the new value - which is incorrect.

This commit fixes this behavior by stopping after the first replacement. It expects people to write the main chart version before the dependencies - which is already the expectation for the GetVersion func anyway, so now both reading and writing the version have the same behavior.

#### Which issue this PR fixes

fixes #7564

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.
