### PR TITLE
fix: switch back go-maven image to non-alpine

### DIFF
--- a/Dockerfile-go-maven
+++ b/Dockerfile-go-maven
@@ -1,4 +1,5 @@
-FROM golang:1.18.6-alpine3.16
+# ToDo: Make it work with alpine, not sure why alpine images complain about java not found
+FROM golang:1.18.6
 
 # Maven
 ENV MAVEN_VERSION 3.6.3
@@ -14,8 +15,7 @@ ARG VERSION
 ARG TARGETARCH
 ARG TARGETOS
 
-RUN apk add --no-cache curl bash git make && \
-  curl -f -L https://repo1.maven.org/maven2/org/apache/maven/apache-maven/$MAVEN_VERSION/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv
+RUN curl -f -L https://repo1.maven.org/maven2/org/apache/maven/apache-maven/$MAVEN_VERSION/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv
 
 RUN curl -f -L https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz  | tar -C /opt -xzv
 


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Ran into issues with alpine images, it cant find java binary even if it exists. Could be because of missing glibc (alpine uses musl), would be good to figure this out in the future. The image size is huge at 2.25 GB!