### PR TITLE
feat: use alpine base image for jx-go

### DIFF
--- a/Dockerfile-go
+++ b/Dockerfile-go
@@ -1,4 +1,4 @@
-FROM golang:1.18.6
+FROM golang:1.18.6-alpine3.16
 
 ARG VERSION
 ARG TARGETARCH


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

```
golang                                                  1.18.6                                     f81bafb819d5   2 weeks ago     965MB
golang                                                  1.18.6-alpine3.16                          b68eed002951   3 weeks ago     328MB
```

I am using at my work, and the jx update bot image is 2.2 GB which is massive!