### PR TITLE
fix: update .golangci.yml for more recent version of linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,15 @@
 linters-settings:
   depguard:
-    list-type: blacklist
-    packages:
-      - github.com/jenkins-x/jx/v2/pkg/log/
-      - github.com/satori/go.uuid
-      - github.com/pborman/uuid
-    packages-with-error-message:
-      - github.com/jenkins-x/jx/v2/pkg/log/: "use jenkins-x/jx-logging instead"
-      - github.com/satori/go.uuid: "use github.com/google/uuid instead"
-      - github.com/pborman/uuid: "use github.com/google/uuid instead"
+    rules:
+      main:
+        list-mode: original
+        deny:
+        - pkg: github.com/jenkins-x/jx/v2/pkg/log
+          desc: "use jenkins-x/jx-logging instead"
+        - pkg: github.com/satori/go.uuid
+          desc: "use github.com/google/uuid instead"
+        - pkg: github.com/pborman/uuid
+          desc: "use github.com/google/uuid instead"
   dupl:
     threshold: 100
   exhaustive:
@@ -21,48 +22,42 @@ linters-settings:
     min-occurrences: 3
   gocritic:
     enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
+    - diagnostic
+    - experimental
+    - opinionated
+    - performance
+    - style
     disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - wrapperFunc
-      - importShadow # not important for now
-      - unnamedResult # not important
+    - dupImport # https://github.com/go-critic/go-critic/issues/845
+    - ifElseChain
+    - octalLiteral
+    - whyNoLint
+    - wrapperFunc
+    - importShadow # not important for now
+    - unnamedResult # not important
   gocyclo:
     min-complexity: 15
   goimports: {}
-  golint:
-    min-confidence: 0
+  revive:
+    confidence: 0
   gofmt:
     simplify: true
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: [argument, case, condition, return]
+  mnd:
+    # don't include the "operation" and "assign"
+    checks: [argument, case, condition, return]
   govet:
-    check-shadowing: true
     settings:
       printf:
         funcs:
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Debugf
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Infof
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Warnf
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Errorf
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Fatalf
+        - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Debugf
+        - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Infof
+        - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Warnf
+        - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Errorf
+        - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Fatalf
   lll:
     line-length: 140
-  maligned:
-    suggest-new: true
   misspell: {}
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
@@ -71,52 +66,46 @@ linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
-    - asciicheck
-    - bodyclose
-    - deadcode
-    - depguard
-    - errcheck
-    - gofmt
-    - goimports
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - ineffassign
-    - misspell
-    - nakedret
-    - rowserrcheck
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-    - varcheck
-    - revive
-    - gocritic
-    - govet
-    - dupl
+  - asciicheck
+  - bodyclose
+  - depguard
+  - errcheck
+  - gofmt
+  - goimports
+  - goprintffuncname
+  - gosec
+  - gosimple
+  - ineffassign
+  - misspell
+  - mnd
+  - nakedret
+  - rowserrcheck
+  - staticcheck
+  - typecheck
+  - unconvert
+  - unparam
+  - unused
+  - revive
+  - gocritic
+  - govet
+  - dupl
 issues:
+  exclude-dirs:
+  - cmd/docs
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
-    #    - path: _test\.go
-    #      linters:
-    #        - gomnd
-    #    https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
+  #    - path: _test\.go
+  #      linters:
+  #        - gomnd
+  #    https://github.com/go-critic/go-critic/issues/926
+  - linters:
+    - gocritic
+    text: "unnecessaryDefer:"
   exclude:
-    - 'shadow: declaration of "err" shadows declaration at'
+  - 'shadow: declaration of "err" shadows declaration at'
   max-same-issues: 0
 
 run:
   timeout: 30m
-  skip-dirs:
-    - cmd/docs
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.42.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/pkg/cmd/dashboard/dashboard.go
+++ b/pkg/cmd/dashboard/dashboard.go
@@ -72,7 +72,7 @@ func NewCmdDashboard() (*cobra.Command, *Options) {
 		Short:   "View the Jenkins X Pipelines Dashboard",
 		Long:    cmdLong,
 		Example: cmdExample,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := o.Run()
 			helper.CheckErr(err)
 		},

--- a/pkg/cmd/namespace/namespace.go
+++ b/pkg/cmd/namespace/namespace.go
@@ -82,7 +82,7 @@ func NewCmdNamespace() (*cobra.Command, *Options) {
 		Short:   "View or change the current namespace context in the current Kubernetes cluster",
 		Long:    cmdLong,
 		Example: cmdExample,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			o.Args = args
 			err := o.Run()
 			helper.CheckErr(err)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -66,7 +66,7 @@ func Main(args []string) *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:   "get TYPE [flags]",
 		Short: "Display one or more resources",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			err := cmd.Help()
 			helper.CheckErr(err)
 		},
