### PR TITLE
Revert "chore(deps): upgrade jenkins-x/jx to version 0.7.13"

### DIFF
--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -13,7 +13,7 @@ const (
 	ApplicationVersion = "0.2.0"
 
 	// GitOpsVersion the version of the jx gitops plugin
-	GitOpsVersion = "0.7.13"
+	GitOpsVersion = "0.7.8"
 
 	// HealthVersion the version of the jx health plugin
 	HealthVersion = "0.0.76"


### PR DESCRIPTION
Reverts jenkins-x/jx#8252

Back to the drawing board. 

BDD tests failed due to:

```
jx gitops helmfile move --output-dir config-root --dir /tmp/generate --dir-includes-release-name
 error: failed to : failed to modify namespace to jx for release jxboot-helmfile-resources in dir /tmp/generate/jx/jxboot-helmfile-resources/jxboot-helmfile-resources: the server doesn't have resource of kind Environment 
```

CustomResourceDefinitions need to be installed before `jx gitops helmfile move` would work properly.




