### PR TITLE
ci: stop github actions on forks

### DIFF
--- a/.github/workflows/jenkins-x-pr.yaml
+++ b/.github/workflows/jenkins-x-pr.yaml
@@ -1,5 +1,6 @@
 jobs:
   pr:
+    if: github.repository_owner == 'jenkins-x'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/jenkins-x-release.yaml
+++ b/.github/workflows/jenkins-x-release.yaml
@@ -1,6 +1,7 @@
 name: Release
 jobs:
   release:
+    if: github.repository_owner == 'jenkins-x'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -97,6 +98,7 @@ jobs:
           ghcr.io/jenkins-x/jx:latest
           ghcr.io/jenkins-x/jx:${{ steps.prep.outputs.version }}
   release2:
+    if: github.repository_owner == 'jenkins-x'
     runs-on: ubuntu-latest
     needs: release
     steps:

--- a/.github/workflows/plugins-pr.yaml
+++ b/.github/workflows/plugins-pr.yaml
@@ -1,5 +1,6 @@
 jobs:
   plugins:
+    if: github.repository_owner == 'jenkins-x'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Everytime I open a PR in the jx repo, I see github actions running on my fork and failing.
This PR runs the jobs only on the main jx repo.