### PR TITLE
fix: Add "all" to list of kinds to clean after deploy in helm template mode

### DIFF
--- a/pkg/helm/helm_template.go
+++ b/pkg/helm/helm_template.go
@@ -528,7 +528,7 @@ func (h *HelmTemplate) deleteOldResources(ns string, releaseName string, version
 }
 
 func (h *HelmTemplate) deleteNamespacedResourcesBySelector(ns string, selector string, wait bool, message string) error {
-	kinds := []string{"pvc", "configmap", "release", "sa", "role", "rolebinding", "secret"}
+	kinds := []string{"all", "pvc", "configmap", "release", "sa", "role", "rolebinding", "secret"}
 	errList := []error{}
 	log.Logger().Debugf("Removing Kubernetes resources from %s using selector: %s from %s", message, util.ColorInfo(selector), strings.Join(kinds, " "))
 	errs := h.deleteResourcesBySelector(ns, kinds, selector, wait)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines https://jenkins-x.io/docs/contributing/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://jenkins-x.io/docs/contributing/code/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.

#### Description

Adding "all" to the kinds of resources to delete that doesn't match the current release in helm template mode. This let's resources like deployments and services be deleted.

#### Special notes for the reviewer(s)

This fixes a regression introduced by #7073. (I find it worrying that no test caught that regression.)
In the earliest versions of jx "all" was the only kind to be deleted, the other ones where added later.

#### Which issue this PR fixes

Fixes: #7486

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
