### PR TITLE
fix: update helm to v2.17.0 to fix the dead helm repo https://storage.googleapis.com/chartmuseum.jenkins-x.io

### DIFF
--- a/pkg/packages/packages.go
+++ b/pkg/packages/packages.go
@@ -29,7 +29,7 @@ const EksCtlVersion = "0.25.0"
 const KubectlVersion = "1.16.5"
 
 // Helm2Version binary version to use
-const Helm2Version = "2.16.9"
+const Helm2Version = "2.17.0"
 
 // Helm3Version binary version to use
 const Helm3Version = "3.2.0"


### PR DESCRIPTION
That's probably my shortest PR, but an urgent one. The helm repo https://storage.googleapis.com/chartmuseum.jenkins-x.io, used prior to helm v2.17.0, is dead. Consequently, any call to `helm init` with an older version fails.

Helm version is fixed in that specific line, for instance used in `jx step verify preinstall` to download `helm`. But the version is also fixed in the various Jenkins-X docker images, for instance used in `make preview`. Both should be updated.

The Jenkins-X images are still highly outdated:
```bash
docker run gcr.io/jenkinsxio/builder-go:latest helm version
> &version.Version{SemVer:"v2.12.2", GitCommit:"7d2b0c73d734f6586ed222a567c5d103fed435be", GitTreeState:"clean"}
```

No idea where the image `gcr.io/jenkinsxio/builder-base` is configured.

fixes #7597