### PR TITLE
fix: corrected funky find charts logic

### DIFF
--- a/pkg/cmd/step/step_tag.go
+++ b/pkg/cmd/step/step_tag.go
@@ -300,10 +300,11 @@ func (o *StepTagOptions) findChartsDir() (string, error) {
 		if appName != "" && paths[len(paths)-2] == appName {
 			r -= 1
 		}
+		log.Logger().Debugf("ranked %s at %d", file, r)
 		return r
 	}
 	less := func(i, j int) bool {
-		return rank(files[i]) < rank(files[j]) || files[i] < files[j]
+		return rank(files[i]) < rank(files[j])
 	}
 	sort.Slice(files, less)
 	// check the most likely file

--- a/pkg/cmd/step/step_tag_test.go
+++ b/pkg/cmd/step/step_tag_test.go
@@ -167,3 +167,39 @@ func TestFindChartsDir(t *testing.T) {
 	assert.Equal(t, chartsDir, val)
 	assert.NoError(t, os.Unsetenv("REPO_NAME"))
 }
+
+func TestFindBestFitChart(t *testing.T) {
+	testData := path.Join("test_data", "step_tag_find_best_fit_chart")
+	dir, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(dir)
+	assert.NoError(t, os.Chdir(testData))
+
+	if val, ok := os.LookupEnv("APP_NAME"); ok {
+		assert.NoError(t, os.Unsetenv("APP_NAME"))
+		defer os.Setenv("APP_NAME", val)
+	} else {
+		defer os.Unsetenv("APP_NAME")
+	}
+	if val, ok := os.LookupEnv("REPO_NAME"); ok {
+		assert.NoError(t, os.Unsetenv("REPO_NAME"))
+		defer os.Setenv("REPO_NAME", val)
+	} else {
+		defer os.Unsetenv("REPO_NAME")
+	}
+
+	chartsDir := filepath.Join("charts", "my-project") + "/"
+	o := StepTagOptions{}
+
+	assert.NoError(t, os.Setenv("APP_NAME", "My.Project"))
+	val, err := o.findChartsDir()
+	assert.NoError(t, err)
+	assert.Equal(t, chartsDir, val)
+	assert.NoError(t, os.Unsetenv("APP_NAME"))
+
+	assert.NoError(t, os.Setenv("REPO_NAME", "my-project"))
+	val, err = o.findChartsDir()
+	assert.NoError(t, err)
+	assert.Equal(t, chartsDir, val)
+	assert.NoError(t, os.Unsetenv("REPO_NAME"))
+}

--- a/pkg/cmd/step/test_data/step_tag_find_best_fit_chart/charts-v1/my-project/Chart.yaml
+++ b/pkg/cmd/step/test_data/step_tag_find_best_fit_chart/charts-v1/my-project/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: my-project
+version: 0.1.0-SNAPSHOT
+appVersion: 0.1.0-SNAPSHOT

--- a/pkg/cmd/step/test_data/step_tag_find_best_fit_chart/charts/my-project/Chart.yaml
+++ b/pkg/cmd/step/test_data/step_tag_find_best_fit_chart/charts/my-project/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: my-project
+version: 0.1.0-SNAPSHOT
+appVersion: 0.1.0-SNAPSHOT


### PR DESCRIPTION
#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

findChartsDir() logic is messed up by an or checking if the file path is greater than the other. Which completely voids the use of the rank() method.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes https://github.com/jenkins-x/jx/issues/7591
