### PR TITLE
chore: revert jx verify to 0.2.2

### DIFF
--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -43,7 +43,7 @@ const (
 	TestVersion = "0.0.48"
 
 	// VerifyVersion the version of the jx verify plugin
-	VerifyVersion = "0.2.3"
+	VerifyVersion = "0.2.2"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Seems like jx3-version PRs are breaking since 3.2.288 which bumped jx-verify to 0.2.3. Reverting that change for now.