### PR TITLE
fix: error checking

### DIFF
--- a/cmd/docs/md_docs.go
+++ b/cmd/docs/md_docs.go
@@ -154,10 +154,7 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 	if _, err := io.WriteString(f, filePrepender(filename)); err != nil {
 		return err
 	}
-	if err := GenMarkdownCustom(cmd, f, linkHandler); err != nil {
-		return err
-	}
-	return nil
+	return GenMarkdownCustom(cmd, f, linkHandler)
 }
 
 // Test to see if we have a reason to print See Also information in docs

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -379,10 +379,7 @@ func handleEndpointExtensions(pluginHandler PluginHandler, cmdArgs []string, plu
 	// invoke cmd binary relaying the current environment and args given
 	// remainingArgs will always have at least one element.
 	// execute will make remainingArgs[0] the "binary name".
-	if err := pluginHandler.Execute(foundBinaryPath, nextArgs, environ); err != nil {
-		return err
-	}
-	return nil
+	return pluginHandler.Execute(foundBinaryPath, nextArgs, environ)
 }
 
 // FindPluginBinary tries to find the jx-foo binary plugin in the plugins dir `~/.jx/plugins/jx/bin` dir `


### PR DESCRIPTION
Some simple error-checking patterns can be reduced to just a single return statement returning a variable of type Error.

for ex :

https://github.com/nishantsikarwar/jx/blob/c88e4a5831f7c737423986c7e93e1bdfd8523f7f/pkg/cmd/root.go#L382

https://github.com/jenkins-x/jx/blob/36061629b2beadb7be407fa7d9a5e7a58b7a023f/pkg/cmd/root.go#L382 
