### PR TITLE
chore: enable revive exported linter and add missing comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,10 @@ linters-settings:
   goimports: {}
   revive:
     confidence: 0
+    rules:
+      - name: exported
+        arguments:
+          - "disableStutteringCheck"
   gofmt:
     simplify: true
   mnd:

--- a/pkg/cmd/dashboard/dashboard.go
+++ b/pkg/cmd/dashboard/dashboard.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// Options command options
 type Options struct {
 	options.BaseOptions
 	KubeClient          kubernetes.Interface
@@ -33,14 +34,17 @@ type Options struct {
 	BrowserHandler      Opener
 }
 
+// Opener interface for opening url
 type Opener interface {
 	Open() error
 }
 
+// Browser handler
 type Browser struct {
 	URL string
 }
 
+// Open url
 func (b *Browser) Open() error {
 	err := browser.OpenURL(b.URL)
 	if err != nil {
@@ -86,6 +90,7 @@ func NewCmdDashboard() (*cobra.Command, *Options) {
 	return cmd, o
 }
 
+// Run command
 func (o *Options) Run() error {
 	var err error
 	o.KubeClient, o.Namespace, err = kube.LazyCreateKubeClientAndNamespace(o.KubeClient, o.Namespace)

--- a/pkg/cmd/namespace/namespace.go
+++ b/pkg/cmd/namespace/namespace.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
+// Options options for namespace
 type Options struct {
 	KubeClient kubernetes.Interface
 	Input      input.Interface
@@ -73,6 +74,7 @@ var (
 	info = termcolor.ColorInfo
 )
 
+// NewCmdNamespace returns the namespace cmd
 func NewCmdNamespace() (*cobra.Command, *Options) {
 	o := &Options{}
 	cmd := &cobra.Command{
@@ -115,6 +117,7 @@ func NewCmdNamespace() (*cobra.Command, *Options) {
 	return cmd, o
 }
 
+// Run implements the command
 func (o *Options) Run() error {
 	var err error
 	currentNS := ""

--- a/pkg/cmd/upgrade/upgrade.go
+++ b/pkg/cmd/upgrade/upgrade.go
@@ -18,7 +18,7 @@ var (
 	`)
 )
 
-// UpgradeOptions the options for upgrading a cluster
+// Options the options for upgrading a cluster
 type Options struct {
 	Cmd *cobra.Command
 }

--- a/pkg/cmd/upgrade/upgrade_cli.go
+++ b/pkg/cmd/upgrade/upgrade_cli.go
@@ -50,7 +50,7 @@ var (
 
 const (
 	// BinaryDownloadBaseURL the base URL for downloading the binary from - will always have "VERSION/jx-OS-ARCH.EXTENSION" appended to it when used
-	BinaryDownloadBaseURL  = "https://github.com/jenkins-x/jx/releases/download/v"
+	BinaryDownloadBaseURL = "https://github.com/jenkins-x/jx/releases/download/v"
 	// LatestVersionstreamURL default version stream
 	LatestVersionstreamURL = "https://github.com/jenkins-x/jx3-versions.git"
 )

--- a/pkg/cmd/upgrade/upgrade_cli.go
+++ b/pkg/cmd/upgrade/upgrade_cli.go
@@ -51,10 +51,11 @@ var (
 const (
 	// BinaryDownloadBaseURL the base URL for downloading the binary from - will always have "VERSION/jx-OS-ARCH.EXTENSION" appended to it when used
 	BinaryDownloadBaseURL  = "https://github.com/jenkins-x/jx/releases/download/v"
+	// LatestVersionstreamURL default version stream
 	LatestVersionstreamURL = "https://github.com/jenkins-x/jx3-versions.git"
 )
 
-// UpgradeOptions the options for upgrading a cluster
+// CLIOptions options for upgrade cli
 type CLIOptions struct {
 	CommandRunner       cmdrunner.CommandRunner
 	GitClient           gitclient.Interface
@@ -63,7 +64,7 @@ type CLIOptions struct {
 	FromEnvironment     bool
 }
 
-// NewCmdUpgrade creates a command object for the command
+// NewCmdUpgradeCLI creates new upgrade cmd
 func NewCmdUpgradeCLI() (*cobra.Command, *CLIOptions) {
 	o := &CLIOptions{}
 
@@ -193,6 +194,7 @@ func (o *CLIOptions) getVersionStreamURL(gitURL string) (string, error) {
 	return gitURL, nil
 }
 
+// NeedsUpgrade returns true if upgrade is needed
 func (*CLIOptions) NeedsUpgrade(currentVersion, latestVersion semver.Version) bool {
 	if latestVersion.EQ(currentVersion) {
 		log.Logger().Infof("You are already on the latest version of jx %s", termcolor.ColorInfo(currentVersion.String()))
@@ -310,6 +312,7 @@ func shouldInstallBinary(name string) (bool, error) {
 	return download, nil
 }
 
+// BinaryWithExtension appends suitable extension
 func BinaryWithExtension(binary string) string {
 	if runtime.GOOS == "windows" {
 		if binary == "gcloud" {

--- a/pkg/cmd/upgrade/upgrade_plugins.go
+++ b/pkg/cmd/upgrade/upgrade_plugins.go
@@ -36,7 +36,7 @@ var (
 	}
 )
 
-// UpgradeOptions the options for upgrading a cluster
+// PluginOptions the options for upgrading plugins
 type PluginOptions struct {
 	CommandRunner cmdrunner.CommandRunner
 	OnlyMandatory bool
@@ -44,7 +44,7 @@ type PluginOptions struct {
 	Path          string
 }
 
-// NewCmdUpgrade creates a command object for the command
+// NewCmdUpgradePlugins creates a command object for upgrading plugins
 func NewCmdUpgradePlugins() (*cobra.Command, *PluginOptions) {
 	o := &PluginOptions{}
 

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -53,7 +53,7 @@ const (
 	TestGoVersion = "1.17.8"
 )
 
-// ShowOptions the options for viewing running PRs
+// Options the options for viewing running PRs
 type Options struct {
 	Verbose bool
 	Quiet   bool
@@ -153,6 +153,7 @@ func getTreeState() string {
 	return TestTreeState
 }
 
+// GetSemverVersion gets the semantic version.
 func GetSemverVersion() (semver.Version, error) {
 	text := getVersion()
 	v, err := semver.Make(text)

--- a/pkg/plugins/helpers.go
+++ b/pkg/plugins/helpers.go
@@ -71,6 +71,7 @@ func InstallStandardPlugin(dir, name string) (string, error) {
 	return extensions.EnsurePluginInstalled(plugin, dir)
 }
 
+// AllPlugins lists all plugins
 func AllPlugins() (validArgs []string) {
 	pluginBinDir, err := homedir.DefaultPluginBinDir()
 	for k := range Plugins {
@@ -115,7 +116,7 @@ func SetupPluginCompletion(cmd *cobra.Command, args []string) {
 	RegisterPluginCommands(root, true)
 }
 
-// RegisterPluginCommand allows adding Cobra command to the command tree or extracting them for usage in
+// RegisterPluginCommands allows adding Cobra command to the command tree or extracting them for usage in
 // e.g. the help function or for registering the completion function
 func RegisterPluginCommands(rootCmd *cobra.Command, list bool) (cmds []*cobra.Command) {
 	var userDefinedCommands []*cobra.Command
@@ -257,6 +258,7 @@ func getPluginCompletions(executablePath string, cmdArgs, environment []string) 
 	return comps, directive
 }
 
+// FindStandardPlugin finds standard plugin
 func FindStandardPlugin(dir, name string) (string, error) {
 	file, err := os.Open(dir)
 	if err != nil {
@@ -297,6 +299,7 @@ func FindStandardPlugin(dir, name string) (string, error) {
 	return InstallStandardPlugin(dir, name)
 }
 
+// Lookup looks up the given file
 func Lookup(filename, pluginBinDir string) (string, error) {
 	path, err := exec.LookPath(filename)
 	if err != nil {
@@ -308,6 +311,7 @@ func Lookup(filename, pluginBinDir string) (string, error) {
 	return path, nil
 }
 
+// Execute performs the command
 func Execute(executablePath string, cmdArgs, environment []string) error {
 	// Windows does not support exec syscall.
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Addresses #8037 by enabling the exported rule for the revive linter in .golangci.yml and fixing the exposed undocumented exported identifiers across the jx repository.

### Changes:
- Enabled exported rule for evive in .golangci.yml.
- Added missing comments in:
  - pkg/cmd/version/version.go
  - pkg/cmd/namespace/namespace.go
  - pkg/cmd/dashboard/dashboard.go
  - pkg/cmd/upgrade/upgrade.go, upgrade_cli.go, upgrade_plugins.go
  - pkg/plugins/helpers.go

Fixes: #8037