### PR TITLE
Revert "chore(deps): bump sigstore/cosign-installer from 2.8.1 to 3.0.1"

### DIFF
--- a/.github/workflows/jenkins-x-release.yaml
+++ b/.github/workflows/jenkins-x-release.yaml
@@ -58,7 +58,7 @@ jobs:
     - name: syft-installer
       uses: anchore/sbom-action/download-syft@v0.13.3
     - name: cosign-installer
-      uses: sigstore/cosign-installer@v3.0.1
+      uses: sigstore/cosign-installer@v2.8.1
     - name: Build and push jx-boot
       uses: docker/build-push-action@v4
       id: push-jx-boot


### PR DESCRIPTION
The upgrade broke the release workflow

Reverts jenkins-x/jx#8524