### PR TITLE
fix(version): update Helm2Version to 2.17.0

### DIFF
--- a/pkg/packages/packages.go
+++ b/pkg/packages/packages.go
@@ -29,7 +29,7 @@ const EksCtlVersion = "0.25.0"
 const KubectlVersion = "1.16.5"
 
 // Helm2Version binary version to use
-const Helm2Version = "2.16.9"
+const Helm2Version = "2.17.0"
 
 // Helm3Version binary version to use
 const Helm3Version = "3.2.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description
Helm v2 was adding the deprecated stable repository by default when helm init was run prior to 2.17.0. Since the deprecated repository is no longer work, all Helm previews that rely on Helm2 are broken. 

Starting in v2.17.0, Helm is adding https://charts.helm.sh/stable repository instead of old one.

https://helm.sh/blog/new-location-stable-incubator-charts/

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes https://github.com/jenkins-x/jenkins-x-builders/pull/1415

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
