### PR TITLE
fix: Correct command in plugin help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Make does not offer a recursive wildcard function, so here's one:
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
 
-SHELL := /bin/bash
+SHELL := /bin/sh
 NAME := jx
 BINARY_NAME := jx
 BUILD_TARGET = build

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -371,10 +371,15 @@ func handleEndpointExtensions(pluginHandler PluginHandler, cmdArgs []string, plu
 	nextArgs := cmdArgs[len(remainingArgs):]
 	log.Logger().Debugf("using the plugin command: %s", termcolor.ColorInfo(foundBinaryPath+" "+strings.Join(nextArgs, " ")))
 
+	// Giving plugin information about how it was invoked, so it can give correct help
+	pluginCommandName := os.Args[0] + " " + strings.Join(remainingArgs, " ")
+	environ := append(os.Environ(),
+		fmt.Sprintf("BINARY_NAME=%s", pluginCommandName),
+		fmt.Sprintf("TOP_LEVEL_COMMAND=%s", pluginCommandName))
 	// invoke cmd binary relaying the current environment and args given
 	// remainingArgs will always have at least one element.
 	// execute will make remainingArgs[0] the "binary name".
-	if err := pluginHandler.Execute(foundBinaryPath, nextArgs, os.Environ()); err != nil {
+	if err := pluginHandler.Execute(foundBinaryPath, nextArgs, environ); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Many plugins support using BINARY_NAME or TOP_LEVEL_COMMAND to form correct usage help.
This fixes makes use of this feature. It seems to me that it is an oversight that it has not been used previously.
