### PR TITLE
feat: add yq to boot image

### DIFF
--- a/Dockerfile-boot
+++ b/Dockerfile-boot
@@ -11,7 +11,7 @@ LABEL maintainer="jenkins-x"
 RUN addgroup -S app \
     && adduser -S -g app app \
     && apk --no-cache add \
-    ca-certificates curl git git-lfs make netcat-openbsd bash
+    ca-certificates curl git git-lfs make netcat-openbsd bash yq
 
 ENV JX_HOME /root/.jx
 ENV JX3_HOME /root/.jx


### PR DESCRIPTION
Even though a lot of juggling with yaml files are possible with `jx gitops` I keep encountering situations when yq would be solve a problem in a simpler than for example adding the functionality to `jx gitops` and a less fragile way than writing an awk or shell script.

In a pipeline I can add a step using a dedicated yq image, but in the jx boot job that isn't really possible.