### PR TITLE
fix: Install vault in image by default

### DIFF
--- a/Dockerfile-boot
+++ b/Dockerfile-boot
@@ -21,7 +21,8 @@ RUN echo using jx version ${VERSION} and OS ${TARGETOS} arch ${TARGETARCH} && \
   curl -L https://github.com/jenkins-x/jx/releases/download/v${VERSION}/jx-${TARGETOS}-${TARGETARCH}.tar.gz | tar xzv && \
   mv jx /usr/bin
 
-RUN jx upgrade plugins --boot --path /usr/bin
+RUN jx upgrade plugins --boot --path /usr/bin && \
+  jx secret plugins upgrade
 
 #RUN chown -R app:app /usr/bin/jx /home
 #USER app


### PR DESCRIPTION
If use vault as secretstorage. need to install vault plugin every time when run jx-boot in jx-git-operator