### PR TITLE
feat(charts): add default gateway api implementation

### DIFF
--- a/charts/gateway-api/Chart.yaml
+++ b/charts/gateway-api/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: gateway-api
+description: A custom Helm chart providing a sensible default Gateway API implementation for Jenkins X
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/gateway-api/templates/gateway.yaml
+++ b/charts/gateway-api/templates/gateway.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.gatewayName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  gatewayClassName: {{ .Values.gatewayClassName }}
+  listeners:
+    {{- range .Values.listeners }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      protocol: {{ .protocol }}
+      allowedRoutes:
+        namespaces:
+          from: {{ .allowedRoutes.namespaces.from }}
+      {{- if .tls }}
+      tls:
+        mode: {{ .tls.mode }}
+        certificateRefs:
+          {{- range .tls.certificateRefs }}
+          - name: {{ .name }}
+            kind: {{ .kind | default "Secret" }}
+          {{- end }}
+      {{- end }}
+    {{- end }}

--- a/charts/gateway-api/templates/httproute-default.yaml
+++ b/charts/gateway-api/templates/httproute-default.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.httproute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.httproute.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  parentRefs:
+    - name: {{ .Values.gatewayName }}
+  {{- if .Values.httproute.hostnames }}
+  hostnames:
+    {{- range .Values.httproute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.httproute.rules }}
+    - matches:
+        {{- range .matches }}
+        - path:
+            type: {{ .path.type }}
+            value: {{ .path.value | quote }}
+        {{- end }}
+      backendRefs:
+        {{- range .backendRefs }}
+        - name: {{ .name }}
+          port: {{ .port }}
+        {{- end }}
+    {{- end }}
+{{- end -}}

--- a/charts/gateway-api/values.yaml
+++ b/charts/gateway-api/values.yaml
@@ -1,0 +1,38 @@
+# Default values for gateway-api.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+gatewayClassName: "envoy"
+gatewayName: "jx-gateway"
+
+listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: https
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Terminate
+      certificateRefs:
+        - name: jx-gateway-tls
+          kind: Secret
+
+httproute:
+  enabled: true
+  name: default-fallback
+  hostnames: []
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: default-backend
+          port: 80


### PR DESCRIPTION
Fixes #8962

## Description

The Kubernetes project recommends migrating from `Ingress`-based approaches to the Gateway API. With the retirement of `ingress-nginx`, Jenkins X needs a standard `Gateway` capability for users who set `httproute` as their `IngressType`.

This PR provides a custom Helm chart (`charts/gateway-api`) with a sensible default Gateway API implementation. It includes out-of-the-box configurations for:
- A generic `Gateway` instance binding to standard HTTP/HTTPS listeners
- Basic TLS and routing structure capabilities based on `gateway.networking.k8s.io/v1`
- A fallback default `HTTPRoute` definition

## Testing

The syntax and logic for rendering the `Gateway` and `HTTPRoute` files have been manually verified to adhere to standard Helm best practices.

Signed-off-by: Mallikarjunadevops
