### PR TITLE
fix: set a bigger memory limit for the meta-pipeline

### DIFF
--- a/pkg/tekton/metapipeline/metapipeline.go
+++ b/pkg/tekton/metapipeline/metapipeline.go
@@ -148,7 +148,7 @@ func createPipeline(params CRDCreationParameters) (*syntax.ParsedPipeline, error
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							"cpu":    resource.MustParse("0.8"),
-							"memory": resource.MustParse("512Mi"),
+							"memory": resource.MustParse("1024Mi"),
 						},
 						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse("0.4"),


### PR DESCRIPTION
the previous default value (512M) was not enough to run `git fetch` on big repositories

fixes #7577