@@ -75,7 +75,7 @@ func Main(args []string) *cobra.Command {
 	addCmd := &cobra.Command{
 		Use:   "add TYPE [flags]",
 		Short: "Adds one or more resources",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			err := cmd.Help()
 			helper.CheckErr(err)
 		},
@@ -84,7 +84,7 @@ func Main(args []string) *cobra.Command {
 		Use:     "build TYPE [flags]",
 		Short:   "Display one or more resources relating to a pipeline build",
 		Aliases: []string{"builds"},
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			err := cmd.Help()
 			helper.CheckErr(err)
 		},
@@ -92,7 +92,7 @@ func Main(args []string) *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:   "create TYPE [flags]",
 		Short: "Create one or more resources",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			err := cmd.Help()
 			helper.CheckErr(err)
 		},
@@ -101,7 +101,7 @@ func Main(args []string) *cobra.Command {
 	startCmd := &cobra.Command{
 		Use:   "start TYPE [flags]",
 		Short: "Starts a resource",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			err := cmd.Help()
 			helper.CheckErr(err)
 		},
@@ -109,7 +109,7 @@ func Main(args []string) *cobra.Command {
 	stopCmd := &cobra.Command{
 		Use:   "stop TYPE [flags]",
 		Short: "Stops a resource",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			err := cmd.Help()
 			helper.CheckErr(err)
 		},
@@ -206,7 +206,7 @@ func aliasCommand(rootCmd *cobra.Command, fn func(cmd *cobra.Command, args []str
 		Use:     name,
 		Short:   "alias for: " + strings.Join(realArgs, " "),
 		Aliases: aliases,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			realArgs = append(realArgs, args...)
 			log.Logger().Debugf("about to invoke alias: %s", strings.Join(realArgs, " "))
 			fn(rootCmd, realArgs)

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -52,7 +52,7 @@ func NewCmdUI() (*cobra.Command, *Options) {
 		Short:   "Views the Jenkins X UI (octant)",
 		Long:    cmdLong,
 		Example: cmdExample,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := o.Run()
 			helper.CheckErr(err)
 		},

--- a/pkg/cmd/upgrade/upgrade.go
+++ b/pkg/cmd/upgrade/upgrade.go
@@ -32,7 +32,7 @@ func NewCmdUpgrade() (*cobra.Command, *Options) {
 		Short:   "Upgrades resources",
 		Long:    cmdLong,
 		Example: cmdExample,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := o.Run()
 			helper.CheckErr(err)
 		},

--- a/pkg/cmd/upgrade/upgrade_cli.go
+++ b/pkg/cmd/upgrade/upgrade_cli.go
@@ -73,7 +73,7 @@ func NewCmdUpgradeCLI() (*cobra.Command, *CLIOptions) {
 		Short:   "Upgrades your local Jenkins X CLI",
 		Long:    cmdCLILong,
 		Example: cmdCLIExample,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := o.Run()
 			helper.CheckErr(err)
 		},

--- a/pkg/cmd/upgrade/upgrade_plugins.go
+++ b/pkg/cmd/upgrade/upgrade_plugins.go
@@ -52,7 +52,7 @@ func NewCmdUpgradePlugins() (*cobra.Command, *PluginOptions) {
 		Short:   "Upgrades all of the plugins in your local Jenkins X CLI",
 		Long:    cmdPluginsLong,
 		Example: cmdPluginsExample,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := o.Run()
 			helper.CheckErr(err)
 		},

--- a/pkg/cmd/upgrade/upgrade_plugins_test.go
+++ b/pkg/cmd/upgrade/upgrade_plugins_test.go
@@ -10,8 +10,8 @@ import (
 func TestUpgrade(t *testing.T) {
 	t.Parallel()
 
-	_, o := upgrade.NewCmdUpgradePlugins()
+	cmd, _ := upgrade.NewCmdUpgradePlugins()
 
-	err := o.Run()
+	err := cmd.Execute()
 	require.NoError(t, err, "failed to run upgrade command")
 }

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -68,7 +68,7 @@ func NewCmdVersion() (*cobra.Command, *Options) {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Displays the version of this command",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			o.run()
 		},
 	}


### PR DESCRIPTION
Linter pipeline has started failing as `service.golangci-lint-version` is no longer honoured so errors were being returned when trying to run deprecated linters. See linter failing here https://github.com/jenkins-x/jx/pull/8676

This PR removes these deprecations and updates each linters config to the latest versions (finding equivalents if possible). Unused args have also been removed as per `revive` linter.