### PR TITLE
fix: switch to alpine base image for jx-go-maven

### DIFF
--- a/Dockerfile-go-maven
+++ b/Dockerfile-go-maven
@@ -1,11 +1,23 @@
-FROM ghcr.io/jenkins-x/jx-go-maven-base-image:0.0.2
+FROM golang:1.18.6-alpine3.16
+
+# Maven
+ENV MAVEN_VERSION 3.6.3
+ENV M2_HOME /opt/apache-maven-$MAVEN_VERSION
+ENV maven.home $M2_HOME
+ENV M2 $M2_HOME/bin
+ENV PATH $M2:$PATH
+ENV JAVA_HOME=/opt/jdk-15.0.1
+ENV PATH=$JAVA_HOME/bin:$PATH
+ENV JX3_HOME /home/.jx3
 
 ARG VERSION
 ARG TARGETARCH
 ARG TARGETOS
 
-#ENV HOME /home
-ENV JX3_HOME /home/.jx3
+RUN apk add --no-cache curl && \
+  curl -f -L https://repo1.maven.org/maven2/org/apache/maven/apache-maven/$MAVEN_VERSION/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv
+
+RUN curl -f -L https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz  | tar -C /opt -xzv
 
 RUN echo using jx version ${VERSION} and OS ${TARGETOS} arch ${TARGETARCH} && \
   mkdir -p /home/.jx3 && \


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Also upgrading to go1.18 (Previously it was go 1.15, which is most likely breaking release pipeline)
Size decreased by 600 MB

```
(base) ➜  jx git:(maven-go-1.18) ✗ docker images | grep maven
jx-go-maven                                             alpine                                     6efd322ce121   About a minute ago   1.62GB
ghcr.io/jenkins-x/jx-go-maven                           latest                                     74f40a9e9983   3 hours ago          2.13GB
```

Also removing archived `ghcr.io/jenkins-x/jx-go-maven-base-image` image. 
https://github.com/jenkins-x/jx-go-maven-base-image (Public archive)
