### PR TITLE
fix: inherit go version from catalog

### DIFF
--- a/.github/workflows/jenkins-x/upload-binaries.sh
+++ b/.github/workflows/jenkins-x/upload-binaries.sh
@@ -13,7 +13,7 @@ git config --global user.email "jenkins-x@googlegroups.com"
 export BRANCH=$(git rev-parse --abbrev-ref HEAD)
 export BUILDDATE=$(date)
 export REV=$(git rev-parse HEAD)
-export GOVERSION="1.17.9"
+export GOVERSION="$(go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/')"
 export ROOTPACKAGE="github.com/$REPOSITORY"
 
 goreleaser release

--- a/.github/workflows/plugins-pr.yaml
+++ b/.github/workflows/plugins-pr.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.17.9'
+          go-version: '1.17.11'
       - run: make ${{ matrix.target }}
       - run: |
           ./build/${{ matrix.target }}/${{ matrix.binary }} version

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,13 @@ ORG := jenkins-x
 ORG_REPO := $(ORG)/$(NAME)
 RELEASE_ORG_REPO := $(ORG_REPO)
 ROOT_PACKAGE := github.com/$(ORG_REPO)
+
+# This version is just used to trigger a new build in case we update the version of go in jx3-pipeline-catalog, and dont have new PRs which use the updated version in the catalog.
+# This does not reflect the go binary version which was used to build the jx binary, and also does not reflect the version in the catalog.
+# The sole purpose of this variable is to build a new binary if we ever need to build a new jx binary with a new go version with no code change.
+# If you notice that this version is not the same as the catalog version, please open a PR, the maintainers are happy to review it.
+DUMMY_GO_VERSION := 1.17.11
+
 GO_VERSION := $(shell $(GO) version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/')
 GO_DEPENDENCIES := $(call rwildcard,pkg/,*.go) $(call rwildcard,cmd/,*.go)
 


### PR DESCRIPTION
Signed-off-by: osamamagdy <osamamagdy174@gmail.com>

fixes #8297 

Here we are making the go version in the pipeline inherited from the image running gorealeaser.
In the makefile we ensure that GO_VERSION == CATALOG_GO_VERSION and error the make file if not.
To Do: How to get the CATALOG_GO_VERSION value?