### PR TITLE
fix: Enable changelog in GitHub release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ scanning/
 myvalues.yaml
 myvalues.yml
 **/extraValues.yaml
-changelog.md
 
 # vim swap files
 *.swp


### PR DESCRIPTION
Since the switch to jenkins-x 3 the releases lack the install instructions and changelog. I think I have tracked down the cause of that.

It seems like goreleaser do git clean. So to use changelog.md generated by jx changelog it needs to be committed. This also makes the changelog.md checked in in the release tag, which is good idea as well.