### PR TITLE
fix: overwrite existing environment variable

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -272,11 +272,10 @@ func handleEndpointExtensions(cmdArgs []string, pluginBinDir string) error {
 
 	// Giving plugin information about how it was invoked, so it can give correct help
 	pluginCommandName := os.Args[0] + " " + strings.Join(remainingArgs, " ")
-	environ := append(os.Environ(),
-		fmt.Sprintf("BINARY_NAME=%s", pluginCommandName),
-		fmt.Sprintf("TOP_LEVEL_COMMAND=%s", pluginCommandName))
+	os.Setenv("BINARY_NAME", pluginCommandName)
+	os.Setenv("TOP_LEVEL_COMMAND", pluginCommandName)
 	// invoke cmd binary relaying the current environment and args given
 	// remainingArgs will always have at least one element.
 	// execute will make remainingArgs[0] the "binary name".
-	return plugins.Execute(foundBinaryPath, nextArgs, environ)
+	return plugins.Execute(foundBinaryPath, nextArgs, os.Environ())
 }


### PR DESCRIPTION
appending an environment variable doesn't do anything if it is already set

# The problem

If the BINARY_NAME environment variable happens to be set the help text are messed up:

```
$ BINARY_NAME=foo jx project --help
Create a new project by importing code, creating a quickstart or custom wizard for spring.

Usage:
  foo [flags]
  foo [command]

Examples:
  # Create a project using the wizard
  foo
---
```

As compared to the correct:

```
jx project --help
Create a new project by importing code, creating a quickstart or custom wizard for spring.

Usage:
  jx project [flags]
  jx project [command]

Examples:
  # Create a project using the wizard
  jx project

```

This PR fixes that:

```
BINARY_NAME=foo ./build/jx project --help
Create a new project by importing code, creating a quickstart or custom wizard for spring.

Usage:
  ./build/jx project [flags]
  ./build/jx project [command]

Examples:
  # Create a project using the wizard
  ./build/jx project
---
```

TOP_LEVEL_COMMAND has basically the same function as BINARY_NAME; some plugins use one and some the other.