### PR TITLE
fix: simplify install instructions

### DIFF
--- a/hack/changelog-header.md
+++ b/hack/changelog-header.md
@@ -3,70 +3,44 @@
 ### amd64
 
 ```shell
-# Download the archive and the cosign generated signature
-curl -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-amd64.tar.gz -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-amd64.tar.gz.sig -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-amd64.tar.gz.pem
-
-# Install cosign: https://docs.sigstore.dev/cosign/installation
-# Verify using cosign
-COSIGN_EXPERIMENTAL=1 cosign verify-blob --certificate jx-linux-amd64.tar.gz.pem --signature jx-linux-amd64.tar.gz.sig jx-linux-amd64.tar.gz
-
-tar -zxvf jx-linux-amd64.tar.gz
+curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-amd64.tar.gz | tar xzv
 sudo mv jx /usr/local/bin
 ```
 
 ### arm
 
 ```shell
-# Download the archive and the cosign generated signature
-curl -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-arm.tar.gz -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-arm.tar.gz.sig -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-arm.tar.gz.pem
-
-# Install cosign: https://docs.sigstore.dev/cosign/installation
-# Verify using cosign
-COSIGN_EXPERIMENTAL=1 cosign verify-blob --certificate jx-linux-arm.tar.gz.pem --signature jx-linux-arm.tar.gz.sig jx-linux-arm.tar.gz
-tar -zxvf jx-linux-arm.tar.gz
+curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-arm.tar.gz | tar xzv
 sudo mv jx /usr/local/bin
 ```
 
 ### arm64
 
 ```shell
-# Download the archive and the cosign generated signature
-curl -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-arm64.tar.gz -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-arm64.tar.gz.sig -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-arm64.tar.gz.pem
-
-# Install cosign: https://docs.sigstore.dev/cosign/installation
-# Verify using cosign
-COSIGN_EXPERIMENTAL=1 cosign verify-blob --certificate jx-linux-arm64.tar.gz.pem --signature jx-linux-arm64.tar.gz.sig jx-linux-arm64.tar.gz
-
-tar -zxvf jx-linux-arm64.tar.gz
+curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-linux-arm64.tar.gz | tar xzv
 sudo mv jx /usr/local/bin
 ```
 
 ## macOS
 
-### amd64
+### Using homebrew
 
 ```shell
-# Download the archive and the cosign generated signature
-curl -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-darwin-amd64.tar.gz -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-darwin-amd64.tar.gz.sig -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-darwin-amd64.tar.gz.pem
+brew install --no-quarantine --cask jenkins-x/jx/jx
+```
 
-# Install cosign: https://docs.sigstore.dev/cosign/installation
-# Verify using cosign
-COSIGN_EXPERIMENTAL=1 cosign verify-blob --certificate jx-darwin-amd64.tar.gz.pem --signature jx-darwin-amd64.tar.gz.sig jx-darwin-amd64.tar.gz
+### Using curl
 
-tar -zxvf jx-darwin-amd64.tar.gz
+#### amd64
+
+```shell
+curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-darwin-amd64.tar.gz | tar xzv
 sudo mv jx /usr/local/bin
 ```
 
-### arm64
+#### arm64
 
 ```shell
-# Download the archive and the cosign generated signature
-curl -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-darwin-arm64.tar.gz -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-darwin-arm64.tar.gz.sig -LO https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-darwin-arm64.tar.gz.pem
-
-# Install cosign: https://docs.sigstore.dev/cosign/installation
-# Verify using cosign
-COSIGN_EXPERIMENTAL=1 cosign verify-blob --certificate jx-darwin-arm64.tar.gz.pem --signature jx-darwin-arm64.tar.gz.sig jx-darwin-arm64.tar.gz
-
-tar -zxvf jx-darwin-arm64.tar.gz
+curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Version}}/jx-darwin-arm64.tar.gz | tar xzv
 sudo mv jx /usr/local/bin
 ```


### PR DESCRIPTION
The current instructions doesn't work with new versions of `cosign`. Also the current instructions makes for an unnecessary obstacle for new users. So I think simplifying the instructions makes most sense. I'm adding homebrew instructions while at it.

Possibly https://jenkins-x.io/v3/admin/setup/jx3/ should be complemented with cosign instructions.