### PR TITLE
fix: use conventional commit message for 'jx step tag'

### DIFF
--- a/pkg/cmd/step/step_tag.go
+++ b/pkg/cmd/step/step_tag.go
@@ -55,7 +55,7 @@ var (
 
 		This commands effectively runs:
 
-		    $ git commit -a -m "release $(VERSION)" --allow-empty
+		    $ git commit -a -m "chore: release $(VERSION)" --allow-empty
 		    $ git tag -fa v$(VERSION) -m "Release version $(VERSION)"
 		    $ git push origin v$(VERSION)
 
@@ -142,12 +142,12 @@ func (o *StepTagOptions) Run() error {
 
 	tag := "v" + o.Flags.Version
 	log.Logger().Debugf("performing git commit")
-	err = o.Git().AddCommit("", fmt.Sprintf("release %s", o.Flags.Version))
+	err = o.Git().AddCommit("", fmt.Sprintf("chore: release %s", o.Flags.Version))
 	if err != nil {
 		return err
 	}
 
-	err = o.Git().CreateTag("", tag, fmt.Sprintf("release %s", o.Flags.Version))
+	err = o.Git().CreateTag("", tag, fmt.Sprintf("Release version %s", o.Flags.Version))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.

#### Description
When there is a relase, its commit message doesn't follow conventional commit convention, which is visible in release changelogs.

<img width="691" alt="image" src="https://user-images.githubusercontent.com/52448671/101528206-48d5a680-398f-11eb-80c2-32ae45c29d3b.png">
