### PR TITLE
fix: Upload release notes

### DIFF
--- a/.github/workflows/jenkins-x/changelog.sh
+++ b/.github/workflows/jenkins-x/changelog.sh
@@ -13,4 +13,4 @@ else
   echo no charts
 fi
 
-jx changelog create --verbose --header-file=hack/changelog-header.md --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=changelog.md --update-release=false
+jx changelog create --verbose --header-file=hack/changelog-header.md --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=CHANGELOG.md --update-release=false

--- a/.github/workflows/jenkins-x/upload-binaries.sh
+++ b/.github/workflows/jenkins-x/upload-binaries.sh
@@ -24,4 +24,4 @@ export REV=$(git rev-parse HEAD)
 export GOVERSION="1.17.9"
 export ROOTPACKAGE="github.com/$REPOSITORY"
 
-goreleaser release --release-notes changelog.md
+goreleaser release


### PR DESCRIPTION
This is an attempt to fix release notes

I don't really know why it doesn't work when using this GitHub Action when it works fine in the tekton pipelines. My hypothesis for this attempt is that the file name is case sensitive here and not in the tekton pipeline.