### PR TITLE
chore: update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,8 @@ archives:
   - name_template: "jx-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 checksum:
   # You can change the name of the checksums file.
   # Default is `jx_{{ .Version }}_checksums.txt`.


### PR DESCRIPTION
## PR Summary
This small PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/jenkins-x/jx/actions/runs/16271693400/job/45940696513#step:11:25): 
```
DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```