### PR TITLE
feat: create multiarch kubectl image for jx

### DIFF
--- a/.github/workflows/jenkins-x-release.yaml
+++ b/.github/workflows/jenkins-x-release.yaml
@@ -141,6 +141,18 @@ jobs:
         registry: ghcr.io
         username: jenkins-x
         password: ${{ secrets.GHCR_TOKEN }}
+    - name: Build and push kubectl
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./Dockerfile-kubectl
+        platforms: linux/amd64,linux/arm64
+        push: true
+        build-args: |
+          VERSION=1.20.2
+        tags: |
+          ghcr.io/jenkins-x/kubectl:latest
+          ghcr.io/jenkins-x/kubectl:1.20.2
     - name: Build and push jx-go
       uses: docker/build-push-action@v3
       with:

--- a/Dockerfile-kubectl
+++ b/Dockerfile-kubectl
@@ -1,0 +1,22 @@
+FROM alpine:3.16.2
+
+ARG VERSION
+ARG TARGETARCH
+ARG TARGETOS
+
+LABEL org.opencontainers.image.authors="Linux Foundation" \
+      org.opencontainers.image.description="Kubectl docker image used by Jenkins X" \
+      org.opencontainers.image.ref.name="alpine:3.16.2" \
+      org.opencontainers.image.source="https://github.com/jenkins-x/jx/blob/main/Dockerfile-kubectl" \
+      org.opencontainers.image.title="kubectl"
+
+RUN apk add --update --no-cache curl &&\
+    adduser -D -u 1001 jx
+
+RUN curl -LO "https://dl.k8s.io/release/v${VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" &&\
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin
+
+USER 1001
+ENTRYPOINT [ "kubectl" ]
+CMD [ "--help" ]


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Related to #8411.

Bitnami images don't support ARM yet, and I am not sure when that will land. We can build and maintain our own kubectl image for our usecase. The image is simple to build and smaller as it uses alpine.
https://github.com/jenkins-x/jx3-versions/blob/be23d4f583b765e832a0046e0ffd4f12be3cd21d/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl#L46 -> This is the current image.

Rancher also publishes it's own kubectl image, but we cant use it, as it's based on scratch, and we need base64 decode in the init script: https://github.com/rancher/kubectl/blob/ecb5988682864a252e55600fcca87b6d3d3d4312/Dockerfile#L12