### PR TITLE
ci: add missing which command to unblock release pipeline

### DIFF
--- a/Dockerfile-tfo-aws
+++ b/Dockerfile-tfo-aws
@@ -6,7 +6,7 @@ ARG VERSION
 
 # install packages
 RUN yum -y update \
-    && yum install -y git tar gzip unzip jq \
+    && yum install -y git tar gzip unzip jq which\
     && yum clean all && rm -rf /var/cache/yum
 
 RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/aws-iam-authenticator && \


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

https://github.com/hypnoglow/helm-s3/blob/master/hack/install.sh#L49 -> the script requires which to find out if curl or wget packages exist.
```
#10 8.558 tar: Error is not recoverable: exiting now
#10 8.558 helm-s3 install hook failed. Please remove the plugin using 'helm plugin remove s3' and install again.
#10 8.558 Error: plugin install hook for "s3" exited with error
#10 8.558 error: failed to install helm plugin s3: failed to run '/root/.jx3/plugins/bin/helm-3.6.2 plugin install https://github.com/hypnoglow/helm-s3' command in directory '', output: 'Downloading and installing helm-s3 v0.10.0 ...
#10 8.558 ERROR: no curl or wget found to download files.
```