### PR TITLE
refactor: upgrade goreleaser to the latest version

### DIFF
--- a/.github/workflows/jenkins-x-release.yaml
+++ b/.github/workflows/jenkins-x-release.yaml
@@ -35,7 +35,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GIT_BOT_TOKEN }}
         REPOSITORY: ${{ github.repository }}
       name: upload-binaries
-      uses: docker://goreleaser/goreleaser:v0.155.0
+      uses: docker://goreleaser/goreleaser:v1.4.1
       with:
         entrypoint: .github/workflows/jenkins-x/upload-binaries.sh
     - name: Set up QEMU

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,4 +71,3 @@ release:
   # You can change the name of the GitHub release.
   # Default is `{{.Tag}}`
   name_template: "{{.Env.VERSION}}"
-


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

We are running an ancient version of goreleaser, it's time to upgrade.
Checked that the config does not have any deprecated flags:
```
 goreleaser check
   • loading config file       file=.goreleaser.yml
   • checking config: 
   • config is valid
```

We will see if it works properly, once this is merged. The release pipeline is anyways broken atm.