### PR TITLE
fix: Find helm plugin as non-root user in jx-boot

### DIFF
--- a/Dockerfile-boot
+++ b/Dockerfile-boot
@@ -15,6 +15,7 @@ RUN addgroup -S app \
 
 ENV JX_HOME /root/.jx
 ENV JX3_HOME /root/.jx
+ENV HELM_DATA_HOME /root/.local/share/helm
 
 RUN echo using jx version ${VERSION} and OS ${TARGETOS} arch ${TARGETARCH} && \
   mkdir -p /home/.jx3 && \


### PR DESCRIPTION
Fixes that helm plugins are not found when container is run as non-root user with the jx-boot image.

In particular in the pull request pipeline of the cluster repo, where the the container is run with tekton as the user.

```
Adding repo local s3://somebucket/jx3
in ./helmfile.yaml: in .helmfiles[3]: in helmfiles/jx/helmfile.yaml: command "/usr/bin/helm" exited with non-zero status:

PATH:
  /usr/bin/helm

ARGS:
  0: helm (4 bytes)
  1: repo (4 bytes)
  2: add (3 bytes)
  3: local (5 bytes)
  4: s3://somebucket/jx3 (30 bytes)
  5: --force-update (14 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

STDERR:
  Error: could not find protocol handler for: s3

COMBINED OUTPUT:
  Error: could not find protocol handler for: s3
make[1]: *** [versionStream/src/Makefile.mk:117: fetch] Error 1
make[1]: Leaving directory '/workspace/source'
error: failed to regen pr: failed to run 'make pr-regen' command in directory '.', output: ''
make: *** [versionStream/src/Makefile.mk:333: pr] Error 1
```

This fix means that the work around I had to make would be unnecessary:

```
        - name: make-pr
          resources: {}
          env:
          - name: HELM_DATA_HOME
            value: /root/.local/share/helm

```