### PR TITLE
fix: add missing curl to jx-go alpine image

### DIFF
--- a/Dockerfile-go
+++ b/Dockerfile-go
@@ -7,7 +7,8 @@ ARG TARGETOS
 #ENV HOME /home
 ENV JX3_HOME /home/.jx3
 
-RUN echo using jx version ${VERSION} and OS ${TARGETOS} arch ${TARGETARCH} && \
+RUN apk add --no-cache curl && \
+  echo using jx version ${VERSION} and OS ${TARGETOS} arch ${TARGETARCH} && \
   mkdir -p /home/.jx3 && \
   curl -L https://github.com/jenkins-x/jx/releases/download/v${VERSION}/jx-${TARGETOS}-${TARGETARCH}.tar.gz | tar xzv && \
   mv jx /usr/bin


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

alpine does not have curl by default, this was breaking all release pipelines.