### PR TITLE
fix: fixes #7574: import from gitlab with complicated project name

### DIFF
--- a/pkg/gits/gitlab.go
+++ b/pkg/gits/gitlab.go
@@ -199,7 +199,7 @@ func (g *GitlabProvider) projectId(org, username, name string) (string, error) {
 	}
 
 	for _, repo := range repos {
-		if repo.Name == name {
+		if repo.Path == name {
 			return strconv.Itoa(repo.ID), nil
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Youssef El Houti <youssef.elhouti@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
The projectId was retrieved by checking the `SourceRepositorySpec.Repo` against Project.Name instead we should check against: `Project.Path` to work also for more complicated project names with upper case spaces...


#### Which issue this PR fixes

fixes #7574 

