### PR TITLE
docs: explain linting after project import

### DIFF
--- a/docs/cmd/jx_import.md
+++ b/docs/cmd/jx_import.md
@@ -12,6 +12,19 @@ jx import
 
 alias for: jx project import
 
+### Validate the imported pipeline
+
+`jx import` can finish even when a trigger configuration refers to a file
+that does not exist. Before relying on the imported pipeline, run the pipeline
+lint command from the project directory:
+
+```
+jx pipeline lint
+```
+
+Fix any invalid references reported by the lint command, such as a typo in a
+`triggers.yaml` source value, and run it again before opening a pull request.
+
 ### Options
 
 ```


### PR DESCRIPTION
## Summary

- document the `jx pipeline lint` check after `jx import`
- call out invalid trigger source references, including typos in `triggers.yaml`
- keep this first increment limited to user-facing guidance as discussed in #7970

## Verification

- `git diff --check`
- Go-based documentation generation was not run because Go is not installed in this environment

This is the documentation-first increment suggested in #7970. The import implementation is provided by the project plugin, so the note gives users a concrete validation step while the implementation work can be handled separately.