### PR TITLE
fix: Make command ctx an alias for plugin jx-context

### DIFF
--- a/pkg/cmd/namespace/namespace.go
+++ b/pkg/cmd/namespace/namespace.go
@@ -78,7 +78,7 @@ func NewCmdNamespace() (*cobra.Command, *Options) {
 	o := &Options{}
 	cmd := &cobra.Command{
 		Use:     "namespace",
-		Aliases: []string{"ns", "ctx"},
+		Aliases: []string{"ns"},
 		Short:   "View or change the current namespace context in the current Kubernetes cluster",
 		Long:    cmdLong,
 		Example: cmdExample,

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -143,6 +143,7 @@ func Main(args []string) *cobra.Command {
 	)
 	generalCommands = append(generalCommands, addCmd, getCmd, createCmd, startCmd, stopCmd,
 		aliasCommand(cmd, doCmd, "import", []string{"project", "import"}, "log"),
+		aliasCommand(cmd, doCmd, "ctx", []string{"context"}),
 	)
 
 	cmd.AddCommand(generalCommands...)


### PR DESCRIPTION
This makes ctx work like in jenkins-x 2