### PR TITLE
fix: plugin usage strings

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -274,7 +274,7 @@ func handleEndpointExtensions(cmdArgs []string, pluginBinDir string) error {
 	log.Logger().Debugf("using the plugin command: %s", termcolor.ColorInfo(foundBinaryPath+" "+strings.Join(nextArgs, " ")))
 
 	// Giving plugin information about how it was invoked, so it can give correct help
-	pluginCommandName := os.Args[0] + " " + strings.Join(remainingArgs, " ")
+	pluginCommandName := os.Args[0] + " " + strings.Join(remainingArgs, " ")
 	environ := append(os.Environ(),
 		fmt.Sprintf("BINARY_NAME=%s", pluginCommandName),
 		fmt.Sprintf("TOP_LEVEL_COMMAND=%s", pluginCommandName))


### PR DESCRIPTION
Since cobra only use the usage string up until the first space as command name in help I change to use non-breakable space in the env variables some plugins (for example jx-gitops) use to set use.

https://github.com/spf13/cobra/blob/v1.8.1/command.go#L1503